### PR TITLE
ci: run golanglint only on PR (removed push to main)

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,8 +1,6 @@
 name: Check links
 
 on:
-  push:
-    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,8 +1,5 @@
 name: golangci-lint
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 permissions:


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows to modify when certain actions are triggered. The most important changes include removing the `push` event trigger for the `check-links` and `golangci-lint` workflows.

Changes to GitHub Actions workflows:

* [`.github/workflows/check-links.yml`](diffhunk://#diff-defd48946787cc6a6a360e44775e44ff3a68817a47f9c8606e5150e54e378ac0L4-L5): Removed the `push` event trigger that was set to trigger on the `main` branch.
* [`.github/workflows/golangci-lint.yml`](diffhunk://#diff-d9a956120ac84289d2650137f64bd8f0893331de05e44cc41899dd984c9e0d48L3-L5): Removed the `push` event trigger that was set to trigger on the `main` branch.