### PR TITLE
[GEN-2226]: replace DefaultOdigosNamespace constant with dynamic GetCurrentNamespace function

### DIFF
--- a/frontend/main.go
+++ b/frontend/main.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/go-logr/logr"
 	"github.com/odigos-io/odigos/common"
-	"github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/destinations"
 	"github.com/odigos-io/odigos/frontend/graph"
 	"github.com/odigos-io/odigos/frontend/kube"
@@ -61,7 +60,7 @@ func parseFlags() Flags {
 	flag.BoolVar(&flags.Debug, "debug", false, "Enable debug mode")
 	flag.StringVar(&flags.KubeConfig, "kubeconfig", defaultKubeConfig, "Path to kubeconfig file")
 	flag.StringVar(&flags.KubeContext, "kube-context", "", "Name of the kubeconfig context to use")
-	flag.StringVar(&flags.Namespace, "namespace", consts.DefaultOdigosNamespace, "Kubernetes namespace where Odigos is installed")
+	flag.StringVar(&flags.Namespace, "namespace", env.GetCurrentNamespace(), "Kubernetes namespace where Odigos is installed")
 	flag.Parse()
 	return flags
 }

--- a/frontend/services/actions/addclusterinfo.go
+++ b/frontend/services/actions/addclusterinfo.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 
 	"github.com/odigos-io/odigos/api/actions/v1alpha1"
-	"github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/frontend/graph/model"
 	"github.com/odigos-io/odigos/frontend/kube"
 	"github.com/odigos-io/odigos/frontend/services"
+	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -19,7 +19,7 @@ type AddClusterInfoDetails struct {
 }
 
 func CreateAddClusterInfo(ctx context.Context, action model.ActionInput) (model.Action, error) {
-	odigosns := consts.DefaultOdigosNamespace
+	ns := env.GetCurrentNamespace()
 
 	var details AddClusterInfoDetails
 	err := json.Unmarshal([]byte(action.Details), &details)
@@ -53,7 +53,7 @@ func CreateAddClusterInfo(ctx context.Context, action model.ActionInput) (model.
 		},
 	}
 
-	generatedAction, err := kube.DefaultClient.ActionsClient.AddClusterInfos(odigosns).Create(ctx, addClusterInfoAction, metav1.CreateOptions{})
+	generatedAction, err := kube.DefaultClient.ActionsClient.AddClusterInfos(ns).Create(ctx, addClusterInfoAction, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create AddClusterInfo: %v", err)
 	}
@@ -80,10 +80,10 @@ func CreateAddClusterInfo(ctx context.Context, action model.ActionInput) (model.
 }
 
 func UpdateAddClusterInfo(ctx context.Context, id string, action model.ActionInput) (model.Action, error) {
-	odigosns := consts.DefaultOdigosNamespace
+	ns := env.GetCurrentNamespace()
 
 	// Fetch the existing action
-	existingAction, err := kube.DefaultClient.ActionsClient.AddClusterInfos(odigosns).Get(ctx, id, metav1.GetOptions{})
+	existingAction, err := kube.DefaultClient.ActionsClient.AddClusterInfos(ns).Get(ctx, id, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch AddClusterInfo: %v", err)
 	}
@@ -118,7 +118,7 @@ func UpdateAddClusterInfo(ctx context.Context, id string, action model.ActionInp
 	existingAction.Spec.ClusterAttributes = clusterAttributes
 
 	// Update the action in Kubernetes
-	updatedAction, err := kube.DefaultClient.ActionsClient.AddClusterInfos(odigosns).Update(ctx, existingAction, metav1.UpdateOptions{})
+	updatedAction, err := kube.DefaultClient.ActionsClient.AddClusterInfos(ns).Update(ctx, existingAction, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to update AddClusterInfo: %v", err)
 	}
@@ -147,10 +147,10 @@ func UpdateAddClusterInfo(ctx context.Context, id string, action model.ActionInp
 }
 
 func DeleteAddClusterInfo(ctx context.Context, id string) error {
-	odigosns := consts.DefaultOdigosNamespace
+	ns := env.GetCurrentNamespace()
 
 	// Delete the action by its ID from Kubernetes
-	err := kube.DefaultClient.ActionsClient.AddClusterInfos(odigosns).Delete(ctx, id, metav1.DeleteOptions{})
+	err := kube.DefaultClient.ActionsClient.AddClusterInfos(ns).Delete(ctx, id, metav1.DeleteOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return fmt.Errorf("AddClusterInfo action with ID %s not found", id)

--- a/frontend/services/actions/addclusterinfo.go
+++ b/frontend/services/actions/addclusterinfo.go
@@ -19,8 +19,6 @@ type AddClusterInfoDetails struct {
 }
 
 func CreateAddClusterInfo(ctx context.Context, action model.ActionInput) (model.Action, error) {
-	ns := env.GetCurrentNamespace()
-
 	var details AddClusterInfoDetails
 	err := json.Unmarshal([]byte(action.Details), &details)
 	if err != nil {
@@ -52,6 +50,8 @@ func CreateAddClusterInfo(ctx context.Context, action model.ActionInput) (model.
 			ClusterAttributes: clusterAttributes,
 		},
 	}
+
+	ns := env.GetCurrentNamespace()
 
 	generatedAction, err := kube.DefaultClient.ActionsClient.AddClusterInfos(ns).Create(ctx, addClusterInfoAction, metav1.CreateOptions{})
 	if err != nil {

--- a/frontend/services/actions/deleteattribute.go
+++ b/frontend/services/actions/deleteattribute.go
@@ -20,8 +20,6 @@ type DeleteAttributeDetails struct {
 
 // CreateDeleteAttribute creates a new DeleteAttribute action in Kubernetes
 func CreateDeleteAttribute(ctx context.Context, action model.ActionInput) (model.Action, error) {
-	ns := env.GetCurrentNamespace()
-
 	var details DeleteAttributeDetails
 	err := json.Unmarshal([]byte(action.Details), &details)
 	if err != nil {
@@ -45,6 +43,8 @@ func CreateDeleteAttribute(ctx context.Context, action model.ActionInput) (model
 			AttributeNamesToDelete: details.AttributeNamesToDelete,
 		},
 	}
+
+	ns := env.GetCurrentNamespace()
 
 	generatedAction, err := kube.DefaultClient.ActionsClient.DeleteAttributes(ns).Create(ctx, deleteAttributeAction, metav1.CreateOptions{})
 	if err != nil {

--- a/frontend/services/actions/deleteattribute.go
+++ b/frontend/services/actions/deleteattribute.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 
 	"github.com/odigos-io/odigos/api/actions/v1alpha1"
-	"github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/frontend/graph/model"
 	"github.com/odigos-io/odigos/frontend/kube"
 	"github.com/odigos-io/odigos/frontend/services"
+	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -20,7 +20,7 @@ type DeleteAttributeDetails struct {
 
 // CreateDeleteAttribute creates a new DeleteAttribute action in Kubernetes
 func CreateDeleteAttribute(ctx context.Context, action model.ActionInput) (model.Action, error) {
-	odigosns := consts.DefaultOdigosNamespace
+	ns := env.GetCurrentNamespace()
 
 	var details DeleteAttributeDetails
 	err := json.Unmarshal([]byte(action.Details), &details)
@@ -46,7 +46,7 @@ func CreateDeleteAttribute(ctx context.Context, action model.ActionInput) (model
 		},
 	}
 
-	generatedAction, err := kube.DefaultClient.ActionsClient.DeleteAttributes(odigosns).Create(ctx, deleteAttributeAction, metav1.CreateOptions{})
+	generatedAction, err := kube.DefaultClient.ActionsClient.DeleteAttributes(ns).Create(ctx, deleteAttributeAction, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create DeleteAttribute: %v", err)
 	}
@@ -66,9 +66,9 @@ func CreateDeleteAttribute(ctx context.Context, action model.ActionInput) (model
 
 // UpdateDeleteAttribute updates an existing DeleteAttribute action in Kubernetes
 func UpdateDeleteAttribute(ctx context.Context, id string, action model.ActionInput) (model.Action, error) {
-	odigosns := consts.DefaultOdigosNamespace
+	ns := env.GetCurrentNamespace()
 
-	existingAction, err := kube.DefaultClient.ActionsClient.DeleteAttributes(odigosns).Get(ctx, id, metav1.GetOptions{})
+	existingAction, err := kube.DefaultClient.ActionsClient.DeleteAttributes(ns).Get(ctx, id, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch DeleteAttribute: %v", err)
 	}
@@ -90,7 +90,7 @@ func UpdateDeleteAttribute(ctx context.Context, id string, action model.ActionIn
 	existingAction.Spec.Signals = signals
 	existingAction.Spec.AttributeNamesToDelete = details.AttributeNamesToDelete
 
-	updatedAction, err := kube.DefaultClient.ActionsClient.DeleteAttributes(odigosns).Update(ctx, existingAction, metav1.UpdateOptions{})
+	updatedAction, err := kube.DefaultClient.ActionsClient.DeleteAttributes(ns).Update(ctx, existingAction, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to update DeleteAttribute: %v", err)
 	}
@@ -110,9 +110,9 @@ func UpdateDeleteAttribute(ctx context.Context, id string, action model.ActionIn
 
 // DeleteDeleteAttribute deletes an existing DeleteAttribute action from Kubernetes
 func DeleteDeleteAttribute(ctx context.Context, id string) error {
-	odigosns := consts.DefaultOdigosNamespace
+	ns := env.GetCurrentNamespace()
 
-	err := kube.DefaultClient.ActionsClient.DeleteAttributes(odigosns).Delete(ctx, id, metav1.DeleteOptions{})
+	err := kube.DefaultClient.ActionsClient.DeleteAttributes(ns).Delete(ctx, id, metav1.DeleteOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return fmt.Errorf("DeleteAttribute action with ID %s not found", id)

--- a/frontend/services/actions/errorsampler.go
+++ b/frontend/services/actions/errorsampler.go
@@ -7,10 +7,10 @@ import (
 	"strconv"
 
 	"github.com/odigos-io/odigos/api/actions/v1alpha1"
-	"github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/frontend/graph/model"
 	"github.com/odigos-io/odigos/frontend/kube"
 	"github.com/odigos-io/odigos/frontend/services"
+	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -21,7 +21,7 @@ type ErrorSamplerDetails struct {
 
 // CreateErrorSampler creates a new ErrorSampler action in Kubernetes
 func CreateErrorSampler(ctx context.Context, action model.ActionInput) (model.Action, error) {
-	odigosns := consts.DefaultOdigosNamespace
+	ns := env.GetCurrentNamespace()
 
 	var details ErrorSamplerDetails
 	err := json.Unmarshal([]byte(action.Details), &details)
@@ -47,7 +47,7 @@ func CreateErrorSampler(ctx context.Context, action model.ActionInput) (model.Ac
 		},
 	}
 
-	generatedAction, err := kube.DefaultClient.ActionsClient.ErrorSamplers(odigosns).Create(ctx, errorSamplerAction, metav1.CreateOptions{})
+	generatedAction, err := kube.DefaultClient.ActionsClient.ErrorSamplers(ns).Create(ctx, errorSamplerAction, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ErrorSampler: %v", err)
 	}
@@ -67,9 +67,9 @@ func CreateErrorSampler(ctx context.Context, action model.ActionInput) (model.Ac
 
 // UpdateErrorSampler updates an existing ErrorSampler action in Kubernetes
 func UpdateErrorSampler(ctx context.Context, id string, action model.ActionInput) (model.Action, error) {
-	odigosns := consts.DefaultOdigosNamespace
+	ns := env.GetCurrentNamespace()
 
-	existingAction, err := kube.DefaultClient.ActionsClient.ErrorSamplers(odigosns).Get(ctx, id, metav1.GetOptions{})
+	existingAction, err := kube.DefaultClient.ActionsClient.ErrorSamplers(ns).Get(ctx, id, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch ErrorSampler: %v", err)
 	}
@@ -91,7 +91,7 @@ func UpdateErrorSampler(ctx context.Context, id string, action model.ActionInput
 	existingAction.Spec.Signals = signals
 	existingAction.Spec.FallbackSamplingRatio = details.FallbackSamplingRatio
 
-	updatedAction, err := kube.DefaultClient.ActionsClient.ErrorSamplers(odigosns).Update(ctx, existingAction, metav1.UpdateOptions{})
+	updatedAction, err := kube.DefaultClient.ActionsClient.ErrorSamplers(ns).Update(ctx, existingAction, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to update ErrorSampler: %v", err)
 	}
@@ -111,9 +111,9 @@ func UpdateErrorSampler(ctx context.Context, id string, action model.ActionInput
 
 // DeleteErrorSampler deletes an existing ErrorSampler action from Kubernetes
 func DeleteErrorSampler(ctx context.Context, id string) error {
-	odigosns := consts.DefaultOdigosNamespace
+	ns := env.GetCurrentNamespace()
 
-	err := kube.DefaultClient.ActionsClient.ErrorSamplers(odigosns).Delete(ctx, id, metav1.DeleteOptions{})
+	err := kube.DefaultClient.ActionsClient.ErrorSamplers(ns).Delete(ctx, id, metav1.DeleteOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return fmt.Errorf("ErrorSampler action with ID %s not found", id)

--- a/frontend/services/actions/errorsampler.go
+++ b/frontend/services/actions/errorsampler.go
@@ -21,8 +21,6 @@ type ErrorSamplerDetails struct {
 
 // CreateErrorSampler creates a new ErrorSampler action in Kubernetes
 func CreateErrorSampler(ctx context.Context, action model.ActionInput) (model.Action, error) {
-	ns := env.GetCurrentNamespace()
-
 	var details ErrorSamplerDetails
 	err := json.Unmarshal([]byte(action.Details), &details)
 	if err != nil {
@@ -47,10 +45,13 @@ func CreateErrorSampler(ctx context.Context, action model.ActionInput) (model.Ac
 		},
 	}
 
+	ns := env.GetCurrentNamespace()
+
 	generatedAction, err := kube.DefaultClient.ActionsClient.ErrorSamplers(ns).Create(ctx, errorSamplerAction, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ErrorSampler: %v", err)
 	}
+
 	detailsString := strconv.FormatFloat(details.FallbackSamplingRatio, 'f', -1, 64)
 	response := &model.ErrorSamplerAction{
 		ID:      generatedAction.Name,

--- a/frontend/services/actions/latencysampler.go
+++ b/frontend/services/actions/latencysampler.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 
 	"github.com/odigos-io/odigos/api/actions/v1alpha1"
-	"github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/frontend/graph/model"
 	"github.com/odigos-io/odigos/frontend/kube"
 	"github.com/odigos-io/odigos/frontend/services"
+	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -20,7 +20,7 @@ type LatencySamplerDetails struct {
 
 // CreateLatencySampler creates a new LatencySampler action in Kubernetes
 func CreateLatencySampler(ctx context.Context, action model.ActionInput) (model.Action, error) {
-	odigosns := consts.DefaultOdigosNamespace
+	ns := env.GetCurrentNamespace()
 
 	var details LatencySamplerDetails
 	err := json.Unmarshal([]byte(action.Details), &details)
@@ -46,7 +46,7 @@ func CreateLatencySampler(ctx context.Context, action model.ActionInput) (model.
 		},
 	}
 
-	generatedAction, err := kube.DefaultClient.ActionsClient.LatencySamplers(odigosns).Create(ctx, latencySamplerAction, metav1.CreateOptions{})
+	generatedAction, err := kube.DefaultClient.ActionsClient.LatencySamplers(ns).Create(ctx, latencySamplerAction, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create LatencySampler: %v", err)
 	}
@@ -73,9 +73,9 @@ func CreateLatencySampler(ctx context.Context, action model.ActionInput) (model.
 
 // UpdateLatencySampler updates an existing LatencySampler action in Kubernetes
 func UpdateLatencySampler(ctx context.Context, id string, action model.ActionInput) (model.Action, error) {
-	odigosns := consts.DefaultOdigosNamespace
+	ns := env.GetCurrentNamespace()
 
-	existingAction, err := kube.DefaultClient.ActionsClient.LatencySamplers(odigosns).Get(ctx, id, metav1.GetOptions{})
+	existingAction, err := kube.DefaultClient.ActionsClient.LatencySamplers(ns).Get(ctx, id, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch LatencySampler: %v", err)
 	}
@@ -98,7 +98,7 @@ func UpdateLatencySampler(ctx context.Context, id string, action model.ActionInp
 	existingAction.Spec.Signals = signals
 	existingAction.Spec.EndpointsFilters = details.EndpointsFilters
 
-	updatedAction, err := kube.DefaultClient.ActionsClient.LatencySamplers(odigosns).Update(ctx, existingAction, metav1.UpdateOptions{})
+	updatedAction, err := kube.DefaultClient.ActionsClient.LatencySamplers(ns).Update(ctx, existingAction, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to update LatencySampler: %v", err)
 	}
@@ -125,9 +125,9 @@ func UpdateLatencySampler(ctx context.Context, id string, action model.ActionInp
 
 // DeleteLatencySampler deletes an existing LatencySampler action from Kubernetes
 func DeleteLatencySampler(ctx context.Context, id string) error {
-	odigosns := consts.DefaultOdigosNamespace
+	ns := env.GetCurrentNamespace()
 
-	err := kube.DefaultClient.ActionsClient.LatencySamplers(odigosns).Delete(ctx, id, metav1.DeleteOptions{})
+	err := kube.DefaultClient.ActionsClient.LatencySamplers(ns).Delete(ctx, id, metav1.DeleteOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return fmt.Errorf("LatencySampler action with ID %s not found", id)

--- a/frontend/services/actions/latencysampler.go
+++ b/frontend/services/actions/latencysampler.go
@@ -20,8 +20,6 @@ type LatencySamplerDetails struct {
 
 // CreateLatencySampler creates a new LatencySampler action in Kubernetes
 func CreateLatencySampler(ctx context.Context, action model.ActionInput) (model.Action, error) {
-	ns := env.GetCurrentNamespace()
-
 	var details LatencySamplerDetails
 	err := json.Unmarshal([]byte(action.Details), &details)
 	if err != nil {
@@ -45,6 +43,8 @@ func CreateLatencySampler(ctx context.Context, action model.ActionInput) (model.
 			EndpointsFilters: details.EndpointsFilters,
 		},
 	}
+
+	ns := env.GetCurrentNamespace()
 
 	generatedAction, err := kube.DefaultClient.ActionsClient.LatencySamplers(ns).Create(ctx, latencySamplerAction, metav1.CreateOptions{})
 	if err != nil {

--- a/frontend/services/actions/piimasking.go
+++ b/frontend/services/actions/piimasking.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 
 	"github.com/odigos-io/odigos/api/actions/v1alpha1"
-	"github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/frontend/graph/model"
 	"github.com/odigos-io/odigos/frontend/kube"
 	"github.com/odigos-io/odigos/frontend/services"
+	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -20,7 +20,7 @@ type PiiMaskingDetails struct {
 
 // CreatePiiMasking creates a new PiiMasking action in Kubernetes
 func CreatePiiMasking(ctx context.Context, action model.ActionInput) (model.Action, error) {
-	odigosns := consts.DefaultOdigosNamespace
+	ns := env.GetCurrentNamespace()
 
 	var details PiiMaskingDetails
 	err := json.Unmarshal([]byte(action.Details), &details)
@@ -46,7 +46,7 @@ func CreatePiiMasking(ctx context.Context, action model.ActionInput) (model.Acti
 		},
 	}
 
-	generatedAction, err := kube.DefaultClient.ActionsClient.PiiMaskings(odigosns).Create(ctx, piiMaskingAction, metav1.CreateOptions{})
+	generatedAction, err := kube.DefaultClient.ActionsClient.PiiMaskings(ns).Create(ctx, piiMaskingAction, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create PiiMasking: %v", err)
 	}
@@ -71,9 +71,9 @@ func CreatePiiMasking(ctx context.Context, action model.ActionInput) (model.Acti
 
 // UpdatePiiMasking updates an existing PiiMasking action in Kubernetes
 func UpdatePiiMasking(ctx context.Context, id string, action model.ActionInput) (model.Action, error) {
-	odigosns := consts.DefaultOdigosNamespace
+	ns := env.GetCurrentNamespace()
 
-	existingAction, err := kube.DefaultClient.ActionsClient.PiiMaskings(odigosns).Get(ctx, id, metav1.GetOptions{})
+	existingAction, err := kube.DefaultClient.ActionsClient.PiiMaskings(ns).Get(ctx, id, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch PiiMasking: %v", err)
 	}
@@ -95,7 +95,7 @@ func UpdatePiiMasking(ctx context.Context, id string, action model.ActionInput) 
 	existingAction.Spec.Signals = signals
 	existingAction.Spec.PiiCategories = details.PiiCategories
 
-	updatedAction, err := kube.DefaultClient.ActionsClient.PiiMaskings(odigosns).Update(ctx, existingAction, metav1.UpdateOptions{})
+	updatedAction, err := kube.DefaultClient.ActionsClient.PiiMaskings(ns).Update(ctx, existingAction, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to update PiiMasking: %v", err)
 	}
@@ -120,9 +120,9 @@ func UpdatePiiMasking(ctx context.Context, id string, action model.ActionInput) 
 
 // DeletePiiMasking deletes an existing PiiMasking action from Kubernetes
 func DeletePiiMasking(ctx context.Context, id string) error {
-	odigosns := consts.DefaultOdigosNamespace
+	ns := env.GetCurrentNamespace()
 
-	err := kube.DefaultClient.ActionsClient.PiiMaskings(odigosns).Delete(ctx, id, metav1.DeleteOptions{})
+	err := kube.DefaultClient.ActionsClient.PiiMaskings(ns).Delete(ctx, id, metav1.DeleteOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return fmt.Errorf("PiiMasking action with ID %s not found", id)

--- a/frontend/services/actions/piimasking.go
+++ b/frontend/services/actions/piimasking.go
@@ -20,8 +20,6 @@ type PiiMaskingDetails struct {
 
 // CreatePiiMasking creates a new PiiMasking action in Kubernetes
 func CreatePiiMasking(ctx context.Context, action model.ActionInput) (model.Action, error) {
-	ns := env.GetCurrentNamespace()
-
 	var details PiiMaskingDetails
 	err := json.Unmarshal([]byte(action.Details), &details)
 	if err != nil {
@@ -45,6 +43,8 @@ func CreatePiiMasking(ctx context.Context, action model.ActionInput) (model.Acti
 			PiiCategories: details.PiiCategories,
 		},
 	}
+
+	ns := env.GetCurrentNamespace()
 
 	generatedAction, err := kube.DefaultClient.ActionsClient.PiiMaskings(ns).Create(ctx, piiMaskingAction, metav1.CreateOptions{})
 	if err != nil {

--- a/frontend/services/actions/probabilisticsampler.go
+++ b/frontend/services/actions/probabilisticsampler.go
@@ -20,8 +20,6 @@ type ProbabilisticSamplerDetails struct {
 
 // CreateProbabilisticSampler creates a new ProbabilisticSampler action in Kubernetes
 func CreateProbabilisticSampler(ctx context.Context, action model.ActionInput) (model.Action, error) {
-	ns := env.GetCurrentNamespace()
-
 	var details ProbabilisticSamplerDetails
 	err := json.Unmarshal([]byte(action.Details), &details)
 	if err != nil {
@@ -45,6 +43,8 @@ func CreateProbabilisticSampler(ctx context.Context, action model.ActionInput) (
 			SamplingPercentage: details.SamplingPercentage,
 		},
 	}
+
+	ns := env.GetCurrentNamespace()
 
 	generatedAction, err := kube.DefaultClient.ActionsClient.ProbabilisticSamplers(ns).Create(ctx, probabilisticSamplerAction, metav1.CreateOptions{})
 	if err != nil {

--- a/frontend/services/actions/probabilisticsampler.go
+++ b/frontend/services/actions/probabilisticsampler.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 
 	"github.com/odigos-io/odigos/api/actions/v1alpha1"
-	"github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/frontend/graph/model"
 	"github.com/odigos-io/odigos/frontend/kube"
 	"github.com/odigos-io/odigos/frontend/services"
+	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -20,7 +20,7 @@ type ProbabilisticSamplerDetails struct {
 
 // CreateProbabilisticSampler creates a new ProbabilisticSampler action in Kubernetes
 func CreateProbabilisticSampler(ctx context.Context, action model.ActionInput) (model.Action, error) {
-	odigosns := consts.DefaultOdigosNamespace
+	ns := env.GetCurrentNamespace()
 
 	var details ProbabilisticSamplerDetails
 	err := json.Unmarshal([]byte(action.Details), &details)
@@ -46,7 +46,7 @@ func CreateProbabilisticSampler(ctx context.Context, action model.ActionInput) (
 		},
 	}
 
-	generatedAction, err := kube.DefaultClient.ActionsClient.ProbabilisticSamplers(odigosns).Create(ctx, probabilisticSamplerAction, metav1.CreateOptions{})
+	generatedAction, err := kube.DefaultClient.ActionsClient.ProbabilisticSamplers(ns).Create(ctx, probabilisticSamplerAction, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ProbabilisticSampler: %v", err)
 	}
@@ -73,9 +73,9 @@ func CreateProbabilisticSampler(ctx context.Context, action model.ActionInput) (
 
 // UpdateProbabilisticSampler updates an existing ProbabilisticSampler action in Kubernetes
 func UpdateProbabilisticSampler(ctx context.Context, id string, action model.ActionInput) (model.Action, error) {
-	odigosns := consts.DefaultOdigosNamespace
+	ns := env.GetCurrentNamespace()
 
-	existingAction, err := kube.DefaultClient.ActionsClient.ProbabilisticSamplers(odigosns).Get(ctx, id, metav1.GetOptions{})
+	existingAction, err := kube.DefaultClient.ActionsClient.ProbabilisticSamplers(ns).Get(ctx, id, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch ProbabilisticSampler: %v", err)
 	}
@@ -98,7 +98,7 @@ func UpdateProbabilisticSampler(ctx context.Context, id string, action model.Act
 	existingAction.Spec.Signals = signals
 	existingAction.Spec.SamplingPercentage = details.SamplingPercentage
 
-	updatedAction, err := kube.DefaultClient.ActionsClient.ProbabilisticSamplers(odigosns).Update(ctx, existingAction, metav1.UpdateOptions{})
+	updatedAction, err := kube.DefaultClient.ActionsClient.ProbabilisticSamplers(ns).Update(ctx, existingAction, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to update ProbabilisticSampler: %v", err)
 	}
@@ -125,9 +125,9 @@ func UpdateProbabilisticSampler(ctx context.Context, id string, action model.Act
 
 // DeleteProbabilisticSampler deletes an existing ProbabilisticSampler action from Kubernetes
 func DeleteProbabilisticSampler(ctx context.Context, id string) error {
-	odigosns := consts.DefaultOdigosNamespace
+	ns := env.GetCurrentNamespace()
 
-	err := kube.DefaultClient.ActionsClient.ProbabilisticSamplers(odigosns).Delete(ctx, id, metav1.DeleteOptions{})
+	err := kube.DefaultClient.ActionsClient.ProbabilisticSamplers(ns).Delete(ctx, id, metav1.DeleteOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return fmt.Errorf("ProbabilisticSampler action with ID %s not found", id)

--- a/frontend/services/actions/renameattribute.go
+++ b/frontend/services/actions/renameattribute.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 
 	"github.com/odigos-io/odigos/api/actions/v1alpha1"
-	"github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/frontend/graph/model"
 	"github.com/odigos-io/odigos/frontend/kube"
 	"github.com/odigos-io/odigos/frontend/services"
+	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -20,7 +20,7 @@ type RenameAttributeDetails struct {
 
 // CreateRenameAttribute creates a new RenameAttribute action in Kubernetes
 func CreateRenameAttribute(ctx context.Context, action model.ActionInput) (model.Action, error) {
-	odigosns := consts.DefaultOdigosNamespace
+	ns := env.GetCurrentNamespace()
 
 	var details RenameAttributeDetails
 	err := json.Unmarshal([]byte(action.Details), &details)
@@ -46,7 +46,7 @@ func CreateRenameAttribute(ctx context.Context, action model.ActionInput) (model
 		},
 	}
 
-	generatedAction, err := kube.DefaultClient.ActionsClient.RenameAttributes(odigosns).Create(ctx, renameAttributeAction, metav1.CreateOptions{})
+	generatedAction, err := kube.DefaultClient.ActionsClient.RenameAttributes(ns).Create(ctx, renameAttributeAction, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create RenameAttribute: %v", err)
 	}
@@ -73,9 +73,9 @@ func CreateRenameAttribute(ctx context.Context, action model.ActionInput) (model
 
 // UpdateRenameAttribute updates an existing RenameAttribute action in Kubernetes
 func UpdateRenameAttribute(ctx context.Context, id string, action model.ActionInput) (model.Action, error) {
-	odigosns := consts.DefaultOdigosNamespace
+	ns := env.GetCurrentNamespace()
 
-	existingAction, err := kube.DefaultClient.ActionsClient.RenameAttributes(odigosns).Get(ctx, id, metav1.GetOptions{})
+	existingAction, err := kube.DefaultClient.ActionsClient.RenameAttributes(ns).Get(ctx, id, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch RenameAttribute: %v", err)
 	}
@@ -98,7 +98,7 @@ func UpdateRenameAttribute(ctx context.Context, id string, action model.ActionIn
 	existingAction.Spec.Signals = signals
 	existingAction.Spec.Renames = details.Renames
 
-	updatedAction, err := kube.DefaultClient.ActionsClient.RenameAttributes(odigosns).Update(ctx, existingAction, metav1.UpdateOptions{})
+	updatedAction, err := kube.DefaultClient.ActionsClient.RenameAttributes(ns).Update(ctx, existingAction, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to update RenameAttribute: %v", err)
 	}
@@ -124,9 +124,9 @@ func UpdateRenameAttribute(ctx context.Context, id string, action model.ActionIn
 }
 
 func DeleteRenameAttribute(ctx context.Context, id string) error {
-	odigosns := consts.DefaultOdigosNamespace
+	ns := env.GetCurrentNamespace()
 
-	err := kube.DefaultClient.ActionsClient.RenameAttributes(odigosns).Delete(ctx, id, metav1.DeleteOptions{})
+	err := kube.DefaultClient.ActionsClient.RenameAttributes(ns).Delete(ctx, id, metav1.DeleteOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return fmt.Errorf("RenameAttribute action with ID %s not found", id)

--- a/frontend/services/actions/renameattribute.go
+++ b/frontend/services/actions/renameattribute.go
@@ -20,8 +20,6 @@ type RenameAttributeDetails struct {
 
 // CreateRenameAttribute creates a new RenameAttribute action in Kubernetes
 func CreateRenameAttribute(ctx context.Context, action model.ActionInput) (model.Action, error) {
-	ns := env.GetCurrentNamespace()
-
 	var details RenameAttributeDetails
 	err := json.Unmarshal([]byte(action.Details), &details)
 	if err != nil {
@@ -45,6 +43,8 @@ func CreateRenameAttribute(ctx context.Context, action model.ActionInput) (model
 			Renames:    details.Renames,
 		},
 	}
+
+	ns := env.GetCurrentNamespace()
 
 	generatedAction, err := kube.DefaultClient.ActionsClient.RenameAttributes(ns).Create(ctx, renameAttributeAction, metav1.CreateOptions{})
 	if err != nil {

--- a/frontend/services/destinations.go
+++ b/frontend/services/destinations.go
@@ -280,7 +280,7 @@ func AddDestinationOwnerReferenceToSecret(ctx context.Context, ns string, dest *
 func PotentialDestinations(ctx context.Context) []destination_recognition.DestinationDetails {
 	ns := env.GetCurrentNamespace()
 
-	relevantNamespaces, err := getRelevantNameSpaces(ctx, env.GetCurrentNamespace())
+	relevantNamespaces, err := getRelevantNameSpaces(ctx, ns)
 	if err != nil {
 		return nil
 	}

--- a/frontend/services/instrumentationrule.go
+++ b/frontend/services/instrumentationrule.go
@@ -7,9 +7,9 @@ import (
 	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	instrumentationrules "github.com/odigos-io/odigos/api/odigos/v1alpha1/instrumentationrules"
 	"github.com/odigos-io/odigos/common"
-	"github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/frontend/graph/model"
 	"github.com/odigos-io/odigos/frontend/kube"
+	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,8 +17,9 @@ import (
 
 // ListInstrumentationRules fetches all instrumentation rules
 func ListInstrumentationRules(ctx context.Context) ([]*model.InstrumentationRule, error) {
-	odigosns := consts.DefaultOdigosNamespace
-	instrumentationRules, err := kube.DefaultClient.OdigosClient.InstrumentationRules(odigosns).List(ctx, metav1.ListOptions{})
+	ns := env.GetCurrentNamespace()
+
+	instrumentationRules, err := kube.DefaultClient.OdigosClient.InstrumentationRules(ns).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("error getting instrumentation rules: %w", err)
 	}
@@ -40,9 +41,9 @@ func ListInstrumentationRules(ctx context.Context) ([]*model.InstrumentationRule
 }
 
 func GetInstrumentationRule(ctx context.Context, id string) (*model.InstrumentationRule, error) {
-	odigosns := consts.DefaultOdigosNamespace
+	ns := env.GetCurrentNamespace()
 
-	rule, err := kube.DefaultClient.OdigosClient.InstrumentationRules(odigosns).Get(ctx, id, metav1.GetOptions{})
+	rule, err := kube.DefaultClient.OdigosClient.InstrumentationRules(ns).Get(ctx, id, metav1.GetOptions{})
 	if err != nil {
 		return nil, handleNotFoundError(err, id, "instrumentation rule")
 	}
@@ -59,10 +60,10 @@ func GetInstrumentationRule(ctx context.Context, id string) (*model.Instrumentat
 }
 
 func UpdateInstrumentationRule(ctx context.Context, id string, input model.InstrumentationRuleInput) (*model.InstrumentationRule, error) {
-	odigosns := consts.DefaultOdigosNamespace
+	ns := env.GetCurrentNamespace()
 
 	// Retrieve existing rule
-	existingRule, err := kube.DefaultClient.OdigosClient.InstrumentationRules(odigosns).Get(ctx, id, metav1.GetOptions{})
+	existingRule, err := kube.DefaultClient.OdigosClient.InstrumentationRules(ns).Get(ctx, id, metav1.GetOptions{})
 	if err != nil {
 		return nil, handleNotFoundError(err, id, "instrumentation rule")
 	}
@@ -123,7 +124,7 @@ func UpdateInstrumentationRule(ctx context.Context, id string, input model.Instr
 	}
 
 	// Update rule in Kubernetes
-	updatedRule, err := kube.DefaultClient.OdigosClient.InstrumentationRules(odigosns).Update(ctx, existingRule, metav1.UpdateOptions{})
+	updatedRule, err := kube.DefaultClient.OdigosClient.InstrumentationRules(ns).Update(ctx, existingRule, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("error updating instrumentation rule: %w", err)
 	}
@@ -140,9 +141,9 @@ func UpdateInstrumentationRule(ctx context.Context, id string, input model.Instr
 }
 
 func DeleteInstrumentationRule(ctx context.Context, id string) (bool, error) {
-	odigosns := consts.DefaultOdigosNamespace
+	ns := env.GetCurrentNamespace()
 
-	err := kube.DefaultClient.OdigosClient.InstrumentationRules(odigosns).Delete(ctx, id, metav1.DeleteOptions{})
+	err := kube.DefaultClient.OdigosClient.InstrumentationRules(ns).Delete(ctx, id, metav1.DeleteOptions{})
 	if err != nil {
 		return false, handleNotFoundError(err, id, "instrumentation rule")
 	}
@@ -151,7 +152,7 @@ func DeleteInstrumentationRule(ctx context.Context, id string) (bool, error) {
 }
 
 func CreateInstrumentationRule(ctx context.Context, input model.InstrumentationRuleInput) (*model.InstrumentationRule, error) {
-	odigosns := consts.DefaultOdigosNamespace
+	ns := env.GetCurrentNamespace()
 
 	ruleName := *input.RuleName
 	notes := *input.Notes
@@ -219,7 +220,7 @@ func CreateInstrumentationRule(ctx context.Context, input model.InstrumentationR
 	}
 
 	// Create the rule in Kubernetes
-	createdRule, err := kube.DefaultClient.OdigosClient.InstrumentationRules(odigosns).Create(ctx, newRule, metav1.CreateOptions{})
+	createdRule, err := kube.DefaultClient.OdigosClient.InstrumentationRules(ns).Create(ctx, newRule, metav1.CreateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("error creating instrumentation rule: %w", err)
 	}

--- a/frontend/services/namespaces.go
+++ b/frontend/services/namespaces.go
@@ -10,6 +10,7 @@ import (
 	"github.com/odigos-io/odigos/frontend/graph/model"
 	"github.com/odigos-io/odigos/frontend/kube"
 	"github.com/odigos-io/odigos/k8sutils/pkg/client"
+	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	"github.com/odigos-io/odigos/k8sutils/pkg/utils"
 
 	"golang.org/x/sync/errgroup"
@@ -26,7 +27,9 @@ type GetNamespacesResponse struct {
 }
 
 func GetK8SNamespaces(ctx context.Context) (GetNamespacesResponse, error) {
-	relevantNameSpaces, err := getRelevantNameSpaces(ctx, consts.DefaultOdigosNamespace)
+	ns := env.GetCurrentNamespace()
+
+	relevantNameSpaces, err := getRelevantNameSpaces(ctx, ns)
 	if err != nil {
 		return GetNamespacesResponse{}, err
 	}


### PR DESCRIPTION
This pull request focuses on updating the namespace handling in the `frontend/graph/schema.resolvers.go` file and related files to use the current namespace dynamically instead of a hardcoded default. The main changes involve replacing the constant `DefaultOdigosNamespace` with the dynamic value obtained from `env.GetCurrentNamespace()`.

Namespace handling updates:

* [`frontend/graph/schema.resolvers.go`](diffhunk://#diff-8e6e95029056db2c0301fc338e0ca5a04356ce5d45ee9514bbd167f2d85bae70R22-R36): Replaced hardcoded `consts.DefaultOdigosNamespace` with `env.GetCurrentNamespace()` for various Kubernetes client operations. [[1]](diffhunk://#diff-8e6e95029056db2c0301fc338e0ca5a04356ce5d45ee9514bbd167f2d85bae70R22-R36) [[2]](diffhunk://#diff-8e6e95029056db2c0301fc338e0ca5a04356ce5d45ee9514bbd167f2d85bae70L143-R155) [[3]](diffhunk://#diff-8e6e95029056db2c0301fc338e0ca5a04356ce5d45ee9514bbd167f2d85bae70L167-R174) [[4]](diffhunk://#diff-8e6e95029056db2c0301fc338e0ca5a04356ce5d45ee9514bbd167f2d85bae70L188-R192) [[5]](diffhunk://#diff-8e6e95029056db2c0301fc338e0ca5a04356ce5d45ee9514bbd167f2d85bae70L206-R210) [[6]](diffhunk://#diff-8e6e95029056db2c0301fc338e0ca5a04356ce5d45ee9514bbd167f2d85bae70L224-R228) [[7]](diffhunk://#diff-8e6e95029056db2c0301fc338e0ca5a04356ce5d45ee9514bbd167f2d85bae70L242-R246) [[8]](diffhunk://#diff-8e6e95029056db2c0301fc338e0ca5a04356ce5d45ee9514bbd167f2d85bae70L260-R264) [[9]](diffhunk://#diff-8e6e95029056db2c0301fc338e0ca5a04356ce5d45ee9514bbd167f2d85bae70L278-R282) [[10]](diffhunk://#diff-8e6e95029056db2c0301fc338e0ca5a04356ce5d45ee9514bbd167f2d85bae70L340-R345) [[11]](diffhunk://#diff-8e6e95029056db2c0301fc338e0ca5a04356ce5d45ee9514bbd167f2d85bae70L400-R405) [[12]](diffhunk://#diff-8e6e95029056db2c0301fc338e0ca5a04356ce5d45ee9514bbd167f2d85bae70L438-R464) [[13]](diffhunk://#diff-8e6e95029056db2c0301fc338e0ca5a04356ce5d45ee9514bbd167f2d85bae70L471-R475) [[14]](diffhunk://#diff-8e6e95029056db2c0301fc338e0ca5a04356ce5d45ee9514bbd167f2d85bae70L502-R505) [[15]](diffhunk://#diff-8e6e95029056db2c0301fc338e0ca5a04356ce5d45ee9514bbd167f2d85bae70L513-R545) [[16]](diffhunk://#diff-8e6e95029056db2c0301fc338e0ca5a04356ce5d45ee9514bbd167f2d85bae70L557-R566) [[17]](diffhunk://#diff-8e6e95029056db2c0301fc338e0ca5a04356ce5d45ee9514bbd167f2d85bae70L576-R580)

* [`frontend/main.go`](diffhunk://#diff-3157268136b8d5514c0baed4c63042c62e3a16048a0346448241152dcd66b209L64-R63): Updated the default namespace flag to use `env.GetCurrentNamespace()` instead of `consts.DefaultOdigosNamespace`.

* [`frontend/services/actions/addclusterinfo.go`](diffhunk://#diff-c2da2861415e61f772e3b44d22810aa34b4eba6070f744709c4b1b6b919a3f09L22-R22): Replaced `consts.DefaultOdigosNamespace` with `env.GetCurrentNamespace()` for creating, updating, and deleting actions. [[1]](diffhunk://#diff-c2da2861415e61f772e3b44d22810aa34b4eba6070f744709c4b1b6b919a3f09L22-R22) [[2]](diffhunk://#diff-c2da2861415e61f772e3b44d22810aa34b4eba6070f744709c4b1b6b919a3f09L56-R56) [[3]](diffhunk://#diff-c2da2861415e61f772e3b44d22810aa34b4eba6070f744709c4b1b6b919a3f09L83-R86) [[4]](diffhunk://#diff-c2da2861415e61f772e3b44d22810aa34b4eba6070f744709c4b1b6b919a3f09L121-R121) [[5]](diffhunk://#diff-c2da2861415e61f772e3b44d22810aa34b4eba6070f744709c4b1b6b919a3f09L150-R153)

These changes ensure that the application dynamically uses the current namespace, improving flexibility and reducing the need for hardcoded values.