### PR TITLE
refactor: use instrumentationconfig in autoscaler

### DIFF
--- a/autoscaler/PROJECT
+++ b/autoscaler/PROJECT
@@ -25,7 +25,7 @@ resources:
     namespaced: true
   controller: true
   domain: odigos.io
-  kind: InstrumentedApplication
+  kind: InstrumentationConfig
   path: github.com/odigos-io/odigos/api/odigos/v1alpha1
   version: v1alpha1
 version: "3"

--- a/autoscaler/controllers/datacollection/configmap_test.go
+++ b/autoscaler/controllers/datacollection/configmap_test.go
@@ -63,9 +63,9 @@ func NewMockTestStatefulSet(ns *corev1.Namespace) *appsv1.StatefulSet {
 
 // givin a workload object (deployment, daemonset, statefulset) return a mock instrumented application
 // with a single container with the GoProgrammingLanguage
-func NewMockInstrumentedApplication(workloadObject client.Object) *odigosv1.InstrumentedApplication {
+func NewMockInstrumentationConfig(workloadObject client.Object) *odigosv1.InstrumentationConfig {
 	gvk, _ := apiutil.GVKForObject(workloadObject, scheme.Scheme)
-	return &odigosv1.InstrumentedApplication{
+	return &odigosv1.InstrumentationConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      workload.CalculateWorkloadRuntimeObjectName(workloadObject.GetName(), gvk.Kind),
 			Namespace: workloadObject.GetNamespace(),
@@ -79,9 +79,9 @@ func NewMockInstrumentedApplication(workloadObject client.Object) *odigosv1.Inst
 	}
 }
 
-func NewMockInstrumentedApplicationWoOwner(workloadObject client.Object) *odigosv1.InstrumentedApplication {
+func NewMockInstrumentationConfigWoOwner(workloadObject client.Object) *odigosv1.InstrumentationConfig {
 	gvk, _ := apiutil.GVKForObject(workloadObject, scheme.Scheme)
-	return &odigosv1.InstrumentedApplication{
+	return &odigosv1.InstrumentationConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      workload.CalculateWorkloadRuntimeObjectName(workloadObject.GetName(), gvk.Kind),
 			Namespace: workloadObject.GetNamespace(),
@@ -118,15 +118,15 @@ func TestCalculateConfigMapData(t *testing.T) {
 	ns := NewMockNamespace("default")
 	ns2 := NewMockNamespace("other-namespace")
 
-	items := []v1alpha1.InstrumentedApplication{
-		*NewMockInstrumentedApplication(NewMockTestDeployment(ns)),
-		*NewMockInstrumentedApplication(NewMockTestDaemonSet(ns)),
-		*NewMockInstrumentedApplication(NewMockTestStatefulSet(ns2)),
-		*NewMockInstrumentedApplicationWoOwner(NewMockTestDeployment(ns2)),
+	items := []v1alpha1.InstrumentationConfig{
+		*NewMockInstrumentationConfig(NewMockTestDeployment(ns)),
+		*NewMockInstrumentationConfig(NewMockTestDaemonSet(ns)),
+		*NewMockInstrumentationConfig(NewMockTestStatefulSet(ns2)),
+		*NewMockInstrumentationConfigWoOwner(NewMockTestDeployment(ns2)),
 	}
 
 	got, err := calculateConfigMapData(
-		&v1alpha1.InstrumentedApplicationList{
+		&v1alpha1.InstrumentationConfigList{
 			Items: items,
 		},
 		NewMockDestinationList(),

--- a/autoscaler/controllers/gateway/deployment.go
+++ b/autoscaler/controllers/gateway/deployment.go
@@ -174,13 +174,13 @@ func getDesiredDeployment(dests *odigosv1.DestinationList, configDataHash string
 								{
 									// let the Go runtime know how many CPUs are available,
 									// without this, Go will assume all the cores are available.
-									Name:  "GOMAXPROCS",
-									ValueFrom:  &corev1.EnvVarSource{
+									Name: "GOMAXPROCS",
+									ValueFrom: &corev1.EnvVarSource{
 										ResourceFieldRef: &corev1.ResourceFieldSelector{
 											ContainerName: containerName,
 											// limitCPU, Kubernetes automatically rounds up the value to an integer
 											// (700m -> 1, 1200m -> 2)
-											Resource:      "limits.cpu",
+											Resource: "limits.cpu",
 										},
 									},
 								},

--- a/autoscaler/controllers/instrumentedapplication_controller.go
+++ b/autoscaler/controllers/instrumentedapplication_controller.go
@@ -26,10 +26,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-type InstrumentedApplicationReconciler struct {
+type InstrumentationConfigReconciler struct {
 	client.Client
 	Scheme               *runtime.Scheme
 	ImagePullSecrets     []string
@@ -38,9 +37,7 @@ type InstrumentedApplicationReconciler struct {
 	DisableNameProcessor bool
 }
 
-func (r *InstrumentedApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx)
-	logger.V(0).Info("Reconciling InstrumentedApps")
+func (r *InstrumentationConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	err := datacollection.Sync(ctx, r.Client, r.Scheme, r.ImagePullSecrets, r.OdigosVersion, r.K8sVersion, r.DisableNameProcessor)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -49,9 +46,9 @@ func (r *InstrumentedApplicationReconciler) Reconcile(ctx context.Context, req c
 	return ctrl.Result{}, nil
 }
 
-func (r *InstrumentedApplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *InstrumentationConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&odigosv1.InstrumentedApplication{}).
+		For(&odigosv1.InstrumentationConfig{}).
 		// this controller only cares about the instrumented application existence.
 		// when it is created or removed, the node collector config map needs to be updated to scrape logs for it's pods.
 		WithEventFilter(&predicate.ExistencePredicate{}).

--- a/autoscaler/main.go
+++ b/autoscaler/main.go
@@ -232,7 +232,7 @@ func main() {
 		K8sVersion:           k8sVersion,
 		DisableNameProcessor: disableNameProcessor,
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "InstrumentedApplication")
+		setupLog.Error(err, "unable to create controller", "controller", "InstrumentationConfig")
 		os.Exit(1)
 	}
 	if err = (&controllers.SecretReconciler{

--- a/autoscaler/main.go
+++ b/autoscaler/main.go
@@ -224,7 +224,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "CollectorsGroup")
 		os.Exit(1)
 	}
-	if err = (&controllers.InstrumentedApplicationReconciler{
+	if err = (&controllers.InstrumentationConfigReconciler{
 		Client:               mgr.GetClient(),
 		Scheme:               mgr.GetScheme(),
 		ImagePullSecrets:     imagePullSecrets,

--- a/cli/cmd/resources/autoscaler.go
+++ b/cli/cmd/resources/autoscaler.go
@@ -218,32 +218,12 @@ func NewAutoscalerClusterRole() *rbacv1.ClusterRole {
 			},
 			{
 				Verbs: []string{
-					"create",
-					"delete",
 					"get",
 					"list",
-					"patch",
-					"update",
 					"watch",
 				},
 				APIGroups: []string{"odigos.io"},
-				Resources: []string{"instrumentedapplications"},
-			},
-			{
-				Verbs: []string{
-					"update",
-				},
-				APIGroups: []string{"odigos.io"},
-				Resources: []string{"instrumentedapplications/finalizers"},
-			},
-			{
-				Verbs: []string{
-					"get",
-					"patch",
-					"update",
-				},
-				APIGroups: []string{"odigos.io"},
-				Resources: []string{"instrumentedapplications/status"},
+				Resources: []string{"instrumentationconfigs"},
 			}, {
 				Verbs: []string{
 					"create",

--- a/helm/odigos/templates/autoscaler/clusterrole.yaml
+++ b/helm/odigos/templates/autoscaler/clusterrole.yaml
@@ -35,7 +35,7 @@ rules:
   - apiGroups:
       - odigos.io
     resources:
-      - instrumentedapplications
+      - instrumentationconfigs
       - collectorsgroups
       - odigosconfigurations
       - destinations
@@ -52,7 +52,6 @@ rules:
       - odigos.io
     resources:
       - collectorsgroups/finalizers
-      - instrumentedapplications/finalizers
       - destinations/finalizers
     verbs:
       - update
@@ -60,7 +59,6 @@ rules:
       - odigos.io
     resources:
       - collectorsgroups/status
-      - instrumentedapplications/status
       - destinations/status
     verbs:
       - get


### PR DESCRIPTION
Part of the effort to retire instrumentedapplication

This object behaves the same, so no changes in functionality is expected.
Updated the RBAC roles and cleaned up unused permissions while at it (we need to do a bigger rbac swap in a different PR).

Tested it to work with both cli and helm (with logs destination that triggers change in collector cm to collect logs).

