### PR TITLE
fix: recalculate instrumentation device when overwritten

### DIFF
--- a/common/instrumentationdevice.go
+++ b/common/instrumentationdevice.go
@@ -40,3 +40,7 @@ func InstrumentationDeviceNameToComponents(deviceName string) (ProgrammingLangua
 	pluginName := strings.Split(deviceName, "/")[1]
 	return InstrumentationPluginNameToComponents(pluginName)
 }
+
+func IsResourceNameOdigosInstrumentation(resourceName string) bool {
+	return strings.HasPrefix(resourceName, OdigosResourceNamespace)
+}

--- a/instrumentor/controllers/instrumentationdevice/manager.go
+++ b/instrumentor/controllers/instrumentationdevice/manager.go
@@ -22,15 +22,15 @@ func countOdigosResources(resources corev1.ResourceList) int {
 	return numOdigosResources
 }
 
-type workloadEnvChangePredicate struct {
+type workloadPodTemplatePredicate struct {
 	predicate.Funcs
 }
 
-func (w workloadEnvChangePredicate) Create(e event.CreateEvent) bool {
+func (w workloadPodTemplatePredicate) Create(e event.CreateEvent) bool {
 	return false
 }
 
-func (w workloadEnvChangePredicate) Update(e event.UpdateEvent) bool {
+func (w workloadPodTemplatePredicate) Update(e event.UpdateEvent) bool {
 
 	if e.ObjectOld == nil || e.ObjectNew == nil {
 		return false
@@ -72,11 +72,11 @@ func (w workloadEnvChangePredicate) Update(e event.UpdateEvent) bool {
 	return false
 }
 
-func (w workloadEnvChangePredicate) Delete(e event.DeleteEvent) bool {
+func (w workloadPodTemplatePredicate) Delete(e event.DeleteEvent) bool {
 	return false
 }
 
-func (w workloadEnvChangePredicate) Generic(e event.GenericEvent) bool {
+func (w workloadPodTemplatePredicate) Generic(e event.GenericEvent) bool {
 	return false
 }
 
@@ -122,7 +122,7 @@ func SetupWithManager(mgr ctrl.Manager) error {
 		ControllerManagedBy(mgr).
 		Named("instrumentationdevice-deployment").
 		For(&appsv1.Deployment{}).
-		WithEventFilter(workloadEnvChangePredicate{}).
+		WithEventFilter(workloadPodTemplatePredicate{}).
 		Complete(&DeploymentReconciler{
 			Client: mgr.GetClient(),
 		})
@@ -134,7 +134,7 @@ func SetupWithManager(mgr ctrl.Manager) error {
 		ControllerManagedBy(mgr).
 		Named("instrumentationdevice-daemonset").
 		For(&appsv1.DaemonSet{}).
-		WithEventFilter(workloadEnvChangePredicate{}).
+		WithEventFilter(workloadPodTemplatePredicate{}).
 		Complete(&DaemonSetReconciler{
 			Client: mgr.GetClient(),
 		})
@@ -145,7 +145,7 @@ func SetupWithManager(mgr ctrl.Manager) error {
 	err = builder.
 		ControllerManagedBy(mgr).
 		For(&appsv1.StatefulSet{}).
-		WithEventFilter(workloadEnvChangePredicate{}).
+		WithEventFilter(workloadPodTemplatePredicate{}).
 		Complete(&StatefulSetReconciler{
 			Client: mgr.GetClient(),
 		})

--- a/instrumentor/controllers/instrumentationdevice/manager.go
+++ b/instrumentor/controllers/instrumentationdevice/manager.go
@@ -49,6 +49,14 @@ func (w workloadEnvChangePredicate) Update(e event.UpdateEvent) bool {
 				return true
 			}
 		}
+		if len(oldPodSpec.Spec.Containers[i].Resources.Limits) != len(newPodSpec.Spec.Containers[i].Resources.Limits) {
+			return true
+		}
+		for k, v := range oldPodSpec.Spec.Containers[i].Resources.Limits {
+			if newPodSpec.Spec.Containers[i].Resources.Limits[k] != v {
+				return true
+			}
+		}
 	}
 
 	return false


### PR DESCRIPTION
After instrumentor injects the instrumentation device and overriden envs to the workload template spec, these value might get over written if the user applies his workload manifest again.

At this point, the instrumentor should pick this up and insert odigos values back into the workload manifest template spec per each container.
Current reconciler only checks if something in the env changed to trigger recalculation, but we should also do it when something in the resource changes, so to inject the resource again if needed