### PR TITLE
use envFromContainerRuntime in e2e asserts

### DIFF
--- a/tests/common/assert/simple-demo-runtime-detected.yaml
+++ b/tests/common/assert/simple-demo-runtime-detected.yaml
@@ -46,9 +46,9 @@ metadata:
 status:
   runtimeDetailsByContainer:
     - containerName: inventory
-      envVars:
-      - name: PYTHONPATH
-        value: /bar # this env exists in the test image
+      envFromContainerRuntime:
+        - name: PYTHONPATH
+          value: /bar # this env exists in the test image
       language: python
       runtimeVersion: 3.11.9
 ---

--- a/tests/e2e/source/08-assert-runtime-detected.yaml
+++ b/tests/e2e/source/08-assert-runtime-detected.yaml
@@ -29,9 +29,9 @@ metadata:
 status:
   runtimeDetailsByContainer:
     - containerName: inventory
-      envVars:
-      - name: PYTHONPATH
-        value: /bar # this env exists in the test image
+      envFromContainerRuntime:
+        - name: PYTHONPATH
+          value: /bar # this env exists in the test image
       language: python
       runtimeVersion: 3.11.9
 ---

--- a/tests/e2e/source/09-assert-runtime-detected.yaml
+++ b/tests/e2e/source/09-assert-runtime-detected.yaml
@@ -29,9 +29,9 @@ metadata:
 status:
   runtimeDetailsByContainer:
     - containerName: inventory
-      envVars:
-      - name: PYTHONPATH
-        value: /bar # this env exists in the test image
+      envFromContainerRuntime:
+        - name: PYTHONPATH
+          value: /bar # this env exists in the test image
       language: python
       runtimeVersion: 3.11.9
 ---

--- a/tests/e2e/workload-lifecycle/01-assert-runtime-detected.yaml
+++ b/tests/e2e/workload-lifecycle/01-assert-runtime-detected.yaml
@@ -100,9 +100,9 @@ metadata:
 status:
   runtimeDetailsByContainer:
     - containerName: nodejs-manifest-env
-      envFromContainerRuntime:
-        - name: NODE_OPTIONS
-          value: "--require /app/execute_before.js --max-old-space-size=256"
+# the env var is present in the pod manifest, hence the container runtime value
+# is not relevant and not populated
+      (envFromContainerRuntime == null): true
       language: javascript
       runtimeVersion: 20.17.0
 ---
@@ -191,9 +191,9 @@ status:
   runtimeDetailsByContainer:
     - containerName: java-supported-manifest-env
       language: java
-      envFromContainerRuntime:
-        - name: JAVA_OPTS
-          value: "-Dnot.work=true"
+# the env var is present in the pod manifest, hence the container runtime value
+# is not relevant and not populated
+      (envFromContainerRuntime == null) : true
       runtimeVersion: 17.0.12+7
 
 ---

--- a/tests/e2e/workload-lifecycle/01-assert-runtime-detected.yaml
+++ b/tests/e2e/workload-lifecycle/01-assert-runtime-detected.yaml
@@ -80,9 +80,9 @@ metadata:
 status:
   runtimeDetailsByContainer:
     - containerName: nodejs-dockerfile-env
-      envVars:
-      - name: NODE_OPTIONS
-        value: "--require /app/execute_before.js --max-old-space-size=256"
+      envFromContainerRuntime:
+        - name: NODE_OPTIONS
+          value: "--require /app/execute_before.js --max-old-space-size=256"
       language: javascript
       runtimeVersion: 20.17.0
 ---
@@ -100,9 +100,9 @@ metadata:
 status:
   runtimeDetailsByContainer:
     - containerName: nodejs-manifest-env
-      envVars:
-      - name: NODE_OPTIONS
-        value: "--require /app/execute_before.js --max-old-space-size=256"
+      envFromContainerRuntime:
+        - name: NODE_OPTIONS
+          value: "--require /app/execute_before.js --max-old-space-size=256"
       language: javascript
       runtimeVersion: 20.17.0
 ---
@@ -170,7 +170,7 @@ status:
   runtimeDetailsByContainer:
     - containerName: java-supported-docker-env
       language: java
-      envVars:
+      envFromContainerRuntime:
         - name: JAVA_OPTS
           value: "-Dthis.does.not.exist=true"
       runtimeVersion: 17.0.12+7
@@ -191,7 +191,7 @@ status:
   runtimeDetailsByContainer:
     - containerName: java-supported-manifest-env
       language: java
-      envVars:
+      envFromContainerRuntime:
         - name: JAVA_OPTS
           value: "-Dnot.work=true"
       runtimeVersion: 17.0.12+7
@@ -244,9 +244,9 @@ metadata:
 status:
   runtimeDetailsByContainer:
     - containerName: python-alpine
-      envVars:
-      - name: PYTHONPATH
-        value: "/app"    
+      envFromContainerRuntime:
+        - name: PYTHONPATH
+          value: "/app"
       language: python
       runtimeVersion: 3.10.15
 ---
@@ -263,7 +263,7 @@ metadata:
       name: python-latest-version
 status:
   runtimeDetailsByContainer:
-    - containerName: python-latest-version        
+    - containerName: python-latest-version
       language: python
       (runtimeVersion != null): true
 ---
@@ -280,7 +280,7 @@ metadata:
       name: python-other-agent
 status:
   runtimeDetailsByContainer:
-    - containerName: python-other-agent        
+    - containerName: python-other-agent
       language: python
       otherAgent:
         name: New Relic Agent

--- a/tests/e2e/workload-lifecycle/01-assert-runtime-detected.yaml
+++ b/tests/e2e/workload-lifecycle/01-assert-runtime-detected.yaml
@@ -193,7 +193,7 @@ status:
       language: java
 # the env var is present in the pod manifest, hence the container runtime value
 # is not relevant and not populated
-      (envFromContainerRuntime == null) : true
+      (envFromContainerRuntime == null): true
       runtimeVersion: 17.0.12+7
 
 ---
@@ -244,9 +244,9 @@ metadata:
 status:
   runtimeDetailsByContainer:
     - containerName: python-alpine
-      envFromContainerRuntime:
-        - name: PYTHONPATH
-          value: "/app"
+# the env var is present in the pod manifest, hence the container runtime value
+# is not relevant and not populated
+      (envFromContainerRuntime == null): true
       language: python
       runtimeVersion: 3.10.15
 ---


### PR DESCRIPTION
To reduce flakiness, and adjust the tests to the updated runtime detection.