### PR TITLE
enhance reconcileWorkload to only get the workload kind

### DIFF
--- a/instrumentor/controllers/startlangdetection/namespace_controller.go
+++ b/instrumentor/controllers/startlangdetection/namespace_controller.go
@@ -43,7 +43,7 @@ func (n *NamespacesReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 	for _, dep := range deps.Items {
 		if _, exists := dep.Labels[consts.OdigosInstrumentationLabel]; !exists {
 			req := ctrl.Request{NamespacedName: client.ObjectKey{Name: dep.Name, Namespace: dep.Namespace}}
-			_, err = reconcileWorkload(ctx, n.Client, &appsv1.Deployment{}, workload.WorkloadKindDeployment, req, n.Scheme)
+			_, err = reconcileWorkload(ctx, n.Client, workload.WorkloadKindDeployment, req, n.Scheme)
 			if err != nil {
 				logger.Error(err, "error requesting runtime details from odiglets", "name", dep.Name, "namespace", dep.Namespace)
 			}
@@ -60,7 +60,7 @@ func (n *NamespacesReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 	for _, st := range sts.Items {
 		if _, exists := st.Labels[consts.OdigosInstrumentationLabel]; !exists {
 			req := ctrl.Request{NamespacedName: client.ObjectKey{Name: st.Name, Namespace: st.Namespace}}
-			_, err = reconcileWorkload(ctx, n.Client, &appsv1.StatefulSet{}, workload.WorkloadKindStatefulSet, req, n.Scheme)
+			_, err = reconcileWorkload(ctx, n.Client, workload.WorkloadKindStatefulSet, req, n.Scheme)
 			if err != nil {
 				logger.Error(err, "error requesting runtime details from odiglets", "name", st.Name, "namespace", st.Namespace)
 			}
@@ -77,7 +77,7 @@ func (n *NamespacesReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 	for _, ds := range dss.Items {
 		if _, exists := ds.Labels[consts.OdigosInstrumentationLabel]; !exists {
 			req := ctrl.Request{NamespacedName: client.ObjectKey{Name: ds.Name, Namespace: ds.Namespace}}
-			_, err = reconcileWorkload(ctx, n.Client, &appsv1.DaemonSet{}, workload.WorkloadKindDaemonSet, req, n.Scheme)
+			_, err = reconcileWorkload(ctx, n.Client, workload.WorkloadKindDaemonSet, req, n.Scheme)
 			if err != nil {
 				logger.Error(err, "error requesting runtime details from odiglets", "name", ds.Name, "namespace", ds.Namespace)
 			}

--- a/instrumentor/controllers/startlangdetection/odigosconfig_controller.go
+++ b/instrumentor/controllers/startlangdetection/odigosconfig_controller.go
@@ -90,7 +90,7 @@ func (r *OdigosConfigReconciler) reconcileUnDisabledFreshWorkload(ctx context.Co
 	// if workload.IsWorkloadInstrumentationEffectiveEnabled
 	if !workload.IsInstrumentationDisabledExplicitly(freshWorkloadCopy) {
 		req := ctrl.Request{NamespacedName: key}
-		_, err = reconcileWorkload(ctx, r.Client, workload.ClientObjectFromWorkloadKind(kind), kind, req, r.Scheme)
+		_, err = reconcileWorkload(ctx, r.Client, kind, req, r.Scheme)
 	}
 	return err
 }

--- a/instrumentor/controllers/startlangdetection/workload_controllers.go
+++ b/instrumentor/controllers/startlangdetection/workload_controllers.go
@@ -8,8 +8,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 
-	appsv1 "k8s.io/api/apps/v1"
-
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
@@ -25,7 +23,7 @@ type DeploymentReconciler struct {
 }
 
 func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	return reconcileWorkload(ctx, r.Client, &appsv1.Deployment{}, workload.WorkloadKindDeployment, req, r.Scheme)
+	return reconcileWorkload(ctx, r.Client, workload.WorkloadKindDeployment, req, r.Scheme)
 }
 
 type DaemonSetReconciler struct {
@@ -34,7 +32,7 @@ type DaemonSetReconciler struct {
 }
 
 func (r *DaemonSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	return reconcileWorkload(ctx, r.Client, &appsv1.DaemonSet{}, workload.WorkloadKindDaemonSet, req, r.Scheme)
+	return reconcileWorkload(ctx, r.Client, workload.WorkloadKindDaemonSet, req, r.Scheme)
 }
 
 type StatefulSetReconciler struct {
@@ -43,10 +41,11 @@ type StatefulSetReconciler struct {
 }
 
 func (r *StatefulSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	return reconcileWorkload(ctx, r.Client, &appsv1.StatefulSet{}, workload.WorkloadKindStatefulSet, req, r.Scheme)
+	return reconcileWorkload(ctx, r.Client, workload.WorkloadKindStatefulSet, req, r.Scheme)
 }
 
-func reconcileWorkload(ctx context.Context, k8sClient client.Client, obj client.Object, objKind workload.WorkloadKind, req ctrl.Request, scheme *runtime.Scheme) (ctrl.Result, error) {
+func reconcileWorkload(ctx context.Context, k8sClient client.Client, objKind workload.WorkloadKind, req ctrl.Request, scheme *runtime.Scheme) (ctrl.Result, error) {
+	obj := workload.ClientObjectFromWorkloadKind(objKind)
 	instConfigName := workload.CalculateWorkloadRuntimeObjectName(req.Name, objKind)
 	err := getWorkloadObject(ctx, k8sClient, req, obj)
 	if err != nil {

--- a/k8sutils/pkg/workload/workloadkinds.go
+++ b/k8sutils/pkg/workload/workloadkinds.go
@@ -94,6 +94,8 @@ func WorkloadKindFromClientObject(w client.Object) WorkloadKind {
 	}
 }
 
+// ClientObjectFromWorkloadKind returns a new instance of the client object for the given workload kind
+// the returned instance is empty and should be used to fetch the actual object from the k8s api server
 func ClientObjectFromWorkloadKind(kind WorkloadKind) client.Object {
 	switch kind {
 	case WorkloadKindDeployment:


### PR DESCRIPTION
Instead of passing an empty object and the object kind, pass only the object kind. Use `workload.ClientObjectFromWorkloadKind(objKind)` within the function.