### PR TITLE
Add event filter for instrumentation-device CG reconciler

### DIFF
--- a/instrumentor/controllers/instrumentationdevice/collectorsgroup_controller.go
+++ b/instrumentor/controllers/instrumentationdevice/collectorsgroup_controller.go
@@ -18,21 +18,86 @@ package instrumentationdevice
 
 import (
 	"context"
+	"errors"
 
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 
+	"github.com/odigos-io/odigos/k8sutils/pkg/consts"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
+// CollectorsGroupReconciler is responsible for reconciling the instrumented workloads
+// once the collectors group becomes ready - by adding the instrumentation device to the workloads.
+// This is necessary to ensure that we won't instrument any workload before the
+// node collectors are ready to receive the data.
 type CollectorsGroupReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 }
 
-func (r *CollectorsGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+type collectorsGroupReadyPredicate struct {
+	predicate.Funcs
+}
 
+func (w collectorsGroupReadyPredicate) Create(e event.CreateEvent) bool {
+	if e.Object == nil {
+		return false
+	}
+
+	if e.Object.GetName() != consts.OdigosNodeCollectorCollectorGroupName {
+		return false
+	}
+
+	cg, ok := e.Object.(*odigosv1.CollectorsGroup)
+	if !ok {
+		return false
+	}
+
+	return cg.Status.Ready
+}
+
+func (w collectorsGroupReadyPredicate) Update(e event.UpdateEvent) bool {
+	if e.ObjectOld == nil || e.ObjectNew == nil {
+		return false
+	}
+
+	if e.ObjectNew.GetName() != consts.OdigosNodeCollectorCollectorGroupName {
+		return false
+	}
+
+	oldCG, ok := e.ObjectOld.(*odigosv1.CollectorsGroup)
+	if !ok {
+		return false
+	}
+
+	newCG, ok := e.ObjectNew.(*odigosv1.CollectorsGroup)
+	if !ok {
+		return false
+	}
+
+	wasReady := oldCG.Status.Ready
+	isReady := newCG.Status.Ready
+
+	return !wasReady && isReady
+}
+
+func (w collectorsGroupReadyPredicate) Delete(e event.DeleteEvent) bool {
+	return false
+}
+
+func (w collectorsGroupReadyPredicate) Generic(e event.GenericEvent) bool {
+	return false
+}
+
+func (r *CollectorsGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
 	isDataCollectionReady := isDataCollectionReady(ctx, r.Client)
 
 	var instApps odigosv1.InstrumentedApplicationList
@@ -40,12 +105,29 @@ func (r *CollectorsGroupReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
+	logger.V(0).Info("Reconciling instrumented applications after node collectors group became ready", "count", len(instApps.Items))
+
+	var reconcileErr error
+
 	for _, runtimeDetails := range instApps.Items {
-		err := reconcileSingleWorkload(ctx, r.Client, &runtimeDetails, isDataCollectionReady)
+		var currentInstApp odigosv1.InstrumentedApplication
+		err := r.Get(ctx, client.ObjectKey{Namespace: runtimeDetails.Namespace, Name: runtimeDetails.Name}, &currentInstApp)
+		if apierrors.IsNotFound(err) {
+			// the loop can take time, so the instrumented application might get deleted
+			// in the meantime, so we ignore the error
+			continue
+		}
+
 		if err != nil {
-			return ctrl.Result{}, err
+			reconcileErr = errors.Join(reconcileErr, err)
+			continue
+		}
+
+		err = reconcileSingleWorkload(ctx, r.Client, &currentInstApp, isDataCollectionReady)
+		if err != nil {
+			reconcileErr = errors.Join(reconcileErr, err)
 		}
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, reconcileErr
 }

--- a/instrumentor/controllers/instrumentationdevice/collectorsgroup_controller.go
+++ b/instrumentor/controllers/instrumentationdevice/collectorsgroup_controller.go
@@ -22,15 +22,11 @@ import (
 
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 
-	"github.com/odigos-io/odigos/k8sutils/pkg/consts"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 // CollectorsGroupReconciler is responsible for reconciling the instrumented workloads
@@ -40,60 +36,6 @@ import (
 type CollectorsGroupReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
-}
-
-type collectorsGroupReadyPredicate struct {
-	predicate.Funcs
-}
-
-func (w collectorsGroupReadyPredicate) Create(e event.CreateEvent) bool {
-	if e.Object == nil {
-		return false
-	}
-
-	if e.Object.GetName() != consts.OdigosNodeCollectorCollectorGroupName {
-		return false
-	}
-
-	cg, ok := e.Object.(*odigosv1.CollectorsGroup)
-	if !ok {
-		return false
-	}
-
-	return cg.Status.Ready
-}
-
-func (w collectorsGroupReadyPredicate) Update(e event.UpdateEvent) bool {
-	if e.ObjectOld == nil || e.ObjectNew == nil {
-		return false
-	}
-
-	if e.ObjectNew.GetName() != consts.OdigosNodeCollectorCollectorGroupName {
-		return false
-	}
-
-	oldCG, ok := e.ObjectOld.(*odigosv1.CollectorsGroup)
-	if !ok {
-		return false
-	}
-
-	newCG, ok := e.ObjectNew.(*odigosv1.CollectorsGroup)
-	if !ok {
-		return false
-	}
-
-	wasReady := oldCG.Status.Ready
-	isReady := newCG.Status.Ready
-
-	return !wasReady && isReady
-}
-
-func (w collectorsGroupReadyPredicate) Delete(e event.DeleteEvent) bool {
-	return false
-}
-
-func (w collectorsGroupReadyPredicate) Generic(e event.GenericEvent) bool {
-	return false
 }
 
 func (r *CollectorsGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/instrumentor/controllers/instrumentationdevice/manager.go
+++ b/instrumentor/controllers/instrumentationdevice/manager.go
@@ -86,7 +86,7 @@ func SetupWithManager(mgr ctrl.Manager) error {
 		ControllerManagedBy(mgr).
 		Named("instrumentationdevice-collectorsgroup").
 		For(&odigosv1.CollectorsGroup{}).
-		WithEventFilter(&collectorsGroupReadyPredicate{}).
+		WithEventFilter(predicate.And(&odigospredicate.OdigosCollectorsGroupNodePredicate, &odigospredicate.CgBecomesReadyPredicate{})).
 		Complete(&CollectorsGroupReconciler{
 			Client: mgr.GetClient(),
 			Scheme: mgr.GetScheme(),

--- a/instrumentor/controllers/instrumentationdevice/manager.go
+++ b/instrumentor/controllers/instrumentationdevice/manager.go
@@ -85,6 +85,7 @@ func SetupWithManager(mgr ctrl.Manager) error {
 		ControllerManagedBy(mgr).
 		Named("instrumentationdevice-collectorsgroup").
 		For(&odigosv1.CollectorsGroup{}).
+		WithEventFilter(&collectorsGroupReadyPredicate{}).
 		Complete(&CollectorsGroupReconciler{
 			Client: mgr.GetClient(),
 			Scheme: mgr.GetScheme(),

--- a/k8sutils/pkg/predicate/cgbecomesready.go
+++ b/k8sutils/pkg/predicate/cgbecomesready.go
@@ -8,6 +8,7 @@ import (
 
 // this event filter will only trigger reconciliation when the collectors group was not ready and now it is ready.
 // some controllers in odigos reacts to this specific event, and should not be triggered by other events such as spec updates or status conditions changes.
+// for create events, it will only trigger reconciliation if the collectors group is ready.
 type CgBecomesReadyPredicate struct{}
 
 func (i *CgBecomesReadyPredicate) Create(e event.CreateEvent) bool {


### PR DESCRIPTION
During the un-instrumentation of a large number of sources`reconcileSingleWorkload` may be called concurrently by the collectors group reconciler and the instrumented-application reconciler.

This race condition can cause the instrumentation device to be added right after its removal as demonstrated in the following log:

```
2024-11-08T12:18:23Z	INFO	removed instrumentation device from workload	{"controller": "instrumentationdevice-instrumentedapplication", "controllerGroup": "odigos.io", "controllerKind": "InstrumentedApplication", "InstrumentedApplication": {"name":"deployment-coupon","namespace":"simple-demo18"}, "namespace": "simple-demo18", "name": "deployment-coupon", "reconcileID": "a50d0c85-fd07-4896-84a3-817472fc3953", "namespace": "simple-demo18", "kind": "&TypeMeta{Kind:Deployment,APIVersion:apps/v1,}", "name": "coupon", "reason": "NoRuntimeDetails"}
2024-11-08T12:18:23Z	DEBUG	instrumented application deleted	{"controller": "deleteinstrumentedapplication-deployment", "controllerGroup": "apps", "controllerKind": "Deployment", "Deployment": {"name":"coupon","namespace":"simple-demo18"}, "namespace": "simple-demo18", "name": "coupon", "reconcileID": "08560386-4960-4ace-aaae-343fd6fb4cc2", "namespace": "simple-demo18", "name": "coupon", "kind": "Deployment"}
2024-11-08T12:18:23Z	INFO	added instrumentation device to workload	{"controller": "instrumentationdevice-collectorsgroup", "controllerGroup": "odigos.io", "controllerKind": "CollectorsGroup", "CollectorsGroup": {"name":"odigos-data-collection","namespace":"odigos-system"}, "namespace": "odigos-system", "name": "odigos-data-collection", "reconcileID": "52989ae7-2686-4e1c-99cb-23b3252535ad", "name": "coupon", "namespace": "simple-demo18"}
```

To address this, an event filter is added to the CG reconciler, which only forward either
1. Create events which have CG ready.
2. Update events where the CG became ready.

In addition, the reconciler is updated to get a fresh copy from the cache of each instrumented app it handles before it reconciles it. This should reduce the chance of handling an old instrumented application and reconciling workloads unnecessarily.