### PR TITLE
chore(scheduler): use instrumentation config instead of application

### DIFF
--- a/cli/cmd/resources/scheduler.go
+++ b/cli/cmd/resources/scheduler.go
@@ -161,7 +161,7 @@ func NewSchedulerClusterRole() *rbacv1.ClusterRole {
 					"watch",
 				},
 				APIGroups: []string{"odigos.io"},
-				Resources: []string{"instrumentedapplications"},
+				Resources: []string{"instrumentationconfigs"},
 			},
 		},
 	}

--- a/helm/odigos/templates/scheduler/clusterrole.yaml
+++ b/helm/odigos/templates/scheduler/clusterrole.yaml
@@ -35,7 +35,7 @@ rules:
   - apiGroups:
       - odigos.io
     resources:
-      - instrumentedapplications
+      - instrumentationconfigs
     verbs:
       - get
       - list

--- a/scheduler/PROJECT
+++ b/scheduler/PROJECT
@@ -6,7 +6,7 @@ repo: github.com/odigos-io/odigos/scheduler
 resources:
 - controller: true
   domain: odigos.io
-  kind: InstrumentedApplication
+  kind: InstrumentationConfig
   version: v1alpha1
 - controller: true
   domain: odigos.io

--- a/scheduler/controllers/collectorsgroup_controller.go
+++ b/scheduler/controllers/collectorsgroup_controller.go
@@ -88,9 +88,9 @@ func (r *CollectorsGroupReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 	}
 
-	var instApps odigosv1.InstrumentedApplicationList
+	var instApps odigosv1.InstrumentationConfigList
 	if err = r.List(ctx, &instApps); err != nil {
-		logger.Error(err, "failed to list InstrumentedApps")
+		logger.Error(err, "failed to list InstrumentationConfigs")
 		return ctrl.Result{}, err
 	}
 

--- a/scheduler/controllers/instrumentationconfig_controller.go
+++ b/scheduler/controllers/instrumentationconfig_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/k8sutils/pkg/consts"
 	"github.com/odigos-io/odigos/k8sutils/pkg/env"
@@ -14,27 +15,26 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// InstrumentedApplicationReconciler reconciles a InstrumentedApplication object
-type InstrumentedApplicationReconciler struct {
+type InstrumentationConfigReconciler struct {
 	client.Client
 	Scheme           *runtime.Scheme
 	ImagePullSecrets []string
 	OdigosVersion    string
 }
 
-func (r *InstrumentedApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *InstrumentationConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
-	logger.V(0).Info("Reconciling InstrumentedApps")
+	logger.V(0).Info("Reconciling InstrumentationConfig")
 
 	namespace := env.GetCurrentNamespace()
 
-	var instrumentedApps odigosv1.InstrumentedApplicationList
-	err := r.List(ctx, &instrumentedApps)
+	var instrumentedConfigs odigosv1.InstrumentationConfigList
+	err := r.List(ctx, &instrumentedConfigs)
 	if err != nil {
-		logger.Error(err, "failed to list InstrumentedApplications")
+		logger.Error(err, "failed to list InstrumentationConfigs")
 		return ctrl.Result{}, err
 	}
-	numberOfInstrumentedApps := len(instrumentedApps.Items)
+	numberOfInstrumentedApps := len(instrumentedConfigs.Items)
 
 	if numberOfInstrumentedApps == 0 {
 		if err = utils.DeleteCollectorGroup(ctx, r.Client, namespace, consts.OdigosNodeCollectorCollectorGroupName); err != nil {
@@ -74,9 +74,8 @@ func (r *InstrumentedApplicationReconciler) Reconcile(ctx context.Context, req c
 	return ctrl.Result{}, nil
 }
 
-// SetupWithManager sets up the controller with the Manager.
-func (r *InstrumentedApplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *InstrumentationConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&odigosv1.InstrumentedApplication{}).
+		For(&odigosv1.InstrumentationConfig{}).
 		Complete(r)
 }

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -99,11 +99,11 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Destination")
 		os.Exit(1)
 	}
-	if err = (&controllers.InstrumentedApplicationReconciler{
+	if err = (&controllers.InstrumentationConfigReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "InstrumentedApplication")
+		setupLog.Error(err, "unable to create controller", "controller", "InstrumentationConfig")
 		os.Exit(1)
 	}
 	//+kubebuilder:scaffold:builder


### PR DESCRIPTION
This PR moves the scheduler component to use `instrumentationconfigs` instead of `instrumentedapplications`. There is an effort to merge them any only use one CRD - the `instrumentationconfigs`.

The content of the object is not examined, it only checks if we have any `instrumentationconfigs` or not. Thus it should be safe.
