### PR TITLE
refactor: start nodejs agent with span processor

### DIFF
--- a/agents/nodejs-native-community/autoinstrumentation.js
+++ b/agents/nodejs-native-community/autoinstrumentation.js
@@ -1,10 +1,25 @@
 try {
-    const [major] = process.versions.node.split('.').map(Number);
+    // Get the major Node.js version using traditional variable assignment and parsing.
+    var nodeVersion = process.versions.node.split('.');
+    var major = parseInt(nodeVersion[0], 10);
+
+    // Check for supported Node.js version
     if (major < 14) {
-      console.error('Odigos: Unsupported Node.js version for OpenTelemetry auto-instrumentation');
+        console.error('Odigos: Unsupported Node.js version for OpenTelemetry auto-instrumentation');
     } else {
-        require('@odigos/opentelemetry-node')
+        // Import the necessary functions using traditional require syntax.
+        var opentelemetryNode = require('@odigos/opentelemetry-node');
+        var createNativeCommunitySpanProcessor = opentelemetryNode.createNativeCommunitySpanProcessor;
+        var startOpenTelemetryAgent = opentelemetryNode.startOpenTelemetryAgent;
+
+        // Retrieve environment variables.
+        var opampServerHost = process.env.ODIGOS_OPAMP_SERVER_HOST;
+        var instrumentationDeviceId = process.env.ODIGOS_INSTRUMENTATION_DEVICE_ID;
+
+        // Create a span processor and start the OpenTelemetry agent.
+        var spanProcessor = createNativeCommunitySpanProcessor();
+        startOpenTelemetryAgent('odigos-native-community', instrumentationDeviceId, opampServerHost, spanProcessor);
     }    
 } catch (e) {
-    console.error('Odigos: Failed to load OpenTelemetry auto-instrumentation', e);
+    console.error('Odigos: Failed to load OpenTelemetry auto-instrumentation agent native-community', e);
 }


### PR DESCRIPTION
See https://github.com/odigos-io/opentelemetry-node/pull/13

This PR starts the nodejs agent by calling a function, and supplying the distro name `'odigos-native-community'`, and a span processor for the community tier that uses batch span processor with OTLP exporter.

CI will pass once we merge the node agent PR