### PR TITLE
Add "unknown" programming language

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,14 @@ build-odiglet:
 build-autoscaler:
 	docker build -t keyval/odigos-autoscaler:$(TAG) . --build-arg SERVICE_NAME=autoscaler
 
+.PHONY: build-instrumentor
+build-instrumentor:
+	docker build -t keyval/odigos-instrumentor:$(TAG) . --build-arg SERVICE_NAME=instrumentor
+
+.PHONY: build-scheduler
+build-scheduler:
+	docker build -t keyval/odigos-scheduler:$(TAG) . --build-arg SERVICE_NAME=scheduler
+
 .PHONY: build-collector
 build-collector:
 	docker build -t keyval/odigos-collector:$(TAG) collector -f collector/Dockerfile
@@ -13,9 +21,9 @@ build-collector:
 .PHONY: build-images
 build-images:
 	make build-autoscaler TAG=$(TAG)
-	docker build -t keyval/odigos-scheduler:$(TAG) . --build-arg SERVICE_NAME=scheduler
+	make build-scheduler TAG=$(TAG)
 	make build-odiglet TAG=$(TAG)
-	docker build -t keyval/odigos-instrumentor:$(TAG) . --build-arg SERVICE_NAME=instrumentor
+	make build-instrumentor TAG=$(TAG)
 	make build-collector TAG=$(TAG)
 
 .PHONY: push-images
@@ -38,6 +46,10 @@ load-to-kind-autoscaler:
 load-to-kind-collector:
 	kind load docker-image keyval/odigos-collector:$(TAG)
 
+.PHONY: load-to-kind-instrumentor
+load-to-kind-instrumentor:
+	kind load docker-image keyval/odigos-instrumentor:$(TAG)
+
 .PHONY: load-to-kind
 load-to-kind:
 	make load-to-kind-autoscaler TAG=$(TAG)
@@ -53,6 +65,10 @@ restart-odiglet:
 .PHONY: restart-autoscaler
 restart-autoscaler:
 	kubectl rollout restart deployment odigos-autoscaler -n odigos-system
+
+.PHONY: restart-instrumentor
+restart-instrumentor:
+	kubectl rollout restart deployment odigos-instrumentor -n odigos-system
 
 .PHONY: restart-collector
 restart-collector:
@@ -71,6 +87,10 @@ deploy-autoscaler:
 .PHONY: deploy-collector
 deploy-collector:
 	make build-collector TAG=$(TAG) && make load-to-kind-collector TAG=$(TAG) && make restart-collector
+
+.PHONY: deploy-instrumentor
+deploy-instrumentor:
+	make build-instrumentor TAG=$(TAG) && make load-to-kind-instrumentor TAG=$(TAG) && make restart-instrumentor
 
 .PHONY: debug-odiglet
 debug-odiglet:

--- a/api/config/crd/bases/odigos.io_instrumentationconfigs.yaml
+++ b/api/config/crd/bases/odigos.io_instrumentationconfigs.yaml
@@ -75,6 +75,7 @@ spec:
                             - dotnet
                             - javascript
                             - mysql
+                            - unknown
                             type: string
                         required:
                         - instrumentationLibraryName

--- a/api/config/crd/bases/odigos.io_instrumentedapplications.yaml
+++ b/api/config/crd/bases/odigos.io_instrumentedapplications.yaml
@@ -107,6 +107,7 @@ spec:
                       - dotnet
                       - javascript
                       - mysql
+                      - unknown
                       type: string
                   required:
                   - containerName

--- a/cli/cmd/resources/crds/instrumentedapps.go
+++ b/cli/cmd/resources/crds/instrumentedapps.go
@@ -80,6 +80,9 @@ func NewInstrumentedApp() *apiextensionsv1.CustomResourceDefinition {
 																{
 																	Raw: []byte(`"mysql"`),
 																},
+																{
+																	Raw: []byte(`"unknown"`),
+																},
 															},
 														},
 														"envVars": {

--- a/common/lang_detection.go
+++ b/common/lang_detection.go
@@ -1,6 +1,6 @@
 package common
 
-// +kubebuilder:validation:Enum=java;python;go;dotnet;javascript;mysql
+// +kubebuilder:validation:Enum=java;python;go;dotnet;javascript;mysql;unknown
 type ProgrammingLanguage string
 
 const (
@@ -12,4 +12,6 @@ const (
 	// This is an experimental feature, It is not a language
 	// but in order to avoid huge refactoring we are adding it here for now
 	MySQLProgrammingLanguage      ProgrammingLanguage = "mysql"
+	// Used when the language detection is not successful for all the available inspectors
+	UnknownProgrammingLanguage    ProgrammingLanguage = "unknown"
 )

--- a/instrumentor/instrumentation/instrumentation.go
+++ b/instrumentor/instrumentation/instrumentation.go
@@ -25,7 +25,7 @@ func ApplyInstrumentationDevicesToPodTemplate(original *v1.PodTemplateSpec, runt
 	var modifiedContainers []v1.Container
 	for _, container := range original.Spec.Containers {
 		containerLanguage := getLanguageOfContainer(runtimeDetails, container.Name)
-		if containerLanguage == nil {
+		if containerLanguage == nil || *containerLanguage == common.UnknownProgrammingLanguage {
 			modifiedContainers = append(modifiedContainers, container)
 			continue
 		}

--- a/odiglet/pkg/kube/runtime_details/shared.go
+++ b/odiglet/pkg/kube/runtime_details/shared.go
@@ -10,6 +10,7 @@ import (
 	"github.com/odigos-io/odigos/odiglet/pkg/log"
 	"github.com/odigos-io/odigos/odiglet/pkg/process"
 	"github.com/odigos-io/odigos/procdiscovery/pkg/inspectors"
+	"github.com/odigos-io/odigos/common"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -71,9 +72,8 @@ func runtimeInspection(pods []corev1.Pod) ([]odigosv1.RuntimeDetailsByContainer,
 			process := processes[0]
 
 			lang := inspectors.DetectLanguage(process)
-			if lang == nil {
+			if lang == common.UnknownProgrammingLanguage {
 				log.Logger.V(0).Info("no supported language detected for container in pod", "process", process, "pod", pod.Name, "container", container.Name, "namespace", pod.Namespace)
-				continue
 			}
 
 			// Convert map to slice for k8s format
@@ -84,7 +84,7 @@ func runtimeInspection(pods []corev1.Pod) ([]odigosv1.RuntimeDetailsByContainer,
 
 			resultsMap[container.Name] = odigosv1.RuntimeDetailsByContainer{
 				ContainerName: container.Name,
-				Language:      *lang,
+				Language:      lang,
 				EnvVars:       envs,
 			}
 		}

--- a/procdiscovery/pkg/inspectors/langdetect.go
+++ b/procdiscovery/pkg/inspectors/langdetect.go
@@ -29,13 +29,13 @@ var inspectorsList = []inspector{
 var ErrLanguageNotDetected = errors.New("language not detected")
 
 // DetectLanguage returns the detected language for the process or nil if the language could not be detected
-func DetectLanguage(process process.Details) *common.ProgrammingLanguage {
+func DetectLanguage(process process.Details) common.ProgrammingLanguage {
 	for _, i := range inspectorsList {
 		language, detected := i.Inspect(&process)
 		if detected {
-			return &language
+			return language
 		}
 	}
 
-	return nil
+	return common.UnknownProgrammingLanguage
 }


### PR DESCRIPTION
* Adding `unknown` to programming languages, indicating that we could not detect any of the currently supported languages.
* Create `InstrumentedApplication` object for cases where the language is unknown but the user requested to instrument.
* Add targets to Makefile to build and deploy the instrumentor