### PR TITLE
fix: set max_recv_msg_size_mib to value in correct units

### DIFF
--- a/common/config/root.go
+++ b/common/config/root.go
@@ -149,7 +149,7 @@ func getBasicConfig(memoryLimiterConfig GenericMap) (*Config, []string) {
 					"protocols": GenericMap{
 						"grpc": GenericMap{
 							// setting it to a large value to avoid dropping batches.
-							"max_recv_msg_size_mib": 128 * 1024 * 1024,
+							"max_recv_msg_size_mib": 128,
 							"endpoint":              "0.0.0.0:4317",
 						},
 						// Node collectors send in gRPC, so this is probably not needed

--- a/common/config/testdata/debugexporter.yaml
+++ b/common/config/testdata/debugexporter.yaml
@@ -3,7 +3,7 @@ receivers:
     protocols:
       grpc:
         endpoint: 0.0.0.0:4317
-        max_recv_msg_size_mib: 134217728
+        max_recv_msg_size_mib: 128
       http:
         endpoint: 0.0.0.0:4318
 exporters:

--- a/common/config/testdata/minimal.yaml
+++ b/common/config/testdata/minimal.yaml
@@ -3,7 +3,7 @@ receivers:
     protocols:
       grpc:
         endpoint: 0.0.0.0:4317
-        max_recv_msg_size_mib: 134217728
+        max_recv_msg_size_mib: 128
       http:
         endpoint: 0.0.0.0:4318
 exporters: {}


### PR DESCRIPTION
The value in `max_recv_msg_size_mib` for otlp receiver in cluster collector config should be in alignment with the memory the deployment has to run. 
It was set accidentally to `128 * 1024 * 1024` (e.g. value in bytes), instead of intended `128` which is a reasonable number to use.

before this change, the value being populated in the config would be `134217728` MiB which makes no sense