### PR TITLE
fix: consider the instrumentation labels when deleting instrumentationConfig

### DIFF
--- a/instrumentor/controllers/deleteinstrumentationconfig/instrumentationconfig_controller.go
+++ b/instrumentor/controllers/deleteinstrumentationconfig/instrumentationconfig_controller.go
@@ -22,6 +22,7 @@ import (
 
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	sourceutils "github.com/odigos-io/odigos/k8sutils/pkg/source"
+	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -88,7 +89,14 @@ func (r *InstrumentationConfigReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, err
 	}
 
-	if !enabled {
+	// check if the workload is enabled by deprecated labels,
+	// once we fully remove the support for the instrumentation labels, we can remove this check
+	enabledByDeprecatedLabels, err := workload.IsWorkloadInstrumentationEffectiveEnabled(ctx, r.Client, workloadObject)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if !enabled && !enabledByDeprecatedLabels {
 		logger.Info("Deleting instrumentationconfig for non-enabled workload")
 		err := r.Client.Delete(ctx, &instrumentationConfig)
 		return ctrl.Result{}, client.IgnoreNotFound(err)


### PR DESCRIPTION
When upgrading from a version without the Sources support, to a version with them (starting from v1.0.144), we need to consider the instrumentation labels on the workloads and namespaces before deleting instrumentationConfig,
Before this fix, instrumentationConfigs are getting deleted on upgrades (before the Source are created by the migration controller).