### PR TITLE
Add `--update` flag to `odigos install`

### DIFF
--- a/docs/cli/odigos_install.mdx
+++ b/docs/cli/odigos_install.mdx
@@ -53,7 +53,9 @@ odigos install --onprem-token ${ODIGOS_TOKEN} --profile ${YOUR_ENTERPRISE_PROFIL
       --skip-webhook-issuer-creation   Skip creating the Issuer and Certificate for the Instrumentor pod webhook if cert-manager is installed.
       --telemetry                      send general telemetry regarding Odigos usage (default true)
       --ui-mode string                 set the UI mode (one-of: normal, readonly) (default "normal")
+      --update                         update an existing Odigos installation
       --version string                 for development purposes only
+      --yes                            skip the confirmation prompt (currently used with --update)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
This would allow `odigos install` to be re-run against an existing installation by passing `--update` (with a confirmation from the user). This could be used to update image prefixes or any other setting set at install time.

Requires odigos to already be installed in the specified namespace. This is to prevent accidental duplicate installs