### PR TITLE
refactor: extract common predicates to k8s utils

### DIFF
--- a/instrumentor/controllers/instrumentationdevice/manager.go
+++ b/instrumentor/controllers/instrumentationdevice/manager.go
@@ -4,6 +4,7 @@ import (
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/common"
 	"github.com/odigos-io/odigos/instrumentor/controllers/utils"
+	odigospredicate "github.com/odigos-io/odigos/k8sutils/pkg/predicate"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -109,7 +110,7 @@ func SetupWithManager(mgr ctrl.Manager) error {
 		ControllerManagedBy(mgr).
 		Named("instrumentationdevice-configmaps").
 		For(&corev1.ConfigMap{}).
-		WithEventFilter(&utils.OnlyUpdatesPredicate{}).
+		WithEventFilter(&odigospredicate.OnlyUpdatesPredicate{}).
 		Complete(&OdigosConfigReconciler{
 			Client: mgr.GetClient(),
 			Scheme: mgr.GetScheme(),

--- a/instrumentor/controllers/startlangdetection/manager.go
+++ b/instrumentor/controllers/startlangdetection/manager.go
@@ -1,7 +1,7 @@
 package startlangdetection
 
 import (
-	"github.com/odigos-io/odigos/instrumentor/controllers/utils"
+	odigospredicate "github.com/odigos-io/odigos/k8sutils/pkg/predicate"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -64,7 +64,7 @@ func SetupWithManager(mgr ctrl.Manager) error {
 		ControllerManagedBy(mgr).
 		Named("startlangdetection-configmaps").
 		For(&corev1.ConfigMap{}).
-		WithEventFilter(&utils.OnlyUpdatesPredicate{}).
+		WithEventFilter(&odigospredicate.OnlyUpdatesPredicate{}).
 		Complete(&OdigosConfigReconciler{
 			Client: mgr.GetClient(),
 			Scheme: mgr.GetScheme(),

--- a/instrumentor/controllers/utils/predicate.go
+++ b/instrumentor/controllers/utils/predicate.go
@@ -5,24 +5,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
-type OnlyUpdatesPredicate struct{}
-
-func (o OnlyUpdatesPredicate) Create(e event.CreateEvent) bool {
-	return false
-}
-
-func (i OnlyUpdatesPredicate) Update(e event.UpdateEvent) bool {
-	return true
-}
-
-func (i OnlyUpdatesPredicate) Delete(e event.DeleteEvent) bool {
-	return false
-}
-
-func (i OnlyUpdatesPredicate) Generic(e event.GenericEvent) bool {
-	return false
-}
-
 type OtelSdkInstrumentationRulePredicate struct{}
 
 func (o OtelSdkInstrumentationRulePredicate) Create(e event.CreateEvent) bool {

--- a/k8sutils/pkg/predicate/cgbecomesready.go
+++ b/k8sutils/pkg/predicate/cgbecomesready.go
@@ -11,6 +11,10 @@ import (
 type CgBecomesReadyPredicate struct{}
 
 func (i *CgBecomesReadyPredicate) Create(e event.CreateEvent) bool {
+	if e.Object == nil {
+		return false
+	}
+
 	cg, ok := e.Object.(*odigosv1.CollectorsGroup)
 	if !ok {
 		return false
@@ -19,6 +23,10 @@ func (i *CgBecomesReadyPredicate) Create(e event.CreateEvent) bool {
 }
 
 func (i *CgBecomesReadyPredicate) Update(e event.UpdateEvent) bool {
+
+	if e.ObjectOld == nil || e.ObjectNew == nil {
+		return false
+	}
 
 	oldCollectorGroup, ok := e.ObjectOld.(*odigosv1.CollectorsGroup)
 	if !ok {

--- a/k8sutils/pkg/predicate/cgbecomesready.go
+++ b/k8sutils/pkg/predicate/cgbecomesready.go
@@ -1,0 +1,47 @@
+package predicate
+
+import (
+	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	cr_predicate "sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// this event filter will only trigger reconciliation when the collectors group was not ready and now it is ready.
+// some controllers in odigos reacts to this specific event, and should not be triggered by other events such as spec updates or status conditions changes.
+type CgBecomesReadyPredicate struct{}
+
+func (i *CgBecomesReadyPredicate) Create(e event.CreateEvent) bool {
+	cg, ok := e.Object.(*odigosv1.CollectorsGroup)
+	if !ok {
+		return false
+	}
+	return cg.Status.Ready
+}
+
+func (i *CgBecomesReadyPredicate) Update(e event.UpdateEvent) bool {
+
+	oldCollectorGroup, ok := e.ObjectOld.(*odigosv1.CollectorsGroup)
+	if !ok {
+		return false
+	}
+	newCollectorGroup, ok := e.ObjectNew.(*odigosv1.CollectorsGroup)
+	if !ok {
+		return false
+	}
+
+	wasReady := oldCollectorGroup.Status.Ready
+	nowReady := newCollectorGroup.Status.Ready
+	becameReady := !wasReady && nowReady
+
+	return becameReady
+}
+
+func (i *CgBecomesReadyPredicate) Delete(e event.DeleteEvent) bool {
+	return false
+}
+
+func (i *CgBecomesReadyPredicate) Generic(e event.GenericEvent) bool {
+	return false
+}
+
+var _ cr_predicate.Predicate = &CgBecomesReadyPredicate{}

--- a/k8sutils/pkg/predicate/existence.go
+++ b/k8sutils/pkg/predicate/existence.go
@@ -1,0 +1,33 @@
+package predicate
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	cr_predicate "sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// existence predicate only allows create and delete events.
+// it is useful when the controller only reacts to the presence of an object (e.g. if it exists or not),
+// and not to it's content or status changes.
+//
+// Notice these 2 things when using this predicate:
+// 1. The event filter will allow events for each object on startup, as all the objects are "created" in the cache.
+// 2. If you have important task to do on delete events, make sure it is applied if the event is missed and the controller restarts, since the delete event will not be triggered on controller restart as the object is no longer in k8s.
+type ExistencePredicate struct{}
+
+func (o ExistencePredicate) Create(e event.CreateEvent) bool {
+	return true
+}
+
+func (i ExistencePredicate) Update(e event.UpdateEvent) bool {
+	return false
+}
+
+func (i ExistencePredicate) Delete(e event.DeleteEvent) bool {
+	return true
+}
+
+func (i ExistencePredicate) Generic(e event.GenericEvent) bool {
+	return false
+}
+
+var _ cr_predicate.Predicate = &ExistencePredicate{}

--- a/k8sutils/pkg/predicate/objectname.go
+++ b/k8sutils/pkg/predicate/objectname.go
@@ -65,7 +65,7 @@ var OdigosConfigMapPredicate = ObjectNamePredicate{
 //		For(&odigosv1.CollectorsGroup{}).
 //		WithEventFilter(&odigospredicates.OdigosCollectorsGroupCluster).
 //		Complete(r)
-var OdigosCollectorsGroupNode = ObjectNamePredicate{
+var OdigosCollectorsGroupNodePredicate = ObjectNamePredicate{
 	AllowedObjectName: odigosk8sconsts.OdigosNodeCollectorCollectorGroupName,
 }
 
@@ -77,8 +77,8 @@ var OdigosCollectorsGroupNode = ObjectNamePredicate{
 //
 //	err = ctrl.NewControllerManagedBy(mgr).
 //		For(&odigosv1.CollectorsGroup{}).
-//		WithEventFilter(&odigospredicates.OdigosCollectorsGroupCluster).
+//		WithEventFilter(&odigospredicates.OdigosCollectorsGroupClusterPredicate).
 //		Complete(r)
-var OdigosCollectorsGroupCluster = ObjectNamePredicate{
+var OdigosCollectorsGroupClusterPredicate = ObjectNamePredicate{
 	AllowedObjectName: odigosk8sconsts.OdigosClusterCollectorCollectorGroupName,
 }

--- a/k8sutils/pkg/predicate/objectname.go
+++ b/k8sutils/pkg/predicate/objectname.go
@@ -12,18 +12,30 @@ type ObjectNamePredicate struct {
 }
 
 func (o ObjectNamePredicate) Create(e event.CreateEvent) bool {
+	if e.Object == nil {
+		return false
+	}
 	return e.Object.GetName() == o.AllowedObjectName
 }
 
 func (i ObjectNamePredicate) Update(e event.UpdateEvent) bool {
+	if e.ObjectNew == nil || e.ObjectOld == nil {
+		return false
+	}
 	return e.ObjectNew.GetName() == i.AllowedObjectName
 }
 
 func (i ObjectNamePredicate) Delete(e event.DeleteEvent) bool {
+	if e.Object == nil {
+		return false
+	}
 	return e.Object.GetName() == i.AllowedObjectName
 }
 
 func (i ObjectNamePredicate) Generic(e event.GenericEvent) bool {
+	if e.Object == nil {
+		return false
+	}
 	return e.Object.GetName() == i.AllowedObjectName
 }
 

--- a/k8sutils/pkg/predicate/objectname.go
+++ b/k8sutils/pkg/predicate/objectname.go
@@ -1,0 +1,72 @@
+package predicate
+
+import (
+	"github.com/odigos-io/odigos/common/consts"
+	odigosk8sconsts "github.com/odigos-io/odigos/k8sutils/pkg/consts"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	cr_predicate "sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+type ObjectNamePredicate struct {
+	AllowedObjectName string
+}
+
+func (o ObjectNamePredicate) Create(e event.CreateEvent) bool {
+	return e.Object.GetName() == o.AllowedObjectName
+}
+
+func (i ObjectNamePredicate) Update(e event.UpdateEvent) bool {
+	return e.ObjectNew.GetName() == i.AllowedObjectName
+}
+
+func (i ObjectNamePredicate) Delete(e event.DeleteEvent) bool {
+	return e.Object.GetName() == i.AllowedObjectName
+}
+
+func (i ObjectNamePredicate) Generic(e event.GenericEvent) bool {
+	return e.Object.GetName() == i.AllowedObjectName
+}
+
+var _ cr_predicate.Predicate = &ObjectNamePredicate{}
+
+// This predicate will only allow config map events on the "odigos-config" object,
+// and will filter out events for possible other config maps which the reconciler should not handle.
+// Example usage:
+// import odigospredicates "github.com/odigos-io/odigos/k8sutils/pkg/predicate"
+// ...
+//
+//	err = ctrl.NewControllerManagedBy(mgr).
+//		For(&corev1.ConfigMap{}).
+//		WithEventFilter(&odigospredicates.OdigosConfigMapPredicate).
+//		Complete(r)
+var OdigosConfigMapPredicate = ObjectNamePredicate{
+	AllowedObjectName: consts.OdigosConfigurationName,
+}
+
+// use this event filter to reconcile only collectors group events for node collectors group objects
+// this is useful if you reconcile only depends on changes from the node collectors group and should not react to cluster collectors group changes
+// example usage:
+// import odigospredicates "github.com/odigos-io/odigos/k8sutils/pkg/predicate"
+// ...
+//
+//	err = ctrl.NewControllerManagedBy(mgr).
+//		For(&odigosv1.CollectorsGroup{}).
+//		WithEventFilter(&odigospredicates.OdigosCollectorsGroupCluster).
+//		Complete(r)
+var OdigosCollectorsGroupNode = ObjectNamePredicate{
+	AllowedObjectName: odigosk8sconsts.OdigosNodeCollectorCollectorGroupName,
+}
+
+// use this event filter to reconcile only collectors group events for cluster collectors group objects
+// this is useful if you reconcile only depends on changes from the cluster collectors group and should not react to node collectors group changes
+// example usage:
+// import odigospredicates "github.com/odigos-io/odigos/k8sutils/pkg/predicate"
+// ...
+//
+//	err = ctrl.NewControllerManagedBy(mgr).
+//		For(&odigosv1.CollectorsGroup{}).
+//		WithEventFilter(&odigospredicates.OdigosCollectorsGroupCluster).
+//		Complete(r)
+var OdigosCollectorsGroupCluster = ObjectNamePredicate{
+	AllowedObjectName: odigosk8sconsts.OdigosClusterCollectorCollectorGroupName,
+}

--- a/k8sutils/pkg/predicate/onlyupdate.go
+++ b/k8sutils/pkg/predicate/onlyupdate.go
@@ -1,0 +1,29 @@
+package predicate
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	cr_predicate "sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// This predicate only allows update events.
+// It is useful if you handle the initial state when the controller starts, and only need to apply changes
+// for example - when monitoring odigos config changes.
+type OnlyUpdatesPredicate struct{}
+
+func (o OnlyUpdatesPredicate) Create(e event.CreateEvent) bool {
+	return false
+}
+
+func (i OnlyUpdatesPredicate) Update(e event.UpdateEvent) bool {
+	return true
+}
+
+func (i OnlyUpdatesPredicate) Delete(e event.DeleteEvent) bool {
+	return false
+}
+
+func (i OnlyUpdatesPredicate) Generic(e event.GenericEvent) bool {
+	return false
+}
+
+var _ cr_predicate.Predicate = &OnlyUpdatesPredicate{}

--- a/scheduler/controllers/destination_controller.go
+++ b/scheduler/controllers/destination_controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/odigos-io/odigos/k8sutils/pkg/utils"
 
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	odigospredicates "github.com/odigos-io/odigos/k8sutils/pkg/predicate"
 	"github.com/odigos-io/odigos/scheduler/controllers/collectorgroups"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -67,5 +68,6 @@ func (r *DestinationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 func (r *DestinationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&odigosv1.Destination{}).
+		WithEventFilter(&odigospredicates.ExistencePredicate{}). // only care when destinations are created or deleted
 		Complete(r)
 }

--- a/scheduler/controllers/nodecollector_controller.go
+++ b/scheduler/controllers/nodecollector_controller.go
@@ -15,6 +15,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 type NodeCollectorsGroupReconciler struct {
@@ -95,8 +96,7 @@ func (r *NodeCollectorsGroupReconciler) SetupWithManager(mgr ctrl.Manager) error
 	err = ctrl.NewControllerManagedBy(mgr).
 		For(&odigosv1.CollectorsGroup{}).
 		Named("nodecollectorgroup-collectorsgroup").
-		WithEventFilter(&odigospredicates.OdigosCollectorsGroupCluster).
-		WithEventFilter(&odigospredicates.CgBecomesReadyPredicate{}).
+		WithEventFilter(predicate.And(&odigospredicates.OdigosCollectorsGroupCluster, &odigospredicates.CgBecomesReadyPredicate{})).
 		Complete(r)
 	if err != nil {
 		return err

--- a/scheduler/controllers/nodecollector_controller.go
+++ b/scheduler/controllers/nodecollector_controller.go
@@ -96,7 +96,7 @@ func (r *NodeCollectorsGroupReconciler) SetupWithManager(mgr ctrl.Manager) error
 	err = ctrl.NewControllerManagedBy(mgr).
 		For(&odigosv1.CollectorsGroup{}).
 		Named("nodecollectorgroup-collectorsgroup").
-		WithEventFilter(predicate.And(&odigospredicates.OdigosCollectorsGroupCluster, &odigospredicates.CgBecomesReadyPredicate{})).
+		WithEventFilter(predicate.And(&odigospredicates.OdigosCollectorsGroupClusterPredicate, &odigospredicates.CgBecomesReadyPredicate{})).
 		Complete(r)
 	if err != nil {
 		return err


### PR DESCRIPTION
Using the right event filters for controllers is very important to reduce resource utilization, avoid un-needed calls to api-server, and reduce chance to race conditions when multiple things changes at the same time.

We keep refining our controller event filters to achieve better stability for odigos.

Right now, we define our custom predicates near the controller where they are used, but this make it less easy to reuse existing common predicates and share code. This PR move some of the common and reuseable predicates to `k8sutils` module and refactor how they are being set up