### PR TITLE
ci: e2e run install fe only for relevant scenarios

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -87,7 +87,7 @@ jobs:
           cluster_name: kind
 
       - name: Install FE
-        if: matrix.test-scenario == 'fe-synthetic'
+        if: matrix.test-scenario == 'multi-apps' || matrix.test-scenario == 'helm-chart'
         run: |
           cd frontend/webapp
           yarn install

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -87,7 +87,8 @@ jobs:
           cluster_name: kind
 
       - name: Install FE
-        if: matrix.test-scenario == 'multi-apps' || matrix.test-scenario == 'helm-chart'
+        # this is used for cypress tests which are not run in every scenario
+        if: matrix.test-scenario == 'multi-apps' || matrix.test-scenario == 'helm-chart' || matrix.test-scenario == 'fe-synthetic'
         run: |
           cd frontend/webapp
           yarn install

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -87,6 +87,7 @@ jobs:
           cluster_name: kind
 
       - name: Install FE
+        if: matrix.test-scenario == 'fe-synthetic'
         run: |
           cd frontend/webapp
           yarn install


### PR DESCRIPTION
The `Install FE` step in `kubernetes-test` job for `e2e` workflow takes a whole minute to run, but it is only needed for cypress which runs in the `multi-apps`, `helm-chart` and `fe-synthetic` scenarios.

Run it conditionally so all the other 2 scenarios will finish 1 minute earlier