### PR TITLE
refactor(autoscaler): use common predicates for event filters

### DIFF
--- a/autoscaler/controllers/datacollectiondaemonset_controller.go
+++ b/autoscaler/controllers/datacollectiondaemonset_controller.go
@@ -5,6 +5,7 @@ import (
 
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/k8sutils/pkg/consts"
+	predicate "github.com/odigos-io/odigos/k8sutils/pkg/predicate"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -19,10 +20,6 @@ type DataCollectionDaemonSetReconciler struct {
 func (r *DataCollectionDaemonSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.V(0).Info("Reconciling DaemonSet")
-
-	if req.Name != consts.OdigosNodeCollectorDaemonSetName {
-		return ctrl.Result{}, nil
-	}
 
 	var ds appsv1.DaemonSet
 	if err := r.Get(ctx, req.NamespacedName, &ds); err != nil {
@@ -60,5 +57,6 @@ func calcDataCollectionReadyStatus(ds *appsv1.DaemonSet) bool {
 func (r *DataCollectionDaemonSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&appsv1.DaemonSet{}).
+		WithEventFilter(&predicate.NodeCollectorsDaemonSetPredicate).
 		Complete(r)
 }

--- a/autoscaler/controllers/destination_controller.go
+++ b/autoscaler/controllers/destination_controller.go
@@ -25,6 +25,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	v1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 )
@@ -65,5 +66,8 @@ func (r *DestinationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 func (r *DestinationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1.Destination{}).
+		// auto scaler only cares about the spec of each destination.
+		// filter out events on resource status and metadata changes.
+		WithEventFilter(&predicate.GenerationChangedPredicate{}).
 		Complete(r)
 }

--- a/autoscaler/controllers/gatewaydeployment_controller.go
+++ b/autoscaler/controllers/gatewaydeployment_controller.go
@@ -5,6 +5,7 @@ import (
 
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/k8sutils/pkg/consts"
+	predicate "github.com/odigos-io/odigos/k8sutils/pkg/predicate"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -19,10 +20,6 @@ type GatewayDeploymentReconciler struct {
 func (r *GatewayDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.V(0).Info("Reconciling Deployment")
-
-	if req.Name != consts.OdigosClusterCollectorDeploymentName {
-		return ctrl.Result{}, nil
-	}
 
 	var dep appsv1.Deployment
 	if err := r.Get(ctx, req.NamespacedName, &dep); err != nil {
@@ -54,5 +51,6 @@ func (r *GatewayDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 func (r *GatewayDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&appsv1.Deployment{}).
+		WithEventFilter(&predicate.ClusterCollectorDeploymentPredicate).
 		Complete(r)
 }

--- a/autoscaler/controllers/instrumentedapplication_controller.go
+++ b/autoscaler/controllers/instrumentedapplication_controller.go
@@ -21,6 +21,7 @@ import (
 
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/autoscaler/controllers/datacollection"
+	predicate "github.com/odigos-io/odigos/k8sutils/pkg/predicate"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -63,5 +64,8 @@ func (r *InstrumentedApplicationReconciler) Reconcile(ctx context.Context, req c
 func (r *InstrumentedApplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&odigosv1.InstrumentedApplication{}).
+		// this controller only cares about the instrumented application existence.
+		// when it is created or removed, the node collector config map needs to be updated to scrape logs for it's pods.
+		WithEventFilter(&predicate.ExistencePredicate{}).
 		Complete(r)
 }

--- a/autoscaler/controllers/processor_controller.go
+++ b/autoscaler/controllers/processor_controller.go
@@ -11,6 +11,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 type ProcessorReconciler struct {
@@ -40,9 +41,11 @@ func (r *ProcessorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	return ctrl.Result{}, nil
 }
 
-// SetupWithManager sets up the controller with the Manager.
 func (r *ProcessorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1.Processor{}).
+		// auto scaler only cares about the spec of each processor.
+		// filter out events on resource status and metadata changes.
+		WithEventFilter(&predicate.GenerationChangedPredicate{}).
 		Complete(r)
 }

--- a/autoscaler/controllers/secret_controller.go
+++ b/autoscaler/controllers/secret_controller.go
@@ -5,10 +5,10 @@ import (
 
 	controllerconfig "github.com/odigos-io/odigos/autoscaler/controllers/controller_config"
 	"github.com/odigos-io/odigos/autoscaler/controllers/gateway"
+	odigospredicate "github.com/odigos-io/odigos/k8sutils/pkg/predicate"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -23,33 +23,6 @@ type SecretReconciler struct {
 	Config           *controllerconfig.ControllerConfig
 }
 
-type secretPredicate struct {
-	predicate.Funcs
-}
-
-func (i *secretPredicate) Create(e event.CreateEvent) bool {
-	return false
-}
-
-func (i *secretPredicate) Update(e event.UpdateEvent) bool {
-	oldSecret, oldOk := e.ObjectOld.(*corev1.Secret)
-	newSecret, newOk := e.ObjectNew.(*corev1.Secret)
-
-	if !oldOk || !newOk {
-		return false
-	}
-
-	return oldSecret.ResourceVersion != newSecret.ResourceVersion
-}
-
-func (i *secretPredicate) Delete(e event.DeleteEvent) bool {
-	return false
-}
-
-func (i *secretPredicate) Generic(e event.GenericEvent) bool {
-	return false
-}
-
 func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.V(0).Info("Reconciling Secret")
@@ -62,10 +35,12 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	return ctrl.Result{}, nil
 }
 
-// SetupWithManager sets up the controller with the Manager.
 func (r *SecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Secret{}).
-		WithEventFilter(&secretPredicate{}).
+		// we need to handle secrets only when they are updated.
+		// this is to trigger redeployment of the cluster collector in case of destination secret change.
+		// when the secret was just created (via auto-scaler restart or initial deployment), the cluster collector will be reconciled by other controllers.
+		WithEventFilter(predicate.And(&odigospredicate.OnlyUpdatesPredicate{}, &predicate.ResourceVersionChangedPredicate{})).
 		Complete(r)
 }

--- a/k8sutils/pkg/predicate/objectname.go
+++ b/k8sutils/pkg/predicate/objectname.go
@@ -82,3 +82,15 @@ var OdigosCollectorsGroupNodePredicate = ObjectNamePredicate{
 var OdigosCollectorsGroupClusterPredicate = ObjectNamePredicate{
 	AllowedObjectName: odigosk8sconsts.OdigosClusterCollectorCollectorGroupName,
 }
+
+// this predicate will only allow events for the odigos node collectors daemon set object.
+// this is useful if you only want to reconcile events for the node collectors daemon set object and ignore other daemon set objects.
+var NodeCollectorsDaemonSetPredicate = ObjectNamePredicate{
+	AllowedObjectName: odigosk8sconsts.OdigosNodeCollectorDaemonSetName,
+}
+
+// this predicate will only allow events for the odigos cluster collectors daemon set object.
+// this is useful if you only want to reconcile events for the cluster collectors daemon set object and ignore other daemon set objects.
+var ClusterCollectorDeploymentPredicate = ObjectNamePredicate{
+	AllowedObjectName: odigosk8sconsts.OdigosClusterCollectorDeploymentName,
+}


### PR DESCRIPTION
This PR:

- shifts to use the common predicates in `k8sutils` over writing them specifically in the controllers.
- splits logic into smaller parts and combine them with `predicate.And` for better readability.
- adds few straight forward predicates to places where they are currently missing