### PR TITLE
Fix UI service and role to support collectors metrics when installed via helm

### DIFF
--- a/helm/odigos/templates/ui/role.yaml
+++ b/helm/odigos/templates/ui/role.yaml
@@ -15,3 +15,11 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch

--- a/helm/odigos/templates/ui/service.yaml
+++ b/helm/odigos/templates/ui/service.yaml
@@ -9,5 +9,7 @@ spec:
   ports:
     - name: ui
       port: 3000
+    - name: otlp
+      port: 4317
   selector:
     app: odigos-ui

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -17,8 +17,9 @@ brew install jq
 ```
 - Odigos cli compiled at `cli` folder. Compile via:
 ```bash
-go build -tags=embed_manifests -o ./cli/odigos ./cli
+cd cli; go build -tags=embed_manifests -o odigos .
 ```
+Go back to the root folder of the project.
 - Odigos images tagged with `e2e-test` preloaded to the cluster. If you are using Kind you can run:
 ```bash
 TAG=e2e-test make build-images load-to-kind 

--- a/tests/e2e/helm-chart/assert-odigos-installed.yaml
+++ b/tests/e2e/helm-chart/assert-odigos-installed.yaml
@@ -82,6 +82,22 @@ status:
       started: true
 ---
 apiVersion: v1
+kind: Service
+metadata:
+  name: ui
+  namespace: odigos-system
+  labels:
+    app.kubernetes.io/name: odigos-ui
+spec:
+  ports:
+    - name: ui
+      port: 3000
+    - name: otlp
+      port: 4317
+  selector:
+    app: odigos-ui
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:

--- a/tests/e2e/helm-chart/assert-odigos-installed.yaml
+++ b/tests/e2e/helm-chart/assert-odigos-installed.yaml
@@ -85,15 +85,17 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ui
-  namespace: odigos-system
-  labels:
-    app.kubernetes.io/name: odigos-ui
+  namespace: odigos-test-ns
 spec:
   ports:
     - name: ui
       port: 3000
+      protocol: TCP
+      targetPort: 3000
     - name: otlp
       port: 4317
+      protocol: TCP
+      targetPort: 4317
   selector:
     app: odigos-ui
 ---

--- a/tests/e2e/multi-apps/assert-odigos-installed.yaml
+++ b/tests/e2e/multi-apps/assert-odigos-installed.yaml
@@ -82,6 +82,22 @@ status:
       started: true
 ---
 apiVersion: v1
+kind: Service
+metadata:
+  name: ui
+  namespace: odigos-system
+  labels:
+    app.kubernetes.io/name: odigos-ui
+spec:
+  ports:
+    - name: ui
+      port: 3000
+    - name: otlp
+      port: 4317
+  selector:
+    app: odigos-ui
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:

--- a/tests/e2e/multi-apps/assert-odigos-installed.yaml
+++ b/tests/e2e/multi-apps/assert-odigos-installed.yaml
@@ -86,14 +86,16 @@ kind: Service
 metadata:
   name: ui
   namespace: odigos-system
-  labels:
-    app.kubernetes.io/name: odigos-ui
 spec:
   ports:
     - name: ui
       port: 3000
+      protocol: TCP
+      targetPort: 3000
     - name: otlp
       port: 4317
+      protocol: TCP
+      targetPort: 4317
   selector:
     app: odigos-ui
 ---


### PR DESCRIPTION
This was already added in https://github.com/odigos-io/odigos-charts/pull/113.
However, during this time and the refactoring and migration to the new helm repo, this change was reverted and caused #1496.
Added an assertion for the UI service in e2e tests.