### PR TITLE
chore: move common strings for "odigos-deployment" cm to consts and use them

### DIFF
--- a/autoscaler/controllers/gateway/deployment.go
+++ b/autoscaler/controllers/gateway/deployment.go
@@ -9,7 +9,8 @@ import (
 	"errors"
 
 	"github.com/odigos-io/odigos/autoscaler/utils"
-	"github.com/odigos-io/odigos/k8sutils/pkg/consts"
+	"github.com/odigos-io/odigos/common/consts"
+	k8sconsts "github.com/odigos-io/odigos/k8sutils/pkg/consts"
 
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/autoscaler/controllers/common"
@@ -105,7 +106,7 @@ func getDesiredDeployment(dests *odigosv1.DestinationList, configDataHash string
 
 	desiredDeployment := &appsv1.Deployment{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      consts.OdigosClusterCollectorDeploymentName,
+			Name:      k8sconsts.OdigosClusterCollectorDeploymentName,
 			Namespace: gateway.Namespace,
 			Labels:    ClusterCollectorGateway,
 		},
@@ -124,7 +125,7 @@ func getDesiredDeployment(dests *odigosv1.DestinationList, configDataHash string
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: consts.OdigosClusterCollectorConfigMapKey,
+							Name: k8sconsts.OdigosClusterCollectorConfigMapKey,
 							VolumeSource: corev1.VolumeSource{
 								ConfigMap: &corev1.ConfigMapVolumeSource{
 									LocalObjectReference: corev1.LocalObjectReference{
@@ -132,8 +133,8 @@ func getDesiredDeployment(dests *odigosv1.DestinationList, configDataHash string
 									},
 									Items: []corev1.KeyToPath{
 										{
-											Key:  consts.OdigosClusterCollectorConfigMapKey,
-											Path: fmt.Sprintf("%s.yaml", consts.OdigosClusterCollectorConfigMapKey),
+											Key:  k8sconsts.OdigosClusterCollectorConfigMapKey,
+											Path: fmt.Sprintf("%s.yaml", k8sconsts.OdigosClusterCollectorConfigMapKey),
 										},
 									},
 								},
@@ -144,18 +145,18 @@ func getDesiredDeployment(dests *odigosv1.DestinationList, configDataHash string
 						{
 							Name:    containerName,
 							Image:   utils.GetCollectorContainerImage(containerImage, odigosVersion),
-							Command: []string{containerCommand, fmt.Sprintf("--config=%s/%s.yaml", confDir, consts.OdigosClusterCollectorConfigMapKey)},
+							Command: []string{containerCommand, fmt.Sprintf("--config=%s/%s.yaml", confDir, k8sconsts.OdigosClusterCollectorConfigMapKey)},
 							EnvFrom: getSecretsFromDests(dests),
 							// Add the ODIGOS_VERSION environment variable from the ConfigMap
 							Env: []corev1.EnvVar{
 								{
-									Name: "ODIGOS_VERSION",
+									Name: consts.OdigosVersionEnvVarName,
 									ValueFrom: &corev1.EnvVarSource{
 										ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 											LocalObjectReference: corev1.LocalObjectReference{
-												Name: "odigos-deployment",
+												Name: k8sconsts.OdigosDeploymentConfigMapName,
 											},
-											Key: "ODIGOS_VERSION",
+											Key: k8sconsts.OdigosDeploymentConfigMapVersionKey,
 										},
 									},
 								},
@@ -190,7 +191,7 @@ func getDesiredDeployment(dests *odigosv1.DestinationList, configDataHash string
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      consts.OdigosClusterCollectorConfigMapKey,
+									Name:      k8sconsts.OdigosClusterCollectorConfigMapKey,
 									MountPath: confDir,
 								},
 							},

--- a/autoscaler/main.go
+++ b/autoscaler/main.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	odigosver "github.com/odigos-io/odigos/k8sutils/pkg/version"
 
@@ -93,7 +94,7 @@ func main() {
 		"The image pull secrets to use for the collectors created by autoscaler")
 	flag.StringVar(&nameutils.ImagePrefix, "image-prefix", "", "The image prefix to use for the collectors created by autoscaler")
 
-	odigosVersion := os.Getenv("ODIGOS_VERSION")
+	odigosVersion := os.Getenv(consts.OdigosVersionEnvVarName)
 	if odigosVersion == "" {
 		flag.StringVar(&odigosVersion, "version", "", "for development purposes only")
 	}

--- a/cli/cmd/resources/autoscaler.go
+++ b/cli/cmd/resources/autoscaler.go
@@ -8,7 +8,8 @@ import (
 	"github.com/odigos-io/odigos/cli/pkg/containers"
 	"github.com/odigos-io/odigos/cli/pkg/kube"
 	"github.com/odigos-io/odigos/common"
-	"github.com/odigos-io/odigos/k8sutils/pkg/consts"
+	"github.com/odigos-io/odigos/common/consts"
+	k8sconsts "github.com/odigos-io/odigos/k8sutils/pkg/consts"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -291,13 +292,13 @@ func NewAutoscalerDeployment(ns string, version string, imagePrefix string, imag
 									},
 								},
 								{
-									Name: "ODIGOS_VERSION",
+									Name: consts.OdigosVersionEnvVarName,
 									ValueFrom: &corev1.EnvVarSource{
 										ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 											LocalObjectReference: corev1.LocalObjectReference{
-												Name: consts.OdigosDeploymentConfigMapName,
+												Name: k8sconsts.OdigosDeploymentConfigMapName,
 											},
-											Key: "ODIGOS_VERSION",
+											Key: k8sconsts.OdigosDeploymentConfigMapVersionKey,
 										},
 									},
 								},

--- a/cli/cmd/resources/instrumentor.go
+++ b/cli/cmd/resources/instrumentor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/odigos-io/odigos/common"
 	"github.com/odigos-io/odigos/common/consts"
 
+	k8sconsts "github.com/odigos-io/odigos/k8sutils/pkg/consts"
 	k8sutilsconsts "github.com/odigos-io/odigos/k8sutils/pkg/consts"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -401,13 +402,13 @@ func NewInstrumentorDeployment(ns string, version string, telemetryEnabled bool,
 									},
 								},
 								{
-									Name: "ODIGOS_TIER",
+									Name: consts.OdigosTierEnvVarName,
 									ValueFrom: &corev1.EnvVarSource{
 										ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 											LocalObjectReference: corev1.LocalObjectReference{
 												Name: k8sutilsconsts.OdigosDeploymentConfigMapName,
 											},
-											Key: "ODIGOS_TIER",
+											Key: k8sconsts.OdigosDeploymentConfigMapTierKey,
 										},
 									},
 								},

--- a/cli/cmd/resources/odigosdeployment.go
+++ b/cli/cmd/resources/odigosdeployment.go
@@ -7,7 +7,7 @@ import (
 	"github.com/odigos-io/odigos/cli/cmd/resources/resourcemanager"
 	"github.com/odigos-io/odigos/cli/pkg/kube"
 	"github.com/odigos-io/odigos/common"
-	"github.com/odigos-io/odigos/k8sutils/pkg/consts"
+	k8sconsts "github.com/odigos-io/odigos/k8sutils/pkg/consts"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,12 +21,12 @@ func NewOdigosDeploymentConfigMap(ns string, odigosVersion string, odigosTier st
 			APIVersion: "v1",
 		},
 		ObjectMeta: v1.ObjectMeta{
-			Name:      consts.OdigosDeploymentConfigMapName,
+			Name:      k8sconsts.OdigosDeploymentConfigMapName,
 			Namespace: ns,
 		},
 		Data: map[string]string{
-			"ODIGOS_VERSION": odigosVersion,
-			"ODIGOS_TIER":    odigosTier,
+			k8sconsts.OdigosDeploymentConfigMapVersionKey: odigosVersion,
+			k8sconsts.OdigosDeploymentConfigMapTierKey:    odigosTier,
 		},
 	}
 }

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -48,7 +48,7 @@ and apply any required migrations and adaptations.`,
 				os.Exit(1)
 			}
 
-			currOdigosVersion := cm.Data["ODIGOS_VERSION"]
+			currOdigosVersion := cm.Data[k8sconsts.OdigosDeploymentConfigMapVersionKey]
 			if currOdigosVersion == "" {
 				fmt.Println("Odigos upgrade failed - unable to read the current Odigos version for migration")
 				os.Exit(1)

--- a/common/consts/consts.go
+++ b/common/consts/consts.go
@@ -6,6 +6,8 @@ import (
 
 const (
 	CurrentNamespaceEnvVar       = "CURRENT_NS"
+	OdigosVersionEnvVarName      = "ODIGOS_VERSION"
+	OdigosTierEnvVarName         = "ODIGOS_TIER"
 	DefaultOdigosNamespace       = "odigos-system"
 	OdigosConfigurationName      = "odigos-config"
 	OdigosEffectiveConfigName    = "effective-config"

--- a/k8sutils/pkg/consts/consts.go
+++ b/k8sutils/pkg/consts/consts.go
@@ -1,6 +1,9 @@
 package consts
 
-import "k8s.io/apimachinery/pkg/util/version"
+import (
+	commonconsts "github.com/odigos-io/odigos/common/consts"
+	"k8s.io/apimachinery/pkg/util/version"
+)
 
 var (
 	DefaultIgnoredNamespaces = []string{"kube-system", "local-path-storage", "istio-system", "linkerd", "kube-node-lease"}
@@ -22,7 +25,9 @@ const (
 )
 
 const (
-	OdigosDeploymentConfigMapName = "odigos-deployment"
+	OdigosDeploymentConfigMapName       = "odigos-deployment"
+	OdigosDeploymentConfigMapVersionKey = commonconsts.OdigosVersionEnvVarName
+	OdigosDeploymentConfigMapTierKey    = commonconsts.OdigosTierEnvVarName
 )
 
 const (

--- a/k8sutils/pkg/env/env.go
+++ b/k8sutils/pkg/env/env.go
@@ -52,7 +52,7 @@ func GetSyncDaemonSetDelay() int {
 }
 
 func GetOdigosTierFromEnv() common.OdigosTier {
-	odigosTierStr := os.Getenv("ODIGOS_TIER")
+	odigosTierStr := os.Getenv(consts.OdigosTierEnvVarName)
 
 	switch odigosTierStr {
 	case string(common.CommunityOdigosTier):

--- a/k8sutils/pkg/getters/odigosversion.go
+++ b/k8sutils/pkg/getters/odigosversion.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/odigos-io/odigos/k8sutils/pkg/consts"
+	k8sconsts "github.com/odigos-io/odigos/k8sutils/pkg/consts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -17,12 +17,12 @@ var (
 // Return the Odigos version installed in the cluster.
 // The function assumes odigos is installed, and will return an error if it is not or if the version cannot be detected (not expected in normal operation).
 func GetOdigosVersionInClusterFromConfigMap(ctx context.Context, client kubernetes.Interface, ns string) (string, error) {
-	cm, err := client.CoreV1().ConfigMaps(ns).Get(ctx, consts.OdigosDeploymentConfigMapName, metav1.GetOptions{})
+	cm, err := client.CoreV1().ConfigMaps(ns).Get(ctx, k8sconsts.OdigosDeploymentConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		return "", ErrNoOdigosDeploymentConfigMap
 	}
 
-	odigosVersion, ok := cm.Data["ODIGOS_VERSION"]
+	odigosVersion, ok := cm.Data[k8sconsts.OdigosDeploymentConfigMapVersionKey]
 	if !ok || odigosVersion == "" {
 		return "", ErrMissingVersionInConfigMap
 	}


### PR DESCRIPTION
Cleanup, in prepration for adding more keys to the `odigos-deployment` configmap