### PR TITLE
[GEN-2227]: fix namespace selection logic in useSourceFormData hook

### DIFF
--- a/frontend/webapp/hooks/sources/useSourceFormData.ts
+++ b/frontend/webapp/hooks/sources/useSourceFormData.ts
@@ -91,7 +91,7 @@ export const useSourceFormData = (params?: UseSourceFormDataParams): UseSourceFo
         // When clicking "select all" on a namespace
 
         if (!isFromInterval && bool) {
-          onSelectNamespace(namespace);
+          setSelectedNamespace(namespace);
           setSelectAllForNamespace(namespace);
         } else {
           setSelectedSources((prev) => ({ ...prev, [namespace]: selectedSources[namespace].map((source) => ({ ...source, selected: bool })) }));


### PR DESCRIPTION
This pull request includes a small change to the `frontend/webapp/hooks/sources/useSourceFormData.ts` file. The change updates the handling of namespace selection within the `useSourceFormData` hook.

* [`frontend/webapp/hooks/sources/useSourceFormData.ts`](diffhunk://#diff-cd2bc3c9473adfb41833260ef193384279ed75ef4b6c6866290ca78a174471e7L94-R94): Replaced the `onSelectNamespace` function call with `setSelectedNamespace` when clicking "select all" on a namespace.