### PR TITLE
Read initial config of go auto instrumentation from instrumentationconfig CR

### DIFF
--- a/odiglet/cmd/main.go
+++ b/odiglet/cmd/main.go
@@ -143,7 +143,7 @@ func startDeviceManager(clientset *kubernetes.Clientset) {
 }
 
 func initEbpf(ctx context.Context, client client.Client, scheme *runtime.Scheme) (ebpf.DirectorsMap, error) {
-	goInstrumentationFactory := ebpf.NewGoInstrumentationFactory()
+	goInstrumentationFactory := ebpf.NewGoInstrumentationFactory(client)
 	goDirector := ebpf.NewEbpfDirector(ctx, client, scheme, common.GoProgrammingLanguage, goInstrumentationFactory)
 	goDirectorKey := ebpf.DirectorKey{
 		Language: common.GoProgrammingLanguage,


### PR DESCRIPTION
Instead of assuming  an empty initial configuration, read the initial configuration from the CR