### PR TITLE
chore: remove direct dependency of api module on otel

### DIFF
--- a/api/generated/odigos/applyconfiguration/odigos/v1alpha1/attributecondition.go
+++ b/api/generated/odigos/applyconfiguration/odigos/v1alpha1/attributecondition.go
@@ -19,13 +19,12 @@ package v1alpha1
 
 import (
 	odigosv1alpha1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
-	attribute "go.opentelemetry.io/otel/attribute"
 )
 
 // AttributeConditionApplyConfiguration represents a declarative configuration of the AttributeCondition type for use
 // with apply.
 type AttributeConditionApplyConfiguration struct {
-	Key      *attribute.Key           `json:"key,omitempty"`
+	Key      *string                  `json:"key,omitempty"`
 	Val      *string                  `json:"val,omitempty"`
 	Operator *odigosv1alpha1.Operator `json:"operator,omitempty"`
 }
@@ -39,7 +38,7 @@ func AttributeCondition() *AttributeConditionApplyConfiguration {
 // WithKey sets the Key field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Key field is set to the value of the last call.
-func (b *AttributeConditionApplyConfiguration) WithKey(value attribute.Key) *AttributeConditionApplyConfiguration {
+func (b *AttributeConditionApplyConfiguration) WithKey(value string) *AttributeConditionApplyConfiguration {
 	b.Key = &value
 	return b
 }

--- a/api/go.mod
+++ b/api/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	go.opentelemetry.io/otel v1.34.0
+	go.opentelemetry.io/otel v1.34.0 // indirect
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
 	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/net v0.34.0 // indirect

--- a/api/odigos/v1alpha1/instrumentationconfig_types.go
+++ b/api/odigos/v1alpha1/instrumentationconfig_types.go
@@ -3,7 +3,6 @@ package v1alpha1
 import (
 	"github.com/odigos-io/odigos/api/odigos/v1alpha1/instrumentationrules"
 	"github.com/odigos-io/odigos/common"
-	"go.opentelemetry.io/otel/attribute"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -89,7 +88,7 @@ type SdkConfig struct {
 // 'Operand' represents the attributes and values that an operator acts upon in an expression
 type AttributeCondition struct {
 	// attribute key (e.g. "url.path")
-	Key attribute.Key `json:"key"`
+	Key string `json:"key"`
 	// currently only string values are supported.
 	Val string `json:"val"`
 	// The operator to use to compare the attribute value.

--- a/docs/api-reference/odigos.io.v1alpha1.mdx
+++ b/docs/api-reference/odigos.io.v1alpha1.mdx
@@ -509,7 +509,7 @@ auto_generated: true
 <code>key</code> <B>[Required]</B>
 </td>
 <td>
-<a href="https://pkg.go.dev/go.opentelemetry.io/otel/attribute#Key"><code>go.opentelemetry.io/otel/attribute.Key</code></a>
+<code>string</code>
 </td>
 <td>
    <p>attribute key (e.g. &quot;url.path&quot;)</p>


### PR DESCRIPTION
It was only used to pull in attribute.Key which is a string.

This change reduces a bit our dependency management and complexity 