### PR TITLE
Ignore NotFound error for Node CG in OpAmp server

### DIFF
--- a/opampserver/pkg/sdkconfig/collectorsgroup_controller.go
+++ b/opampserver/pkg/sdkconfig/collectorsgroup_controller.go
@@ -35,7 +35,7 @@ func (d *CollectorsGroupReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	var collectorsGroup odigosv1.CollectorsGroup
 	err := d.Client.Get(ctx, req.NamespacedName, &collectorsGroup)
 	if err != nil {
-		return ctrl.Result{}, err
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	tracesEnabled := slices.Contains(collectorsGroup.Status.ReceiverSignals, common.TracesObservabilitySignal)


### PR DESCRIPTION
Once all the apps are un-instrumented we remove the node CG.
This causes repeated reconcile errors in the OpAmp server:

> {"level":"error","ts":1730064874.9696624,"caller":"controller/controller.go:316","msg":"Reconciler error","controller":"collectorsgroup","controllerGroup":"odigos.io","controllerKind":"CollectorsGroup","CollectorsGroup":{"name":"odigos-data-collection","namespace":"odigos-system"},"namespace":"odigos-system","name":"odigos-data-collection","reconcileID":"59801121-08a6-495c-b6af-38c8d02c6cf7","error":"CollectorsGroup.odigos.io \"odigos-data-collection\" not found","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:316\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:224"}