### PR TITLE
feat: enable webhook also for enterprise

### DIFF
--- a/instrumentor/instrumentation/instrumentation.go
+++ b/instrumentor/instrumentation/instrumentation.go
@@ -11,7 +11,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/odigos-io/odigos/common"
-	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	"github.com/odigos-io/odigos/k8sutils/pkg/envoverwrite"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -268,15 +267,11 @@ func patchEnvVarsForContainer(runtimeDetails *odigosv1.InstrumentedApplication, 
 }
 
 func SetInjectInstrumentationLabel(original *corev1.PodTemplateSpec) {
-	odigosTier := env.GetOdigosTierFromEnv()
 
-	// inject the instrumentation annotation for oss tier only
-	if odigosTier == common.CommunityOdigosTier {
-		if original.Labels == nil {
-			original.Labels = make(map[string]string)
-		}
-		original.Labels["odigos.io/inject-instrumentation"] = "true"
+	if original.Labels == nil {
+		original.Labels = make(map[string]string)
 	}
+	original.Labels["odigos.io/inject-instrumentation"] = "true"
 }
 
 // RemoveInjectInstrumentationLabel removes the "odigos.io/inject-instrumentation" label if it exists.

--- a/instrumentor/instrumentation/instrumentation.go
+++ b/instrumentor/instrumentation/instrumentation.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/common/envOverwrite"
+	"github.com/odigos-io/odigos/k8sutils/pkg/consts"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/odigos-io/odigos/common"
@@ -271,14 +272,14 @@ func SetInjectInstrumentationLabel(original *corev1.PodTemplateSpec) {
 	if original.Labels == nil {
 		original.Labels = make(map[string]string)
 	}
-	original.Labels["odigos.io/inject-instrumentation"] = "true"
+	original.Labels[consts.OdigosInjectInstrumentationLabel] = "true"
 }
 
 // RemoveInjectInstrumentationLabel removes the "odigos.io/inject-instrumentation" label if it exists.
 func RemoveInjectInstrumentationLabel(original *corev1.PodTemplateSpec) bool {
 	if original.Labels != nil {
-		if _, ok := original.Labels["odigos.io/inject-instrumentation"]; ok {
-			delete(original.Labels, "odigos.io/inject-instrumentation")
+		if _, ok := original.Labels[consts.OdigosInjectInstrumentationLabel]; ok {
+			delete(original.Labels, consts.OdigosInjectInstrumentationLabel)
 			return true
 		}
 	}

--- a/k8sutils/pkg/consts/consts.go
+++ b/k8sutils/pkg/consts/consts.go
@@ -7,8 +7,12 @@ const (
 	CollectorsRoleNodeCollector  CollectorRole = "NODE_COLLECTOR"
 )
 
-// OdigosCollectorRoleLabel is the label used to identify the role of the Odigos collector.
-const OdigosCollectorRoleLabel = "odigos.io/collector-role"
+const (
+	// OdigosInjectInstrumentationLabel is the label used to enable the mutating webhook.
+	OdigosInjectInstrumentationLabel = "odigos.io/inject-instrumentation"
+	// OdigosCollectorRoleLabel is the label used to identify the role of the Odigos collector.
+	OdigosCollectorRoleLabel = "odigos.io/collector-role"
+)
 
 const (
 	OdigosDeploymentConfigMapName = "odigos-deployment"


### PR DESCRIPTION

Simplified the `SetInjectInstrumentationLabel` function by removing the `odigosTier` variable and the conditional check for the community tier, ensuring that the instrumentation label is always injected.