### PR TITLE
Include `-0` for the min version to allow EKS versions

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -50,7 +50,7 @@ var (
 var (
 	// minK8SVersionForInstallation is the minimum Kubernetes version required for Odigos installation
 	// this value must be in sync with the one defined in the kubeVersion field in Chart.yaml
-	minK8SVersionForInstallation = version.MustParse("v1.20.15")
+	minK8SVersionForInstallation = version.MustParse("v1.20.15-0")
 )
 
 type ResourceCreationFunc func(ctx context.Context, cmd *cobra.Command, client *kube.Client, ns string) error

--- a/helm/odigos/Chart.yaml
+++ b/helm/odigos/Chart.yaml
@@ -8,4 +8,5 @@ version: "0.0.0"
 appVersion: "v0.0.0"
 icon: https://d2q89wckrml3k4.cloudfront.net/logo.png
 # minimum kubernetes version required, this value must be in sync with the CLI install value
-kubeVersion: ">= 1.20.15"
+# we must include '-0' to allow versions such as v1.23.17-eks-ce1d5eb
+kubeVersion: ">= 1.20.15-0"


### PR DESCRIPTION
For versions such as `v1.23.17-eks-ce1d5eb` we would get the following error:

> Error: chart requires kubeVersion: >= 1.20.15 which is incompatible with Kubernetes v1.23.17-eks-ce1d5eb
