### PR TITLE
Reduce k8s cache memory usage

### DIFF
--- a/k8sutils/pkg/env/env.go
+++ b/k8sutils/pkg/env/env.go
@@ -22,6 +22,7 @@ func getEnvVarOrDefault(envKey string, defaultVal string) string {
 	return defaultVal
 }
 
+// GetCurrentNamespace returns the namespace odigos is running in
 func GetCurrentNamespace() string {
 	return getEnvVarOrDefault(consts.CurrentNamespaceEnvVar, consts.DefaultOdigosNamespace)
 }

--- a/odiglet/Makefile
+++ b/odiglet/Makefile
@@ -3,6 +3,9 @@
 build-odiglet: generate
 	go build -o odiglet cmd/main.go
 
+debug-build-odiglet: generate
+	go build -o odiglet -gcflags "all=-N -l" cmd/main.go
+
 generate:
 	go mod download
 	GO_AUTO_PATH=$$(go list -m -f '{{.Dir}}' "go.opentelemetry.io/auto") && \

--- a/odiglet/README.md
+++ b/odiglet/README.md
@@ -1,0 +1,9 @@
+# Odiglet
+
+## Development
+One of Odiglet's jobs is to manage the different eBPF instrumentations. Loading an eBPF instrumentation requires having compiled eBPF programs (.o files). This compilation is taking place in Odiglet's Dockerfile and it requires the auto instrumentation code. This makes debugging locally on a non-linux system different compared to the other Odigos components.
+Assuming a setup with an active kind cluster with Odigos installed:
+1. Run `make debug-odiglet` or `TAG=<some_tag> make debug-odiglet` which will build Odiglet in a debug image which includes a Go debugger.
+In addition, it will port-forward the debugger port for remote debug.
+2. Using vscode launch the `Remote Odiglet` configuration.
+3. Debug the code.

--- a/odiglet/pkg/kube/instrumentation_ebpf/pods.go
+++ b/odiglet/pkg/kube/instrumentation_ebpf/pods.go
@@ -3,12 +3,13 @@ package instrumentation_ebpf
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/odigos-io/odigos/common"
+	"github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/odiglet/pkg/ebpf"
 	runtime_details "github.com/odigos-io/odigos/odiglet/pkg/kube/runtime_details"
 	kubeutils "github.com/odigos-io/odigos/odiglet/pkg/kube/utils"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -25,6 +26,11 @@ type PodsReconciler struct {
 
 func (p *PodsReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
+
+	if request.Namespace == consts.DefaultOdigosNamespace {
+		return ctrl.Result{}, nil
+	}
+
 	var pod corev1.Pod
 	err := p.Client.Get(ctx, request.NamespacedName, &pod)
 	if err != nil {
@@ -88,28 +94,19 @@ func (p *PodsReconciler) instrumentWithEbpf(ctx context.Context, pod *corev1.Pod
 func (p *PodsReconciler) getPodWorkloadObject(ctx context.Context, pod *corev1.Pod) (*common.PodWorkload, error) {
 	for _, owner := range pod.OwnerReferences {
 		if owner.Kind == "ReplicaSet" {
-			var rs appsv1.ReplicaSet
-			err := p.Client.Get(ctx, client.ObjectKey{
+			// ReplicaSet name is in the format <deployment-name>-<random-string>
+			hyphenIndex := strings.Index(owner.Name, "-")
+			if hyphenIndex == -1 {
+				// It is possible for a user to define a bare ReplicaSet without a deployment, currently not supporting this
+				return nil, errors.New("replicaset name does not contain a hyphen")
+			}
+			// Extract deployment name from ReplicaSet name
+			deploymentName := owner.Name[:hyphenIndex]
+			return &common.PodWorkload{
+				Name:      deploymentName,
 				Namespace: pod.Namespace,
-				Name:      owner.Name,
-			}, &rs)
-			if err != nil {
-				return nil, err
-			}
-
-			if rs.OwnerReferences == nil {
-				return nil, errors.New("replicaset has no owner reference")
-			}
-
-			for _, rsOwner := range rs.OwnerReferences {
-				if rsOwner.Kind == "Deployment" || rsOwner.Kind == "DaemonSet" || rsOwner.Kind == "StatefulSet" {
-					return &common.PodWorkload{
-						Name:      rsOwner.Name,
-						Namespace: pod.Namespace,
-						Kind:      rsOwner.Kind,
-					}, nil
-				}
-			}
+				Kind:      "Deployment",
+			}, nil
 		} else if owner.Kind == "DaemonSet" || owner.Kind == "Deployment" || owner.Kind == "StatefulSet" {
 			return &common.PodWorkload{
 				Name:      owner.Name,

--- a/odiglet/pkg/kube/instrumentation_ebpf/pods.go
+++ b/odiglet/pkg/kube/instrumentation_ebpf/pods.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 
 	"github.com/odigos-io/odigos/common"
-	"github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/odiglet/pkg/ebpf"
 	runtime_details "github.com/odigos-io/odigos/odiglet/pkg/kube/runtime_details"
 	kubeutils "github.com/odigos-io/odigos/odiglet/pkg/kube/utils"
+	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -27,7 +27,7 @@ type PodsReconciler struct {
 func (p *PodsReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
-	if request.Namespace == consts.DefaultOdigosNamespace {
+	if request.Namespace == env.GetCurrentNamespace() {
 		return ctrl.Result{}, nil
 	}
 

--- a/odiglet/pkg/kube/manager.go
+++ b/odiglet/pkg/kube/manager.go
@@ -4,10 +4,10 @@ import (
 	"context"
 
 	"github.com/odigos-io/odigos/odiglet/pkg/ebpf"
+	"github.com/odigos-io/odigos/odiglet/pkg/env"
 	"github.com/odigos-io/odigos/odiglet/pkg/kube/instrumentation_ebpf"
 	"github.com/odigos-io/odigos/odiglet/pkg/kube/runtime_details"
 	"github.com/odigos-io/odigos/odiglet/pkg/log"
-	"github.com/odigos-io/odigos/odiglet/pkg/env"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
@@ -38,8 +38,12 @@ func CreateManager() (ctrl.Manager, error) {
 	return manager.New(config.GetConfigOrDie(), manager.Options{
 		Scheme: scheme,
 		Cache: cache.Options{
+			// ManagedFields are removed to save space. This can save a lot of space and recommended in the cache package.
+			// running `kubectl get .... --show-managed-fields` will show the managed fields.
+			DefaultTransform: cache.TransformStripManagedFields(),
 			ByObject: map[client.Object]cache.ByObject{
 				&corev1.Pod{} :{
+					// only watch and list pods in the current node
 					Field: fields.OneTermEqualSelector("spec.nodeName", env.Current.NodeName),
 				},
 			},

--- a/odiglet/pkg/kube/runtime_details/workload_predicate.go
+++ b/odiglet/pkg/kube/runtime_details/workload_predicate.go
@@ -1,7 +1,7 @@
 package runtime_details
 
 import (
-	"github.com/odigos-io/odigos/common/consts"
+	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -34,7 +34,7 @@ func (i *WorkloadEnabledPredicate) Update(e event.UpdateEvent) bool {
 		return false
 	}
 	// filter our own namespace
-	if e.ObjectNew.GetNamespace() == consts.DefaultOdigosNamespace {
+	if e.ObjectNew.GetNamespace() == env.GetCurrentNamespace() {
 		return false
 	}
 


### PR DESCRIPTION
The following changes are made to reduce memory consumption in odiglet:
* Only include pods within the same node in the cache. This will make sure that we are only reconciling pods that are in the same node as odiglet (instead of filtering them after querying).
* Avoid saving the managed fields for cached objects https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/cache#TransformStripManagedFields
* Avoid querying ReplicaSet (which increased the memory consumption).