### PR TITLE
feat: removing leader election from instrumentor/scheduler/autoscaler

### DIFF
--- a/autoscaler/main.go
+++ b/autoscaler/main.go
@@ -149,8 +149,6 @@ func main() {
 			},
 		},
 		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "f681cfed.odigos.io",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/instrumentor/main.go
+++ b/instrumentor/main.go
@@ -107,8 +107,6 @@ func main() {
 			BindAddress: metricsAddr,
 		},
 		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "201bdfa0.odigos.io",
 		Cache: cache.Options{
 			DefaultTransform: cache.TransformStripManagedFields(),
 			// Store minimum amount of data for every object type.

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -77,8 +77,6 @@ func main() {
 			BindAddress: metricsAddr,
 		},
 		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "ce024640.odigos.io",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
When the API server is slow or unresponsive, services configured with leader election may encounter errors like this:
```
2024-10-07T21:59:35Z	ERROR	setup	problem running manager	{"error": "leader election lost"}
main.main
	/workspace/scheduler/main.go:122
runtime.main
	/usr/local/go/src/runtime/proc.go:271

```

**What is leader election?**
Leader election in Kubernetes is a process where one instance of a component (such as a controller) is selected to act as the "leader" and perform certain tasks, while other instances remain idle. This mechanism ensures that only one instance manages a resource at a time, preventing conflicts. If the leader fails or becomes unavailable, a new leader is elected, ensuring high availability.


In Odigos, these components not scale, no handoffs needed in case one pod is down and we can avoid above errors with removing this.
To make it easier to re-enable, I keep the flag controlling it at the top of each main file for convenience. 
