### PR TITLE
fix: cleanup overwritten envs when language changes

### DIFF
--- a/common/envOverwrite/overwriter.go
+++ b/common/envOverwrite/overwriter.go
@@ -63,7 +63,7 @@ var EnvValuesMap = map[string]envValues{
 // the are 2 parts to the environment value: odigos part and user part.
 // either one can be set or empty.
 // so we have 4 cases to handle:
-func GetPatchedEnvValue(envName string, observedValue string, currentSdk common.OtelSdk, language common.ProgrammingLanguage) *string {
+func GetPatchedEnvValue(envName string, observedValue string, currentSdk *common.OtelSdk, language common.ProgrammingLanguage) *string {
 	envMetadata, ok := EnvValuesMap[envName]
 	if !ok {
 		// Odigos does not manipulate this environment variable, so ignore it
@@ -75,7 +75,12 @@ func GetPatchedEnvValue(envName string, observedValue string, currentSdk common.
 		return nil
 	}
 
-	desiredOdigosPart, ok := envMetadata.values[currentSdk]
+	if currentSdk == nil {
+		// When we have no sdk injected, we should not inject any odigos values.
+		return nil
+	}
+
+	desiredOdigosPart, ok := envMetadata.values[*currentSdk]
 	if !ok {
 		// No specific overwrite is required for this SDK
 		return nil

--- a/common/envOverwrite/overwriter_test.go
+++ b/common/envOverwrite/overwriter_test.go
@@ -17,7 +17,7 @@ func TestGetPatchedEnvValue(t *testing.T) {
 		name                 string
 		envName              string
 		observedValue        string
-		sdk                  common.OtelSdk
+		sdk                  *common.OtelSdk
 		programmingLanguage  common.ProgrammingLanguage
 		patchedValueExpected string
 	}{
@@ -25,7 +25,7 @@ func TestGetPatchedEnvValue(t *testing.T) {
 			name:                 "un-relevant env var",
 			envName:              "PATH",
 			observedValue:        "/usr/local/bin:/usr/bin:/bin",
-			sdk:                  common.OtelSdkNativeCommunity,
+			sdk:                  &common.OtelSdkNativeCommunity,
 			programmingLanguage:  common.JavascriptProgrammingLanguage,
 			patchedValueExpected: "",
 		},
@@ -33,7 +33,7 @@ func TestGetPatchedEnvValue(t *testing.T) {
 			name:                 "only user value",
 			envName:              "NODE_OPTIONS",
 			observedValue:        userVal,
-			sdk:                  common.OtelSdkNativeCommunity,
+			sdk:                  &common.OtelSdkNativeCommunity,
 			programmingLanguage:  common.JavascriptProgrammingLanguage,
 			patchedValueExpected: userVal + " " + nodeOptionsNativeCommunity,
 		},
@@ -41,7 +41,7 @@ func TestGetPatchedEnvValue(t *testing.T) {
 			name:                 "only odigos value",
 			envName:              "NODE_OPTIONS",
 			observedValue:        nodeOptionsNativeCommunity,
-			sdk:                  common.OtelSdkNativeCommunity,
+			sdk:                  &common.OtelSdkNativeCommunity,
 			programmingLanguage:  common.JavascriptProgrammingLanguage,
 			patchedValueExpected: "",
 		},
@@ -49,7 +49,7 @@ func TestGetPatchedEnvValue(t *testing.T) {
 			name:                 "user value with odigos value matching SDKs",
 			envName:              "NODE_OPTIONS",
 			observedValue:        userVal + " " + nodeOptionsNativeCommunity,
-			sdk:                  common.OtelSdkNativeCommunity,
+			sdk:                  &common.OtelSdkNativeCommunity,
 			programmingLanguage:  common.JavascriptProgrammingLanguage,
 			patchedValueExpected: userVal + " " + nodeOptionsNativeCommunity,
 		},
@@ -57,7 +57,7 @@ func TestGetPatchedEnvValue(t *testing.T) {
 			name:                 "user value with odigos value with different SDKs",
 			envName:              "NODE_OPTIONS",
 			observedValue:        userVal + " " + nodeOptionsNativeCommunity,
-			sdk:                  common.OtelSdkEbpfEnterprise,
+			sdk:                  &common.OtelSdkEbpfEnterprise,
 			programmingLanguage:  common.JavascriptProgrammingLanguage,
 			patchedValueExpected: userVal + " " + nodeOptionsEbpfEnterprise,
 		},
@@ -67,7 +67,7 @@ func TestGetPatchedEnvValue(t *testing.T) {
 			name:                 "observed odigos value different from SDK",
 			envName:              "NODE_OPTIONS",
 			observedValue:        nodeOptionsNativeCommunity,
-			sdk:                  common.OtelSdkEbpfEnterprise,
+			sdk:                  &common.OtelSdkEbpfEnterprise,
 			programmingLanguage:  common.JavascriptProgrammingLanguage,
 			patchedValueExpected: "",
 		},
@@ -75,15 +75,23 @@ func TestGetPatchedEnvValue(t *testing.T) {
 			name:                 "observed env is for a different programming language than what detected",
 			envName:              "NODE_OPTIONS",
 			observedValue:        userVal,
-			sdk:                  common.OtelSdkNativeCommunity,
+			sdk:                  &common.OtelSdkNativeCommunity,
 			programmingLanguage:  common.PythonProgrammingLanguage,
+			patchedValueExpected: "",
+		},
+		{
+			name:                 "no otel sdk (unknown language or ignored container)",
+			envName:              "NODE_OPTIONS",
+			observedValue:        userVal,
+			sdk:                  nil,
+			programmingLanguage:  common.UnknownProgrammingLanguage,
 			patchedValueExpected: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			patchedValue := GetPatchedEnvValue(tt.envName, tt.observedValue, tt.sdk, tt.programmingLanguage)
+			patchedValue := GetPatchedEnvValue(tt.envName, tt.observedValue, &tt.sdk, tt.programmingLanguage)
 			if patchedValue == nil {
 				assert.Equal(t, tt.patchedValueExpected, "", "mismatch in GetPatchedEnvValue: %s", tt.name)
 			} else {

--- a/common/envOverwrite/overwriter_test.go
+++ b/common/envOverwrite/overwriter_test.go
@@ -91,7 +91,7 @@ func TestGetPatchedEnvValue(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			patchedValue := GetPatchedEnvValue(tt.envName, tt.observedValue, &tt.sdk, tt.programmingLanguage)
+			patchedValue := GetPatchedEnvValue(tt.envName, tt.observedValue, tt.sdk, tt.programmingLanguage)
 			if patchedValue == nil {
 				assert.Equal(t, tt.patchedValueExpected, "", "mismatch in GetPatchedEnvValue: %s", tt.name)
 			} else {

--- a/instrumentor/instrumentation/instrumentation.go
+++ b/instrumentor/instrumentation/instrumentation.go
@@ -36,7 +36,7 @@ func ApplyInstrumentationDevicesToPodTemplate(original *corev1.PodTemplateSpec, 
 		containerLanguage := getLanguageOfContainer(runtimeDetails, container.Name)
 		if containerLanguage == nil || *containerLanguage == common.UnknownProgrammingLanguage || *containerLanguage == common.IgnoredProgrammingLanguage {
 			// always patch the env vars, even if the language is unknown or ignored.
-			// this is necessary we sync the envs to the detected language if changed for any reason.
+			// this is necessary to sync the existing envs with the missing language if changed for any reason.
 			err = patchEnvVarsForContainer(runtimeDetails, &container, nil, *containerLanguage, manifestEnvOriginal)
 			if err != nil {
 				return fmt.Errorf("%w: %v", ErrPatchEnvVars, err)

--- a/tests/e2e/workload-lifecycle/01-assert-apps-installed.yaml
+++ b/tests/e2e/workload-lifecycle/01-assert-apps-installed.yaml
@@ -96,3 +96,17 @@ status:
       started: true
   phase: Running
 ---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: language-change
+  namespace: default
+status:
+  containerStatuses:
+    - name: language-change
+      ready: true
+      restartCount: 0
+      started: true
+  phase: Running
+---

--- a/tests/e2e/workload-lifecycle/01-assert-instrumented.yaml
+++ b/tests/e2e/workload-lifecycle/01-assert-instrumented.yaml
@@ -172,3 +172,26 @@ status:
       status: "True"
       type: AppliedInstrumentationDevice
 ---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentedApplication
+metadata:
+  namespace: default
+  name: deployment-language-change
+status:
+  conditions:
+    - message: "Instrumentation device applied successfully"
+      observedGeneration: 1
+      reason: InstrumentationDeviceApplied
+      status: "True"
+      type: AppliedInstrumentationDevice
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationInstance
+metadata:
+  namespace: default
+  labels:
+    instrumented-app: deployment-language-change
+status:
+  healthy: true
+  # no need to verify all properties, as this is not the intent of this test
+---

--- a/tests/e2e/workload-lifecycle/01-assert-runtime-detected.yaml
+++ b/tests/e2e/workload-lifecycle/01-assert-runtime-detected.yaml
@@ -122,3 +122,23 @@ spec:
     - containerName: cpp-http-server
       language: unknown
 ---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentedApplication
+metadata:
+  name: deployment-language-change
+  namespace: default
+  ownerReferences:
+    - apiVersion: apps/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Deployment
+      name: language-change
+spec:
+  runtimeDetails:
+    - containerName: language-change
+      envVars:
+      - name: NODE_OPTIONS
+        value: "--require /app/execute_before.js --max-old-space-size=256"
+      language: javascript
+      runtimeVersion: 20.17.0
+---

--- a/tests/e2e/workload-lifecycle/01-assert-workloads.yaml
+++ b/tests/e2e/workload-lifecycle/01-assert-workloads.yaml
@@ -198,4 +198,35 @@ status:
   readyReplicas: 1
   replicas: 1
   updatedReplicas: 1
-
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "2" # the deployment spec changed when odigos resource was added
+  generation: 2 # the deployment spec changed when odigos resource was added
+  labels:
+    app: language-change
+  name: language-change
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: language-change
+  template:
+    spec:
+      containers:
+      - name: language-change
+        resources:
+          limits:
+            instrumentation.odigos.io/javascript-native-community: "1"
+        env:
+        - name: NODE_OPTIONS
+          value: "--require /app/execute_before.js --max-old-space-size=256 --require /var/odigos/nodejs/autoinstrumentation.js"
+status:
+  availableReplicas: 1
+  observedGeneration: 2 # the deployment spec changed when odigos resource was added
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1
+---

--- a/tests/e2e/workload-lifecycle/01-generate-traffic.yaml
+++ b/tests/e2e/workload-lifecycle/01-generate-traffic.yaml
@@ -30,3 +30,4 @@ spec:
               curl -s --fail http://nodejs-dockerfile-env:3000
               curl -s --fail http://nodejs-manifest-env:3000
               curl -s --fail http://cpp-http-server:3000
+              curl -s --fail http://language-change:3000

--- a/tests/e2e/workload-lifecycle/01-install-test-apps.yaml
+++ b/tests/e2e/workload-lifecycle/01-install-test-apps.yaml
@@ -246,3 +246,38 @@ spec:
     - protocol: TCP
       port: 3000
 ---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: language-change
+  namespace: default
+  labels:
+    app: language-change
+spec:
+  selector:
+    matchLabels:
+      app: language-change
+  template:
+    metadata:
+      labels:
+        app: language-change
+    spec:
+      containers:
+        - name: language-change
+          image: nodejs-dockerfile-env:v0.0.1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: language-change
+  namespace: default
+spec:
+  selector:
+    app: language-change
+  ports:
+    - protocol: TCP
+      port: 3000
+---

--- a/tests/e2e/workload-lifecycle/01-wait-for-trace.yaml
+++ b/tests/e2e/workload-lifecycle/01-wait-for-trace.yaml
@@ -5,6 +5,7 @@ query: |
   { resource.service.name = "nodejs-minimum-version" } ||
   { resource.service.name = "nodejs-latest-version" } ||
   { resource.service.name = "nodejs-dockerfile-env" } ||
-  { resource.service.name = "nodejs-manifest-env" }
+  { resource.service.name = "nodejs-manifest-env" } ||
+  { resource.service.name = "language-change" }
 expected:
-  count: 4
+  count: 5

--- a/tests/e2e/workload-lifecycle/02-assert-workload-update.yaml
+++ b/tests/e2e/workload-lifecycle/02-assert-workload-update.yaml
@@ -198,4 +198,32 @@ status:
   readyReplicas: 1
   replicas: 1
   updatedReplicas: 1
-
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "4"
+    (odigos.io/manifest-env-original-val == null): true
+  generation: 5 # started as 2, updated by test once, then by instrumentor and again after new runtime details updated
+  labels:
+    app: language-change
+  name: language-change
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: language-change
+  template:
+    spec:
+      containers:
+      - (env == null): true
+        image: cpp-http-server:v0.0.1
+        name: language-change
+        resources: {}
+status:
+  availableReplicas: 1
+  observedGeneration: 5
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1

--- a/tests/e2e/workload-lifecycle/02-update-workload-manifests.yaml
+++ b/tests/e2e/workload-lifecycle/02-update-workload-manifests.yaml
@@ -176,3 +176,28 @@ spec:
           ports:
             - containerPort: 3000
 ---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: language-change
+  namespace: default
+  labels:
+    app: language-change
+spec:
+  selector:
+    matchLabels:
+      app: language-change
+  template:
+    metadata:
+      labels:
+        app: language-change
+      annotations:
+        odigos-test-step: "2"
+    spec:
+      containers:
+        - name: language-change
+          image: cpp-http-server:v0.0.1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+---

--- a/tests/e2e/workload-lifecycle/README.md
+++ b/tests/e2e/workload-lifecycle/README.md
@@ -47,6 +47,17 @@ This e2e test verify various scenarios related to the lifecycle of workloads in 
 - Workload with a language odigos does not support.
 - Should not be instrumented or restarted.
 
+## Multi Language Workloads
+
+### language-change
+
+A workload that starts as nodejs in step 1 and changes to cpp (unknown in odigos) in step 2.
+This is not very realistic, but it's a way to test if odigos can handle a change in the workload language.
+Since the runtime detection mechanism is not bullet-proof, we can't guarantee that the detected language will not modify from known to unknown and vice-versa.
+In case we run into this scenario, we should be able to handle it gracefully.
+
+It would be best to simulate a more realistic scenario where the workload still runs nodejs but it is not detected. however, this is more complex and is left for future improvements.
+
 ## Steps
 
 ## Step 01 - Deploy Initial Workloads and Instrumentation
@@ -85,6 +96,11 @@ Verify the expected state for each workload according to it's caracteristics.
 - cpp-http-server
   - should NOT detect the runtime language and report it as `unknown`
   - should NOT add instrumentation device
+- language-change
+  - should detect the runtime version
+  - should add instrumentation device
+  - should report health in the instrumented instance CR
+  - agent should load and report traces
 
 ## Step 02 - Update Workload Manifest
 
@@ -115,3 +131,7 @@ This steps will make a change in the workload manifests and make sure that after
 - cpp-http-server
   - deployment manifest should be patched by odigos
   - workload should not restart and agent should not load
+- language-change
+  - deployment should revert the instrumentation device
+  - deployment should revert the injected env vars
+  - deployment should remove the env override annotation

--- a/tests/e2e/workload-lifecycle/chainsaw-test.yaml
+++ b/tests/e2e/workload-lifecycle/chainsaw-test.yaml
@@ -108,6 +108,13 @@ spec:
     try:
     - apply:
         file: 02-update-workload-manifests.yaml
+    - script:
+        timeout: 60s
+        content: |
+          # this is temporary and is here to trigger runtime detection after the language-change deployment is updated to simulate this scenario.
+          # after the migration to the new runtime detection mechanism, we will no longer need to restart the instrumentor.
+          kubectl rollout restart deployment odigos-instrumentor -n odigos-system
+          sleep 30
     - assert:
         file: 02-assert-workload-update.yaml
   


### PR DESCRIPTION
Handle few edge cases for env overwriter:
1. if language changes from something to unknown/ignored -> we must cleanup any env variables which were injected for the previous language, to sync them with the resource in use.
2. cleanup the env overwirtter annotation when it is empty
3. add e2e scenario to reproduce this case and verify it's behavior