### PR TITLE
fix: Add predicate for the OdigosConfig reconciler in autoscaler

### DIFF
--- a/autoscaler/controllers/odigosconfig_controller.go
+++ b/autoscaler/controllers/odigosconfig_controller.go
@@ -4,12 +4,15 @@ import (
 	"context"
 
 	controllerconfig "github.com/odigos-io/odigos/autoscaler/controllers/controller_config"
+	odigospredicate "github.com/odigos-io/odigos/k8sutils/pkg/predicate"
+
 	"github.com/odigos-io/odigos/autoscaler/controllers/gateway"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 type OdigosConfigReconciler struct {
@@ -34,8 +37,8 @@ func (r *OdigosConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *OdigosConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// TODO: Clean up noise from too broad of a definition here
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1.ConfigMap{}).
+		WithEventFilter(predicate.And(odigospredicate.OdigosConfigMapPredicate, odigospredicate.ConfigMapDataChangedPredicate{})).
 		Complete(r)
 }

--- a/k8sutils/pkg/predicate/cm_changed.go
+++ b/k8sutils/pkg/predicate/cm_changed.go
@@ -10,6 +10,7 @@ import (
 
 // this event filter will only trigger reconciliation when the configmap data was changed.
 // the reconciled type must be corev1.ConfigMap
+// note: this preidcate currently only check the Data field of the ConfigMap (without BinaryData)
 type ConfigMapDataChangedPredicate struct{}
 
 func (o ConfigMapDataChangedPredicate) Create(e event.CreateEvent) bool {


### PR DESCRIPTION
Following #1722, use the `ConfigMapDataChangedPredicate` in conjunction with `OdigosConfigMapPredicate` to only handle update events from our config map in autoscaler.