### PR TITLE
chore(instrumentor): event filter to ignore instrumented applications

### DIFF
--- a/instrumentor/controllers/instrumentationdevice/manager.go
+++ b/instrumentor/controllers/instrumentationdevice/manager.go
@@ -97,6 +97,7 @@ func SetupWithManager(mgr ctrl.Manager) error {
 		ControllerManagedBy(mgr).
 		Named("instrumentationdevice-instrumentedapplication").
 		For(&odigosv1.InstrumentedApplication{}).
+		WithEventFilter(&predicate.GenerationChangedPredicate{}).
 		Complete(&InstrumentedApplicationReconciler{
 			Client: mgr.GetClient(),
 			Scheme: mgr.GetScheme(),


### PR DESCRIPTION

When instrumented application updates, we only care if it's a change to the runtime details. this is achieved with the generation field on the object.
