### PR TITLE
Add missing destination providers

### DIFF
--- a/docs/quickstart/next-steps.mdx
+++ b/docs/quickstart/next-steps.mdx
@@ -17,18 +17,25 @@ Odigos supports all the major observability backends, both open-source and comme
 Select the relevant backend for your use case below to connect it to Odigos.
 
 <CardGroup cols={4}>
+  <Card title="AppDynamics" href="/backends/appdynamics" />
   <Card title="AWS S3" href="/backends/s3" />
+  <Card title="Axiom" href="/backends/axiom" />
   <Card title="Azure Blob Storage" href="/backends/azureblob" />
+  <Card title="Causely" href="/backends/causely" />
+  <Card title="Chronosphere" href="/backends/chronosphere" />
   <Card title="Coralogix" href="/backends/coralogix" />
   <Card title="Datadog" href="/backends/datadog" />
+  <Card title="Dynatrace" href="/backends/dynatrace" />
   <Card title="Elasticsearch" href="/backends/elasticsearch" />
+  <Card title="Gigapipe" href="/backends/gigapipe" />
+  <Card title="Google Cloud Monitoring" href="/backends/googlecloud" />
+  <Card title="Google Cloud Storage" href="/backends/gcs" />
   <Card title="Grafana Cloud Loki" href="/backends/grafanacloudloki" />
   <Card title="Grafana Cloud Prometheus" href="/backends/grafanacloudprometheus" />
   <Card title="Grafana Cloud Tempo" href="/backends/grafanacloudtempo" />
-  <Card title="Google Cloud Storage" href="/backends/gcs" />
-  <Card title="Google Cloud Monitoring" href="/backends/googlecloud" />
   <Card title="Honeycomb" href="/backends/honeycomb" />
   <Card title="Jaeger" href="/backends/jaeger" />
+  <Card title="Last9" href="/backends/last9" />
   <Card title="Lightstep" href="/backends/lightstep" />
   <Card title="Logz.io" href="/backends/logzio" />
   <Card title="Loki" href="/backends/loki" />
@@ -41,6 +48,6 @@ Select the relevant backend for your use case below to connect it to Odigos.
   <Card title="Sentry" href="/backends/sentry" />
   <Card title="SigNoz" href="/backends/signoz" />
   <Card title="Splunk" href="/backends/splunk" />
+  <Card title="Sumo Logic" href="/backends/sumologic" />
   <Card title="Tempo" href="/backends/tempo" />
-  <Card title="Causely" href="/backends/causely" />
 </CardGroup>


### PR DESCRIPTION
I found that the destinations in `backends-overview.mdx` didn't match those in this file so I added them. Also alphabetically sorted the cards.