### PR TITLE
cli: support custom scheduler, frontend, and collector images

### DIFF
--- a/autoscaler/controllers/collectorsgroup_controller.go
+++ b/autoscaler/controllers/collectorsgroup_controller.go
@@ -52,7 +52,7 @@ func (r *CollectorsGroupReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
-	err = datacollection.Sync(ctx, r.Client, r.Scheme, r.ImagePullSecrets, r.OdigosVersion, r.K8sVersion, r.DisableNameProcessor)
+	err = datacollection.Sync(ctx, r.Client, r.Scheme, r.ImagePullSecrets, r.OdigosVersion, r.K8sVersion, r.DisableNameProcessor, r.Config.CollectorImage)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/autoscaler/controllers/controller_config/controller_config.go
+++ b/autoscaler/controllers/controller_config/controller_config.go
@@ -3,5 +3,6 @@ package controllerconfig
 import "k8s.io/apimachinery/pkg/util/version"
 
 type ControllerConfig struct {
-	K8sVersion *version.Version
+	K8sVersion     *version.Version
+	CollectorImage string
 }

--- a/autoscaler/controllers/datacollection/root.go
+++ b/autoscaler/controllers/datacollection/root.go
@@ -19,7 +19,7 @@ const (
 	syncDaemonsetRetry = 3
 )
 
-func Sync(ctx context.Context, c client.Client, scheme *runtime.Scheme, imagePullSecrets []string, odigosVersion string, k8sVersion *version.Version, disableNameProcessor bool) error {
+func Sync(ctx context.Context, c client.Client, scheme *runtime.Scheme, imagePullSecrets []string, odigosVersion string, k8sVersion *version.Version, disableNameProcessor bool, collectorImage string) error {
 	logger := log.FromContext(ctx)
 
 	var sources odigosv1.InstrumentationConfigList
@@ -51,12 +51,12 @@ func Sync(ctx context.Context, c client.Client, scheme *runtime.Scheme, imagePul
 		return err
 	}
 
-	return syncDataCollection(&sources, &dests, &processors, &dataCollectionCollectorGroup, ctx, c, scheme, imagePullSecrets, odigosVersion, k8sVersion, disableNameProcessor)
+	return syncDataCollection(&sources, &dests, &processors, &dataCollectionCollectorGroup, ctx, c, scheme, imagePullSecrets, odigosVersion, k8sVersion, disableNameProcessor, collectorImage)
 }
 
 func syncDataCollection(sources *odigosv1.InstrumentationConfigList, dests *odigosv1.DestinationList, processors *odigosv1.ProcessorList,
 	dataCollection *odigosv1.CollectorsGroup, ctx context.Context, c client.Client,
-	scheme *runtime.Scheme, imagePullSecrets []string, odigosVersion string, k8sVersion *version.Version, disableNameProcessor bool) error {
+	scheme *runtime.Scheme, imagePullSecrets []string, odigosVersion string, k8sVersion *version.Version, disableNameProcessor bool, collectorImage string) error {
 	logger := log.FromContext(ctx)
 	logger.V(0).Info("Syncing data collection")
 
@@ -66,7 +66,7 @@ func syncDataCollection(sources *odigosv1.InstrumentationConfigList, dests *odig
 		return err
 	}
 
-	dm.RunSyncDaemonSetWithDelayAndSkipNewCalls(time.Duration(env.GetSyncDaemonSetDelay())*time.Second, syncDaemonsetRetry, dests, dataCollection, ctx, c, scheme, imagePullSecrets, odigosVersion, k8sVersion)
+	dm.RunSyncDaemonSetWithDelayAndSkipNewCalls(time.Duration(env.GetSyncDaemonSetDelay())*time.Second, syncDaemonsetRetry, dests, dataCollection, ctx, c, scheme, imagePullSecrets, odigosVersion, k8sVersion, collectorImage)
 
 	return nil
 }

--- a/autoscaler/controllers/gateway/root.go
+++ b/autoscaler/controllers/gateway/root.go
@@ -82,7 +82,7 @@ func syncGateway(dests *odigosv1.DestinationList, processors *odigosv1.Processor
 		return err
 	}
 
-	_, err = syncDeployment(dests, gateway, ctx, c, scheme, imagePullSecrets, odigosVersion)
+	_, err = syncDeployment(dests, gateway, ctx, c, scheme, imagePullSecrets, odigosVersion, config.CollectorImage)
 	if err != nil {
 		logger.Error(err, "Failed to sync deployment")
 		return err

--- a/autoscaler/controllers/instrumentedapplication_controller.go
+++ b/autoscaler/controllers/instrumentedapplication_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	controllerconfig "github.com/odigos-io/odigos/autoscaler/controllers/controller_config"
 	"github.com/odigos-io/odigos/autoscaler/controllers/datacollection"
 	predicate "github.com/odigos-io/odigos/k8sutils/pkg/predicate"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -35,10 +36,11 @@ type InstrumentationConfigReconciler struct {
 	OdigosVersion        string
 	K8sVersion           *version.Version
 	DisableNameProcessor bool
+	Config               *controllerconfig.ControllerConfig
 }
 
 func (r *InstrumentationConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	err := datacollection.Sync(ctx, r.Client, r.Scheme, r.ImagePullSecrets, r.OdigosVersion, r.K8sVersion, r.DisableNameProcessor)
+	err := datacollection.Sync(ctx, r.Client, r.Scheme, r.ImagePullSecrets, r.OdigosVersion, r.K8sVersion, r.DisableNameProcessor, r.Config.CollectorImage)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/autoscaler/controllers/processor_controller.go
+++ b/autoscaler/controllers/processor_controller.go
@@ -35,7 +35,7 @@ func (r *ProcessorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
-	err = datacollection.Sync(ctx, r.Client, r.Scheme, r.ImagePullSecrets, r.OdigosVersion, r.K8sVersion, r.DisableNameProcessor)
+	err = datacollection.Sync(ctx, r.Client, r.Scheme, r.ImagePullSecrets, r.OdigosVersion, r.K8sVersion, r.DisableNameProcessor, r.Config.CollectorImage)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/autoscaler/main.go
+++ b/autoscaler/main.go
@@ -67,8 +67,9 @@ import (
 )
 
 var (
-	scheme   = runtime.NewScheme()
-	setupLog = ctrl.Log.WithName("setup")
+	scheme                = runtime.NewScheme()
+	setupLog              = ctrl.Log.WithName("setup")
+	defaultCollectorImage = "keyval/odigos-collector"
 )
 
 func init() {
@@ -216,8 +217,14 @@ func main() {
 	// at the time of writing (2024-10-22) only dotnet and java native agent are using the name processor.
 	_, disableNameProcessor := os.LookupEnv("DISABLE_NAME_PROCESSOR")
 
+	collectorImage := defaultCollectorImage
+	if collectorImageEnv, ok := os.LookupEnv("COLLECTOR_IMAGE"); ok {
+		collectorImage = collectorImageEnv
+	}
+
 	config := &controllerconfig.ControllerConfig{
-		K8sVersion: k8sVersion,
+		K8sVersion:     k8sVersion,
+		CollectorImage: collectorImage,
 	}
 
 	if err = (&controllers.DestinationReconciler{
@@ -262,6 +269,7 @@ func main() {
 		OdigosVersion:        odigosVersion,
 		K8sVersion:           k8sVersion,
 		DisableNameProcessor: disableNameProcessor,
+		Config:               config,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "InstrumentationConfig")
 		os.Exit(1)

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -44,6 +44,9 @@ var (
 	instrumentorImage string
 	odigletImage      string
 	autoScalerImage   string
+	schedulerImage    string
+	frontendImage     string
+	collectorImage    string
 	imagePrefix       string
 )
 
@@ -223,6 +226,9 @@ func createOdigosConfig(odigosTier common.OdigosTier) common.OdigosConfiguration
 		OdigletImage:              odigletImage,
 		InstrumentorImage:         instrumentorImage,
 		AutoscalerImage:           autoScalerImage,
+		SchedulerImage:            schedulerImage,
+		FrontendImage:             frontendImage,
+		CollectorImage:            collectorImage,
 		Profiles:                  selectedProfiles,
 	}
 }
@@ -249,6 +255,9 @@ func init() {
 	installCmd.Flags().StringVar(&odigletImage, "odiglet-image", "", "odiglet container image name")
 	installCmd.Flags().StringVar(&instrumentorImage, "instrumentor-image", "keyval/odigos-instrumentor", "instrumentor container image name")
 	installCmd.Flags().StringVar(&autoScalerImage, "autoscaler-image", "keyval/odigos-autoscaler", "autoscaler container image name")
+	installCmd.Flags().StringVar(&schedulerImage, "scheduler-image", "keyval/odigos-scheduler", "scheduler container image name")
+	installCmd.Flags().StringVar(&frontendImage, "frontend-image", "keyval/odigos-ui", "frontend container image name")
+	installCmd.Flags().StringVar(&collectorImage, "collector-image", "keyval/odigos-collector", "collector container image name")
 	installCmd.Flags().StringVar(&imagePrefix, "image-prefix", "", "prefix for all container images. used when your cluster doesn't have access to docker hub")
 	installCmd.Flags().BoolVar(&psp, "psp", false, "enable pod security policy")
 	installCmd.Flags().StringSliceVar(&userInputIgnoredNamespaces, "ignore-namespace", k8sconsts.DefaultIgnoredNamespaces, "namespaces not to show in odigos ui")

--- a/cli/cmd/resources/autoscaler.go
+++ b/cli/cmd/resources/autoscaler.go
@@ -225,7 +225,7 @@ func NewAutoscalerLeaderElectionRoleBinding(ns string) *rbacv1.RoleBinding {
 	}
 }
 
-func NewAutoscalerDeployment(ns string, version string, imagePrefix string, imageName string, disableNameProcessor bool) *appsv1.Deployment {
+func NewAutoscalerDeployment(ns string, version string, imagePrefix string, imageName string, disableNameProcessor bool, collectorImage string) *appsv1.Deployment {
 
 	optionalEnvs := []corev1.EnvVar{}
 
@@ -290,6 +290,10 @@ func NewAutoscalerDeployment(ns string, version string, imagePrefix string, imag
 											FieldPath: "metadata.namespace",
 										},
 									},
+								},
+								{
+									Name:  "COLLECTOR_IMAGE",
+									Value: collectorImage,
 								},
 								{
 									Name: consts.OdigosVersionEnvVarName,
@@ -385,7 +389,7 @@ func (a *autoScalerResourceManager) InstallFromScratch(ctx context.Context) erro
 		NewAutoscalerClusterRole(),
 		NewAutoscalerClusterRoleBinding(a.ns),
 		NewAutoscalerLeaderElectionRoleBinding(a.ns),
-		NewAutoscalerDeployment(a.ns, a.odigosVersion, a.config.ImagePrefix, a.config.AutoscalerImage, disableNameProcessor),
+		NewAutoscalerDeployment(a.ns, a.odigosVersion, a.config.ImagePrefix, a.config.AutoscalerImage, disableNameProcessor, a.config.CollectorImage),
 	}
 	return a.client.ApplyResources(ctx, a.config.ConfigVersion, resources)
 }

--- a/cli/cmd/resources/scheduler.go
+++ b/cli/cmd/resources/scheduler.go
@@ -19,7 +19,6 @@ import (
 )
 
 const (
-	SchedulerImage                  = "keyval/odigos-scheduler"
 	SchedulerServiceName            = "scheduler"
 	SchedulerDeploymentName         = "odigos-scheduler"
 	SchedulerAppLabelValue          = SchedulerDeploymentName
@@ -181,7 +180,7 @@ func NewSchedulerClusterRoleBinding(ns string) *rbacv1.ClusterRoleBinding {
 	}
 }
 
-func NewSchedulerDeployment(ns string, version string, imagePrefix string) *appsv1.Deployment {
+func NewSchedulerDeployment(ns string, version string, imagePrefix string, imageName string) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
@@ -214,7 +213,7 @@ func NewSchedulerDeployment(ns string, version string, imagePrefix string) *apps
 					Containers: []corev1.Container{
 						{
 							Name:  SchedulerContainerName,
-							Image: containers.GetImageName(imagePrefix, SchedulerImage, version),
+							Image: containers.GetImageName(imagePrefix, imageName, version),
 							Command: []string{
 								"/app",
 							},
@@ -331,7 +330,7 @@ func (a *schedulerResourceManager) InstallFromScratch(ctx context.Context) error
 		NewSchedulerRoleBinding(a.ns),
 		NewSchedulerClusterRole(),
 		NewSchedulerClusterRoleBinding(a.ns),
-		NewSchedulerDeployment(a.ns, a.odigosVersion, a.config.ImagePrefix),
+		NewSchedulerDeployment(a.ns, a.odigosVersion, a.config.ImagePrefix, a.config.SchedulerImage),
 	}
 	return a.client.ApplyResources(ctx, a.config.ConfigVersion, resources)
 }

--- a/cli/cmd/resources/ui.go
+++ b/cli/cmd/resources/ui.go
@@ -19,7 +19,6 @@ import (
 )
 
 const (
-	UIImage              = "keyval/odigos-ui"
 	UIServiceName        = "ui"
 	UIDeploymentName     = "odigos-ui"
 	UIAppLabelValue      = "odigos-ui"
@@ -38,7 +37,7 @@ func (u *uiResourceManager) Name() string {
 	return "UI"
 }
 
-func NewUIDeployment(ns string, version string, imagePrefix string) *appsv1.Deployment {
+func NewUIDeployment(ns string, version string, imagePrefix string, imageName string) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
@@ -71,7 +70,7 @@ func NewUIDeployment(ns string, version string, imagePrefix string) *appsv1.Depl
 					Containers: []corev1.Container{
 						{
 							Name:  UIContainerName,
-							Image: containers.GetImageName(imagePrefix, UIImage, version),
+							Image: containers.GetImageName(imagePrefix, imageName, version),
 							Args: []string{
 								"--namespace=$(CURRENT_NS)",
 							},
@@ -313,7 +312,7 @@ func (u *uiResourceManager) InstallFromScratch(ctx context.Context) error {
 		NewUIRoleBinding(u.ns),
 		NewUIClusterRole(),
 		NewUIClusterRoleBinding(u.ns),
-		NewUIDeployment(u.ns, u.odigosVersion, u.config.ImagePrefix),
+		NewUIDeployment(u.ns, u.odigosVersion, u.config.ImagePrefix, u.config.FrontendImage),
 		NewUIService(u.ns),
 	}
 	return u.client.ApplyResources(ctx, u.config.ConfigVersion, resources)

--- a/common/odigos_config.go
+++ b/common/odigos_config.go
@@ -99,6 +99,9 @@ type OdigosConfiguration struct {
 	OdigletImage              string                         `json:"odigletImage,omitempty"`
 	InstrumentorImage         string                         `json:"instrumentorImage,omitempty"`
 	AutoscalerImage           string                         `json:"autoscalerImage,omitempty"`
+	SchedulerImage            string                         `json:"schedulerImage,omitempty"`
+	FrontendImage             string                         `json:"frontendImage,omitempty"`
+	CollectorImage            string                         `json:"collectorImage,omitempty"`
 	SkipWebhookIssuerCreation bool                           `json:"skipWebhookIssuerCreation,omitempty"`
 	CollectorGateway          *CollectorGatewayConfiguration `json:"collectorGateway,omitempty"`
 	CollectorNode             *CollectorNodeConfiguration    `json:"collectorNode,omitempty"`


### PR DESCRIPTION
Working on openshift certification, I wanted to test custom images (based on the red hat base) for these components, but didn't see any way in the cli to set them. It follows the pattern we already have for custom odiglet, autoscaler, and instrumentor images.