### PR TITLE
fix: odigos describe when pipeline is not created

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -59,6 +59,16 @@
             "cwd": "${workspaceFolder}/cli",
             "args": ["uninstall", "--yes"],
             "buildFlags": "-tags=embed_manifests"
+        },
+        {
+            "name": "cli describe",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/cli",
+            "cwd": "${workspaceFolder}/cli",
+            "args": ["describe"],
+            "buildFlags": "-tags=embed_manifests"
         }
     ]
 }

--- a/k8sutils/pkg/describe/odigos.go
+++ b/k8sutils/pkg/describe/odigos.go
@@ -275,7 +275,7 @@ func printOdigosPipeline(odigosResources odigosResources, sb *strings.Builder) {
 	numDestinations := len(odigosResources.Destinations.Items)
 	numInstrumentationConfigs := len(odigosResources.InstrumentationConfigs.Items)
 	// odigos will only initiate pipeline if there are any sources or destinations
-	expectingPipeline := numDestinations > 0 || numInstrumentationConfigs > 0
+	expectingPipeline := numDestinations > 0
 
 	printOdigosPipelineStatus(numInstrumentationConfigs, numDestinations, expectingPipeline, sb)
 	printClusterCollectorStatus(odigosResources.ClusterCollector, expectingPipeline, sb)


### PR DESCRIPTION
This PR adds some handling for when the pipeline has not yet been created, making sure the `odigos describe` output is well formmated.

It also adds a human readable text to describe the expected state for cluster and node collectors

![image](https://github.com/user-attachments/assets/23f503cc-d4f9-45a8-b7a3-94b8dd9abbfa)
