### PR TITLE
feat: odiglet to not delete c files

### DIFF
--- a/odiglet/pkg/instrumentation/fs/copy_test.go
+++ b/odiglet/pkg/instrumentation/fs/copy_test.go
@@ -15,7 +15,7 @@ func TestGetFiles(t *testing.T) {
 		t.Fatalf("createTestFiles failed: %v", err)
 	}
 
-	gotFiles, err := getFiles(tempDir + "/dir1")
+	gotFiles, err := getFiles(tempDir+"/dir1", false)
 	if err != nil {
 		t.Fatalf("getFiles failed: %v", err)
 	}

--- a/odiglet/pkg/instrumentation/fs/remove.go
+++ b/odiglet/pkg/instrumentation/fs/remove.go
@@ -1,0 +1,44 @@
+package fs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/odigos-io/odigos/odiglet/pkg/log"
+)
+
+func removeFilesInDir(hostDir string) error {
+	keepCFiles := !ShouldRecreateAllCFiles()
+	log.Logger.V(0).Info(fmt.Sprintf("Removing files in directory: %s, keepCFiles: %s", hostDir, fmt.Sprintf("%t", keepCFiles)))
+
+	return filepath.Walk(hostDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip the root directory itself]
+		if path == hostDir {
+			return nil
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		if keepCFiles {
+			switch ext := filepath.Ext(info.Name()); ext {
+			case ".so", ".node", "node.d", ".a":
+				return nil
+			}
+		}
+
+		// Remove the file
+		err = os.Remove(path)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+}

--- a/odiglet/pkg/instrumentation/fs/remove.go
+++ b/odiglet/pkg/instrumentation/fs/remove.go
@@ -9,8 +9,8 @@ import (
 )
 
 func removeFilesInDir(hostDir string) error {
-	keepCFiles := !ShouldRecreateAllCFiles()
-	log.Logger.V(0).Info(fmt.Sprintf("Removing files in directory: %s, keepCFiles: %s", hostDir, fmt.Sprintf("%t", keepCFiles)))
+	shouldRecreateCFiles := ShouldRecreateAllCFiles()
+	log.Logger.V(0).Info(fmt.Sprintf("Removing files in directory: %s, shouldRecreateCFiles: %s", hostDir, fmt.Sprintf("%t", shouldRecreateCFiles)))
 
 	return filepath.Walk(hostDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -26,7 +26,7 @@ func removeFilesInDir(hostDir string) error {
 			return nil
 		}
 
-		if keepCFiles {
+		if !shouldRecreateCFiles {
 			switch ext := filepath.Ext(info.Name()); ext {
 			case ".so", ".node", "node.d", ".a":
 				return nil


### PR DESCRIPTION
Odiglet should not delete the c files (.so, .node etc) files once restart.
in the enterprise it is causing the instrumentation to break.
The solution is to skip the recreating of these files, if you want them to be deleted you should put
`RECREATE_ALL_C_FILES` env var in the init container, and then it will react the same as it was until now