### PR TITLE
ci: deprecate old chart repo syncs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,15 +89,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
 
-      # TODO: Remove once we are ready to fully sunset managing charts in a separate repo
-      - name: Trigger Release PR in Odigos Charts
-        run: |
-          curl -X POST \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token ${{ secrets.RELEASE_BOT_TOKEN }}" \
-            https://api.github.com/repos/odigos-io/odigos-charts/dispatches \
-            -d '{"event_type": "create_release_pr", "client_payload": {"tag": "${{ env.TAG }}"}}'
-
       - uses: ko-build/setup-ko@v0.7
 
       - name: publish cli image to docker registries

--- a/scripts/release-charts.sh
+++ b/scripts/release-charts.sh
@@ -30,8 +30,6 @@ if [[ $(git diff -- ${CHARTDIRS[*]} | wc -c) -ne 0 ]]; then
 	exit 1
 fi
 
-# Ignore errors because it will mostly always error locally
-helm repo add odigos https://odigos-io.github.io/odigos-charts 2> /dev/null || true
 git worktree add $TMPDIR gh-pages -f
 
 # Update index with new packages


### PR DESCRIPTION
This PR stops syncing the previous helm repo at https://github.com/odigos-io/odigos-charts

The crds there are not relevant for long time, and the new helm repo is available for 5 month to migrate. see [this blog post](https://odigos.io/blog/helm-chart-repository-deprecation).

This PR completes the migration 