### PR TITLE
fix: replace IBM Sarama URL in docs to fix check-links

### DIFF
--- a/docs/instrumentations/golang/ebpf.mdx
+++ b/docs/instrumentations/golang/ebpf.mdx
@@ -53,7 +53,7 @@ The following go modules will be auto instrumented by Odigos:
 - [`github.com/rabbitmq/amqp091-go`](https://pkg.go.dev/github.com/rabbitmq/amqp091-go) ⭐️ versions `>= v1.4.0`. messaging client for RabbitMQ
 - [`github.com/segmentio/kafka-go`](https://pkg.go.dev/github.com/segmentio/kafka-go) versions `>= v0.4.1`. messaging client for Apache Kafka
 - [`github.com/apache/pulsar-client-go`](https://pkg.go.dev/github.com/apache/pulsar-client-go) ⭐️ versions `>= v0.12.0`. messaging client for Apache Pulsar
-- [`github.com/IBM/sarama`](https://pkg.go.dev/github.com/IBM/sarama) ⭐️ versions `>= v1.40.0`. messaging client for Apache Kafka
+- [`github.com/IBM/sarama`](https://github.com/IBM/sarama) ⭐️ versions `>= v1.40.0`. messaging client for Apache Kafka
 
 ### RPC (Remote Procedure Call)
 


### PR DESCRIPTION
This pull request includes a small change to the `docs/instrumentations/golang/ebpf.mdx` file. The change updates the link for the `github.com/IBM/sarama` module to point to its GitHub repository instead of its Go package documentation.

* Updated the link for `github.com/IBM/sarama` to point to the GitHub repository.