### PR TITLE
Webhook injection no kubelet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cli/odigos
 .venv
 **/__pycache__/
 **/*.pyc
+serving-certs/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,10 @@
             "request": "launch",
             "mode": "debug",
             "program": "${workspaceFolder}/instrumentor",
-            "cwd": "${workspaceFolder}/instrumentor"
+            "cwd": "${workspaceFolder}/instrumentor",
+            "env": {
+                "LOCAL_MUTATING_WEBHOOK_CERT_DIR": "${workspaceFolder}/serving-certs"
+            }            
         },
         {
             "name": "frontend",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,3 +167,36 @@ make debug-odiglet
 
 Then, you can attach a debugger to the Odiglet pod. For example, if you are using Goland, you can follow the instructions [here](https://www.jetbrains.com/help/go/attach-to-running-go-processes-with-debugger.html#step-3-create-the-remote-run-debug-configuration-on-the-client-computer) to attach to a remote process.
 For Visual Studio Code, you can use the `.vscode/launch.json` file in this repo to attach to the Odiglet pod.
+
+
+
+## Instrumentor
+
+### Debugging
+If the Mutating Webhook is enabled, follow these steps:
+
+1. Copy the TLS certificate and key:
+Create a local directory and extract the certificate and key by running the following command:  
+```
+mkdir -p serving-certs && kubectl get secret instrumentor-webhook-cert -n odigos-system -o jsonpath='{.data.tls\.crt}' | base64 -d > serving-certs/tls.crt && kubectl get secret instrumentor-webhook-cert -n odigos-system -o jsonpath='{.data.tls\.key}' | base64 -d > serving-certs/tls.key
+```
+
+
+2. Apply this service to the cluster, it will replace the existing `odigos-instrumentor` service:
+
+```
+apiVersion: v1
+kind: Service
+metadata:
+  name: odigos-instrumentor
+  namespace: odigos-system
+spec:
+  type: ExternalName
+  externalName: host.docker.internal
+  ports:
+    - name: webhook-server
+      port: 9443
+      protocol: TCP
+```
+
+Once this is done, you can use the .vscode/launch.json configuration and run instrumentor local for debugging.

--- a/instrumentor/controllers/instrumentationdevice/pods_webhook.go
+++ b/instrumentor/controllers/instrumentationdevice/pods_webhook.go
@@ -7,9 +7,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	corev1 "k8s.io/api/core/v1"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	EnvVarNamespace     = "ODIGOS_CONTAINER_NAMESPACE"
+	EnvVarWorkloadKind  = "ODIGOS_WORKLOAD_KIND"
+	EnvVarContainerName = "ODIGOS_CONTAINER_NAME"
+	EnvVarPodName       = "ODIGOS_POD_NAME"
 )
 
 type PodsWebhook struct{}
@@ -17,8 +23,6 @@ type PodsWebhook struct{}
 var _ webhook.CustomDefaulter = &PodsWebhook{}
 
 func (p *PodsWebhook) Default(ctx context.Context, obj runtime.Object) error {
-	// TODO(edenfed): add object selector to mutatingwebhookconfiguration
-	log := logf.FromContext(ctx)
 	pod, ok := obj.(*corev1.Pod)
 	if !ok {
 		return fmt.Errorf("expected a Pod but got a %T", obj)
@@ -28,7 +32,58 @@ func (p *PodsWebhook) Default(ctx context.Context, obj runtime.Object) error {
 		pod.Annotations = map[string]string{}
 	}
 
-	//pod.Annotations["odigos.io/instrumented-webhook"] = "true"
-	log.V(0).Info("Defaulted Pod", "name", pod.Name)
+	// Inject ODIGOS environment variables into all containers
+	injectOdigosEnvVars(pod)
+
 	return nil
+}
+
+func injectOdigosEnvVars(pod *corev1.Pod) {
+
+	namespace := pod.Namespace
+	workloadKind := getWorkloadKind(pod)
+
+	for i := range pod.Spec.Containers {
+		container := &pod.Spec.Containers[i]
+
+		envVars := []corev1.EnvVar{
+			{
+				Name:  EnvVarNamespace,
+				Value: namespace,
+			},
+			{
+				Name:  EnvVarWorkloadKind,
+				Value: workloadKind,
+			},
+			{
+				Name:  EnvVarContainerName,
+				Value: container.Name,
+			},
+			{
+				Name: EnvVarPodName,
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "metadata.name",
+					},
+				},
+			},
+		}
+
+		container.Env = append(container.Env, envVars...)
+	}
+}
+
+// We can assume ReplicaSet is Deployment because this come after we identify the workload is supported by Odigos
+func getWorkloadKind(pod *corev1.Pod) string {
+	for _, ownerRef := range pod.OwnerReferences {
+		switch ownerRef.Kind {
+		case "ReplicaSet":
+			return "Deployment"
+		case "StatefulSet":
+			return "StatefulSet"
+		case "DaemonSet":
+			return "DaemonSet"
+		}
+	}
+	return "Unknown"
 }

--- a/instrumentor/main.go
+++ b/instrumentor/main.go
@@ -33,6 +33,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
@@ -98,7 +99,7 @@ func main() {
 	logger := zapr.NewLogger(zapLogger)
 	ctrl.SetLogger(logger)
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	mgrOptions := ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
@@ -173,7 +174,20 @@ func main() {
 				},
 			},
 		},
-	})
+	}
+
+	// Check if the environment variable `LOCAL_WEBHOOK_CERT_DIR` is set.
+	// If defined, add WebhookServer options with the specified certificate directory.
+	// This is used primarily for local development environments to provide a custom path for serving TLS certificates.
+	localCertDir := os.Getenv("LOCAL_MUTATING_WEBHOOK_CERT_DIR")
+	if localCertDir != "" {
+		mgrOptions.WebhookServer = webhook.NewServer(webhook.Options{
+			CertDir: localCertDir,
+		})
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mgrOptions)
+
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)

--- a/k8sutils/pkg/workload/ownerreference.go
+++ b/k8sutils/pkg/workload/ownerreference.go
@@ -1,36 +1,48 @@
 package workload
 
 import (
-	"errors"
+	"fmt"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// GetWorkloadFromOwnerReference retrieves both the workload name and workload kind
+// from the provided owner reference.
 func GetWorkloadFromOwnerReference(ownerReference metav1.OwnerReference) (workloadName string, workloadKind WorkloadKind, err error) {
-	ownerName := ownerReference.Name
-	ownerKind := ownerReference.Kind
+
+	workloadName, workloadKind, err = GetWorkloadNameAndKind(ownerReference.Name, ownerReference.Kind)
+	if err != nil {
+		return "", "", err
+	}
+
+	return workloadName, workloadKind, nil
+}
+
+func GetWorkloadNameAndKind(ownerName, ownerKind string) (string, WorkloadKind, error) {
 	if ownerKind == "ReplicaSet" {
-		// ReplicaSet name is in the format <deployment-name>-<random-string>
-		hyphenIndex := strings.LastIndex(ownerName, "-")
-		if hyphenIndex == -1 {
-			// It is possible for a user to define a bare ReplicaSet without a deployment, currently not supporting this
-			err = errors.New("replicaset name does not contain a hyphen")
-			return
-		}
-		// Extract deployment name from ReplicaSet name
-		workloadName = ownerName[:hyphenIndex]
-		workloadKind = WorkloadKindDeployment
-		return
+		return extractDeploymentInfo(ownerName)
+	}
+	return handleNonReplicaSet(ownerName, ownerKind)
+}
+
+// extractDeploymentInfo extracts deployment information from a ReplicaSet name
+func extractDeploymentInfo(replicaSetName string) (string, WorkloadKind, error) {
+	hyphenIndex := strings.LastIndex(replicaSetName, "-")
+	if hyphenIndex == -1 {
+		return "", "", fmt.Errorf("replicaset name '%s' does not contain a hyphen", replicaSetName)
 	}
 
-	workloadKind = WorkloadKindFromString(ownerKind)
+	deploymentName := replicaSetName[:hyphenIndex]
+	return deploymentName, WorkloadKindDeployment, nil
+}
+
+// handleNonReplicaSet processes non-ReplicaSet workload types
+func handleNonReplicaSet(ownerName, ownerKind string) (string, WorkloadKind, error) {
+	workloadKind := WorkloadKindFromString(ownerKind)
 	if workloadKind == "" {
-		err = ErrKindNotSupported
-		return
+		return "", "", ErrKindNotSupported
 	}
-	workloadName = ownerName
 
-	err = nil
-	return
+	return ownerName, workloadKind, nil
 }

--- a/opampserver/pkg/server/handlers.go
+++ b/opampserver/pkg/server/handlers.go
@@ -11,17 +11,20 @@ import (
 	"github.com/odigos-io/odigos/k8sutils/pkg/instrumentation_instance"
 	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
 	"github.com/odigos-io/odigos/opampserver/pkg/connection"
-	"github.com/odigos-io/odigos/opampserver/pkg/deviceid"
+	di "github.com/odigos-io/odigos/opampserver/pkg/deviceid"
 	"github.com/odigos-io/odigos/opampserver/pkg/sdkconfig"
 	"github.com/odigos-io/odigos/opampserver/pkg/sdkconfig/configresolvers"
 	"github.com/odigos-io/odigos/opampserver/protobufs"
 	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type ConnectionHandlers struct {
-	deviceIdCache *deviceid.DeviceIdCache
+	deviceIdCache *di.DeviceIdCache
 	sdkConfig     *sdkconfig.SdkConfigManager
 	logger        logr.Logger
 	kubeclient    client.Client
@@ -29,7 +32,15 @@ type ConnectionHandlers struct {
 	nodeName      string
 }
 
-func (c *ConnectionHandlers) OnNewConnection(ctx context.Context, deviceId string, firstMessage *protobufs.AgentToServer) (*connection.ConnectionInfo, *protobufs.ServerToAgent, error) {
+type opampAgentAttributesKeys struct {
+	ProgrammingLanguage string
+	ContainerName       string
+	PodName             string
+	WorkloadKind        string
+	Namespace           string
+}
+
+func (c *ConnectionHandlers) OnNewConnection(ctx context.Context, deviceId string, firstMessage *protobufs.AgentToServer, kubeClient *kubernetes.Clientset) (*connection.ConnectionInfo, *protobufs.ServerToAgent, error) {
 
 	if firstMessage.AgentDescription == nil {
 		// first message must be agent description.
@@ -53,25 +64,19 @@ func (c *ConnectionHandlers) OnNewConnection(ctx context.Context, deviceId strin
 		return nil, nil, fmt.Errorf("missing pid in agent description")
 	}
 
-	var programmingLanguage string
-	for _, attr := range firstMessage.AgentDescription.IdentifyingAttributes {
-		if attr.Key == string(semconv.TelemetrySDKLanguageKey) {
-			programmingLanguage = attr.Value.GetStringValue()
-			break
-		}
-	}
-	if programmingLanguage == "" {
+	attrs := extractOpampAgentAttributes(firstMessage.AgentDescription.IdentifyingAttributes)
+
+	if attrs.ProgrammingLanguage == "" {
 		return nil, nil, fmt.Errorf("missing programming language in agent description")
 	}
 
-	k8sAttributes, pod, err := c.deviceIdCache.GetAttributesFromDevice(ctx, deviceId)
+	k8sAttributes, pod, err := c.resolveK8sAttributes(ctx, attrs, deviceId, kubeClient, c.logger)
 	if err != nil {
-		c.logger.Error(err, "failed to get attributes from device", "deviceId", deviceId)
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to process k8s attributes: %w", err)
 	}
 
 	podWorkload := workload.PodWorkload{
-		Namespace: pod.GetNamespace(),
+		Namespace: k8sAttributes.Namespace,
 		Kind:      workload.WorkloadKind(k8sAttributes.WorkloadKind),
 		Name:      k8sAttributes.WorkloadName,
 	}
@@ -83,7 +88,7 @@ func (c *ConnectionHandlers) OnNewConnection(ctx context.Context, deviceId strin
 		return nil, nil, err
 	}
 
-	fullRemoteConfig, err := c.sdkConfig.GetFullConfig(ctx, remoteResourceAttributes, &podWorkload, instrumentedAppName, programmingLanguage)
+	fullRemoteConfig, err := c.sdkConfig.GetFullConfig(ctx, remoteResourceAttributes, &podWorkload, instrumentedAppName, attrs.ProgrammingLanguage)
 	if err != nil {
 		c.logger.Error(err, "failed to get full config", "k8sAttributes", k8sAttributes)
 		return nil, nil, err
@@ -96,7 +101,7 @@ func (c *ConnectionHandlers) OnNewConnection(ctx context.Context, deviceId strin
 		Pod:                      pod,
 		ContainerName:            k8sAttributes.ContainerName,
 		Pid:                      pid,
-		ProgrammingLanguage:      programmingLanguage,
+		ProgrammingLanguage:      attrs.ProgrammingLanguage,
 		InstrumentedAppName:      instrumentedAppName,
 		AgentRemoteConfig:        fullRemoteConfig,
 		RemoteResourceAttributes: remoteResourceAttributes,
@@ -190,4 +195,69 @@ func (c *ConnectionHandlers) UpdateInstrumentationInstanceStatus(ctx context.Con
 	}
 
 	return nil
+}
+
+// resolveK8sAttributes resolves K8s resource attributes using either direct attributes from opamp agent or device cache
+func (c *ConnectionHandlers) resolveK8sAttributes(ctx context.Context, attrs opampAgentAttributesKeys,
+	deviceId string, kubeClient *kubernetes.Clientset, logger logr.Logger) (*di.K8sResourceAttributes, *corev1.Pod, error) {
+
+	if attrs.hasRequiredAttributes() {
+		podInfoResolver := di.NewK8sPodInfoResolver(logger, kubeClient)
+		return resolveFromDirectAttributes(ctx, attrs, podInfoResolver, kubeClient)
+	}
+	return c.deviceIdCache.GetAttributesFromDevice(ctx, deviceId)
+}
+
+func extractOpampAgentAttributes(attributes []*protobufs.KeyValue) opampAgentAttributesKeys {
+	result := opampAgentAttributesKeys{}
+
+	for _, attr := range attributes {
+		switch attr.Key {
+		case string(semconv.TelemetrySDKLanguageKey):
+			result.ProgrammingLanguage = attr.Value.GetStringValue()
+		case string(semconv.ContainerNameKey):
+			result.ContainerName = attr.Value.GetStringValue()
+		case string(semconv.K8SPodNameKey):
+			result.PodName = attr.Value.GetStringValue()
+		case string(semconv.K8SNamespaceNameKey):
+			result.Namespace = attr.Value.GetStringValue()
+		case "k8s.workload.kind":
+			result.WorkloadKind = attr.Value.GetStringValue()
+		}
+	}
+
+	return result
+}
+
+func (k opampAgentAttributesKeys) hasRequiredAttributes() bool {
+	return k.ContainerName != "" && k.PodName != "" && k.WorkloadKind != "" && k.Namespace != ""
+}
+
+func resolveFromDirectAttributes(ctx context.Context, attrs opampAgentAttributesKeys,
+	podInfoResolver *di.K8sPodInfoResolver, kubeClient *kubernetes.Clientset) (*di.K8sResourceAttributes, *corev1.Pod, error) {
+
+	workloadName, _, err := workload.GetWorkloadNameAndKind(attrs.PodName, attrs.WorkloadKind)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get workload name and kind: %w", err)
+	}
+
+	serviceName := podInfoResolver.ResolveServiceName(ctx, attrs.PodName, attrs.WorkloadKind, &di.ContainerDetails{
+		PodName: attrs.PodName,
+	})
+
+	pod, err := kubeClient.CoreV1().Pods(attrs.Namespace).Get(ctx, attrs.PodName, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	k8sAttributes := &di.K8sResourceAttributes{
+		Namespace:       attrs.Namespace,
+		PodName:         attrs.PodName,
+		ContainerName:   attrs.ContainerName,
+		WorkloadKind:    attrs.WorkloadKind,
+		WorkloadName:    workloadName,
+		OtelServiceName: serviceName,
+	}
+
+	return k8sAttributes, pod, nil
 }

--- a/opampserver/pkg/server/server.go
+++ b/opampserver/pkg/server/server.go
@@ -84,7 +84,7 @@ func StartOpAmpServer(ctx context.Context, logger logr.Logger, mgr ctrl.Manager,
 		var serverToAgent *protobufs.ServerToAgent
 		connectionInfo, exists := connectionCache.GetConnection(instanceUid)
 		if !exists {
-			connectionInfo, serverToAgent, err = handlers.OnNewConnection(ctx, deviceId, &agentToServer)
+			connectionInfo, serverToAgent, err = handlers.OnNewConnection(ctx, deviceId, &agentToServer, kubeClient)
 			if err != nil {
 				logger.Error(err, "Failed to process new connection")
 				w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
This pull request includes several changes to enhance the debugging setup, improve environment variable handling, and refactor code for better readability and maintainability. The most important changes include updates to the debugging configuration, injection of environment variables, and refactoring of workload handling.

### Debugging Enhancements:
* [`.vscode/launch.json`](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L20-R23): Added environment variables for local mutating webhook certificate directory to facilitate local debugging.
* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R170-R202): Added detailed instructions for debugging the Instrumentor when the Mutating Webhook is enabled.

### Environment Variable Injection:
* [`instrumentor/controllers/instrumentationdevice/pods_webhook.go`](diffhunk://#diff-09f9653d9c6c1a8bb7d52e7f3bf0060e0176369df0ee04d04bfb6b4d620794ddL10-L21): Introduced constants for ODIGOS environment variables and added a function to inject these variables into all containers. [[1]](diffhunk://#diff-09f9653d9c6c1a8bb7d52e7f3bf0060e0176369df0ee04d04bfb6b4d620794ddL10-L21) [[2]](diffhunk://#diff-09f9653d9c6c1a8bb7d52e7f3bf0060e0176369df0ee04d04bfb6b4d620794ddL31-R89)
* [`instrumentor/main.go`](diffhunk://#diff-e36937e3510a3c05ef5f17e89c712712f4a500188cfc4818fba7e5015ebe47b2L101-R102): Added logic to check for a local webhook certificate directory and configure the WebhookServer accordingly for local development. [[1]](diffhunk://#diff-e36937e3510a3c05ef5f17e89c712712f4a500188cfc4818fba7e5015ebe47b2L101-R102) [[2]](diffhunk://#diff-e36937e3510a3c05ef5f17e89c712712f4a500188cfc4818fba7e5015ebe47b2R177-R190)

### Refactoring:
* [`k8sutils/pkg/workload/ownerreference.go`](diffhunk://#diff-183ad6413c2a5e4a1aad9e9566e87fc06f88ed51afe6c6fffcb521d9f74ee556L4-R47): Refactored workload handling functions to separate concerns and improve readability.
* [`opampserver/pkg/server/handlers.go`](diffhunk://#diff-944e905a1aea43bd5f8a4c5ad17b404e63ea772321096a15829fb2951723a8d8L14-R43): Refactored the `OnNewConnection` method to extract and handle agent attributes more efficiently and added helper functions for resolving Kubernetes attributes. [[1]](diffhunk://#diff-944e905a1aea43bd5f8a4c5ad17b404e63ea772321096a15829fb2951723a8d8L14-R43) [[2]](diffhunk://#diff-944e905a1aea43bd5f8a4c5ad17b404e63ea772321096a15829fb2951723a8d8L56-R79) [[3]](diffhunk://#diff-944e905a1aea43bd5f8a4c5ad17b404e63ea772321096a15829fb2951723a8d8L86-R91) [[4]](diffhunk://#diff-944e905a1aea43bd5f8a4c5ad17b404e63ea772321096a15829fb2951723a8d8L99-R104) [[5]](diffhunk://#diff-944e905a1aea43bd5f8a4c5ad17b404e63ea772321096a15829fb2951723a8d8R199-R263)

### Minor Imports Adjustments:
* [`instrumentor/main.go`](diffhunk://#diff-e36937e3510a3c05ef5f17e89c712712f4a500188cfc4818fba7e5015ebe47b2R36): Added missing import for `webhook` package.
* [`opampserver/pkg/server/handlers.go`](diffhunk://#diff-944e905a1aea43bd5f8a4c5ad17b404e63ea772321096a15829fb2951723a8d8L14-R43): Aliased the `deviceid` import for consistency.

These changes collectively improve the development experience and code maintainability.