### PR TITLE
Use request.Namespace in Pod webhook

### DIFF
--- a/instrumentor/controllers/instrumentationdevice/pods_webhook.go
+++ b/instrumentor/controllers/instrumentationdevice/pods_webhook.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -61,6 +62,13 @@ func (p *PodsWebhook) getServiceNameForEnv(ctx context.Context, pod *corev1.Pod)
 		logger.Error(err, "failed to extract pod workload details from pod. skipping OTEL_SERVICE_NAME injection")
 		return nil, nil
 	}
+
+	req, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		logger.Error(err, "failed to get admission request from context")
+		return nil, nil
+	}
+	podWorkload.Namespace = req.Namespace
 
 	workloadObj, err := workload.GetWorkloadObject(ctx, client.ObjectKey{Namespace: podWorkload.Namespace, Name: podWorkload.Name}, podWorkload.Kind, p.Client)
 	if err != nil {

--- a/tests/e2e/workload-lifecycle/02-update-workload-manifests.yaml
+++ b/tests/e2e/workload-lifecycle/02-update-workload-manifests.yaml
@@ -55,6 +55,8 @@ metadata:
   namespace: default
   labels:
     app: nodejs-minimum-version
+  annotations:
+    odigos.io/reported-name: nodejs-minimum-version-reported
 spec:
   selector:
     matchLabels:
@@ -80,6 +82,8 @@ metadata:
   namespace: default
   labels:
     app: nodejs-latest-version
+  annotations:
+    odigos.io/reported-name: nodejs-latest-version-reported
 spec:
   selector:
     matchLabels:
@@ -105,6 +109,8 @@ metadata:
   namespace: default
   labels:
     app: nodejs-dockerfile-env
+  annotations:
+    odigos.io/reported-name: nodejs-dockerfile-env-reported
 spec:
   selector:
     matchLabels:
@@ -130,6 +136,8 @@ metadata:
   namespace: default
   labels:
     app: nodejs-manifest-env
+  annotations:
+    odigos.io/reported-name: nodejs-manifest-env-reported
 spec:
   selector:
     matchLabels:
@@ -183,6 +191,8 @@ metadata:
   namespace: default
   labels:
     app: java-supported-version
+  annotations:
+    odigos.io/reported-name: java-supported-version-reported
 spec:
   selector:
     matchLabels:
@@ -212,6 +222,8 @@ metadata:
   namespace: default
   labels:
     app: java-azul
+  annotations:
+    odigos.io/reported-name: java-azul-reported
 spec:
   selector:
     matchLabels:
@@ -241,6 +253,8 @@ metadata:
   namespace: default
   labels:
     app: java-supported-docker-env
+  annotations:
+    odigos.io/reported-name: java-supported-docker-env-reported
 spec:
   selector:
     matchLabels:
@@ -271,6 +285,8 @@ metadata:
   namespace: default
   labels:
     app: java-supported-manifest-env
+  annotations:
+    odigos.io/reported-name: java-supported-manifest-env-reported
 spec:
   selector:
     matchLabels:
@@ -301,6 +317,8 @@ metadata:
   namespace: default
   labels:
     app: java-latest-version
+  annotations:
+    odigos.io/reported-name: java-latest-version-reported
 spec:
   selector:
     matchLabels:
@@ -331,6 +349,8 @@ metadata:
   namespace: default
   labels:
     app: java-old-version
+  annotations:
+    odigos.io/reported-name: java-old-version-reported
 spec:
   selector:
     matchLabels:
@@ -360,6 +380,8 @@ metadata:
   namespace: default
   labels:
     app: python-latest-version
+  annotations:
+    odigos.io/reported-name: python-latest-version-reported
 spec:
   selector:
     matchLabels:
@@ -397,6 +419,8 @@ metadata:
   namespace: default
   labels:
     app: python-alpine
+  annotations:
+    odigos.io/reported-name: python-alpine-reported
 spec:
   selector:
     matchLabels:
@@ -434,6 +458,8 @@ metadata:
   namespace: default
   labels:
     app: python-not-supported
+  annotations:
+    odigos.io/reported-name: python-not-supported-reported
 spec:
   selector:
     matchLabels:
@@ -471,6 +497,8 @@ metadata:
   namespace: default
   labels:
     app: python-min-version
+  annotations:
+    odigos.io/reported-name: python-min-version-reported
 spec:
   selector:
     matchLabels:

--- a/tests/e2e/workload-lifecycle/02-wait-for-trace.yaml
+++ b/tests/e2e/workload-lifecycle/02-wait-for-trace.yaml
@@ -2,18 +2,19 @@ apiVersion: e2e.tests.odigos.io/v1
 kind: TraceTest
 description: This test waits for a trace that is generated from the successful instrumented services.
 query: |
-  { resource.service.name = "nodejs-minimum-version" } ||
-  { resource.service.name = "nodejs-latest-version" } ||
-  { resource.service.name = "nodejs-dockerfile-env" } ||
-  { resource.service.name = "nodejs-manifest-env" } ||
-  { resource.service.name = "java-supported-version" } ||   
-  { resource.service.name = "java-latest-version" } ||
-  { resource.service.name = "java-old-version" } ||
-  { resource.service.name = "java-supported-docker-env" } ||
-  { resource.service.name = "java-supported-manifest-env" } ||
-  { resource.service.name = "java-azul" } ||
-  { resource.service.name = "python-latest-version" && span.http.route = "insert-random/" } ||
-  { resource.service.name = "python-alpine" && span.http.route = "insert-random/" } ||
-  { resource.service.name = "python-min-version" && span.http.route = "insert-random/" }
+  { resource.service.name = "nodejs-minimum-version-reported" } ||
+  { resource.service.name = "nodejs-latest-version-reported" } ||
+  { resource.service.name = "nodejs-dockerfile-env-reported" } ||
+  { resource.service.name = "nodejs-manifest-env-reported" } ||
+  { resource.service.name = "java-supported-version-reported" } ||
+  { resource.service.name = "java-latest-version-reported" } ||
+  { resource.service.name = "java-old-version-reported" } ||
+  { resource.service.name = "java-supported-docker-env-reported" } ||
+  { resource.service.name = "java-supported-manifest-env-reported" } ||
+  { resource.service.name = "java-azul-reported" } ||
+  { resource.service.name = "python-latest-version-reported" && span.http.route = "insert-random/" } ||
+  { resource.service.name = "python-alpine-reported" && span.http.route = "insert-random/" } ||
+  { resource.service.name = "python-not-supported-reported" && span.http.route = "insert-random/" } ||
+  { resource.service.name = "python-min-version-reported" && span.http.route = "insert-random/" }
 expected:
-  count: 26 # 13 before +13 new ones
+  count: 13


### PR DESCRIPTION
In older versions of k8s (prior to https://github.com/kubernetes/kubernetes/pull/94637 in ~1.24), the Pod object received by an admission webhook isn't guaranteed to have its namespace set. Instead, we should use the namespace from the admission request.

I found this while adding tests that use the `odigos.io/reported-name` annotation, and saw that the service name wasn't taking effect on some pods. The instrumentor would fail to parse some of them with the following error:

```
2025-01-03T20:38:36Z	ERROR	admission	failed to get workload object from cache. cannot check for workload annotation. using workload name as OTEL_SERVICE_NAME	{"webhookGroup": "", "webhookKind": "Pod", "Pod": {"name":"","namespace":"default"}, "namespace": "default", "name": "", "resource": {"group":"","version":"v1","resource":"pods"}, "user": "system:serviceaccount:kube-system:replicaset-controller", "requestID": "8e9331f3-b5fa-4334-a238-a755a32d7b62", "error": "Deployment.apps \"inventory\" not found"}
github.com/odigos-io/odigos/instrumentor/controllers/instrumentationdevice.(*PodsWebhook).getServiceNameForEnv
	/workspace/instrumentor/controllers/instrumentationdevice/pods_webhook.go:67
github.com/odigos-io/odigos/instrumentor/controllers/instrumentationdevice.(*PodsWebhook).Default
	/workspace/instrumentor/controllers/instrumentationdevice/pods_webhook.go:46
```

(https://github.com/odigos-io/odigos/pull/2008#issuecomment-2569829498)

This uses the request namespace instead, which is always set(https://github.com/kubernetes/kubernetes/issues/113952#issuecomment-1317042694).