### PR TITLE
Add PersistentPreRun to the root CLI cmd to set the kube client and cluster details once for all commands

### DIFF
--- a/cli/cmd/cloud.go
+++ b/cli/cmd/cloud.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/odigos-io/odigos/cli/cmd/resources"
 	"github.com/odigos-io/odigos/cli/cmd/resources/odigospro"
-	"github.com/odigos-io/odigos/cli/pkg/kube"
+	cmdcontext "github.com/odigos-io/odigos/cli/pkg/cmd_context"
 	"github.com/odigos-io/odigos/common"
 	"github.com/spf13/cobra"
 )
@@ -28,7 +28,7 @@ var cloudCmd = &cobra.Command{
 	Long:  `Used to interact with odigos managed service.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
-		client := kube.KubeClientFromContextOrExit(ctx)
+		client := cmdcontext.KubeClientFromContextOrExit(ctx)
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)
 		if resources.IsErrNoOdigosNamespaceFound(err) {

--- a/cli/cmd/cloud.go
+++ b/cli/cmd/cloud.go
@@ -27,8 +27,8 @@ var cloudCmd = &cobra.Command{
 	Short: "Manage odigos cloud",
 	Long:  `Used to interact with odigos managed service.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client := kube.GetCLIClient()
 		ctx := cmd.Context()
+		client := kube.KubeClientFromContextOrExit(ctx)
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)
 		if resources.IsErrNoOdigosNamespaceFound(err) {

--- a/cli/cmd/cloud.go
+++ b/cli/cmd/cloud.go
@@ -27,10 +27,7 @@ var cloudCmd = &cobra.Command{
 	Short: "Manage odigos cloud",
 	Long:  `Used to interact with odigos managed service.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := kube.CreateClient(cmd)
-		if err != nil {
-			kube.PrintClientErrorAndExit(err)
-		}
+		client := kube.GetCLIClient()
 		ctx := cmd.Context()
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)

--- a/cli/cmd/describe.go
+++ b/cli/cmd/describe.go
@@ -22,10 +22,7 @@ var describeCmd = &cobra.Command{
 	Long:  `Print detailed description odigos deployment, which can be used to troubleshoot issues`,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		client, err := kube.CreateClient(cmd)
-		if err != nil {
-			kube.PrintClientErrorAndExit(err)
-		}
+		client := kube.GetCLIClient()
 		ctx := cmd.Context()
 
 		odigosNs, err := resources.GetOdigosNamespace(client, ctx)
@@ -66,10 +63,7 @@ var describeSourceDeploymentCmd = &cobra.Command{
 	Aliases: []string{"deploy", "deployments", "deploy.apps", "deployment.apps", "deployments.apps"},
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := kube.CreateClient(cmd)
-		if err != nil {
-			kube.PrintClientErrorAndExit(err)
-		}
+		client := kube.GetCLIClient()
 		ctx := cmd.Context()
 		name := args[0]
 		ns := cmd.Flag("namespace").Value.String()
@@ -96,10 +90,7 @@ var describeSourceDaemonSetCmd = &cobra.Command{
 	Aliases: []string{"ds", "daemonsets", "ds.apps", "daemonset.apps", "daemonsets.apps"},
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := kube.CreateClient(cmd)
-		if err != nil {
-			kube.PrintClientErrorAndExit(err)
-		}
+		client := kube.GetCLIClient()
 
 		ctx := cmd.Context()
 		name := args[0]
@@ -127,10 +118,7 @@ var describeSourceStatefulSetCmd = &cobra.Command{
 	Aliases: []string{"sts", "statefulsets", "sts.apps", "statefulset.apps", "statefulsets.apps"},
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := kube.CreateClient(cmd)
-		if err != nil {
-			kube.PrintClientErrorAndExit(err)
-		}
+		client := kube.GetCLIClient()
 
 		ctx := cmd.Context()
 		name := args[0]

--- a/cli/cmd/describe.go
+++ b/cli/cmd/describe.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/odigos-io/odigos/cli/cmd/resources"
 	"github.com/odigos-io/odigos/cli/pkg/kube"
+	cmdcontext "github.com/odigos-io/odigos/cli/pkg/cmd_context"
 	"github.com/odigos-io/odigos/k8sutils/pkg/describe"
 	"github.com/spf13/cobra"
 )
@@ -22,7 +23,7 @@ var describeCmd = &cobra.Command{
 	Long:  `Print detailed description odigos deployment, which can be used to troubleshoot issues`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
-		client := kube.KubeClientFromContextOrExit(ctx)
+		client := cmdcontext.KubeClientFromContextOrExit(ctx)
 
 		odigosNs, err := resources.GetOdigosNamespace(client, ctx)
 		if err != nil {
@@ -63,7 +64,7 @@ var describeSourceDeploymentCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
-		client := kube.KubeClientFromContextOrExit(ctx)
+		client := cmdcontext.KubeClientFromContextOrExit(ctx)
 
 		name := args[0]
 		ns := cmd.Flag("namespace").Value.String()
@@ -91,7 +92,7 @@ var describeSourceDaemonSetCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
-		client := kube.KubeClientFromContextOrExit(ctx)
+		client := cmdcontext.KubeClientFromContextOrExit(ctx)
 
 		name := args[0]
 		ns := cmd.Flag("namespace").Value.String()
@@ -119,7 +120,7 @@ var describeSourceStatefulSetCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
-		client := kube.KubeClientFromContextOrExit(ctx)
+		client := cmdcontext.KubeClientFromContextOrExit(ctx)
 
 		name := args[0]
 		ns := cmd.Flag("namespace").Value.String()

--- a/cli/cmd/describe.go
+++ b/cli/cmd/describe.go
@@ -21,9 +21,8 @@ var describeCmd = &cobra.Command{
 	Short: "Show details on odigos deployment",
 	Long:  `Print detailed description odigos deployment, which can be used to troubleshoot issues`,
 	Run: func(cmd *cobra.Command, args []string) {
-
-		client := kube.GetCLIClient()
 		ctx := cmd.Context()
+		client := kube.KubeClientFromContextOrExit(ctx)
 
 		odigosNs, err := resources.GetOdigosNamespace(client, ctx)
 		if err != nil {
@@ -63,8 +62,9 @@ var describeSourceDeploymentCmd = &cobra.Command{
 	Aliases: []string{"deploy", "deployments", "deploy.apps", "deployment.apps", "deployments.apps"},
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := kube.GetCLIClient()
 		ctx := cmd.Context()
+		client := kube.KubeClientFromContextOrExit(ctx)
+
 		name := args[0]
 		ns := cmd.Flag("namespace").Value.String()
 
@@ -90,9 +90,9 @@ var describeSourceDaemonSetCmd = &cobra.Command{
 	Aliases: []string{"ds", "daemonsets", "ds.apps", "daemonset.apps", "daemonsets.apps"},
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := kube.GetCLIClient()
-
 		ctx := cmd.Context()
+		client := kube.KubeClientFromContextOrExit(ctx)
+
 		name := args[0]
 		ns := cmd.Flag("namespace").Value.String()
 
@@ -118,9 +118,9 @@ var describeSourceStatefulSetCmd = &cobra.Command{
 	Aliases: []string{"sts", "statefulsets", "sts.apps", "statefulset.apps", "statefulsets.apps"},
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := kube.GetCLIClient()
-
 		ctx := cmd.Context()
+		client := kube.KubeClientFromContextOrExit(ctx)
+
 		name := args[0]
 		ns := cmd.Flag("namespace").Value.String()
 

--- a/cli/cmd/diagnose.go
+++ b/cli/cmd/diagnose.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"github.com/odigos-io/odigos/cli/cmd/diagnose_util"
 	"github.com/odigos-io/odigos/cli/pkg/kube"
+	cmdcontext "github.com/odigos-io/odigos/cli/pkg/cmd_context"
 	"github.com/spf13/cobra"
 	"io"
 	"os"
@@ -32,7 +33,7 @@ var diagnoseCmd = &cobra.Command{
 	Long:  `Diagnose Client Cluster to identify issues and resolve them. This command is useful for troubleshooting and debugging.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
-		client := kube.KubeClientFromContextOrExit(ctx)
+		client := cmdcontext.KubeClientFromContextOrExit(ctx)
 
 		err := startDiagnose(ctx, client)
 		if err != nil {

--- a/cli/cmd/diagnose.go
+++ b/cli/cmd/diagnose.go
@@ -32,12 +32,9 @@ var diagnoseCmd = &cobra.Command{
 	Long:  `Diagnose Client Cluster to identify issues and resolve them. This command is useful for troubleshooting and debugging.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
-		client, err := kube.CreateClient(cmd)
-		if err != nil {
-			kube.PrintClientErrorAndExit(err)
-		}
+		client := kube.GetCLIClient()
 
-		err = startDiagnose(ctx, client)
+		err := startDiagnose(ctx, client)
 		if err != nil {
 			fmt.Printf("The diagnose script crashed on: %v\n", err)
 		}

--- a/cli/cmd/diagnose.go
+++ b/cli/cmd/diagnose.go
@@ -32,7 +32,7 @@ var diagnoseCmd = &cobra.Command{
 	Long:  `Diagnose Client Cluster to identify issues and resolve them. This command is useful for troubleshooting and debugging.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
-		client := kube.GetCLIClient()
+		client := kube.KubeClientFromContextOrExit(ctx)
 
 		err := startDiagnose(ctx, client)
 		if err != nil {

--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -46,8 +46,8 @@ func restartPodsAfterCloudLogin(ctx context.Context, client *kube.Client, ns str
 
 // both login and update trigger this function.
 func updateApiKey(cmd *cobra.Command, args []string) {
-	client := kube.GetCLIClient()
 	ctx := cmd.Context()
+	client := kube.KubeClientFromContextOrExit(ctx)
 
 	ns, err := resources.GetOdigosNamespace(client, ctx)
 	if resources.IsErrNoOdigosNamespaceFound(err) {

--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -46,10 +46,7 @@ func restartPodsAfterCloudLogin(ctx context.Context, client *kube.Client, ns str
 
 // both login and update trigger this function.
 func updateApiKey(cmd *cobra.Command, args []string) {
-	client, err := kube.CreateClient(cmd)
-	if err != nil {
-		kube.PrintClientErrorAndExit(err)
-	}
+	client := kube.GetCLIClient()
 	ctx := cmd.Context()
 
 	ns, err := resources.GetOdigosNamespace(client, ctx)

--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/odigos-io/odigos/cli/cmd/resources"
 	"github.com/odigos-io/odigos/cli/cmd/resources/odigospro"
+	cmdcontext "github.com/odigos-io/odigos/cli/pkg/cmd_context"
 	"github.com/odigos-io/odigos/cli/pkg/kube"
 	"github.com/odigos-io/odigos/cli/pkg/labels"
 	"github.com/odigos-io/odigos/cli/pkg/log"
@@ -47,7 +48,7 @@ func restartPodsAfterCloudLogin(ctx context.Context, client *kube.Client, ns str
 // both login and update trigger this function.
 func updateApiKey(cmd *cobra.Command, args []string) {
 	ctx := cmd.Context()
-	client := kube.KubeClientFromContextOrExit(ctx)
+	client := cmdcontext.KubeClientFromContextOrExit(ctx)
 
 	ns, err := resources.GetOdigosNamespace(client, ctx)
 	if resources.IsErrNoOdigosNamespaceFound(err) {

--- a/cli/cmd/logout.go
+++ b/cli/cmd/logout.go
@@ -23,8 +23,8 @@ var logoutCmd = &cobra.Command{
 	You can run 'odigos ui' to manage your Odigos installation locally.
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client := kube.GetCLIClient()
 		ctx := cmd.Context()
+		client := kube.KubeClientFromContextOrExit(ctx)
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)
 		if resources.IsErrNoOdigosNamespaceFound(err) {

--- a/cli/cmd/logout.go
+++ b/cli/cmd/logout.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/odigos-io/odigos/cli/cmd/resources"
 	"github.com/odigos-io/odigos/cli/cmd/resources/odigospro"
+	cmdcontext "github.com/odigos-io/odigos/cli/pkg/cmd_context"
 	"github.com/odigos-io/odigos/cli/pkg/confirm"
-	"github.com/odigos-io/odigos/cli/pkg/kube"
 	"github.com/odigos-io/odigos/common"
 	"github.com/odigos-io/odigos/k8sutils/pkg/getters"
 	"github.com/spf13/cobra"
@@ -24,7 +24,7 @@ var logoutCmd = &cobra.Command{
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
-		client := kube.KubeClientFromContextOrExit(ctx)
+		client := cmdcontext.KubeClientFromContextOrExit(ctx)
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)
 		if resources.IsErrNoOdigosNamespaceFound(err) {

--- a/cli/cmd/logout.go
+++ b/cli/cmd/logout.go
@@ -23,10 +23,7 @@ var logoutCmd = &cobra.Command{
 	You can run 'odigos ui' to manage your Odigos installation locally.
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := kube.CreateClient(cmd)
-		if err != nil {
-			kube.PrintClientErrorAndExit(err)
-		}
+		client := kube.GetCLIClient()
 		ctx := cmd.Context()
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)

--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -17,10 +17,7 @@ var profileCmd = &cobra.Command{
 	Short: "Manage odigos profiles",
 	Long:  `Odigos profiles are used to apply some specific preset configuration to the odigos installation`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := kube.CreateClient(cmd)
-		if err != nil {
-			kube.PrintClientErrorAndExit(err)
-		}
+		client := kube.GetCLIClient()
 		ctx := cmd.Context()
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)
@@ -78,10 +75,7 @@ var addProfileCmd = &cobra.Command{
 	Long:  `Add a profile by its name to the current Odigos installation.`,
 	Args:  cobra.ExactArgs(1), // Ensure exactly one argument is passed (the profile name)
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := kube.CreateClient(cmd)
-		if err != nil {
-			kube.PrintClientErrorAndExit(err)
-		}
+		client := kube.GetCLIClient()
 		ctx := cmd.Context()
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)
@@ -164,10 +158,7 @@ var removeProfileCmd = &cobra.Command{
 	Long:  `Remove a profile by its name from the current Odigos installation.`,
 	Args:  cobra.ExactArgs(1), // Ensure exactly one argument is passed (the profile name)
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := kube.CreateClient(cmd)
-		if err != nil {
-			kube.PrintClientErrorAndExit(err)
-		}
+		client := kube.GetCLIClient()
 		ctx := cmd.Context()
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)

--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/odigos-io/odigos/cli/cmd/resources"
 	"github.com/odigos-io/odigos/cli/cmd/resources/odigospro"
-	"github.com/odigos-io/odigos/cli/pkg/kube"
+	cmdcontext "github.com/odigos-io/odigos/cli/pkg/cmd_context"
 	"github.com/odigos-io/odigos/common"
 	"github.com/odigos-io/odigos/k8sutils/pkg/getters"
 	"github.com/spf13/cobra"
@@ -18,7 +18,7 @@ var profileCmd = &cobra.Command{
 	Long:  `Odigos profiles are used to apply some specific preset configuration to the odigos installation`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
-		client := kube.KubeClientFromContextOrExit(ctx)
+		client := cmdcontext.KubeClientFromContextOrExit(ctx)
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)
 		if resources.IsErrNoOdigosNamespaceFound(err) {
@@ -76,7 +76,7 @@ var addProfileCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1), // Ensure exactly one argument is passed (the profile name)
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
-		client := kube.KubeClientFromContextOrExit(ctx)
+		client := cmdcontext.KubeClientFromContextOrExit(ctx)
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)
 		if resources.IsErrNoOdigosNamespaceFound(err) {
@@ -159,7 +159,7 @@ var removeProfileCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1), // Ensure exactly one argument is passed (the profile name)
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
-		client := kube.KubeClientFromContextOrExit(ctx)
+		client := cmdcontext.KubeClientFromContextOrExit(ctx)
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)
 		if resources.IsErrNoOdigosNamespaceFound(err) {

--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -17,8 +17,8 @@ var profileCmd = &cobra.Command{
 	Short: "Manage odigos profiles",
 	Long:  `Odigos profiles are used to apply some specific preset configuration to the odigos installation`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client := kube.GetCLIClient()
 		ctx := cmd.Context()
+		client := kube.KubeClientFromContextOrExit(ctx)
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)
 		if resources.IsErrNoOdigosNamespaceFound(err) {
@@ -75,8 +75,8 @@ var addProfileCmd = &cobra.Command{
 	Long:  `Add a profile by its name to the current Odigos installation.`,
 	Args:  cobra.ExactArgs(1), // Ensure exactly one argument is passed (the profile name)
 	Run: func(cmd *cobra.Command, args []string) {
-		client := kube.GetCLIClient()
 		ctx := cmd.Context()
+		client := kube.KubeClientFromContextOrExit(ctx)
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)
 		if resources.IsErrNoOdigosNamespaceFound(err) {
@@ -158,8 +158,8 @@ var removeProfileCmd = &cobra.Command{
 	Long:  `Remove a profile by its name from the current Odigos installation.`,
 	Args:  cobra.ExactArgs(1), // Ensure exactly one argument is passed (the profile name)
 	Run: func(cmd *cobra.Command, args []string) {
-		client := kube.GetCLIClient()
 		ctx := cmd.Context()
+		client := kube.KubeClientFromContextOrExit(ctx)
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)
 		if resources.IsErrNoOdigosNamespaceFound(err) {

--- a/cli/cmd/resources/applyresources.go
+++ b/cli/cmd/resources/applyresources.go
@@ -7,12 +7,11 @@ import (
 
 	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/cli/cmd/resources/resourcemanager"
-	"github.com/odigos-io/odigos/cli/pkg/autodetect"
+	cmdcontext "github.com/odigos-io/odigos/cli/pkg/cmd_context"
 	"github.com/odigos-io/odigos/cli/pkg/kube"
 	"github.com/odigos-io/odigos/cli/pkg/log"
 	"github.com/odigos-io/odigos/common"
 	"github.com/odigos-io/odigos/common/consts"
-	k8sconsts "github.com/odigos-io/odigos/k8sutils/pkg/consts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 )
@@ -32,10 +31,7 @@ func ApplyResourceManagers(ctx context.Context, client *kube.Client, resourceMan
 
 func DeleteOldOdigosSystemObjects(ctx context.Context, client *kube.Client, ns string, config *common.OdigosConfiguration) error {
 	resources := kube.GetManagedResources(ns)
-	k8sVersion := autodetect.GetK8SVersion()
-	if k8sVersion == nil {
-		fmt.Printf("Unknown k8s version, assuming oldest supported version: %s\n", k8sconsts.MinK8SVersionForInstallation)
-	}
+	k8sVersion := cmdcontext.K8SVersionFromContext(ctx)
 	for _, resource := range resources {
 		l := log.Print(fmt.Sprintf("Syncing %s", resource.Resource.Resource))
 		err := client.DeleteOldOdigosSystemObjects(ctx, resource, config.ConfigVersion, k8sVersion)

--- a/cli/cmd/resources/applyresources.go
+++ b/cli/cmd/resources/applyresources.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/cli/cmd/resources/resourcemanager"
+	"github.com/odigos-io/odigos/cli/pkg/autodetect"
 	"github.com/odigos-io/odigos/cli/pkg/kube"
 	"github.com/odigos-io/odigos/cli/pkg/log"
 	"github.com/odigos-io/odigos/common"
@@ -32,7 +33,7 @@ func DeleteOldOdigosSystemObjects(ctx context.Context, client *kube.Client, ns s
 	resources := kube.GetManagedResources(ns)
 	for _, resource := range resources {
 		l := log.Print(fmt.Sprintf("Syncing %s", resource.Resource.Resource))
-		err := client.DeleteOldOdigosSystemObjects(ctx, resource, config.ConfigVersion)
+		err := client.DeleteOldOdigosSystemObjects(ctx, resource, config.ConfigVersion, autodetect.GetK8SVersion())
 		if err != nil {
 			l.Error(err)
 			os.Exit(1)

--- a/cli/cmd/resources/applyresources.go
+++ b/cli/cmd/resources/applyresources.go
@@ -12,6 +12,7 @@ import (
 	"github.com/odigos-io/odigos/cli/pkg/log"
 	"github.com/odigos-io/odigos/common"
 	"github.com/odigos-io/odigos/common/consts"
+	k8sconsts "github.com/odigos-io/odigos/k8sutils/pkg/consts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 )
@@ -31,9 +32,13 @@ func ApplyResourceManagers(ctx context.Context, client *kube.Client, resourceMan
 
 func DeleteOldOdigosSystemObjects(ctx context.Context, client *kube.Client, ns string, config *common.OdigosConfiguration) error {
 	resources := kube.GetManagedResources(ns)
+	k8sVersion := autodetect.GetK8SVersion()
+	if k8sVersion == nil {
+		fmt.Printf("Unknown k8s version, assuming oldest supported version: %s\n", k8sconsts.MinK8SVersionForInstallation)
+	}
 	for _, resource := range resources {
 		l := log.Print(fmt.Sprintf("Syncing %s", resource.Resource.Resource))
-		err := client.DeleteOldOdigosSystemObjects(ctx, resource, config.ConfigVersion, autodetect.GetK8SVersion())
+		err := client.DeleteOldOdigosSystemObjects(ctx, resource, config.ConfigVersion, k8sVersion)
 		if err != nil {
 			l.Error(err)
 			os.Exit(1)

--- a/cli/cmd/resources/odiglet.go
+++ b/cli/cmd/resources/odiglet.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/odigos-io/odigos/cli/pkg/autodetect"
+	cmdcontext "github.com/odigos-io/odigos/cli/pkg/cmd_context"
 
 	"github.com/odigos-io/odigos/cli/cmd/resources/odigospro"
 	"github.com/odigos-io/odigos/cli/cmd/resources/resourcemanager"
@@ -416,7 +417,7 @@ func NewResourceQuota(ns string) *corev1.ResourceQuota {
 	}
 }
 
-func NewOdigletDaemonSet(ns string, version string, imagePrefix string, imageName string, odigosTier common.OdigosTier, openshiftEnabled bool, goAutoIncludeCodeAttributes bool) *appsv1.DaemonSet {
+func NewOdigletDaemonSet(ns string, version string, imagePrefix string, imageName string, odigosTier common.OdigosTier, openshiftEnabled bool, goAutoIncludeCodeAttributes bool, clusterDetails *autodetect.ClusterDetails) *appsv1.DaemonSet {
 
 	dynamicEnv := []corev1.EnvVar{}
 	if odigosTier == common.CloudOdigosTier {
@@ -434,7 +435,7 @@ func NewOdigletDaemonSet(ns string, version string, imagePrefix string, imageNam
 
 	odigosSeLinuxHostVolumes := []corev1.Volume{}
 	odigosSeLinuxHostVolumeMounts := []corev1.VolumeMount{}
-	if openshiftEnabled || autodetect.GetClusterKind() == autodetect.KindOpenShift {
+	if openshiftEnabled || clusterDetails.Kind == autodetect.KindOpenShift {
 		odigosSeLinuxHostVolumes = append(odigosSeLinuxHostVolumes, selinuxHostVolumes()...)
 		odigosSeLinuxHostVolumeMounts = append(odigosSeLinuxHostVolumeMounts, selinuxHostVolumeMounts()...)
 	}
@@ -452,7 +453,7 @@ func NewOdigletDaemonSet(ns string, version string, imagePrefix string, imageNam
 	rollingUpdate := &appsv1.RollingUpdateDaemonSet{
 		MaxUnavailable: &maxUnavailable,
 	}
-	k8sversionInCluster := autodetect.GetK8SVersion()
+	k8sversionInCluster := clusterDetails.K8SVersion
 	if k8sversionInCluster != nil && k8sversionInCluster.AtLeast(k8sversion.MustParse("v1.22")) {
 		maxSurge := intstr.FromInt(0)
 		rollingUpdate.MaxSurge = &maxSurge
@@ -726,14 +727,16 @@ func (a *odigletResourceManager) InstallFromScratch(ctx context.Context) error {
 		NewOdigletClusterRoleBinding(a.ns),
 	}
 
+	clusterKind := cmdcontext.ClusterKindFromContext(ctx)
+
 	// if openshift is enabled, we need to create additional SCC cluster role binding first
-	if a.config.OpenshiftEnabled || autodetect.GetClusterKind() == autodetect.KindOpenShift {
+	if a.config.OpenshiftEnabled || clusterKind == autodetect.KindOpenShift {
 		resources = append(resources, NewSCCRoleBinding(a.ns))
 		resources = append(resources, NewSCClusterRoleBinding(a.ns))
 	}
 
 	// if gke, create resource quota
-	if autodetect.GetClusterKind() == autodetect.KindGKE {
+	if clusterKind == autodetect.KindGKE {
 		resources = append(resources, NewResourceQuota(a.ns))
 	}
 
@@ -748,7 +751,11 @@ func (a *odigletResourceManager) InstallFromScratch(ctx context.Context) error {
 
 	// before creating the daemonset, we need to create the service account, cluster role and cluster role binding
 	resources = append(resources,
-		NewOdigletDaemonSet(a.ns, a.odigosVersion, a.config.ImagePrefix, odigletImage, a.odigosTier, a.config.OpenshiftEnabled, goAutoIncludeCodeAttributes))
+		NewOdigletDaemonSet(a.ns, a.odigosVersion, a.config.ImagePrefix, odigletImage, a.odigosTier, a.config.OpenshiftEnabled, goAutoIncludeCodeAttributes,
+			&autodetect.ClusterDetails{
+				Kind:       clusterKind,
+				K8SVersion: cmdcontext.K8SVersionFromContext(ctx),
+			}))
 
 	return a.client.ApplyResources(ctx, a.config.ConfigVersion, resources)
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -23,8 +23,11 @@ Key Features of Odigos:
 
 Get started with Odigos today to effortlessly improve the observability of your Kubernetes services!`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		client := kube.SetCLIClientOrExit(cmd)
-		autodetect.SetK8SClusterDetails(cmd.Context(), kubeConfig, client)
+		client := kube.GetCLIClientOrExit(cmd)
+		ctx := cmd.Context()
+		autodetect.SetK8SClusterDetails(ctx, kubeConfig, client)
+		ctx = kube.ContextWithKubeClient(ctx, client)
+		cmd.SetContext(ctx)
 	},
 }
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/odigos-io/odigos/cli/pkg/autodetect"
+	cmdcontext "github.com/odigos-io/odigos/cli/pkg/cmd_context"
 	"github.com/odigos-io/odigos/cli/pkg/kube"
 	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	"github.com/spf13/cobra"
@@ -23,10 +24,14 @@ Key Features of Odigos:
 
 Get started with Odigos today to effortlessly improve the observability of your Kubernetes services!`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		client := kube.GetCLIClientOrExit(cmd)
 		ctx := cmd.Context()
-		autodetect.SetK8SClusterDetails(ctx, kubeConfig, client)
-		ctx = kube.ContextWithKubeClient(ctx, client)
+
+		client := kube.GetCLIClientOrExit(cmd)
+		ctx = cmdcontext.ContextWithKubeClient(ctx, client)
+
+		details := autodetect.GetK8SClusterDetails(ctx, kubeConfig, client)
+		ctx = cmdcontext.ContextWithClusterDetails(ctx, details)
+
 		cmd.SetContext(ctx)
 	},
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"os"
 
+	"github.com/odigos-io/odigos/cli/pkg/autodetect"
+	"github.com/odigos-io/odigos/cli/pkg/kube"
 	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	"github.com/spf13/cobra"
 )
@@ -20,9 +22,10 @@ Key Features of Odigos:
 - Streamlined Kubernetes operations with observability at the forefront.
 
 Get started with Odigos today to effortlessly improve the observability of your Kubernetes services!`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	// Run: func(cmd *cobra.Command, args []string) { },
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		client := kube.SetCLIClientOrExit(cmd)
+		autodetect.SetK8SClusterDetails(cmd.Context(), kubeConfig, client)
+	},
 }
 
 var (

--- a/cli/cmd/ui.go
+++ b/cli/cmd/ui.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/odigos-io/odigos/cli/cmd/resources"
+	cmdcontext "github.com/odigos-io/odigos/cli/pkg/cmd_context"
 	"github.com/odigos-io/odigos/cli/pkg/kube"
 	corev1 "k8s.io/api/core/v1"
 
@@ -35,7 +36,7 @@ var uiCmd = &cobra.Command{
 	Long:  `Start the Odigos UI. This command will port-forward the odigos-ui pod to your local machine.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
-		client := kube.KubeClientFromContextOrExit(ctx)
+		client := cmdcontext.KubeClientFromContextOrExit(ctx)
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)
 		if err != nil {

--- a/cli/cmd/ui.go
+++ b/cli/cmd/ui.go
@@ -35,7 +35,7 @@ var uiCmd = &cobra.Command{
 	Long:  `Start the Odigos UI. This command will port-forward the odigos-ui pod to your local machine.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
-		client := kube.GetCLIClient()
+		client := kube.KubeClientFromContextOrExit(ctx)
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)
 		if err != nil {

--- a/cli/cmd/ui.go
+++ b/cli/cmd/ui.go
@@ -35,10 +35,7 @@ var uiCmd = &cobra.Command{
 	Long:  `Start the Odigos UI. This command will port-forward the odigos-ui pod to your local machine.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
-		client, err := kube.CreateClient(cmd)
-		if err != nil {
-			kube.PrintClientErrorAndExit(err)
-		}
+		client := kube.GetCLIClient()
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)
 		if err != nil {

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -32,8 +32,8 @@ var uninstallCmd = &cobra.Command{
 	Use:   "uninstall",
 	Short: "Unistall Odigos from your cluster",
 	Run: func(cmd *cobra.Command, args []string) {
-		client := kube.GetCLIClient()
 		ctx := cmd.Context()
+		client := kube.KubeClientFromContextOrExit(ctx)
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)
 		if err != nil && !resources.IsErrNoOdigosNamespaceFound(err) {

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -11,6 +11,7 @@ import (
 	"github.com/odigos-io/odigos/k8sutils/pkg/envoverwrite"
 
 	"github.com/odigos-io/odigos/cli/cmd/resources"
+	cmdcontext "github.com/odigos-io/odigos/cli/pkg/cmd_context"
 	"github.com/odigos-io/odigos/cli/pkg/confirm"
 	"github.com/odigos-io/odigos/cli/pkg/kube"
 	"github.com/odigos-io/odigos/cli/pkg/labels"
@@ -33,7 +34,7 @@ var uninstallCmd = &cobra.Command{
 	Short: "Unistall Odigos from your cluster",
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
-		client := kube.KubeClientFromContextOrExit(ctx)
+		client := cmdcontext.KubeClientFromContextOrExit(ctx)
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)
 		if err != nil && !resources.IsErrNoOdigosNamespaceFound(err) {

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -32,12 +32,7 @@ var uninstallCmd = &cobra.Command{
 	Use:   "uninstall",
 	Short: "Unistall Odigos from your cluster",
 	Run: func(cmd *cobra.Command, args []string) {
-		client, err := kube.CreateClient(cmd)
-
-		if err != nil {
-			kube.PrintClientErrorAndExit(err)
-		}
-
+		client := kube.GetCLIClient()
 		ctx := cmd.Context()
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -30,11 +30,7 @@ var upgradeCmd = &cobra.Command{
 This command will upgrade the Odigos version in the cluster to the version of Odigos CLI
 and apply any required migrations and adaptations.`,
 	Run: func(cmd *cobra.Command, args []string) {
-
-		client, err := kube.CreateClient(cmd)
-		if err != nil {
-			kube.PrintClientErrorAndExit(err)
-		}
+		client := kube.GetCLIClient()
 		ctx := cmd.Context()
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -30,8 +30,8 @@ var upgradeCmd = &cobra.Command{
 This command will upgrade the Odigos version in the cluster to the version of Odigos CLI
 and apply any required migrations and adaptations.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		client := kube.GetCLIClient()
 		ctx := cmd.Context()
+		client := kube.KubeClientFromContextOrExit(ctx)
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)
 		if err != nil {

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/odigos-io/odigos/cli/cmd/resources"
 	"github.com/odigos-io/odigos/cli/cmd/resources/odigospro"
+	cmdcontext "github.com/odigos-io/odigos/cli/pkg/cmd_context"
 	"github.com/odigos-io/odigos/cli/pkg/confirm"
-	"github.com/odigos-io/odigos/cli/pkg/kube"
 	"github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/common/utils"
 	k8sconsts "github.com/odigos-io/odigos/k8sutils/pkg/consts"
@@ -31,7 +31,7 @@ This command will upgrade the Odigos version in the cluster to the version of Od
 and apply any required migrations and adaptations.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
-		client := kube.KubeClientFromContextOrExit(ctx)
+		client := cmdcontext.KubeClientFromContextOrExit(ctx)
 
 		ns, err := resources.GetOdigosNamespace(client, ctx)
 		if err != nil {

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/odigos-io/odigos/cli/cmd/resources"
+	cmdcontext "github.com/odigos-io/odigos/cli/pkg/cmd_context"
 	"github.com/odigos-io/odigos/cli/pkg/kube"
 	"github.com/odigos-io/odigos/k8sutils/pkg/getters"
 	"github.com/spf13/cobra"
@@ -67,7 +68,7 @@ func getOdigosVersionInCluster(cmd *cobra.Command) (string, error) {
 
 func getOdigosKubeClientAndNamespace(cmd *cobra.Command) (*kube.Client, string, error) {
 	ctx := cmd.Context()
-	client := kube.KubeClientFromContextOrExit(ctx)
+	client := cmdcontext.KubeClientFromContextOrExit(ctx)
 
 	ns, err := resources.GetOdigosNamespace(client, ctx)
 	if err != nil {

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -66,10 +66,7 @@ func getOdigosVersionInCluster(cmd *cobra.Command) (string, error) {
 }
 
 func getOdigosKubeClientAndNamespace(cmd *cobra.Command) (*kube.Client, string, error) {
-	client, err := kube.CreateClient(cmd)
-	if err != nil {
-		return nil, "", err
-	}
+	client := kube.GetCLIClient()
 	ctx := cmd.Context()
 
 	ns, err := resources.GetOdigosNamespace(client, ctx)

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -66,8 +66,8 @@ func getOdigosVersionInCluster(cmd *cobra.Command) (string, error) {
 }
 
 func getOdigosKubeClientAndNamespace(cmd *cobra.Command) (*kube.Client, string, error) {
-	client := kube.GetCLIClient()
 	ctx := cmd.Context()
+	client := kube.KubeClientFromContextOrExit(ctx)
 
 	ns, err := resources.GetOdigosNamespace(client, ctx)
 	if err != nil {

--- a/cli/pkg/cmd_context/client.go
+++ b/cli/pkg/cmd_context/client.go
@@ -1,0 +1,44 @@
+package cmdcontext
+
+import (
+	"context"
+	"errors"
+
+	"github.com/odigos-io/odigos/cli/pkg/kube"
+)
+
+var (
+	ErrCtxIsNil = errors.New("context is nil when trying to get kube client")
+	ErrCtxWithoutKubeClient = errors.New("context does not contain kube client")
+)
+
+type kubeClientContextKeyType int
+
+const currentClientKey kubeClientContextKeyType = iota
+
+// ContextWithKubeClient returns a copy of parent with kubeClient set as the current client.
+func ContextWithKubeClient(parent context.Context, kubeClient *kube.Client) context.Context {
+	return context.WithValue(parent, currentClientKey, kubeClient)
+}
+
+// KubeClientFromContextOrExit returns the current kube client from ctx.
+//
+// If no client is currently set in ctx the program will exit with an error message.
+func KubeClientFromContextOrExit(ctx context.Context) *kube.Client {
+	client, err := KubeClientFromContext(ctx)
+	if err != nil {
+		kube.PrintClientErrorAndExit(err)
+	}
+	return client
+}
+
+// KubeClientFromContext returns the current kube client from ctx.
+func KubeClientFromContext(ctx context.Context) (*kube.Client, error) {
+	if ctx == nil {
+		return nil, ErrCtxIsNil
+	}
+	if client, ok := ctx.Value(currentClientKey).(*kube.Client); ok {
+		return client, nil
+	}
+	return nil, ErrCtxWithoutKubeClient
+}

--- a/cli/pkg/cmd_context/cluster_info.go
+++ b/cli/pkg/cmd_context/cluster_info.go
@@ -1,0 +1,66 @@
+package cmdcontext
+
+import (
+	"context"
+	"errors"
+
+	"k8s.io/apimachinery/pkg/util/version"
+
+	"github.com/odigos-io/odigos/cli/pkg/autodetect"
+	"github.com/odigos-io/odigos/cli/pkg/kube"
+)
+
+var (
+	ErrCtxWithoutClusterDetails = errors.New("context does not contain cluster info")
+)
+
+type clusterDetailsContextKeyType int
+
+const currentClusterDetailsKey clusterDetailsContextKeyType = iota
+
+// ContextWithClusterDetails returns a copy of parent with ClusterDetails set as the current details.
+func ContextWithClusterDetails(parent context.Context, clusterDetails *autodetect.ClusterDetails) context.Context {
+	return context.WithValue(parent, currentClusterDetailsKey, clusterDetails)
+}
+
+// ClusterDetailsFromContextOrExit returns the current cluster details from ctx.
+//
+// If no details are currently set in ctx the program will exit with an error message.
+func ClusterDetailsFromContextOrExit(ctx context.Context)  *autodetect.ClusterDetails {
+	details, err := ClusterDetailsFromContext(ctx)
+	if err != nil {
+		kube.PrintClientErrorAndExit(err)
+	}
+	return details
+}
+
+// ClusterDetailsFromContext returns the current cluster details from ctx.
+func ClusterDetailsFromContext(ctx context.Context) ( *autodetect.ClusterDetails, error) {
+	if ctx == nil {
+		return nil, ErrCtxIsNil
+	}
+	if details, ok := ctx.Value(currentClusterDetailsKey).( *autodetect.ClusterDetails); ok {
+		return details, nil
+	}
+	return nil, ErrCtxWithoutClusterDetails
+}
+
+// ClusterKindFromContext returns the current cluster kind from ctx.
+// If no kind is currently set in ctx, it returns autodetect.KindUnknown
+func ClusterKindFromContext(ctx context.Context) autodetect.Kind {
+	details, err := ClusterDetailsFromContext(ctx)
+	if err != nil {
+		return autodetect.KindUnknown
+	}
+	return details.Kind
+}
+
+// K8SVersionFromContext returns the current k8s version from ctx.
+// If no version is currently set in ctx, it returns nil
+func K8SVersionFromContext(ctx context.Context) *version.Version {
+	details, err := ClusterDetailsFromContext(ctx)
+	if err != nil {
+		return nil
+	}
+	return details.K8SVersion
+}

--- a/cli/pkg/kube/client.go
+++ b/cli/pkg/kube/client.go
@@ -2,7 +2,6 @@ package kube
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -45,39 +44,10 @@ type Object interface {
 	runtime.Object
 }
 
-type kubeClientContextKeyType int
-
-const currentClientKey kubeClientContextKeyType = iota
-
-// ContextWithKubeClient returns a copy of parent with kubeClient set as the current client.
-func ContextWithKubeClient(parent context.Context, kubeClient *Client) context.Context {
-	return context.WithValue(parent, currentClientKey, kubeClient)
-}
-
-// KubeClientFromContextOrExit returns the current kube client from ctx.
-//
-// If no client is currently set in ctx the program will exit with an error message.
-func KubeClientFromContextOrExit(ctx context.Context) *Client {
-	if ctx == nil {
-		PrintClientErrorAndExit(errors.New("context is nil when trying to get kube client"))
-		return nil
-	}
-	if client, ok := ctx.Value(currentClientKey).(*Client); ok {
-		return client
-	}
-	PrintClientErrorAndExit(errors.New("context does not contain kube client"))
-	return nil
-}
-
 // GetCLIClientOrExit returns the current kube client from cmd.Context() if one exists.
 // otherwise it creates a new client and returns it.
 func GetCLIClientOrExit(cmd *cobra.Command) *Client {
-	cmdCtx := cmd.Context()
-	if cmdCtx != nil {
-		if client, ok := cmdCtx.Value(currentClientKey).(*Client); ok {
-			return client
-		}
-	}
+	// we can check the cmd context for client, but currently avoiding that due to circular dependencies
 	client, err := createClient(cmd)
 	if err != nil {
 		PrintClientErrorAndExit(err)

--- a/k8sutils/pkg/consts/consts.go
+++ b/k8sutils/pkg/consts/consts.go
@@ -1,5 +1,7 @@
 package consts
 
+import "k8s.io/apimachinery/pkg/util/version"
+
 type CollectorRole string
 
 const (
@@ -49,3 +51,9 @@ func OdigosInjectedEnvVars() []string {
 		OdigosEnvVarPodName,
 	}
 }
+
+var (
+	// MinK8SVersionForInstallation is the minimum Kubernetes version required for Odigos installation
+	// this value must be in sync with the one defined in the kubeVersion field in Chart.yaml
+	MinK8SVersionForInstallation = version.MustParse("v1.20.15-0")
+)


### PR DESCRIPTION
Add `PersistentPreRun` which will be inherited by all sub-commands of the root command.
Perform a client initialzation in that function and set the cluster kind and k8s version as well - so they can be used by all commands. Both the kube client and the cluster details are set on the command context and can be used by all the commands.
The helper function from k8sutils `GetKubernetesVersion` can't be used outside of the cluster by the CLI since it as using a rest client which states:

> // InClusterConfig returns a config object which uses the service account
// kubernetes gives to pods. It's intended for clients that expect to be
// running inside a pod running on kubernetes. It will return ErrNotInCluster
// if called from a process not running in a kubernetes environment.
func InClusterConfig() (*Config, error) {

Hence, removing the use of this function from the CLI, and using the k8s version which was calculated in the `PersistentPreRun` function.
Before this change `odigos upgrade` resulted in errors such as:

> Syncing customresourcedefinitionsDeleteOldOdigosSystemObjects failed to get k8s version, proceeding.. :unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined                 ✔
Syncing deploymentsDeleteOldOdigosSystemObjects failed to get k8s version, proceeding.. :unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined                               ✔
Syncing daemonsetsDeleteOldOdigosSystemObjects failed to get k8s version, proceeding.. :unable to load in-cluster 