### PR TITLE
fix: some minors for qryn destination

### DIFF
--- a/destinations/data/qryn.yaml
+++ b/destinations/data/qryn.yaml
@@ -3,7 +3,7 @@ kind: Destination
 metadata:
   type: qryn-oss
   displayName: qryn
-  category: self-hosted
+  category: self hosted
 spec:
   image: qryn.svg
   signals:
@@ -14,6 +14,12 @@ spec:
     logs:
       supported: true
   fields:
+    - name: QRYN_OSS_URL
+      displayName: API Url
+      componentType: input
+      componentProps:
+        type: text
+        required: true
     - name: QRYN_OSS_PASSWORD
       displayName: Basic auth password
       componentType: input
@@ -25,12 +31,6 @@ spec:
       componentType: input
       componentProps:
         type: text
-    - name: QRYN_OSS_URL
-      displayName: API Url
-      componentType: input
-      componentProps:
-        type: text
-        required: true
     - name: QRYN_OSS_RESOURCE_TO_TELEMETRY_CONVERSION
       displayName: Convert container attributes to labels
       componentType: dropdown

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -207,6 +207,7 @@
             "backends/dynatrace",
             "backends/elasticsearch",
             "backends/gcs",
+            "backends/gigapipe",
             "backends/googlecloud",
             "backends/grafanacloudloki",
             "backends/grafanacloudprometheus",


### PR DESCRIPTION
- docs - add `gigapipe` destination to `mint.json` for it to show up in docs.
- ui - fix the destination category so it shows up in the UI with the other destinations as self hosted.
- ui - make the required qryn URL field first in the list, so it shows up first in ui
