### PR TITLE
feat: node collector info in odigos describe

### DIFF
--- a/autoscaler/controllers/common/deployedcondition.go
+++ b/autoscaler/controllers/common/deployedcondition.go
@@ -1,0 +1,44 @@
+package common
+
+import (
+	"encoding/json"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func GetCollectorsGroupDeployedConditionsPatch(err error) string {
+
+	status := metav1.ConditionTrue
+	if err != nil {
+		status = metav1.ConditionFalse
+	}
+
+	message := "Gateway collector is deployed in the cluster"
+	if err != nil {
+		message = err.Error()
+	}
+
+	reason := "GatewayDeployedCreatedSuccessfully"
+	if err != nil {
+		// in the future, we can be more specific and break it down to
+		// more detailed reasons about what exactly failed
+		reason = "GatewayDeployedCreationFailed"
+	}
+
+	patch := map[string]interface{}{
+		"status": map[string]interface{}{
+			"conditions": []metav1.Condition{{
+				Type:               "Deployed",
+				Status:             status,
+				Reason:             reason,
+				Message:            message,
+				LastTransitionTime: metav1.NewTime(time.Now()),
+			}},
+		},
+	}
+
+	patchData, _ := json.Marshal(patch)
+	// marshal error is ignored as it is not expected to happen
+	return string(patchData)
+}

--- a/k8sutils/pkg/describe/common.go
+++ b/k8sutils/pkg/describe/common.go
@@ -26,3 +26,10 @@ func describeText(sb *strings.Builder, indent int, printftext string, args ...in
 	lineText := fmt.Sprintf(printftext, args...)
 	sb.WriteString(fmt.Sprintf("%s%s\n", indentText, lineText))
 }
+
+func boolToText(b bool) string {
+	if b {
+		return "True"
+	}
+	return "False"
+}

--- a/k8sutils/pkg/describe/common.go
+++ b/k8sutils/pkg/describe/common.go
@@ -26,10 +26,3 @@ func describeText(sb *strings.Builder, indent int, printftext string, args ...in
 	lineText := fmt.Sprintf(printftext, args...)
 	sb.WriteString(fmt.Sprintf("%s%s\n", indentText, lineText))
 }
-
-func boolToText(b bool) string {
-	if b {
-		return "True"
-	}
-	return "False"
-}

--- a/k8sutils/pkg/describe/odigos.go
+++ b/k8sutils/pkg/describe/odigos.go
@@ -232,6 +232,19 @@ func printNodeCollectorStatus(nodeCollector nodeCollectorResources, expectingNod
 
 	ready := nodeCollector.CollectorsGroup.Status.Ready
 	describeText(sb, 2, wrapTextSuccessOfFailure(fmt.Sprintf("Ready: %s", boolToText(ready)), ready))
+
+	// this is copied from k8sutils/pkg/describe/describe.go
+	// I hope the info is accurate since there can be many edge cases
+	describeText(sb, 2, "Desired Number of Nodes Scheduled: %d", nodeCollector.DaemonSet.Status.DesiredNumberScheduled)
+	currentMeetsDesired := nodeCollector.DaemonSet.Status.DesiredNumberScheduled == nodeCollector.DaemonSet.Status.CurrentNumberScheduled
+	describeText(sb, 2, wrapTextSuccessOfFailure(fmt.Sprintf("Current Number of Nodes Scheduled: %d", nodeCollector.DaemonSet.Status.CurrentNumberScheduled), currentMeetsDesired))
+	updatedMeetsDesired := nodeCollector.DaemonSet.Status.DesiredNumberScheduled == nodeCollector.DaemonSet.Status.UpdatedNumberScheduled
+	describeText(sb, 2, wrapTextSuccessOfFailure(fmt.Sprintf("Number of Nodes Scheduled with Up-to-date Pods: %d", nodeCollector.DaemonSet.Status.UpdatedNumberScheduled), updatedMeetsDesired))
+	availableMeetsDesired := nodeCollector.DaemonSet.Status.DesiredNumberScheduled == nodeCollector.DaemonSet.Status.NumberAvailable
+	describeText(sb, 2, wrapTextSuccessOfFailure(fmt.Sprintf("Number of Nodes Scheduled with Available Pods: %d", nodeCollector.DaemonSet.Status.NumberAvailable), availableMeetsDesired))
+	noMisscheduled := nodeCollector.DaemonSet.Status.NumberMisscheduled == 0
+	describeText(sb, 2, wrapTextSuccessOfFailure(fmt.Sprintf("Number of Nodes Misscheduled: %d", nodeCollector.DaemonSet.Status.NumberMisscheduled), noMisscheduled))
+	describeText(sb, 2, "Pods Status:\t%d Running / %d Waiting / %d Succeeded / %d Failed", nodeCollector.DaemonSet.Status.CurrentNumberScheduled, nodeCollector.DaemonSet.Status.NumberAvailable, nodeCollector.DaemonSet.Status.NumberAvailable, nodeCollector.DaemonSet.Status.NumberMisscheduled)
 }
 
 func printOdigosPipeline(clusterCollector clusterCollectorResources, nodeCollector nodeCollectorResources, destinations *odigosv1.DestinationList, instrumentationConfigs *odigosv1.InstrumentationConfigList, sb *strings.Builder) {

--- a/k8sutils/pkg/describe/odigos.go
+++ b/k8sutils/pkg/describe/odigos.go
@@ -156,15 +156,15 @@ func printClusterCollectorStatus(clusterCollector clusterCollectorResources, exp
 		describeText(sb, 2, wrapTextInRed("Deployed: Status Unavailable"))
 	} else {
 		if deployedCondition.Status == metav1.ConditionTrue {
-			describeText(sb, 2, wrapTextInGreen("Deployed: True"))
+			describeText(sb, 2, wrapTextInGreen("Deployed: true"))
 		} else {
-			describeText(sb, 2, wrapTextInRed("Deployed: False"))
+			describeText(sb, 2, wrapTextInRed("Deployed: false"))
 			describeText(sb, 2, wrapTextInRed(fmt.Sprintf("Reason: %s", deployedCondition.Message)))
 		}
 	}
 
 	ready := clusterCollector.CollectorsGroup.Status.Ready
-	describeText(sb, 2, wrapTextSuccessOfFailure(fmt.Sprintf("Ready: %s", boolToText(ready)), ready))
+	describeText(sb, 2, wrapTextSuccessOfFailure(fmt.Sprintf("Ready: %t", ready), ready))
 
 	if clusterCollector.LatestRevisionPods == nil || clusterCollector.Deployment == nil {
 		describeText(sb, 2, wrapTextInRed("Number of Replicas: Status Unavailable"))
@@ -231,7 +231,7 @@ func printNodeCollectorStatus(nodeCollector nodeCollectorResources, expectingNod
 	}
 
 	ready := nodeCollector.CollectorsGroup.Status.Ready
-	describeText(sb, 2, wrapTextSuccessOfFailure(fmt.Sprintf("Ready: %s", boolToText(ready)), ready))
+	describeText(sb, 2, wrapTextSuccessOfFailure(fmt.Sprintf("Ready: %t", ready), ready))
 
 	// this is copied from k8sutils/pkg/describe/describe.go
 	// I hope the info is accurate since there can be many edge cases

--- a/k8sutils/pkg/describe/odigos.go
+++ b/k8sutils/pkg/describe/odigos.go
@@ -251,7 +251,6 @@ func printNodeCollectorStatus(nodeCollector nodeCollectorResources, expectingNod
 	describeText(sb, 2, wrapTextSuccessOfFailure(fmt.Sprintf("Number of Nodes Scheduled with Available Pods: %d", nodeCollector.DaemonSet.Status.NumberAvailable), availableMeetsDesired))
 	noMisscheduled := nodeCollector.DaemonSet.Status.NumberMisscheduled == 0
 	describeText(sb, 2, wrapTextSuccessOfFailure(fmt.Sprintf("Number of Nodes Misscheduled: %d", nodeCollector.DaemonSet.Status.NumberMisscheduled), noMisscheduled))
-	describeText(sb, 2, "Pods Status:\t%d Running / %d Waiting / %d Succeeded / %d Failed", nodeCollector.DaemonSet.Status.CurrentNumberScheduled, nodeCollector.DaemonSet.Status.NumberAvailable, nodeCollector.DaemonSet.Status.NumberAvailable, nodeCollector.DaemonSet.Status.NumberMisscheduled)
 }
 
 func printOdigosPipeline(odigosResources odigosResources, sb *strings.Builder) {

--- a/scheduler/controllers/collectorsgroup_controller.go
+++ b/scheduler/controllers/collectorsgroup_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/k8sutils/pkg/utils"
 	"github.com/odigos-io/odigos/scheduler/controllers/collectorgroups"


### PR DESCRIPTION
This PR:

- record the status of autoscaler node collector info into the collector group condition to make it available for display.
- enhance the `odigos describe` command to include info about the node collector deployment:

![image](https://github.com/user-attachments/assets/9d45ebb0-8a3d-44c7-a3da-de3daaacb167)
