### PR TITLE
ci: arrange make build targets to start with the longest ones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ build-ui:
 
 .PHONY: build-images
 build-images:
-	make -j 3 build-autoscaler build-scheduler build-odiglet build-instrumentor build-collector build-ui TAG=$(TAG)
+	make -j 3 build-ui build-collector build-odiglet build-autoscaler build-scheduler build-instrumentor TAG=$(TAG)
 
 .PHONY: push-odiglet
 push-odiglet:


### PR DESCRIPTION
When we run `make -j 3`, make will start with the ones in the beginning of the list, so this PR arrange them so that the heavy builds are first (ui, odiglet, collector) and only then comes the lighter ones (autoscaler, instrumentor, schedualr)

Hopeful, it will decrease a bit from CI time, better using the resources available 