### PR TITLE
refactor: describe source use 2 phases

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -67,7 +67,7 @@
             "mode": "debug",
             "program": "${workspaceFolder}/cli",
             "cwd": "${workspaceFolder}/cli",
-            "args": ["describe"],
+            "args": ["describe source deployment membership"],
             "buildFlags": "-tags=embed_manifests"
         }
     ]

--- a/cli/cmd/describe.go
+++ b/cli/cmd/describe.go
@@ -78,7 +78,12 @@ var describeSourceDeploymentCmd = &cobra.Command{
 		if describeRemoteFlag {
 			describeText = executeRemoteSourceDescribe(ctx, client, "deployment", ns, name)
 		} else {
-			describeText = describe.DescribeDeployment(ctx, client.Interface, client.OdigosClient, ns, name)
+			desc, err := describe.DescribeDeployment(ctx, client.Interface, client.OdigosClient, ns, name)
+			if err != nil {
+				describeText = fmt.Sprintf("Failed to describe deployment: %s", err)
+			} else {
+				describeText = describe.DescribeSourceToText(desc)
+			}
 		}
 		fmt.Println(describeText)
 	},
@@ -104,7 +109,12 @@ var describeSourceDaemonSetCmd = &cobra.Command{
 		if describeRemoteFlag {
 			describeText = executeRemoteSourceDescribe(ctx, client, "daemonset", ns, name)
 		} else {
-			describeText = describe.DescribeDaemonSet(ctx, client.Interface, client.OdigosClient, ns, name)
+			desc, err := describe.DescribeDaemonSet(ctx, client.Interface, client.OdigosClient, ns, name)
+			if err != nil {
+				describeText = fmt.Sprintf("Failed to describe daemonset: %s", err)
+			} else {
+				describeText = describe.DescribeSourceToText(desc)
+			}
 		}
 		fmt.Println(describeText)
 	},
@@ -130,7 +140,12 @@ var describeSourceStatefulSetCmd = &cobra.Command{
 		if describeRemoteFlag {
 			describeText = executeRemoteSourceDescribe(ctx, client, "statefulset", ns, name)
 		} else {
-			describeText = describe.DescribeStatefulSet(ctx, client.Interface, client.OdigosClient, ns, name)
+			desc, err := describe.DescribeStatefulSet(ctx, client.Interface, client.OdigosClient, ns, name)
+			if err != nil {
+				describeText = fmt.Sprintf("Failed to describe statefulset: %s", err)
+			} else {
+				describeText = describe.DescribeSourceToText(desc)
+			}
 		}
 		fmt.Println(describeText)
 	},

--- a/frontend/endpoints/describe.go
+++ b/frontend/endpoints/describe.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/odigos-io/odigos/frontend/kube"
 	"github.com/odigos-io/odigos/k8sutils/pkg/describe"
+	"github.com/odigos-io/odigos/k8sutils/pkg/describe/source"
 	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 )
 
@@ -40,19 +41,37 @@ func DescribeOdigos(c *gin.Context) {
 
 func DescribeSource(c *gin.Context, ns string, kind string, name string) {
 	ctx := c.Request.Context()
+	var desc *source.SourceAnalyze
+	var err error
 	switch kind {
 	case "deployment":
-		describeText := describe.DescribeDeployment(ctx, kube.DefaultClient.Interface, kube.DefaultClient.OdigosClient, ns, name)
-		c.Writer.WriteString(describeText)
+		desc, err = describe.DescribeDeployment(ctx, kube.DefaultClient.Interface, kube.DefaultClient.OdigosClient, ns, name)
 	case "daemonset":
-		describeText := describe.DescribeDaemonSet(ctx, kube.DefaultClient.Interface, kube.DefaultClient.OdigosClient, ns, name)
-		c.Writer.WriteString(describeText)
+		desc, err = describe.DescribeDaemonSet(ctx, kube.DefaultClient.Interface, kube.DefaultClient.OdigosClient, ns, name)
 	case "statefulset":
-		describeText := describe.DescribeStatefulSet(ctx, kube.DefaultClient.Interface, kube.DefaultClient.OdigosClient, ns, name)
-		c.Writer.WriteString(describeText)
+		desc, err = describe.DescribeStatefulSet(ctx, kube.DefaultClient.Interface, kube.DefaultClient.OdigosClient, ns, name)
 	default:
 		c.JSON(404, gin.H{
 			"message": "kind not supported",
 		})
+		return
+	}
+
+	if err != nil {
+		c.JSON(500, gin.H{
+			"message": err.Error(),
+		})
+		return
+	}
+
+	// Check for the Accept header
+	acceptHeader := c.GetHeader("Accept")
+
+	if acceptHeader == "application/json" {
+		// Return JSON response if Accept header is "application/json"
+		c.JSON(200, desc)
+	} else {
+		describeText := describe.DescribeSourceToText(desc)
+		c.String(200, describeText)
 	}
 }

--- a/k8sutils/pkg/describe/source.go
+++ b/k8sutils/pkg/describe/source.go
@@ -168,9 +168,11 @@ func printPodsInfo(analyze *source.SourceAnalyze, pods *corev1.PodList, instrume
 			for _, ii := range container.InstrumentationInstances {
 				printProperty(sb, 3, &ii.Healthy)
 				printProperty(sb, 3, ii.Message)
-				describeText(sb, 3, "Identifying Attributes:")
-				for _, attr := range ii.IdentifyingAttributes {
-					printProperty(sb, 4, &attr)
+				if len(ii.IdentifyingAttributes) > 0 {
+					describeText(sb, 3, "Identifying Attributes:")
+					for _, attr := range ii.IdentifyingAttributes {
+						printProperty(sb, 4, &attr)
+					}
 				}
 			}
 		}

--- a/k8sutils/pkg/describe/source.go
+++ b/k8sutils/pkg/describe/source.go
@@ -29,24 +29,10 @@ func printWorkloadManifestInfo(analyze *source.SourceAnalyze, sb *strings.Builde
 	return analyze.Labels.Instrumented.Value.(bool)
 }
 
-func printInstrumentationConfigInfo(instrumentationConfig *odigosv1.InstrumentationConfig, instrumented bool, sb *strings.Builder) {
-	instrumentationConfigNotFound := instrumentationConfig == nil
-	statusAsExpected := instrumentationConfigNotFound == !instrumented
+func printInstrumentationConfigInfo(analyze *source.SourceAnalyze, sb *strings.Builder) {
 	sb.WriteString("\nInstrumentation Config:\n")
-	if instrumentationConfigNotFound {
-		if statusAsExpected {
-			sb.WriteString(wrapTextInGreen("  Workload not instrumented, no instrumentation config\n"))
-		} else {
-			sb.WriteString("  Not yet created\n")
-		}
-	} else {
-		createAtText := "  Created at " + instrumentationConfig.GetCreationTimestamp().String()
-		sb.WriteString(wrapTextSuccessOfFailure(createAtText, statusAsExpected) + "\n")
-	}
-
-	if !statusAsExpected {
-		sb.WriteString("  Troubleshooting: https://docs.odigos.io/architecture/troubleshooting#2-odigos-instrumentation-config\n")
-	}
+	printProperty(sb, 1, &analyze.InstrumentationConfig.Created)
+	printProperty(sb, 1, analyze.InstrumentationConfig.CreateTime)
 }
 
 func printRuntimeDetails(instrumentationConfig *odigosv1.InstrumentationConfig, instrumented bool, sb *strings.Builder) {
@@ -315,7 +301,7 @@ func PrintDescribeSource(ctx context.Context, kubeClient kubernetes.Interface, o
 	}
 
 	instrumented := printWorkloadManifestInfo(analyze, &sb)
-	printInstrumentationConfigInfo(resources.InstrumentationConfig, instrumented, &sb)
+	printInstrumentationConfigInfo(analyze, &sb)
 	printRuntimeDetails(resources.InstrumentationConfig, instrumented, &sb)
 	printInstrumentedApplicationInfo(resources.InstrumentedApplication, instrumented, &sb)
 	containerNameToExpectedDevices := printAppliedInstrumentationDeviceInfo(workloadObj, resources.InstrumentedApplication, instrumented, &sb)

--- a/k8sutils/pkg/describe/source/analyze.go
+++ b/k8sutils/pkg/describe/source/analyze.go
@@ -3,6 +3,7 @@ package source
 import (
 	"fmt"
 
+	"github.com/odigos-io/odigos/common"
 	"github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/k8sutils/pkg/describe/properties"
 )
@@ -19,6 +20,18 @@ type InstrumentationConfigAnalyze struct {
 	CreateTime *properties.EntityProperty `json:"createTime"`
 }
 
+type ContainerRuntimeInfo struct {
+	ContainerName  properties.EntityProperty   `json:"containerName"`
+	Language       properties.EntityProperty   `json:"language"`
+	RuntimeVersion properties.EntityProperty   `json:"runtimeVersion"`
+	EnvVars        []properties.EntityProperty `json:"envVars"`
+}
+
+type RuntimeInfoAnalyze struct {
+	Generation properties.EntityProperty `json:"generation"`
+	Containers []ContainerRuntimeInfo    `json:"containers"`
+}
+
 type SourceAnalyze struct {
 	Name      properties.EntityProperty    `json:"name"`
 	Kind      properties.EntityProperty    `json:"kind"`
@@ -26,6 +39,7 @@ type SourceAnalyze struct {
 	Labels    InstrumentationLabelsAnalyze `json:"labels"`
 
 	InstrumentationConfig InstrumentationConfigAnalyze `json:"instrumentationConfig"`
+	RuntimeInfo           *RuntimeInfoAnalyze          `json:"runtimeInfo"`
 }
 
 func analyzeInstrumentationLabels(resource *OdigosSourceResources, workloadObj *K8sSourceObject) (InstrumentationLabelsAnalyze, bool) {
@@ -125,10 +139,66 @@ func analyzeInstrumentationConfig(resources *OdigosSourceResources, instrumented
 	}
 }
 
+func analyzeRuntimeInfo(resources *OdigosSourceResources) *RuntimeInfoAnalyze {
+	if resources.InstrumentationConfig == nil {
+		return nil
+	}
+
+	generation := properties.EntityProperty{
+		Name:  "Workload Generation",
+		Value: resources.InstrumentationConfig.Status.ObservedWorkloadGeneration,
+	}
+
+	containers := make([]ContainerRuntimeInfo, 0, len(resources.InstrumentationConfig.Status.RuntimeDetailsByContainer))
+
+	for _, container := range resources.InstrumentationConfig.Status.RuntimeDetailsByContainer {
+
+		containerName := properties.EntityProperty{
+			Name:  "Container Name",
+			Value: container.ContainerName,
+		}
+
+		language := properties.EntityProperty{
+			Name:   "Programming Language",
+			Value:  container.Language,
+			Status: properties.GetSuccessOrError(container.Language != common.UnknownProgrammingLanguage),
+		}
+
+		runtimeVersion := properties.EntityProperty{
+			Name:  "Runtime Version",
+			Value: container.RuntimeVersion,
+		}
+		if container.RuntimeVersion == "" {
+			runtimeVersion.Value = "not available"
+		}
+
+		envVars := make([]properties.EntityProperty, 0, len(container.EnvVars))
+		for _, envVar := range container.EnvVars {
+			envVars = append(envVars, properties.EntityProperty{
+				Name:  envVar.Name,
+				Value: envVar.Value,
+			})
+		}
+
+		containers = append(containers, ContainerRuntimeInfo{
+			ContainerName:  containerName,
+			Language:       language,
+			RuntimeVersion: runtimeVersion,
+			EnvVars:        envVars,
+		})
+	}
+
+	return &RuntimeInfoAnalyze{
+		Generation: generation,
+		Containers: containers,
+	}
+}
+
 func AnalyzeSource(resources *OdigosSourceResources, workloadObj *K8sSourceObject) *SourceAnalyze {
 
 	labelsAnalysis, instrumented := analyzeInstrumentationLabels(resources, workloadObj)
 	icAnalysis := analyzeInstrumentationConfig(resources, instrumented)
+	runtimeAnalysis := analyzeRuntimeInfo(resources, instrumented)
 
 	return &SourceAnalyze{
 		Name:      properties.EntityProperty{Name: "Name", Value: workloadObj.GetName()},
@@ -137,5 +207,6 @@ func AnalyzeSource(resources *OdigosSourceResources, workloadObj *K8sSourceObjec
 		Labels:    labelsAnalysis,
 
 		InstrumentationConfig: icAnalysis,
+		RuntimeInfo:           runtimeAnalysis,
 	}
 }

--- a/k8sutils/pkg/describe/source/analyze.go
+++ b/k8sutils/pkg/describe/source/analyze.go
@@ -1,0 +1,87 @@
+package source
+
+import (
+	"fmt"
+
+	"github.com/odigos-io/odigos/common/consts"
+	"github.com/odigos-io/odigos/k8sutils/pkg/describe/properties"
+)
+
+type InstrumentationLabelsAnalyze struct {
+	Instrumented     properties.EntityProperty  `json:"instrumented"`
+	Workload         *properties.EntityProperty `json:"workload"`
+	Namespace        *properties.EntityProperty `json:"namespace"`
+	InstrumentedText properties.EntityProperty  `json:"instrumentedText"`
+}
+
+type SourceAnalyze struct {
+	Name      properties.EntityProperty `json:"name"`
+	Kind      properties.EntityProperty `json:"kind"`
+	Namespace properties.EntityProperty `json:"namespace"`
+
+	Labels InstrumentationLabelsAnalyze `json:"labels"`
+}
+
+func analyzeInstrumentationLabels(resource *OdigosSourceResources, workloadObj *K8sSourceObject) InstrumentationLabelsAnalyze {
+
+	workloadLabel, workloadFound := workloadObj.GetLabels()[consts.OdigosInstrumentationLabel]
+	nsLabel, nsFound := resource.Namespace.GetLabels()[consts.OdigosInstrumentationLabel]
+
+	workload := &properties.EntityProperty{Name: "Workload", Value: "unset"}
+	if workloadFound {
+		workload.Value = fmt.Sprintf("%s=%s", consts.OdigosInstrumentationLabel, workloadLabel)
+	}
+
+	ns := &properties.EntityProperty{Name: "Namespace", Value: "unset"}
+	if nsFound {
+		ns.Value = fmt.Sprintf("%s=%s", consts.OdigosInstrumentationLabel, nsLabel)
+	}
+
+	var instrumented bool
+	var decisionText string
+
+	if workloadFound {
+		instrumented = workloadLabel == consts.InstrumentationEnabled
+		if instrumented {
+			decisionText = "Workload is instrumented because the " + workloadObj.Kind + " contains the label '" + consts.OdigosInstrumentationLabel + "=" + workloadLabel + "'"
+		} else {
+			decisionText = "Workload is NOT instrumented because the " + workloadObj.Kind + " contains the label '" + consts.OdigosInstrumentationLabel + "=" + workloadLabel + "'"
+		}
+	} else {
+		instrumented = nsLabel == consts.InstrumentationEnabled
+		if instrumented {
+			decisionText = "Workload is instrumented because the " + workloadObj.Kind + " is not labeled, and the namespace is labeled with '" + consts.OdigosInstrumentationLabel + "=" + nsLabel + "'"
+		} else {
+			if nsFound {
+				decisionText = "Workload is NOT instrumented because the " + workloadObj.Kind + " is not labeled, and the namespace is labeled with '" + consts.OdigosInstrumentationLabel + "=" + nsLabel + "'"
+			} else {
+				decisionText = "Workload is NOT instrumented because neither the workload nor the namespace has the '" + consts.OdigosInstrumentationLabel + "' label set"
+			}
+		}
+	}
+
+	instrumentedProperty := properties.EntityProperty{
+		Name:  "Instrumented",
+		Value: instrumented,
+	}
+	decisionTextProperty := properties.EntityProperty{
+		Name:  "DecisionText",
+		Value: decisionText,
+	}
+
+	return InstrumentationLabelsAnalyze{
+		Instrumented:     instrumentedProperty,
+		Workload:         workload,
+		Namespace:        ns,
+		InstrumentedText: decisionTextProperty,
+	}
+}
+
+func AnalyzeSource(resources *OdigosSourceResources, workloadObj *K8sSourceObject) *SourceAnalyze {
+	return &SourceAnalyze{
+		Name:      properties.EntityProperty{Name: "Name", Value: workloadObj.GetName()},
+		Kind:      properties.EntityProperty{Name: "Kind", Value: workloadObj.Kind},
+		Namespace: properties.EntityProperty{Name: "Namespace", Value: workloadObj.GetNamespace()},
+		Labels:    analyzeInstrumentationLabels(resources, workloadObj),
+	}
+}


### PR DESCRIPTION
this PR makes it so that `odigos describe source` uses 2 phases: analyze and print.

This allows the UI and tools to fetch the describe result and use it, without converting it to human text