### PR TITLE
Pprof integration

### DIFF
--- a/autoscaler/main.go
+++ b/autoscaler/main.go
@@ -42,7 +42,11 @@ import (
 	"github.com/odigos-io/odigos/autoscaler/controllers"
 	"github.com/odigos-io/odigos/autoscaler/controllers/actions"
 	nameutils "github.com/odigos-io/odigos/autoscaler/utils"
+
 	//+kubebuilder:scaffold:imports
+
+	"net/http"
+	_ "net/http/pprof"
 )
 
 var (
@@ -97,6 +101,15 @@ func main() {
 		setupLog.Error(nil, "ODIGOS_VERSION environment variable is not set and version flag is not provided")
 		os.Exit(1)
 	}
+
+	go func() {
+		setupLog.Info("Starting pprof server")
+		if err := http.ListenAndServe(":6060", nil); err != nil {
+			setupLog.Error(err, "Failed to start pprof server")
+			os.Exit(1)
+		}
+	} ()
+
 	setupLog.Info("Starting odigos autoscaler", "version", odigosVersion)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{

--- a/autoscaler/main.go
+++ b/autoscaler/main.go
@@ -38,6 +38,7 @@ import (
 
 	apiactions "github.com/odigos-io/odigos/api/actions/v1alpha1"
 	observabilitycontrolplanev1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	"github.com/odigos-io/odigos/common"
 
 	"github.com/odigos-io/odigos/autoscaler/controllers"
 	"github.com/odigos-io/odigos/autoscaler/controllers/actions"
@@ -45,7 +46,6 @@ import (
 
 	//+kubebuilder:scaffold:imports
 
-	"net/http"
 	_ "net/http/pprof"
 )
 
@@ -102,13 +102,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	go func() {
-		setupLog.Info("Starting pprof server")
-		if err := http.ListenAndServe(":6060", nil); err != nil {
-			setupLog.Error(err, "Failed to start pprof server")
-			os.Exit(1)
-		}
-	} ()
+	go common.StartPprofServer(setupLog)
 
 	setupLog.Info("Starting odigos autoscaler", "version", odigosVersion)
 

--- a/common/consts/consts.go
+++ b/common/consts/consts.go
@@ -10,6 +10,7 @@ const (
 	DefaultOdigosConfigurationName = "odigos-config"
 	OTLPPort                       = 4317
 	OTLPHttpPort                   = 4318
+	PprofOdigosPort                = 6060
 	OdigosInstrumentationLabel     = "odigos-instrumentation"
 	InstrumentationEnabled         = "enabled"
 	InstrumentationDisabled        = "disabled"

--- a/common/go.mod
+++ b/common/go.mod
@@ -11,6 +11,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.10.0 // indirect
+	github.com/go-logr/logr v1.4.1
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect

--- a/common/go.sum
+++ b/common/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
+github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
+github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
 github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD876Lmtgy7VtROAbHHXk8no=

--- a/common/pprof.go
+++ b/common/pprof.go
@@ -1,0 +1,20 @@
+package common
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/go-logr/logr"
+	"github.com/odigos-io/odigos/common/consts"
+)
+
+// StartPprofServer starts the pprof server. This is blocking, so it should be run in a goroutine.
+// If the server is unable to start, the process will exit with a non-zero exit code.
+func StartPprofServer(logger logr.Logger) {
+	logger.Info("Starting pprof server")
+	addr := fmt.Sprintf(":%d", consts.PprofOdigosPort)
+	if err := http.ListenAndServe(addr, nil); err != nil {
+		os.Exit(-1)
+	}
+}

--- a/common/pprof.go
+++ b/common/pprof.go
@@ -3,7 +3,6 @@ package common
 import (
 	"fmt"
 	"net/http"
-	"os"
 
 	"github.com/go-logr/logr"
 	"github.com/odigos-io/odigos/common/consts"
@@ -15,6 +14,6 @@ func StartPprofServer(logger logr.Logger) {
 	logger.Info("Starting pprof server")
 	addr := fmt.Sprintf(":%d", consts.PprofOdigosPort)
 	if err := http.ListenAndServe(addr, nil); err != nil {
-		os.Exit(-1)
+		logger.Error(err, "unable to start pprof server")
 	}
 }

--- a/destinations/go.mod
+++ b/destinations/go.mod
@@ -8,6 +8,7 @@ require (
 )
 
 require (
+	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect

--- a/destinations/go.sum
+++ b/destinations/go.sum
@@ -1,6 +1,8 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
+github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/instrumentor/main.go
+++ b/instrumentor/main.go
@@ -123,7 +123,7 @@ func main() {
 
 	go func() {
 		setupLog.Info("Starting pprof server")
-		if err := http.ListenAndServe(:6060); err != nil {
+		if err := http.ListenAndServe(":6060", nil); err != nil {
 			setupLog.Error(err, "Failed to start pprof server")
 			os.Exit(1)
 		}

--- a/instrumentor/main.go
+++ b/instrumentor/main.go
@@ -41,7 +41,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	ctrlzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+
 	//+kubebuilder:scaffold:imports
+
+	"net/http"
+	_ "net/http/pprof"
 )
 
 var (
@@ -116,6 +120,14 @@ func main() {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
+
+	go func() {
+		setupLog.Info("Starting pprof server")
+		if err := http.ListenAndServe(:6060); err != nil {
+			setupLog.Error(err, "Failed to start pprof server")
+			os.Exit(1)
+		}
+	} ()
 
 	if !telemetryDisabled {
 		go report.Start(mgr.GetClient())

--- a/instrumentor/main.go
+++ b/instrumentor/main.go
@@ -26,6 +26,7 @@ import (
 	bridge "github.com/odigos-io/opentelemetry-zap-bridge"
 
 	v1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	"github.com/odigos-io/odigos/common"
 
 	"github.com/odigos-io/odigos/instrumentor/controllers/deleteinstrumentedapplication"
 	"github.com/odigos-io/odigos/instrumentor/controllers/instrumentationdevice"
@@ -44,7 +45,6 @@ import (
 
 	//+kubebuilder:scaffold:imports
 
-	"net/http"
 	_ "net/http/pprof"
 )
 
@@ -121,13 +121,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	go func() {
-		setupLog.Info("Starting pprof server")
-		if err := http.ListenAndServe(":6060", nil); err != nil {
-			setupLog.Error(err, "Failed to start pprof server")
-			os.Exit(1)
-		}
-	} ()
+	go common.StartPprofServer(setupLog)
 
 	if !telemetryDisabled {
 		go report.Start(mgr.GetClient())

--- a/odiglet/cmd/main.go
+++ b/odiglet/cmd/main.go
@@ -17,6 +17,9 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+
+	"net/http"
+	_ "net/http/pprof"
 )
 
 func main() {
@@ -44,6 +47,14 @@ func main() {
 	}
 
 	ctx := signals.SetupSignalHandler()
+
+	go func () {
+		log.Logger.V(0).Info("Starting pprof server")
+		if err := http.ListenAndServe(":6060", nil); err != nil {
+			log.Logger.Error(err, "Failed to start pprof server")
+			os.Exit(-1)
+		}
+	} ()
 
 	go startDeviceManager(clientset)
 

--- a/odiglet/cmd/main.go
+++ b/odiglet/cmd/main.go
@@ -18,7 +18,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
-	"net/http"
 	_ "net/http/pprof"
 )
 
@@ -48,13 +47,7 @@ func main() {
 
 	ctx := signals.SetupSignalHandler()
 
-	go func () {
-		log.Logger.V(0).Info("Starting pprof server")
-		if err := http.ListenAndServe(":6060", nil); err != nil {
-			log.Logger.Error(err, "Failed to start pprof server")
-			os.Exit(-1)
-		}
-	} ()
+	go common.StartPprofServer(log.Logger)
 
 	go startDeviceManager(clientset)
 

--- a/odiglet/go.mod
+++ b/odiglet/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/odigos-io/odigos/k8sutils v0.0.0
 	github.com/odigos-io/odigos/procdiscovery v0.0.0
 	github.com/odigos-io/opentelemetry-zap-bridge v0.0.5
-	github.com/otiai10/copy v1.14.0
 	go.opentelemetry.io/auto v0.13.0-alpha.0.20240615124104-22d9af3d1a11
 	go.opentelemetry.io/otel v1.27.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.27.0
@@ -85,7 +84,6 @@ require (
 	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 // indirect
 	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/oauth2 v0.20.0 // indirect
-	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.21.0 // indirect
 	golang.org/x/term v0.20.0 // indirect
 	golang.org/x/text v0.15.0 // indirect

--- a/odiglet/go.sum
+++ b/odiglet/go.sum
@@ -256,10 +256,6 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.32.0 h1:JRYU78fJ1LPxlckP6Txi/EYqJvjtMrDC04/MM5XRHPk=
 github.com/onsi/gomega v1.32.0/go.mod h1:a4x4gW6Pz2yK1MAmvluYme5lvYTn61afQ2ETw/8n4Lg=
-github.com/otiai10/copy v1.14.0 h1:dCI/t1iTdYGtkvCuBG2BgR6KZa83PTclw4U5n2wAllU=
-github.com/otiai10/copy v1.14.0/go.mod h1:ECfuL02W+/FkTWZWgQqXPWZgW9oeKCSQ5qVfSc4qc4w=
-github.com/otiai10/mint v1.5.1 h1:XaPLeE+9vGbuyEHem1JNk3bYc7KKqyI/na0/mLd/Kks=
-github.com/otiai10/mint v1.5.1/go.mod h1:MJm72SBthJjz8qhefc4z1PYEieWmy8Bku7CjcAqyUSM=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -429,8 +425,6 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
-golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/odiglet/pkg/instrumentation/fs/agents.go
+++ b/odiglet/pkg/instrumentation/fs/agents.go
@@ -1,6 +1,7 @@
 package fs
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -35,11 +36,12 @@ func CopyAgentsDirectoryToHost() error {
 		}
 	}
 
-	cmd := exec.Command("cp", "-R", containerDir + "/", hostDir + "/")
-	err = cmd.Run()
+	cmd := exec.Command("/bin/bash", "-c", "cp -r " + containerDir + "/* "  + hostDir)
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return err
+		return fmt.Errorf("error copying agents directory to host: %v, output %s", err, output)
 	}
+
 
 	// Check if the semanage command exists when running on RHEL/CoreOS
 	_, err = exec.LookPath(filepath.Join(chrootDir, semanagePath))

--- a/odiglet/pkg/instrumentation/fs/agents.go
+++ b/odiglet/pkg/instrumentation/fs/agents.go
@@ -7,7 +7,6 @@ import (
 	"syscall"
 
 	"github.com/odigos-io/odigos/odiglet/pkg/log"
-	cp "github.com/otiai10/copy"
 )
 
 const (
@@ -36,7 +35,8 @@ func CopyAgentsDirectoryToHost() error {
 		}
 	}
 
-	err = cp.Copy(containerDir, hostDir, cp.Options{})
+	cmd := exec.Command("cp", "-R", containerDir + "/", hostDir + "/")
+	err = cmd.Run()
 	if err != nil {
 		return err
 	}

--- a/procdiscovery/go.mod
+++ b/procdiscovery/go.mod
@@ -5,6 +5,7 @@ go 1.22.0
 require github.com/odigos-io/odigos/common v1.0.48
 
 require (
+	github.com/go-logr/logr v1.4.1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect
 )

--- a/procdiscovery/go.sum
+++ b/procdiscovery/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
+github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
* Initial integration of pprof in odiglet, autoscaler and instrumentor.
* Remove the library call to copy directories from the container to the host and use `cp` instead. The library call to `Copy` looked like it took an un-reasonable amount of un-released memory.
<img width="486" alt="dirs_copy_mem" src="https://github.com/odigos-io/odigos/assets/73110295/17985ddb-244d-4c63-90e4-2cb3aa474f71">

