### PR TITLE
feat: record installation method into odigos-deployment

### DIFF
--- a/cli/cmd/resources/odigosdeployment.go
+++ b/cli/cmd/resources/odigosdeployment.go
@@ -8,6 +8,7 @@ import (
 	"github.com/odigos-io/odigos/cli/pkg/kube"
 	"github.com/odigos-io/odigos/common"
 	k8sconsts "github.com/odigos-io/odigos/k8sutils/pkg/consts"
+	"github.com/odigos-io/odigos/k8sutils/pkg/installationmethod"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,8 +26,9 @@ func NewOdigosDeploymentConfigMap(ns string, odigosVersion string, odigosTier st
 			Namespace: ns,
 		},
 		Data: map[string]string{
-			k8sconsts.OdigosDeploymentConfigMapVersionKey: odigosVersion,
-			k8sconsts.OdigosDeploymentConfigMapTierKey:    odigosTier,
+			k8sconsts.OdigosDeploymentConfigMapVersionKey:            odigosVersion,
+			k8sconsts.OdigosDeploymentConfigMapTierKey:               odigosTier,
+			k8sconsts.OdigosDeploymentConfigMapInstallationMethodKey: string(installationmethod.K8sInstallationMethodOdigosCli),
 		},
 	}
 }

--- a/helm/odigos/templates/odigos-deployment.yaml
+++ b/helm/odigos/templates/odigos-deployment.yaml
@@ -6,3 +6,4 @@ metadata:
 data:
   ODIGOS_VERSION: {{ .Values.image.tag | default .Chart.AppVersion }}
   ODIGOS_TIER: "{{- if .Values.onPremToken }}onprem{{- else }}community{{- end }}"
+  installation-method: helm

--- a/k8sutils/pkg/consts/consts.go
+++ b/k8sutils/pkg/consts/consts.go
@@ -25,9 +25,10 @@ const (
 )
 
 const (
-	OdigosDeploymentConfigMapName       = "odigos-deployment"
-	OdigosDeploymentConfigMapVersionKey = commonconsts.OdigosVersionEnvVarName
-	OdigosDeploymentConfigMapTierKey    = commonconsts.OdigosTierEnvVarName
+	OdigosDeploymentConfigMapName                  = "odigos-deployment"
+	OdigosDeploymentConfigMapVersionKey            = commonconsts.OdigosVersionEnvVarName
+	OdigosDeploymentConfigMapTierKey               = commonconsts.OdigosTierEnvVarName
+	OdigosDeploymentConfigMapInstallationMethodKey = "installation-method"
 )
 
 const (

--- a/k8sutils/pkg/describe/odigos.go
+++ b/k8sutils/pkg/describe/odigos.go
@@ -49,6 +49,8 @@ func DescribeOdigosToText(analyze *odigos.OdigosAnalyze) string {
 	var sb strings.Builder
 
 	printProperty(&sb, 0, &analyze.OdigosVersion)
+	printProperty(&sb, 0, &analyze.Tier)
+	printProperty(&sb, 0, &analyze.InstallationMethod)
 	sb.WriteString("\n")
 	printOdigosPipeline(analyze, &sb)
 

--- a/k8sutils/pkg/describe/odigos/analyze.go
+++ b/k8sutils/pkg/describe/odigos/analyze.go
@@ -36,6 +36,8 @@ type NodeCollectorAnalyze struct {
 
 type OdigosAnalyze struct {
 	OdigosVersion        properties.EntityProperty `json:"odigosVersion"`
+	OdigosTier           properties.EntityProperty `json:"odigosTier"`
+	InstallationMethod   properties.EntityProperty `json:"installationMethod"`
 	NumberOfDestinations int                       `json:"numberOfDestinations"`
 	NumberOfSources      int                       `json:"numberOfSources"`
 	ClusterCollector     ClusterCollectorAnalyze   `json:"clusterCollector"`

--- a/k8sutils/pkg/describe/odigos/resources.go
+++ b/k8sutils/pkg/describe/odigos/resources.go
@@ -6,8 +6,7 @@ import (
 
 	odigosclientset "github.com/odigos-io/odigos/api/generated/odigos/clientset/versioned/typed/odigos/v1alpha1"
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
-	"github.com/odigos-io/odigos/k8sutils/pkg/consts"
-	"github.com/odigos-io/odigos/k8sutils/pkg/getters"
+	k8sconsts "github.com/odigos-io/odigos/k8sutils/pkg/consts"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -27,7 +26,7 @@ type NodeCollectorResources struct {
 }
 
 type OdigosResources struct {
-	OdigosVersion          string
+	OdigosDeployment       *corev1.ConfigMap // guaranteed to exist
 	ClusterCollector       ClusterCollectorResources
 	NodeCollector          NodeCollectorResources
 	Destinations           *odigosv1.DestinationList
@@ -38,14 +37,14 @@ func getClusterCollectorResources(ctx context.Context, kubeClient kubernetes.Int
 
 	clusterCollector := ClusterCollectorResources{}
 
-	cg, err := odigosClient.CollectorsGroups(odigosNs).Get(ctx, consts.OdigosClusterCollectorCollectorGroupName, metav1.GetOptions{})
+	cg, err := odigosClient.CollectorsGroups(odigosNs).Get(ctx, k8sconsts.OdigosClusterCollectorCollectorGroupName, metav1.GetOptions{})
 	if err == nil {
 		clusterCollector.CollectorsGroup = cg
 	} else if !apierrors.IsNotFound(err) {
 		return nil, err
 	}
 
-	dep, err := kubeClient.AppsV1().Deployments(odigosNs).Get(ctx, consts.OdigosClusterCollectorDeploymentName, metav1.GetOptions{})
+	dep, err := kubeClient.AppsV1().Deployments(odigosNs).Get(ctx, k8sconsts.OdigosClusterCollectorDeploymentName, metav1.GetOptions{})
 	if err == nil {
 		clusterCollector.Deployment = dep
 	} else if !apierrors.IsNotFound(err) {
@@ -96,14 +95,14 @@ func getNodeCollectorResources(ctx context.Context, kubeClient kubernetes.Interf
 
 	nodeCollector := NodeCollectorResources{}
 
-	cg, err := odigosClient.CollectorsGroups(odigosNs).Get(ctx, consts.OdigosNodeCollectorCollectorGroupName, metav1.GetOptions{})
+	cg, err := odigosClient.CollectorsGroups(odigosNs).Get(ctx, k8sconsts.OdigosNodeCollectorCollectorGroupName, metav1.GetOptions{})
 	if err == nil {
 		nodeCollector.CollectorsGroup = cg
 	} else if !apierrors.IsNotFound(err) {
 		return nil, err
 	}
 
-	ds, err := kubeClient.AppsV1().DaemonSets(odigosNs).Get(ctx, consts.OdigosNodeCollectorDaemonSetName, metav1.GetOptions{})
+	ds, err := kubeClient.AppsV1().DaemonSets(odigosNs).Get(ctx, k8sconsts.OdigosNodeCollectorDaemonSetName, metav1.GetOptions{})
 	if err == nil {
 		nodeCollector.DaemonSet = ds
 	} else if !apierrors.IsNotFound(err) {
@@ -117,11 +116,11 @@ func GetRelevantOdigosResources(ctx context.Context, kubeClient kubernetes.Inter
 
 	odigos := OdigosResources{}
 
-	odigosVersion, err := getters.GetOdigosVersionInClusterFromConfigMap(ctx, kubeClient, odigosNs)
+	odigosDeployment, err := kubeClient.CoreV1().ConfigMaps(odigosNs).Get(ctx, k8sconsts.OdigosDeploymentConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
-	odigos.OdigosVersion = odigosVersion
+	odigos.OdigosDeployment = odigosDeployment
 
 	cc, err := getClusterCollectorResources(ctx, kubeClient, odigosClient, odigosNs)
 	if err != nil {

--- a/k8sutils/pkg/installationmethod/installationmethod.go
+++ b/k8sutils/pkg/installationmethod/installationmethod.go
@@ -1,0 +1,8 @@
+package installationmethod
+
+type K8sInstallationMethod string
+
+const (
+	K8sInstallationMethodOdigosCli K8sInstallationMethod = "odigos-cli"
+	K8sInstallationMethodHelm      K8sInstallationMethod = "helm"
+)


### PR DESCRIPTION
This PR adds "instllation method" to `odigos-deployment` config map, so we can reliably know if the current installation is deployed via "helm" or "odigos-cli".

We can later use this info to warn or block usages which we do not support and might end up with a broken deployment or odigos.

This PR also adds the installation method and tier to the describe cli command:

```
go run -tags=embed_manifests . describe                           
Odigos Version: v1.0.142
Tier: community
Installation Method: helm

....
```