### PR TITLE
fix: ns reconcile race condition on delete crds

### DIFF
--- a/instrumentor/controllers/deleteinstrumentedapplication/manager.go
+++ b/instrumentor/controllers/deleteinstrumentedapplication/manager.go
@@ -53,7 +53,7 @@ func SetupWithManager(mgr ctrl.Manager) error {
 		ControllerManagedBy(mgr).
 		Named("deleteinstrumentedapplication-namespace").
 		For(&corev1.Namespace{}).
-		WithEventFilter(predicate.LabelChangedPredicate{}).
+		WithEventFilter(&NsLabelBecameDisabledPredicate{}).
 		Complete(&NamespaceReconciler{
 			Client: mgr.GetClient(),
 			Scheme: mgr.GetScheme(),

--- a/instrumentor/controllers/deleteinstrumentedapplication/namespace_controller.go
+++ b/instrumentor/controllers/deleteinstrumentedapplication/namespace_controller.go
@@ -18,16 +18,55 @@ package deleteinstrumentedapplication
 
 import (
 	"context"
+	"errors"
 
+	"github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+type NsLabelBecameDisabledPredicate struct{}
+
+func (i *NsLabelBecameDisabledPredicate) Create(e event.CreateEvent) bool {
+	// new namespace should start empty.
+	// existing namespace inserted into cache on startup should not trigger this
+	return false
+}
+
+func (i *NsLabelBecameDisabledPredicate) Update(e event.UpdateEvent) bool {
+	if e.ObjectOld == nil || e.ObjectNew == nil {
+		return false
+	}
+
+	oldNs, ok := e.ObjectOld.(*corev1.Namespace)
+	if !ok {
+		return false
+	}
+	newNs, ok := e.ObjectNew.(*corev1.Namespace)
+	if !ok {
+		return false
+	}
+
+	// if the namespace was not labeled for instrumentation before, and now it is, we should not trigger
+	// if the namespace was labeled for instrumentation before, and now it is not, we should trigger
+	return workload.IsObjectLabeledForInstrumentation(oldNs) && !workload.IsObjectLabeledForInstrumentation(newNs)
+}
+
+func (i *NsLabelBecameDisabledPredicate) Delete(e event.DeleteEvent) bool {
+	return false
+}
+
+func (i *NsLabelBecameDisabledPredicate) Generic(e event.GenericEvent) bool {
+	return false
+}
 
 // NamespaceReconciler reconciles a Namespace object
 type NamespaceReconciler struct {
@@ -44,8 +83,8 @@ func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		logger.Error(err, "error fetching namespace object")
 		return ctrl.Result{}, err
 	}
-
-	// If namespace is labeled, skip
+	// this reconciler handles cases where ns becomes uninstrumented,
+	// and workloads that are not labeled and instrumented inherently from the ns should be deleted
 	if err == nil && workload.IsObjectLabeledForInstrumentation(&ns) {
 		return ctrl.Result{}, nil
 	}
@@ -59,16 +98,9 @@ func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	for _, dep := range deps.Items {
-		if !workload.IsObjectLabeledForInstrumentation(&dep) {
-			if err := deleteWorkloadInstrumentedApplication(ctx, r.Client, &dep); err != nil {
-				logger.Error(err, "error removing runtime details")
-				return ctrl.Result{}, err
-			}
-			err = removeReportedNameAnnotation(ctx, r.Client, &dep)
-			if err != nil {
-				logger.Error(err, "error removing reported name annotation from deployment")
-				return ctrl.Result{}, err
-			}
+		err := syncGenericWorkloadListToNs(ctx, r.Client, workload.WorkloadKindDeployment, client.ObjectKey{Namespace: dep.Namespace, Name: dep.Name})
+		if err != nil {
+			return ctrl.Result{}, err
 		}
 	}
 
@@ -80,16 +112,9 @@ func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	for _, s := range ss.Items {
-		if !workload.IsObjectLabeledForInstrumentation(&s) {
-			if err := deleteWorkloadInstrumentedApplication(ctx, r.Client, &s); err != nil {
-				logger.Error(err, "error removing runtime details")
-				return ctrl.Result{}, err
-			}
-			err = removeReportedNameAnnotation(ctx, r.Client, &s)
-			if err != nil {
-				logger.Error(err, "error removing reported name annotation from statefulset")
-				return ctrl.Result{}, err
-			}
+		err := syncGenericWorkloadListToNs(ctx, r.Client, workload.WorkloadKindStatefulSet, client.ObjectKey{Namespace: s.Namespace, Name: s.Name})
+		if err != nil {
+			return ctrl.Result{}, err
 		}
 	}
 
@@ -101,18 +126,47 @@ func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	for _, d := range ds.Items {
-		if !workload.IsObjectLabeledForInstrumentation(&d) {
-			if err := deleteWorkloadInstrumentedApplication(ctx, r.Client, &d); err != nil {
-				logger.Error(err, "error removing runtime details")
-				return ctrl.Result{}, err
-			}
-			err = removeReportedNameAnnotation(ctx, r.Client, &d)
-			if err != nil {
-				logger.Error(err, "error removing reported name annotation from daemonset")
-				return ctrl.Result{}, err
-			}
+		err := syncGenericWorkloadListToNs(ctx, r.Client, workload.WorkloadKindDaemonSet, client.ObjectKey{Namespace: d.Namespace, Name: d.Name})
+		if err != nil {
+			return ctrl.Result{}, err
 		}
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func syncGenericWorkloadListToNs(ctx context.Context, c client.Client, kind workload.WorkloadKind, key client.ObjectKey) error {
+
+	freshWorkloadCopy := workload.ClientObjectFromWorkloadKind(kind)
+	workloadGetErr := c.Get(ctx, key, freshWorkloadCopy)
+	if workloadGetErr != nil {
+		if apierrors.IsNotFound(workloadGetErr) {
+			// if the workload been deleted, we don't need to do anything
+			return nil
+		} else {
+			return workloadGetErr
+		}
+	}
+
+	if !isInheritingInstrumentationFromNs(freshWorkloadCopy) {
+		return nil
+	}
+
+	var err error
+	err = errors.Join(err, deleteWorkloadInstrumentedApplication(ctx, c, freshWorkloadCopy))
+	err = errors.Join(err, removeReportedNameAnnotation(ctx, c, freshWorkloadCopy))
+	return err
+}
+
+// this function indicates that the odigos instrumentation label is missing from the workload object manifest.
+// when reconciling the namespace, the usecase is to delete instrumentation for workloads that were only
+// instrumented due to the label on the namespace. These are workloads with the label missing.
+// (they inherit the instrumentation from the namespace this way)
+func isInheritingInstrumentationFromNs(obj client.Object) bool {
+	labels := obj.GetLabels()
+	if labels == nil {
+		return true
+	}
+	_, exists := labels[consts.OdigosInstrumentationLabel]
+	return !exists
 }

--- a/instrumentor/main.go
+++ b/instrumentor/main.go
@@ -30,9 +30,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/odigos-io/odigos/common/consts"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/labels"
 
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -178,9 +176,6 @@ func main() {
 						newDs.Spec.Template.Spec = ds.Spec.Template.Spec
 						return newDs, nil
 					},
-				},
-				&corev1.Namespace{}: {
-					Label: labels.Set{consts.OdigosInstrumentationLabel: consts.InstrumentationEnabled}.AsSelector(),
 				},
 				&corev1.ConfigMap{}: {
 					Field: client.InNamespace(env.GetCurrentNamespace()).AsSelector(),


### PR DESCRIPTION
The delete instrumented application controllers in instrumentor are responsible to delete the instrumentated application and instrumentation config once the workload and namespace labels are changed.

Specifically, it has a ns reconcile, and once detects labels change for a ns and the ns is uninstrumented, it loops on all deployments, ds and ss to delete any instrumentations for workloads that inheritaed instrumentation from ns.

There were few bugs fixed in this PR:
- the ns reconciler would list the workloads, and then iterate them one by one. This can take time. When UI instruments workloads, it starts by setting the label on the ns and then iterates the workloads. This mean that the ns reconciler might have read stale data and use it to delete instrumentation, even if the workload has already being labeld. It is fixed by always `Get`ing a fresh workload object when iterating the list.
- the reconciler was attempting to delete any uninstrumented workload. In the ns case, we should only care for workloads without label which inherited the instrumentation from the ns (and ignore those that are already marked with "disabled" which are handled in another controller. This fix is to narrow the check for only those cases.
- the event filter allowed any label changes, it was narrowed to only allow ns label changed from `enabled` to something else, making this reconciler being called less times. For that the cache is modified to store all ns so we can know when the labels has changed. This should not be significant compared to other objects we store in cache.