### PR TITLE
chore: narrow down the rbac permissions for schedualer

### DIFF
--- a/helm/odigos/templates/scheduler/clusterrole.yaml
+++ b/helm/odigos/templates/scheduler/clusterrole.yaml
@@ -6,37 +6,8 @@ rules:
   - apiGroups:
       - odigos.io
     resources:
-      - collectorsgroups
-      - destinations
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - odigos.io
-    resources:
-      - collectorsgroups/finalizers
-      - destinations/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - odigos.io
-    resources:
-      - collectorsgroups/status
-      - destinations/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - odigos.io
-    resources:
       - instrumentationconfigs
     verbs:
-      - get
       - list
+      - get
       - watch

--- a/helm/odigos/templates/scheduler/role-binding.yaml
+++ b/helm/odigos/templates/scheduler/role-binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: odigos-scheduler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: odigos-scheduler
+subjects:
+  - kind: ServiceAccount
+    name: odigos-scheduler

--- a/helm/odigos/templates/scheduler/role.yaml
+++ b/helm/odigos/templates/scheduler/role.yaml
@@ -1,0 +1,51 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: odigos-scheduler
+rules:
+  - apiGroups:
+    - ""
+    resourceNames:
+    - odigos-config
+    resources:
+    - configmaps
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - odigos.io
+    resources:
+    - collectorsgroups
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - odigos.io
+    resources:
+    - collectorsgroups/status
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
+    - odigos.io
+    resources:
+    - destinations
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - odigos.io
+    resources:
+    - destinations/status
+    verbs:
+    - get
+    - patch
+    - update

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -94,6 +94,12 @@ func main() {
 				&corev1.ConfigMap{}: {
 					Field: odigosConfigSelector,
 				},
+				&odigosv1.CollectorsGroup{}: {
+					Field: nsSelector,
+				},
+				&odigosv1.Destination{}: {
+					Field: nsSelector,
+				},
 			},
 		},
 		HealthProbeBindAddress: probeAddr,


### PR DESCRIPTION
In this PR:

- move destinations and collectorsgroup rbac permission to be role (on odigos ns) instead of clusterrole. These live anyway only in our ns, but it looks better in rbac reviews.
- removed unused create/delete/update/patch for the destinations, as we only read them.
- currently the leader election role brings in configmaps permissions, but I also added the permissions we need for the reconcilers so not to mix unrelated things. we will need to also understand and address the leader election role later on.
- removed the finalizers permissions, as we don't use finalizers and it's unused.
- created some consts in cli files for better structure to the references
- synced helm files with the changes
- tested both helm and cli locally to make sure it works

InstrumentationConfig is left as a clusterrole, since they belong to the various namespaces where the sources reside.