### PR TITLE
fix: cases where opamp agent send disconnect message as a first messa…

### DIFF
--- a/opampserver/pkg/server/server.go
+++ b/opampserver/pkg/server/server.go
@@ -117,7 +117,11 @@ func StartOpAmpServer(ctx context.Context, logger logr.Logger, mgr ctrl.Manager,
 		}
 
 		if isAgentDisconnect {
-			logger.Info("Agent disconnected", "workloadNamespace", connectionInfo.Workload.Namespace, "workloadName", connectionInfo.Workload.Name, "workloadKind", connectionInfo.Workload.Kind)
+
+			// This may occurs when Odiglet restarts, and a previously connected pod sends a disconnect message right after reconnecting.
+			if connectionInfo != nil {
+				logger.Info("Agent disconnected", "workloadNamespace", connectionInfo.Workload.Namespace, "workloadName", connectionInfo.Workload.Name, "workloadKind", connectionInfo.Workload.Kind)
+			}
 			// if agent disconnects, remove the connection from the cache
 			// as it is not expected to send additional messages
 			connectionCache.RemoveConnection(instanceUid)


### PR DESCRIPTION
This pull request includes a small change to the `opampserver/pkg/server/server.go` file. The change adds a conditional check and a log message for when an agent disconnects, providing more context about the disconnection event.

* [`opampserver/pkg/server/server.go`](diffhunk://#diff-40765722bcac3eb6423c21c04c925939c535a973a088d4b2d6bf99008a167892R120-R124): Added a conditional check to log information about the agent's workload when an agent disconnects, specifically when `connectionInfo` is not `nil`. 