### PR TITLE
ci: build the cli in concurrent to the docker images

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,27 +10,43 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-odigos-images:
-    runs-on: warp-ubuntu-latest-x64-8x-spot
+
+  build-cli:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "~1.22"
+          check-latest: true
+          cache: true
+          cache-dependency-path: |
+            **/go.sum
 
       - name: Build CLI
         run: |
           cd cli
           go build -tags=embed_manifests -o odigos
 
-      - name: Build Odigos Images
-        run: |
-          TAG=e2e-test make build-images
-          docker save -o odigos-images.tar $(docker images --format "{{.Repository}}:{{.Tag}}" | grep "odigos")
-
       - name: Upload CLI
         uses: actions/upload-artifact@v3
         with:
           name: odigos-cli
           path: cli/odigos
+
+  build-odigos-images:
+    runs-on: warp-ubuntu-latest-x64-8x-spot
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build Odigos Images
+        run: |
+          TAG=e2e-test make build-images
+          docker save -o odigos-images.tar $(docker images --format "{{.Repository}}:{{.Tag}}" | grep "odigos")
 
       - name: Upload Odigos Images
         uses: actions/upload-artifact@v3
@@ -39,7 +55,9 @@ jobs:
           path: odigos-images.tar
 
   kubernetes-test:
-    needs: build-odigos-images
+    needs: 
+      - build-odigos-images
+      - build-cli
     runs-on: warp-ubuntu-latest-x64-8x-spot
     strategy:
       fail-fast: false


### PR DESCRIPTION
Currently we are building the cli and docker images one after the other.
Since the cli takes ~30 seconds to build, we can benefit from doing it in parallel to the docker images, reducing 30 seconds from CI time