### PR TITLE
mark instrumentedApplication as deprecated

### DIFF
--- a/api/config/crd/bases/odigos.io_instrumentedapplications.yaml
+++ b/api/config/crd/bases/odigos.io_instrumentedapplications.yaml
@@ -20,8 +20,10 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: InstrumentedApplication is the Schema for the instrumentedapplications
-          API
+        description: |-
+          InstrumentedApplication is the Schema for the instrumentedapplications API
+
+          Deprecated: in favour of InstrumentationConfig
         properties:
           apiVersion:
             description: |-
@@ -41,21 +43,27 @@ spec:
           metadata:
             type: object
           spec:
-            description: InstrumentedApplicationSpec defines the desired state of
-              InstrumentedApplication
+            description: |-
+              InstrumentedApplicationSpec defines the desired state of InstrumentedApplication
+
+              Deprecated: in favour of InstrumentationConfig
             properties:
               options:
                 items:
+                  description: 'Deprecated: configuration is done via InstrumentationConfig'
                   properties:
                     containerName:
                       type: string
                     instrumentationsLibraries:
                       items:
+                        description: 'Deprecated: configuration is done via InstrumentationConfig'
                         properties:
                           libraryName:
                             type: string
                           options:
                             items:
+                              description: 'Deprecated: configuration is done via
+                                InstrumentationConfig'
                               properties:
                                 optionKey:
                                   type: string
@@ -158,8 +166,10 @@ spec:
                 type: array
             type: object
           status:
-            description: InstrumentedApplicationStatus defines the observed state
-              of InstrumentedApplication
+            description: |-
+              InstrumentedApplicationStatus defines the observed state of InstrumentedApplication
+
+              Deprecated: in favour of InstrumentationConfig
             properties:
               conditions:
                 description: Represents the observations of a nstrumentedApplication's

--- a/api/odigos/v1alpha1/instrumentationconfig_types.go
+++ b/api/odigos/v1alpha1/instrumentationconfig_types.go
@@ -29,6 +29,14 @@ type EnvVar struct {
 	Value string `json:"value"`
 }
 
+type ProcessingState string
+
+const (
+	ProcessingStateFailed    ProcessingState = "Failed"    // Used when CRI fails to detect the runtime envs
+	ProcessingStateSucceeded ProcessingState = "Succeeded" // Indicates that CRI successfully processed the runtime environments, even if no environments were detected.
+	ProcessingStateSkipped   ProcessingState = "Skipped"   // Used when env originally come from manifest
+)
+
 // +kubebuilder:object:generate=true
 type RuntimeDetailsByContainer struct {
 	ContainerName  string                     `json:"containerName"`

--- a/api/odigos/v1alpha1/instrumentedapplication_types.go
+++ b/api/odigos/v1alpha1/instrumentedapplication_types.go
@@ -22,38 +22,40 @@ import (
 )
 
 // +kubebuilder:object:generate=true
+//
+// Deprecated: configuration is done via InstrumentationConfig
 type ConfigOption struct {
 	OptionKey string          `json:"optionKey"`
 	SpanKind  common.SpanKind `json:"spanKind"`
 }
 
 // +kubebuilder:object:generate=true
+//
+// Deprecated: configuration is done via InstrumentationConfig
 type InstrumentationLibraryOptions struct {
 	LibraryName string         `json:"libraryName"`
 	Options     []ConfigOption `json:"options"`
 }
 
-type ProcessingState string
-
-const (
-	ProcessingStateFailed    ProcessingState = "Failed"    // Used when CRI fails to detect the runtime envs
-	ProcessingStateSucceeded ProcessingState = "Succeeded" // Indicates that CRI successfully processed the runtime environments, even if no environments were detected.
-	ProcessingStateSkipped   ProcessingState = "Skipped"   // Used when env originally come from manifest
-)
-
 // +kubebuilder:object:generate=true
+//
+// Deprecated: configuration is done via InstrumentationConfig
 type OptionByContainer struct {
 	ContainerName            string                          `json:"containerName"`
 	InstrumentationLibraries []InstrumentationLibraryOptions `json:"instrumentationsLibraries"`
 }
 
 // InstrumentedApplicationSpec defines the desired state of InstrumentedApplication
+//
+// Deprecated: in favour of InstrumentationConfig
 type InstrumentedApplicationSpec struct {
 	RuntimeDetails []RuntimeDetailsByContainer `json:"runtimeDetails,omitempty"`
 	Options        []OptionByContainer         `json:"options,omitempty"`
 }
 
 // InstrumentedApplicationStatus defines the observed state of InstrumentedApplication
+//
+// Deprecated: in favour of InstrumentationConfig
 type InstrumentedApplicationStatus struct {
 	// Represents the observations of a nstrumentedApplication's current state.
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" protobuf:"bytes,1,rep,name=conditions"`
@@ -66,6 +68,8 @@ type InstrumentedApplicationStatus struct {
 //+kubebuilder:metadata:labels=odigos.io/system-object=true
 
 // InstrumentedApplication is the Schema for the instrumentedapplications API
+//
+// Deprecated: in favour of InstrumentationConfig
 type InstrumentedApplication struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -77,6 +81,8 @@ type InstrumentedApplication struct {
 //+kubebuilder:object:root=true
 
 // InstrumentedApplicationList contains a list of InstrumentedApplication
+//
+// Deprecated: in favour of InstrumentationConfigList
 type InstrumentedApplicationList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/docs/api-reference/odigos.io.v1alpha1.mdx
+++ b/docs/api-reference/odigos.io.v1alpha1.mdx
@@ -267,6 +267,7 @@ auto_generated: true
 ## `InstrumentedApplication` <a id="odigos-io-v1alpha1-InstrumentedApplication"></a>
     
 <p>InstrumentedApplication is the Schema for the instrumentedapplications API</p>
+<p>Deprecated: in favour of InstrumentationConfig</p>
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Type</th><th>Description</th></tr></thead>
@@ -925,6 +926,8 @@ Known .status.conditions.type are: &quot;Available&quot;, &quot;Progressing&quot
 
 - [InstrumentationLibraryOptions](#odigos-io-v1alpha1-InstrumentationLibraryOptions)
 
+<p>Deprecated: configuration is done via InstrumentationConfig</p>
+
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Type</th><th>Description</th></tr></thead>
 <tbody>
@@ -1481,6 +1484,8 @@ In Go, SpanKind is used because the same instrumentation library can be utilized
 
 - [OptionByContainer](#odigos-io-v1alpha1-OptionByContainer)
 
+<p>Deprecated: configuration is done via InstrumentationConfig</p>
+
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Type</th><th>Description</th></tr></thead>
 <tbody>
@@ -1775,6 +1780,7 @@ Known .status.conditions.type are: &quot;Available&quot;, &quot;Progressing&quot
 - [InstrumentedApplication](#odigos-io-v1alpha1-InstrumentedApplication)
 
 <p>InstrumentedApplicationSpec defines the desired state of InstrumentedApplication</p>
+<p>Deprecated: in favour of InstrumentationConfig</p>
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Type</th><th>Description</th></tr></thead>
@@ -1814,6 +1820,7 @@ Known .status.conditions.type are: &quot;Available&quot;, &quot;Progressing&quot
 - [InstrumentedApplication](#odigos-io-v1alpha1-InstrumentedApplication)
 
 <p>InstrumentedApplicationStatus defines the observed state of InstrumentedApplication</p>
+<p>Deprecated: in favour of InstrumentationConfig</p>
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Type</th><th>Description</th></tr></thead>
@@ -2012,6 +2019,8 @@ used for odigos enterprise</p>
 **Appears in:**
 
 - [InstrumentedApplicationSpec](#odigos-io-v1alpha1-InstrumentedApplicationSpec)
+
+<p>Deprecated: configuration is done via InstrumentationConfig</p>
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Type</th><th>Description</th></tr></thead>

--- a/helm/odigos/templates/crds/odigos.io_instrumentedapplications.yaml
+++ b/helm/odigos/templates/crds/odigos.io_instrumentedapplications.yaml
@@ -20,8 +20,10 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: InstrumentedApplication is the Schema for the instrumentedapplications
-          API
+        description: |-
+          InstrumentedApplication is the Schema for the instrumentedapplications API
+
+          Deprecated: in favour of InstrumentationConfig
         properties:
           apiVersion:
             description: |-
@@ -41,21 +43,27 @@ spec:
           metadata:
             type: object
           spec:
-            description: InstrumentedApplicationSpec defines the desired state of
-              InstrumentedApplication
+            description: |-
+              InstrumentedApplicationSpec defines the desired state of InstrumentedApplication
+
+              Deprecated: in favour of InstrumentationConfig
             properties:
               options:
                 items:
+                  description: 'Deprecated: configuration is done via InstrumentationConfig'
                   properties:
                     containerName:
                       type: string
                     instrumentationsLibraries:
                       items:
+                        description: 'Deprecated: configuration is done via InstrumentationConfig'
                         properties:
                           libraryName:
                             type: string
                           options:
                             items:
+                              description: 'Deprecated: configuration is done via
+                                InstrumentationConfig'
                               properties:
                                 optionKey:
                                   type: string
@@ -158,8 +166,10 @@ spec:
                 type: array
             type: object
           status:
-            description: InstrumentedApplicationStatus defines the observed state
-              of InstrumentedApplication
+            description: |-
+              InstrumentedApplicationStatus defines the observed state of InstrumentedApplication
+
+              Deprecated: in favour of InstrumentationConfig
             properties:
               conditions:
                 description: Represents the observations of a nstrumentedApplication's


### PR DESCRIPTION
* Mark `InstrumentedApplication` and all its related fields as deprecated.
* Move `ProcessingState`  (which is not deprecated) to `instrumentationconfig_types.go`.