### PR TITLE
chore(cli): delete old deprecated code for very old versions

### DIFF
--- a/cli/pkg/kube/client.go
+++ b/cli/pkg/kube/client.go
@@ -8,8 +8,6 @@ import (
 
 	k8sutils "github.com/odigos-io/odigos/k8sutils/pkg/client"
 
-	appsv1 "k8s.io/api/apps/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
@@ -108,76 +106,7 @@ func (c *Client) ApplyResources(ctx context.Context, configVersion int, objs []O
 	return nil
 }
 
-// this function is a temporary hack upgrade from versions <v1.0.23 to >v1.0.23
-// we changed the selector label on DaemonSets and Deployments from "app" to "app.kubernetes.io/name",
-// and apparently this field id immutable:
-// ERROR Deployment.apps "odigos-instrumentor" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app.kubernetes.io/name":"odigos-instrumentor"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
-// Once we end support for odigos versions <v1.0.23 we can remove this function
-func (c *Client) deleteResourceBeforeAppending(ctx context.Context, obj Object) error {
-	gvk := obj.GetObjectKind().GroupVersionKind()
-	switch gvk.Kind {
-
-	case "DaemonSet":
-		dm, err := c.AppsV1().DaemonSets(obj.GetNamespace()).Get(ctx, obj.GetName(), metav1.GetOptions{})
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				return nil
-			}
-			return err
-		}
-		currentSelectorLabels := dm.Spec.Selector.MatchLabels
-
-		newDs, ok := obj.(*appsv1.DaemonSet)
-		if !ok {
-			return fmt.Errorf("could not cast object to DaemonSet")
-		}
-		newSelectorLabels := newDs.Spec.Selector.MatchLabels
-
-		// compare the labels by value and delete the current ds if they are different
-		if !k8slabels.SelectorFromSet(currentSelectorLabels).Matches(k8slabels.Set(newSelectorLabels)) {
-			err = c.AppsV1().DaemonSets(obj.GetNamespace()).Delete(ctx, obj.GetName(), metav1.DeleteOptions{})
-			if err != nil {
-				return err
-			}
-		}
-
-	case "Deployment":
-		dep, err := c.AppsV1().Deployments(obj.GetNamespace()).Get(ctx, obj.GetName(), metav1.GetOptions{})
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				return nil
-			}
-			return err
-		}
-
-		currentSelectorLabels := dep.Spec.Selector.MatchLabels
-
-		newDep, ok := obj.(*appsv1.Deployment)
-		if !ok {
-			return fmt.Errorf("could not cast object to Deployment")
-		}
-
-		newSelectorLabels := newDep.Spec.Selector.MatchLabels
-
-		// compare the labels by value and delete the current deployment if they are different
-		if !k8slabels.SelectorFromSet(currentSelectorLabels).Matches(k8slabels.Set(newSelectorLabels)) {
-			err = c.AppsV1().Deployments(obj.GetNamespace()).Delete(ctx, obj.GetName(), metav1.DeleteOptions{})
-			if err != nil {
-				return err
-			}
-		}
-
-	}
-
-	return nil
-}
-
 func (c *Client) ApplyResource(ctx context.Context, configVersion int, obj Object) error {
-
-	err := c.deleteResourceBeforeAppending(ctx, obj)
-	if err != nil {
-		return err
-	}
 
 	labels := obj.GetLabels()
 	if labels == nil {
@@ -199,7 +128,7 @@ func (c *Client) ApplyResource(ctx context.Context, configVersion int, obj Objec
 	gvk := obj.GetObjectKind().GroupVersionKind()
 	ns := obj.GetNamespace()
 	resource := TypeMetaToDynamicResource(gvk)
-	_, err = c.Dynamic.Resource(resource).Namespace(ns).Patch(ctx, resourceName, k8stypes.ApplyPatchType, depBytes, patchOptions)
+	_, err := c.Dynamic.Resource(resource).Namespace(ns).Patch(ctx, resourceName, k8stypes.ApplyPatchType, depBytes, patchOptions)
 	return err
 }
 


### PR DESCRIPTION
This code is for migration from `v1.0.23` to > `v1.0.23` which is no longer relevant