### PR TITLE
[GEN-2224] add "mutable" and "profileName" fields to InstrumentationRule model

### DIFF
--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -257,8 +257,10 @@ type ComplexityRoot struct {
 	InstrumentationRule struct {
 		Disabled                 func(childComplexity int) int
 		InstrumentationLibraries func(childComplexity int) int
+		Mutable                  func(childComplexity int) int
 		Notes                    func(childComplexity int) int
 		PayloadCollection        func(childComplexity int) int
+		ProfileName              func(childComplexity int) int
 		RuleID                   func(childComplexity int) int
 		RuleName                 func(childComplexity int) int
 		Workloads                func(childComplexity int) int
@@ -1386,6 +1388,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.InstrumentationRule.InstrumentationLibraries(childComplexity), true
 
+	case "InstrumentationRule.mutable":
+		if e.complexity.InstrumentationRule.Mutable == nil {
+			break
+		}
+
+		return e.complexity.InstrumentationRule.Mutable(childComplexity), true
+
 	case "InstrumentationRule.notes":
 		if e.complexity.InstrumentationRule.Notes == nil {
 			break
@@ -1399,6 +1408,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.InstrumentationRule.PayloadCollection(childComplexity), true
+
+	case "InstrumentationRule.profileName":
+		if e.complexity.InstrumentationRule.ProfileName == nil {
+			break
+		}
+
+		return e.complexity.InstrumentationRule.ProfileName(childComplexity), true
 
 	case "InstrumentationRule.ruleId":
 		if e.complexity.InstrumentationRule.RuleID == nil {
@@ -4517,6 +4533,10 @@ func (ec *executionContext) fieldContext_ComputePlatform_instrumentationRules(_ 
 				return ec.fieldContext_InstrumentationRule_notes(ctx, field)
 			case "disabled":
 				return ec.fieldContext_InstrumentationRule_disabled(ctx, field)
+			case "mutable":
+				return ec.fieldContext_InstrumentationRule_mutable(ctx, field)
+			case "profileName":
+				return ec.fieldContext_InstrumentationRule_profileName(ctx, field)
 			case "workloads":
 				return ec.fieldContext_InstrumentationRule_workloads(ctx, field)
 			case "instrumentationLibraries":
@@ -8689,6 +8709,94 @@ func (ec *executionContext) fieldContext_InstrumentationRule_disabled(_ context.
 	return fc, nil
 }
 
+func (ec *executionContext) _InstrumentationRule_mutable(ctx context.Context, field graphql.CollectedField, obj *model.InstrumentationRule) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InstrumentationRule_mutable(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Mutable, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InstrumentationRule_mutable(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InstrumentationRule",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InstrumentationRule_profileName(ctx context.Context, field graphql.CollectedField, obj *model.InstrumentationRule) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InstrumentationRule_profileName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ProfileName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InstrumentationRule_profileName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InstrumentationRule",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _InstrumentationRule_workloads(ctx context.Context, field graphql.CollectedField, obj *model.InstrumentationRule) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_InstrumentationRule_workloads(ctx, field)
 	if err != nil {
@@ -10427,6 +10535,10 @@ func (ec *executionContext) fieldContext_Mutation_createInstrumentationRule(ctx 
 				return ec.fieldContext_InstrumentationRule_notes(ctx, field)
 			case "disabled":
 				return ec.fieldContext_InstrumentationRule_disabled(ctx, field)
+			case "mutable":
+				return ec.fieldContext_InstrumentationRule_mutable(ctx, field)
+			case "profileName":
+				return ec.fieldContext_InstrumentationRule_profileName(ctx, field)
 			case "workloads":
 				return ec.fieldContext_InstrumentationRule_workloads(ctx, field)
 			case "instrumentationLibraries":
@@ -10498,6 +10610,10 @@ func (ec *executionContext) fieldContext_Mutation_updateInstrumentationRule(ctx 
 				return ec.fieldContext_InstrumentationRule_notes(ctx, field)
 			case "disabled":
 				return ec.fieldContext_InstrumentationRule_disabled(ctx, field)
+			case "mutable":
+				return ec.fieldContext_InstrumentationRule_mutable(ctx, field)
+			case "profileName":
+				return ec.fieldContext_InstrumentationRule_profileName(ctx, field)
 			case "workloads":
 				return ec.fieldContext_InstrumentationRule_workloads(ctx, field)
 			case "instrumentationLibraries":
@@ -20014,6 +20130,16 @@ func (ec *executionContext) _InstrumentationRule(ctx context.Context, sel ast.Se
 			out.Values[i] = ec._InstrumentationRule_notes(ctx, field, obj)
 		case "disabled":
 			out.Values[i] = ec._InstrumentationRule_disabled(ctx, field, obj)
+		case "mutable":
+			out.Values[i] = ec._InstrumentationRule_mutable(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "profileName":
+			out.Values[i] = ec._InstrumentationRule_profileName(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "workloads":
 			out.Values[i] = ec._InstrumentationRule_workloads(ctx, field, obj)
 		case "instrumentationLibraries":

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -289,6 +289,8 @@ type InstrumentationRule struct {
 	RuleName                 *string                           `json:"ruleName,omitempty"`
 	Notes                    *string                           `json:"notes,omitempty"`
 	Disabled                 *bool                             `json:"disabled,omitempty"`
+	Mutable                  bool                              `json:"mutable"`
+	ProfileName              string                            `json:"profileName"`
 	Workloads                []*PodWorkload                    `json:"workloads,omitempty"`
 	InstrumentationLibraries []*InstrumentationLibraryGlobalID `json:"instrumentationLibraries,omitempty"`
 	PayloadCollection        *PayloadCollection                `json:"payloadCollection,omitempty"`

--- a/frontend/graph/schema.graphqls
+++ b/frontend/graph/schema.graphqls
@@ -117,6 +117,8 @@ type InstrumentationRule {
   ruleName: String
   notes: String
   disabled: Boolean
+  mutable: Boolean!
+  profileName: String!
   workloads: [PodWorkload!]
   instrumentationLibraries: [InstrumentationLibraryGlobalId!]
   payloadCollection: PayloadCollection

--- a/frontend/services/instrumentationrule.go
+++ b/frontend/services/instrumentationrule.go
@@ -10,6 +10,7 @@ import (
 	"github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/frontend/graph/model"
 	"github.com/odigos-io/odigos/frontend/kube"
+	k8sconsts "github.com/odigos-io/odigos/k8sutils/pkg/consts"
 	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,12 +26,17 @@ func ListInstrumentationRules(ctx context.Context) ([]*model.InstrumentationRule
 
 	var gqlRules []*model.InstrumentationRule
 	for _, rule := range instrumentationRules.Items {
+		annotations := rule.GetAnnotations()
+		profileName := annotations[k8sconsts.OdigosProfileAnnotation]
+		mutable := profileName == ""
 
 		gqlRules = append(gqlRules, &model.InstrumentationRule{
 			RuleID:                   rule.Name,
 			RuleName:                 &rule.Spec.RuleName,
 			Notes:                    &rule.Spec.Notes,
 			Disabled:                 &rule.Spec.Disabled,
+			Mutable:                  mutable,
+			ProfileName:              profileName,
 			Workloads:                convertWorkloads(rule.Spec.Workloads),
 			InstrumentationLibraries: convertInstrumentationLibraries(rule.Spec.InstrumentationLibraries),
 			PayloadCollection:        convertPayloadCollection(rule.Spec.PayloadCollection),

--- a/frontend/webapp/containers/main/instrumentation-rules/rule-drawer/build-card.ts
+++ b/frontend/webapp/containers/main/instrumentation-rules/rule-drawer/build-card.ts
@@ -3,13 +3,14 @@ import type { InstrumentationRuleSpec } from '@/types';
 import { DataCardRow, DataCardFieldTypes } from '@/reuseable-components';
 
 const buildCard = (rule: InstrumentationRuleSpec) => {
-  const { type, ruleName, notes, disabled, payloadCollection } = rule;
+  const { type, ruleName, notes, disabled, profileName, payloadCollection } = rule;
 
   const arr: DataCardRow[] = [
     { title: DISPLAY_TITLES.TYPE, value: type },
     { type: DataCardFieldTypes.ACTIVE_STATUS, title: DISPLAY_TITLES.STATUS, value: String(!disabled) },
     { title: DISPLAY_TITLES.NAME, value: ruleName },
     { title: DISPLAY_TITLES.NOTES, value: notes },
+    { title: DISPLAY_TITLES.MANAGED_BY_PROFILE, value: profileName },
     { type: DataCardFieldTypes.DIVIDER, width: '100%' },
   ];
 

--- a/frontend/webapp/containers/main/instrumentation-rules/rule-drawer/build-drawer-item.ts
+++ b/frontend/webapp/containers/main/instrumentation-rules/rule-drawer/build-drawer-item.ts
@@ -3,7 +3,7 @@ import { type InstrumentationRuleSpec, type InstrumentationRuleInput, PayloadCol
 
 const buildDrawerItem = (id: string, formData: InstrumentationRuleInput, drawerItem: InstrumentationRuleSpec): InstrumentationRuleSpec => {
   const { ruleName, notes, disabled, payloadCollection } = formData;
-  const { workloads, instrumentationLibraries } = drawerItem;
+  const { mutable, profileName, workloads, instrumentationLibraries } = drawerItem;
 
   return {
     ruleId: id,
@@ -11,6 +11,8 @@ const buildDrawerItem = (id: string, formData: InstrumentationRuleInput, drawerI
     type: deriveTypeFromRule(formData),
     notes,
     disabled,
+    mutable,
+    profileName,
     payloadCollection: {
       [PayloadCollectionType.HTTP_REQUEST]: payloadCollection[PayloadCollectionType.HTTP_REQUEST] || undefined,
       [PayloadCollectionType.HTTP_RESPONSE]: payloadCollection[PayloadCollectionType.HTTP_RESPONSE] || undefined,

--- a/frontend/webapp/containers/main/instrumentation-rules/rule-drawer/index.tsx
+++ b/frontend/webapp/containers/main/instrumentation-rules/rule-drawer/index.tsx
@@ -71,7 +71,7 @@ export const RuleDrawer: React.FC<Props> = () => {
   const { id, item } = selectedItem as { id: string; item: InstrumentationRuleSpecMapped };
 
   const handleEdit = (bool?: boolean) => {
-    if (item.type === InstrumentationRuleType.UNKNOWN_TYPE && (bool || bool === undefined)) {
+    if (!item.mutable && (bool || bool === undefined)) {
       addNotification({
         type: NOTIFICATION_TYPE.WARNING,
         title: FORM_ALERTS.FORBIDDEN,
@@ -91,7 +91,18 @@ export const RuleDrawer: React.FC<Props> = () => {
   };
 
   const handleDelete = async () => {
-    await deleteInstrumentationRule(id);
+    if (!item.mutable) {
+      addNotification({
+        type: NOTIFICATION_TYPE.WARNING,
+        title: FORM_ALERTS.FORBIDDEN,
+        message: FORM_ALERTS.CANNOT_DELETE_RULE,
+        crdType: OVERVIEW_ENTITY_TYPES.RULE,
+        target: id,
+        hideFromHistory: true,
+      });
+    } else {
+      await deleteInstrumentationRule(id);
+    }
   };
 
   const handleSave = async (newTitle: string) => {

--- a/frontend/webapp/graphql/queries/compute-platform.ts
+++ b/frontend/webapp/graphql/queries/compute-platform.ts
@@ -130,6 +130,8 @@ export const GET_INSTRUMENTATION_RULES = gql`
         ruleName
         notes
         disabled
+        mutable
+        profileName
         # workloads {}
         # instrumentationLibraries {}
         payloadCollection {

--- a/frontend/webapp/types/instrumentation-rules.ts
+++ b/frontend/webapp/types/instrumentation-rules.ts
@@ -77,6 +77,8 @@ export interface InstrumentationRuleSpec {
   type?: InstrumentationRuleType; // does not come from backend, it's derived during GET
   notes: string;
   disabled: boolean;
+  mutable: boolean;
+  profileName: string;
   workloads?: PodWorkload[];
   instrumentationLibraries?: InstrumentationLibraryGlobalId[];
   payloadCollection?: PayloadCollection;

--- a/frontend/webapp/utils/constants/string.tsx
+++ b/frontend/webapp/utils/constants/string.tsx
@@ -41,7 +41,8 @@ export const FORM_ALERTS = {
   REQUIRED_FIELDS: 'Required fields are missing',
   FIELD_IS_REQUIRED: 'This field is required',
   FORBIDDEN: 'Forbidden',
-  CANNOT_EDIT_RULE: 'Cannot edit instrumentation rule of this type',
+  CANNOT_EDIT_RULE: 'Cannot edit a system-managed instrumentation rule',
+  CANNOT_DELETE_RULE: 'Cannot delete a system-managed instrumentation rule',
   LATENCY_HTTP_ROUTE: 'HTTP route must start with a forward slash "/"',
 };
 

--- a/frontend/webapp/utils/constants/string.tsx
+++ b/frontend/webapp/utils/constants/string.tsx
@@ -88,4 +88,5 @@ export const DISPLAY_TITLES = {
   LANGUAGE: 'Language',
   MONITORS: 'Monitors',
   SIGNALS_FOR_PROCESSING: 'Signals for Processing',
+  MANAGED_BY_PROFILE: 'Managed by Profile',
 };


### PR DESCRIPTION
This pull request introduces several changes to the `frontend/graph` and `frontend/webapp` directories to add new fields and functionality related to `InstrumentationRule`. The most important changes include adding the `mutable` and `profileName` fields to the `InstrumentationRule` type, updating the GraphQL schema and queries, and modifying the frontend components to handle these new fields.

### GraphQL Schema and Model Updates:
* Added `mutable` and `profileName` fields to the `InstrumentationRule` struct in `frontend/graph/model/models_gen.go` and updated the GraphQL schema in `frontend/graph/schema.graphqls`. [[1]](diffhunk://#diff-642ccd7ed71fdfa394bd7f7fd99c9c33e20ff18c876a91cb989d379a44390469R292-R293) [[2]](diffhunk://#diff-bc07b91dedd1782d9ddbbb6374ad97c7604f9a267de5174645723d863c732f80R120-R121)

### Backend Logic Updates:
* Updated the `ListInstrumentationRules` function in `frontend/services/instrumentationrule.go` to populate the new fields based on annotations.
* Modified the `Complexity` and `executionContext` functions in `frontend/graph/generated.go` to handle the new fields. [[1]](diffhunk://#diff-4bacf1f13939a5c243f3f83d21f4560b331d13667d81ea5945ed1f57ddb205f2R1391-R1397) [[2]](diffhunk://#diff-4bacf1f13939a5c243f3f83d21f4560b331d13667d81ea5945ed1f57ddb205f2R1412-R1418) [[3]](diffhunk://#diff-4bacf1f13939a5c243f3f83d21f4560b331d13667d81ea5945ed1f57ddb205f2R4536-R4539) [[4]](diffhunk://#diff-4bacf1f13939a5c243f3f83d21f4560b331d13667d81ea5945ed1f57ddb205f2R8712-R8799) [[5]](diffhunk://#diff-4bacf1f13939a5c243f3f83d21f4560b331d13667d81ea5945ed1f57ddb205f2R10538-R10541) [[6]](diffhunk://#diff-4bacf1f13939a5c243f3f83d21f4560b331d13667d81ea5945ed1f57ddb205f2R10613-R10616) [[7]](diffhunk://#diff-4bacf1f13939a5c243f3f83d21f4560b331d13667d81ea5945ed1f57ddb205f2R20133-R20142)

### Frontend Component Updates:
* Updated the `RuleDrawer` component in `frontend/webapp/containers/main/instrumentation-rules/rule-drawer/index.tsx` to handle the `mutable` field and restrict editing or deleting system-managed rules. [[1]](diffhunk://#diff-759940924dd4ee0c6895f60e21ca040542d9cf1d3f69162677c9983d62b12f8cL74-R74) [[2]](diffhunk://#diff-759940924dd4ee0c6895f60e21ca040542d9cf1d3f69162677c9983d62b12f8cR94-R105)
* Added `mutable` and `profileName` fields to the `GET_INSTRUMENTATION_RULES` GraphQL query in `frontend/webapp/graphql/queries/compute-platform.ts`.
* Updated the `InstrumentationRuleSpec` interface in `frontend/webapp/types/instrumentation-rules.ts` to include the new fields.
* Enhanced the `FORM_ALERTS` constants in `frontend/webapp/utils/constants/string.tsx` to include new alert messages for system-managed rules.