### PR TITLE
fix: z-index for dropdown component

### DIFF
--- a/frontend/webapp/reuseable-components/dropdown/index.tsx
+++ b/frontend/webapp/reuseable-components/dropdown/index.tsx
@@ -191,6 +191,7 @@ const AbsoluteContainer = styled.div<{ $openUpwards: boolean }>`
   position: absolute;
   ${({ $openUpwards }) => ($openUpwards ? 'bottom' : 'top')}: calc(100% + 8px);
   left: 0;
+  z-index: 1;
   display: flex;
   flex-direction: column;
   overflow-y: auto;


### PR DESCRIPTION
This pull request includes a small change to the `frontend/webapp/reuseable-components/dropdown/index.tsx` file. The change adds a `z-index` property to the `AbsoluteContainer` styled component to ensure proper stacking order.

* [`frontend/webapp/reuseable-components/dropdown/index.tsx`](diffhunk://#diff-707b6e11fbf977d74c45816fab07924a0eaa2d139b296cc58b74c98fd76f463dR194): Added `z-index: 1` to the `AbsoluteContainer` styled component to manage stacking context.