### PR TITLE
fix: add event filter to prevent cg status from being reconciled indefinitely 

### DIFF
--- a/api/config/crd/bases/odigos.io_collectorsgroups.yaml
+++ b/api/config/crd/bases/odigos.io_collectorsgroups.yaml
@@ -42,8 +42,6 @@ spec:
           spec:
             description: CollectorsGroupSpec defines the desired state of Collector
             properties:
-              inputSvc:
-                type: string
               role:
                 enum:
                 - CLUSTER_GATEWAY

--- a/api/generated/odigos/applyconfiguration/odigos/v1alpha1/collectorsgroupspec.go
+++ b/api/generated/odigos/applyconfiguration/odigos/v1alpha1/collectorsgroupspec.go
@@ -24,22 +24,13 @@ import (
 // CollectorsGroupSpecApplyConfiguration represents a declarative configuration of the CollectorsGroupSpec type for use
 // with apply.
 type CollectorsGroupSpecApplyConfiguration struct {
-	InputSvc *string                       `json:"inputSvc,omitempty"`
-	Role     *v1alpha1.CollectorsGroupRole `json:"role,omitempty"`
+	Role *v1alpha1.CollectorsGroupRole `json:"role,omitempty"`
 }
 
 // CollectorsGroupSpecApplyConfiguration constructs a declarative configuration of the CollectorsGroupSpec type for use with
 // apply.
 func CollectorsGroupSpec() *CollectorsGroupSpecApplyConfiguration {
 	return &CollectorsGroupSpecApplyConfiguration{}
-}
-
-// WithInputSvc sets the InputSvc field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the InputSvc field is set to the value of the last call.
-func (b *CollectorsGroupSpecApplyConfiguration) WithInputSvc(value string) *CollectorsGroupSpecApplyConfiguration {
-	b.InputSvc = &value
-	return b
 }
 
 // WithRole sets the Role field in the declarative configuration to the given value

--- a/api/odigos/v1alpha1/collectorsgroup_types.go
+++ b/api/odigos/v1alpha1/collectorsgroup_types.go
@@ -32,8 +32,7 @@ const (
 
 // CollectorsGroupSpec defines the desired state of Collector
 type CollectorsGroupSpec struct {
-	InputSvc string              `json:"inputSvc,omitempty"`
-	Role     CollectorsGroupRole `json:"role"`
+	Role CollectorsGroupRole `json:"role"`
 }
 
 // CollectorsGroupStatus defines the observed state of Collector

--- a/autoscaler/controllers/collectorsgroup_controller.go
+++ b/autoscaler/controllers/collectorsgroup_controller.go
@@ -22,6 +22,8 @@ import (
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/autoscaler/controllers/datacollection"
 	"github.com/odigos-io/odigos/autoscaler/controllers/gateway"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -29,6 +31,28 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+type onlyCreatePredicate struct {
+	predicate.Funcs
+}
+
+func (i *onlyCreatePredicate) Create(e event.CreateEvent) bool {
+	return true
+}
+
+func (i *onlyCreatePredicate) Update(e event.UpdateEvent) bool {
+	return false
+}
+
+func (i *onlyCreatePredicate) Delete(e event.DeleteEvent) bool {
+	return false
+}
+
+func (i *onlyCreatePredicate) Generic(e event.GenericEvent) bool {
+	return false
+}
+
+var _ predicate.Predicate = &onlyCreatePredicate{}
 
 // CollectorsGroupReconciler reconciles a CollectorsGroup object
 type CollectorsGroupReconciler struct {
@@ -78,5 +102,6 @@ func (r *CollectorsGroupReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 func (r *CollectorsGroupReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&odigosv1.CollectorsGroup{}).
+		WithEventFilter(&onlyCreatePredicate{}).
 		Complete(r)
 }

--- a/tests/e2e/workload-lifecycle/services/java-http-server/java-azul.Dockerfile
+++ b/tests/e2e/workload-lifecycle/services/java-http-server/java-azul.Dockerfile
@@ -3,7 +3,7 @@ COPY src /home/app/src
 COPY pom.xml /home/app
 RUN mvn -f /home/app/pom.xml clean package
 
-FROM azul/zulu-openjdk-alpine:17.0.12_7-jre
+FROM azul/zulu-openjdk-alpine:17.0.12-jre-headless
 COPY --from=build /home/app/target/*.jar /app/java-azul.jar
 USER 15000
 CMD ["java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseZGC", "-jar", "/app/java-azul.jar"]

--- a/tests/e2e/workload-lifecycle/services/java-http-server/java-azul.Dockerfile
+++ b/tests/e2e/workload-lifecycle/services/java-http-server/java-azul.Dockerfile
@@ -3,7 +3,7 @@ COPY src /home/app/src
 COPY pom.xml /home/app
 RUN mvn -f /home/app/pom.xml clean package
 
-FROM azul/zulu-openjdk-alpine:17-jre
+FROM azul/zulu-openjdk-alpine:17.0.12_7-jre
 COPY --from=build /home/app/target/*.jar /app/java-azul.jar
 USER 15000
 CMD ["java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseZGC", "-jar", "/app/java-azul.jar"]

--- a/tests/e2e/workload-lifecycle/services/java-http-server/java-supported-docker-env.Dockerfile
+++ b/tests/e2e/workload-lifecycle/services/java-http-server/java-supported-docker-env.Dockerfile
@@ -3,7 +3,7 @@ COPY src /home/app/src
 COPY pom.xml /home/app
 RUN mvn -f /home/app/pom.xml clean package
 
-FROM eclipse-temurin:17-jre-jammy
+FROM eclipse-temurin:17.0.12_7-jre-jammy
 ENV JAVA_OPTS="-Dthis.does.not.exist=true"
 COPY --from=build /home/app/target/*.jar /app/java-supported-docker-env.jar
 USER 15000

--- a/tests/e2e/workload-lifecycle/services/java-http-server/java-supported-manifest-env.Dockerfile
+++ b/tests/e2e/workload-lifecycle/services/java-http-server/java-supported-manifest-env.Dockerfile
@@ -3,7 +3,7 @@ COPY src /home/app/src
 COPY pom.xml /home/app
 RUN mvn -f /home/app/pom.xml clean package
 
-FROM eclipse-temurin:17-jre-jammy
+FROM eclipse-temurin:17.0.12_7-jre-jammy
 COPY --from=build /home/app/target/*.jar /app/java-supported-manifest-env.jar
 USER 15000
 CMD ["java","-jar", "/app/java-supported-manifest-env.jar"]

--- a/tests/e2e/workload-lifecycle/services/java-http-server/java-supported-version.Dockerfile
+++ b/tests/e2e/workload-lifecycle/services/java-http-server/java-supported-version.Dockerfile
@@ -3,7 +3,7 @@ COPY src /home/app/src
 COPY pom.xml /home/app
 RUN mvn -f /home/app/pom.xml clean package
 
-FROM eclipse-temurin:17-jre-jammy
+FROM eclipse-temurin:17.0.12_7-jre-jammy
 COPY --from=build /home/app/target/*.jar /app/java-supported-version.jar
 USER 15000
 CMD ["java","-jar", "/app/java-supported-version.jar"]


### PR DESCRIPTION
1. add event filter for reconciler of collector group - to prevent endless reconcile loops
2. remove unused property from collector group CRD
3. pin version of java base image in tests for deterministic test result