### PR TITLE
chore: map only needed keys from odigos-deployment in envFrom

### DIFF
--- a/cli/cmd/resources/autoscaler.go
+++ b/cli/cmd/resources/autoscaler.go
@@ -290,19 +290,23 @@ func NewAutoscalerDeployment(ns string, version string, imagePrefix string, imag
 										},
 									},
 								},
+								{
+									Name: "ODIGOS_VERSION",
+									ValueFrom: &corev1.EnvVarSource{
+										ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: consts.OdigosDeploymentConfigMapName,
+											},
+											Key: "ODIGOS_VERSION",
+										},
+									},
+								},
 							}, optionalEnvs...),
 							EnvFrom: []corev1.EnvFromSource{
 								{
 									ConfigMapRef: &corev1.ConfigMapEnvSource{
 										LocalObjectReference: corev1.LocalObjectReference{
 											Name: ownTelemetryOtelConfig,
-										},
-									},
-								},
-								{
-									ConfigMapRef: &corev1.ConfigMapEnvSource{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: consts.OdigosDeploymentConfigMapName,
 										},
 									},
 								},

--- a/cli/cmd/resources/instrumentor.go
+++ b/cli/cmd/resources/instrumentor.go
@@ -400,19 +400,23 @@ func NewInstrumentorDeployment(ns string, version string, telemetryEnabled bool,
 										},
 									},
 								},
+								{
+									Name: "ODIGOS_TIER",
+									ValueFrom: &corev1.EnvVarSource{
+										ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: k8sutilsconsts.OdigosDeploymentConfigMapName,
+											},
+											Key: "ODIGOS_TIER",
+										},
+									},
+								},
 							},
 							EnvFrom: []corev1.EnvFromSource{
 								{
 									ConfigMapRef: &corev1.ConfigMapEnvSource{
 										LocalObjectReference: corev1.LocalObjectReference{
 											Name: ownTelemetryOtelConfig,
-										},
-									},
-								},
-								{
-									ConfigMapRef: &corev1.ConfigMapEnvSource{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: k8sutilsconsts.OdigosDeploymentConfigMapName,
 										},
 									},
 								},

--- a/helm/odigos/templates/autoscaler/deployment.yaml
+++ b/helm/odigos/templates/autoscaler/deployment.yaml
@@ -39,12 +39,15 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: ODIGOS_VERSION
+            valueFrom:
+              configMapKeyRef:
+                key: ODIGOS_VERSION
+                name: odigos-deployment                
         envFrom:
           - configMapRef:
               name: odigos-own-telemetry-otel-config
               optional: true
-          - configMapRef:
-              name: odigos-deployment
         livenessProbe:
           httpGet:
             path: /healthz

--- a/helm/odigos/templates/instrumentor/deployment.yaml
+++ b/helm/odigos/templates/instrumentor/deployment.yaml
@@ -40,6 +40,11 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: ODIGOS_TIER
+            valueFrom:
+              configMapKeyRef:
+                key: ODIGOS_TIER
+                name: odigos-deployment                
         volumeMounts:
           - name: webhook-cert
             mountPath: /tmp/k8s-webhook-server/serving-certs
@@ -48,8 +53,6 @@ spec:
           - configMapRef:
               name: odigos-own-telemetry-otel-config
               optional: true
-          - configMapRef:
-              name: odigos-deployment
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
This is so we can add new keys to `odigos-deployment` without warring about them blowing up deployments that map them as `envFrom`. This PR makes it so we can only map what we actually use