### PR TITLE
Add Red Hat UBI images to publish-modules workflow

### DIFF
--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -76,19 +76,33 @@ jobs:
   publish-docker-images:
     strategy:
       matrix:
+        dockerfile: ['Dockerfile', 'Dockerfile.rhel']
+        service: ['autoscaler', 'scheduler', 'instrumentor', 'collector', 'odiglet', 'ui']
         include:
           - service: autoscaler
             runner: ubuntu-latest
+            summary: "Autoscaler for Odigos"
+            description: "Autoscaler manages the installation of Odigos components."
           - service: scheduler
             runner: ubuntu-latest
+            summary: "Scheduler for Odigos"
+            description: "Scheduler manages the installation of OpenTelemetry Collectors with Odigos."
           - service: instrumentor
             runner: ubuntu-latest
+            summary: "Instrumentor for Odigos"
+            description: "Instrumentor manages auto-instrumentation for workloads with Odigos."
           - service: collector
             runner: large-runner
+            summary: "Odigos Collector"
+            description: "The Odigos build of the OpenTelemetry Collector."
           - service: odiglet
             runner: ubuntu-latest
+            summary: "Odiglet for Odigos"
+            description: "Odiglet is the core component of Odigos managing auto-instrumentation. This image requires a root user to load and manage eBPF programs."
           - service: ui
             runner: ubuntu-latest
+            summary: "UI for Odigos"
+            description: "UI provides the frontend webapp for managing an Odigos installation."
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout repository
@@ -120,17 +134,21 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: keyval/odigos-${{ matrix.service }}:${{ steps.extract_tag.outputs.tag }}
+          tags: keyval/odigos-${{ matrix.service }}${{ matrix.dockerfile == 'Dockerfile.rhel' && '-ubi9' || '' }}:${{ steps.extract_tag.outputs.tag }}
           build-args: |
             SERVICE_NAME=${{ matrix.service }}
             ODIGOS_VERSION=${{ steps.extract_tag.outputs.tag }}
+            RELEASE=${{ steps.extract_tag.outputs.tag }}
+            VERSION=${{ steps.extract_tag.outputs.tag }}
+            SUMMARY=${{ matrix.summary }}
+            DESCRIPTION=${{ matrix.description }}
           platforms: linux/amd64,linux/arm64
           file: >-
             ${{
-              (matrix.service == 'odiglet' && 'odiglet/Dockerfile') ||
-              (matrix.service == 'collector' && 'collector/Dockerfile') ||
-              (matrix.service == 'ui' && 'frontend/Dockerfile') ||
-              'Dockerfile'
+              (matrix.service == 'odiglet' && 'odiglet/${{ matrix.dockerfile }}') ||
+              (matrix.service == 'collector' && 'collector/${{ matrix.dockerfile }}') ||
+              (matrix.service == 'ui' && 'frontend/${{ matrix.dockerfile }}') ||
+              '${{ matrix.dockerfile }}'
             }}
           context: >-
             ${{


### PR DESCRIPTION
This will publish the Red Hat-based images from https://github.com/odigos-io/odigos/pull/2252 alongside our normal released images.

Logic:

* Add 2 matrix values: `Dockerfile` and `Dockerfile.rhel` to run for each service
* Add a matrix value for each service: `['autoscaler', 'scheduler', 'instrumentor', 'collector', 'odiglet', 'ui']`
* Add the appropriate `summary` and `description` to each service in the `include` section (used for image labels)

This should produce 12 jobs from the current 6.

I tested this matrix approach in a simple PR https://github.com/damemi/odigos/pull/5. The output showed 12 tests as expected: https://github.com/damemi/odigos/actions/runs/12938761839?pr=5 In addition, each test adds a simple logging step to confirm that `summary`, `description`, and `runner` were also passed as expected. (https://github.com/damemi/odigos/actions/runs/12938761839/job/36089599433?pr=5#step:2:1)