### PR TITLE
feat: break components lib to smaller libs

### DIFF
--- a/frontend/webapp/components/common/buttons/selection-button/index.tsx
+++ b/frontend/webapp/components/common/buttons/selection-button/index.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import Image from 'next/image';
 import styled from 'styled-components';
-import { Badge, Button, type SVG, Text, Theme } from '@odigos/ui-components';
+import { Theme } from '@odigos/ui-theme';
+import { type SVG } from '@odigos/ui-icons';
+import { Badge, Button, Text } from '@odigos/ui-components';
 
 interface Props {
   label: string;

--- a/frontend/webapp/components/common/dropdowns/monitor-dropdown/index.tsx
+++ b/frontend/webapp/components/common/dropdowns/monitor-dropdown/index.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
-import { Dropdown, MONITORS_OPTIONS, type DropdownProps } from '@odigos/ui-components';
+import { MONITORS_OPTIONS } from '@odigos/ui-utils';
+import { Dropdown, type DropdownProps } from '@odigos/ui-components';
 
 interface Props {
   title?: string;

--- a/frontend/webapp/components/main/header/cp-title/index.tsx
+++ b/frontend/webapp/components/main/header/cp-title/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import { K8sLogo } from '@odigos/ui-icons';
+import { Text } from '@odigos/ui-components';
+import { PLATFORM_TYPE } from '@odigos/ui-utils';
 import styled, { useTheme } from 'styled-components';
-import { K8sLogo, PLATFORM_TYPE, Text } from '@odigos/ui-components';
 
 interface Props {
   type: PLATFORM_TYPE;

--- a/frontend/webapp/components/main/header/index.tsx
+++ b/frontend/webapp/components/main/header/index.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { useConfig } from '@/hooks';
+import { Theme } from '@odigos/ui-theme';
 import { PlatformTitle } from './cp-title';
 import { FORM_ALERTS, SLACK_LINK } from '@/utils';
 import { NotificationManager } from '@/components';
 import styled, { useTheme } from 'styled-components';
+import { NOTIFICATION_TYPE, PLATFORM_TYPE } from '@odigos/ui-utils';
+import { OdigosLogoText, SlackLogo, TerminalIcon } from '@odigos/ui-icons';
+import { FlexRow, IconButton, Status, ToggleDarkMode, Tooltip } from '@odigos/ui-components';
 import { DRAWER_OTHER_TYPES, useDarkModeStore, useDrawerStore, useStatusStore } from '@/store';
-import { FlexRow, IconButton, NOTIFICATION_TYPE, OdigosLogoText, PLATFORM_TYPE, SlackLogo, Status, TerminalIcon, Theme, ToggleDarkMode, Tooltip } from '@odigos/ui-components';
 
 interface MainHeaderProps {}
 

--- a/frontend/webapp/components/nodes-data-flow/nodes/add-node.tsx
+++ b/frontend/webapp/components/nodes-data-flow/nodes/add-node.tsx
@@ -1,9 +1,12 @@
 import React, { Fragment } from 'react';
 import styled from 'styled-components';
+import { Theme } from '@odigos/ui-theme';
 import { usePendingStore } from '@/store';
+import { PlusIcon } from '@odigos/ui-icons';
 import { NODE_TYPES, OVERVIEW_NODE_TYPES } from '@/types';
+import { ENTITY_TYPES, HEALTH_STATUS } from '@odigos/ui-utils';
 import { Handle, type Node, type NodeProps, Position } from '@xyflow/react';
-import { ENTITY_TYPES, FadeLoader, FlexColumn, FlexRow, HEALTH_STATUS, PlusIcon, Text, Theme } from '@odigos/ui-components';
+import { FadeLoader, FlexColumn, FlexRow, Text } from '@odigos/ui-components';
 
 interface Props
   extends NodeProps<

--- a/frontend/webapp/components/nodes-data-flow/nodes/base-node.tsx
+++ b/frontend/webapp/components/nodes-data-flow/nodes/base-node.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useAppStore, usePendingStore } from '@/store';
+import { ErrorTriangleIcon, type SVG } from '@odigos/ui-icons';
+import { Checkbox, DataTab, FadeLoader } from '@odigos/ui-components';
 import { Handle, type Node, type NodeProps, Position } from '@xyflow/react';
+import { ENTITY_TYPES, HEALTH_STATUS, SIGNAL_TYPE, type WorkloadId } from '@odigos/ui-utils';
 import { type ActionDataParsed, type ActualDestination, type InstrumentationRuleSpec, type K8sActualSource, NODE_TYPES } from '@/types';
-import { Checkbox, DataTab, ENTITY_TYPES, ErrorTriangleIcon, FadeLoader, HEALTH_STATUS, SIGNAL_TYPE, type SVG, type WorkloadId } from '@odigos/ui-components';
 
 interface Props
   extends NodeProps<

--- a/frontend/webapp/components/nodes-data-flow/nodes/header-node.tsx
+++ b/frontend/webapp/components/nodes-data-flow/nodes/header-node.tsx
@@ -1,10 +1,11 @@
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
+import { ENTITY_TYPES } from '@odigos/ui-utils';
 import type { Node, NodeProps } from '@xyflow/react';
 import { K8sActualSource, NODE_TYPES } from '@/types';
 import { useAppStore, usePendingStore } from '@/store';
 import { usePaginatedSources, useSourceCRUD } from '@/hooks';
-import { Badge, Checkbox, ENTITY_TYPES, FadeLoader, Text } from '@odigos/ui-components';
+import { Badge, Checkbox, FadeLoader, Text } from '@odigos/ui-components';
 
 interface Props
   extends NodeProps<

--- a/frontend/webapp/components/nodes-data-flow/nodes/scroll-node.tsx
+++ b/frontend/webapp/components/nodes-data-flow/nodes/scroll-node.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useRef, useState } from 'react';
 import BaseNode from './base-node';
 import styled from 'styled-components';
+import { type SVG } from '@odigos/ui-icons';
 import { useNodeDataFlowHandlers } from '@/hooks';
 import { type Node, type NodeProps } from '@xyflow/react';
 import { type K8sActualSource, NODE_TYPES } from '@/types';
-import { ENTITY_TYPES, HEALTH_STATUS, type SVG, type WorkloadId } from '@odigos/ui-components';
+import { ENTITY_TYPES, HEALTH_STATUS, type WorkloadId } from '@odigos/ui-utils';
 
 interface Props
   extends NodeProps<

--- a/frontend/webapp/components/notification/notification-manager.tsx
+++ b/frontend/webapp/components/notification/notification-manager.tsx
@@ -1,10 +1,13 @@
 import React, { useRef, useState } from 'react';
 import { ACTION } from '@/utils';
 import { useClickNotif } from '@/hooks';
+import { Theme } from '@odigos/ui-theme';
 import { type Notification } from '@/types';
 import { useNotificationStore } from '@/store';
 import styled, { useTheme } from 'styled-components';
-import { getStatusIcon, IconButton, NoDataFound, NOTIFICATION_TYPE, NotificationIcon, Text, Theme, TrashIcon, useOnClickOutside, useTimeAgo } from '@odigos/ui-components';
+import { NotificationIcon, TrashIcon } from '@odigos/ui-icons';
+import { IconButton, NoDataFound, Text } from '@odigos/ui-components';
+import { getStatusIcon, NOTIFICATION_TYPE, useOnClickOutside, useTimeAgo } from '@odigos/ui-utils';
 
 const RelativeContainer = styled.div`
   position: relative;

--- a/frontend/webapp/components/overview/add-entity/index.tsx
+++ b/frontend/webapp/components/overview/add-entity/index.tsx
@@ -1,7 +1,10 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useModalStore } from '@/store';
+import { Theme } from '@odigos/ui-theme';
+import { PlusIcon } from '@odigos/ui-icons';
 import styled, { css, useTheme } from 'styled-components';
-import { Button, type DropdownProps, ENTITY_TYPES, getEntityIcon, PlusIcon, Text, Theme, useOnClickOutside } from '@odigos/ui-components';
+import { Button, type DropdownProps, Text } from '@odigos/ui-components';
+import { ENTITY_TYPES, getEntityIcon, useOnClickOutside } from '@odigos/ui-utils';
 
 // Styled components for the dropdown UI
 const Container = styled.div`

--- a/frontend/webapp/components/overview/all-drawers/cli-drawer.tsx
+++ b/frontend/webapp/components/overview/all-drawers/cli-drawer.tsx
@@ -3,36 +3,9 @@ import { useDrawerStore } from '@/store';
 import styled, { useTheme } from 'styled-components';
 import { DATA_CARDS, SEVEN_DAYS_IN_MS } from '@/utils';
 import { useDescribeOdigos, useTokenCRUD } from '@/hooks';
-import {
-  Button,
-  CheckIcon,
-  CodeBracketsIcon,
-  CodeIcon,
-  CopyIcon,
-  CrossIcon,
-  DATA_CARD_FIELD_TYPES,
-  DataCard,
-  Divider,
-  Drawer,
-  EditIcon,
-  FlexColumn,
-  FlexRow,
-  getStatusIcon,
-  IconButton,
-  Input,
-  isOverTime,
-  KeyIcon,
-  ListIcon,
-  NOTIFICATION_TYPE,
-  safeJsonStringify,
-  Segment,
-  Text,
-  Tooltip,
-  useCopy,
-  useKeyDown,
-  useOnClickOutside,
-  useTimeAgo,
-} from '@odigos/ui-components';
+import { CheckIcon, CodeBracketsIcon, CodeIcon, CopyIcon, CrossIcon, EditIcon, KeyIcon, ListIcon } from '@odigos/ui-icons';
+import { getStatusIcon, isOverTime, NOTIFICATION_TYPE, safeJsonStringify, useCopy, useKeyDown, useOnClickOutside, useTimeAgo } from '@odigos/ui-utils';
+import { Button, DATA_CARD_FIELD_TYPES, DataCard, Divider, Drawer, FlexColumn, FlexRow, IconButton, Input, Segment, Text, Tooltip } from '@odigos/ui-components';
 
 interface Props {}
 

--- a/frontend/webapp/components/overview/all-drawers/index.tsx
+++ b/frontend/webapp/components/overview/all-drawers/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { CliDrawer } from './cli-drawer';
-import { ENTITY_TYPES } from '@odigos/ui-components';
+import { ENTITY_TYPES } from '@odigos/ui-utils';
 import { DRAWER_OTHER_TYPES, useDrawerStore } from '@/store';
 import { ActionDrawer, DestinationDrawer, RuleDrawer, SourceDrawer } from '@/containers';
 

--- a/frontend/webapp/components/overview/all-modals/index.tsx
+++ b/frontend/webapp/components/overview/all-modals/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useModalStore } from '@/store';
-import { ENTITY_TYPES } from '@odigos/ui-components';
+import { ENTITY_TYPES } from '@odigos/ui-utils';
 import { ActionModal, AddSourceModal, DestinationModal, RuleModal } from '@/containers';
 
 const AllModals = () => {

--- a/frontend/webapp/components/setup/header/index.tsx
+++ b/frontend/webapp/components/setup/header/index.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
+import { Theme } from '@odigos/ui-theme';
 import { useDarkModeStore } from '@/store';
-import { FlexRow, NavigationButtons, type NavigationButtonsProps, OdigosLogoText, Text, Theme, ToggleDarkMode } from '@odigos/ui-components';
+import { OdigosLogoText } from '@odigos/ui-icons';
+import { FlexRow, NavigationButtons, type NavigationButtonsProps, Text, ToggleDarkMode } from '@odigos/ui-components';
 
 interface Props extends NavigationButtonsProps {}
 

--- a/frontend/webapp/components/setup/menu/index.tsx
+++ b/frontend/webapp/components/setup/menu/index.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect } from 'react';
 import { type StepProps } from '@/types';
+import { Text } from '@odigos/ui-components';
+import { CheckIcon } from '@odigos/ui-icons';
 import styled, { css } from 'styled-components';
-import { CheckIcon, Text } from '@odigos/ui-components';
 
 const Container = styled.div`
   display: flex;

--- a/frontend/webapp/containers/main/actions/action-drawer/build-drawer-item.ts
+++ b/frontend/webapp/containers/main/actions/action-drawer/build-drawer-item.ts
@@ -1,4 +1,4 @@
-import { safeJsonParse } from '@odigos/ui-components';
+import { safeJsonParse } from '@odigos/ui-utils';
 import type { ActionDataParsed, ActionInput } from '@/types';
 
 const buildDrawerItem = (id: string, formData: ActionInput, drawerItem: ActionDataParsed): ActionDataParsed => {

--- a/frontend/webapp/containers/main/actions/action-drawer/index.tsx
+++ b/frontend/webapp/containers/main/actions/action-drawer/index.tsx
@@ -8,7 +8,8 @@ import { type ActionDataParsed } from '@/types';
 import buildDrawerItem from './build-drawer-item';
 import { useActionCRUD, useActionFormData } from '@/hooks';
 import OverviewDrawer from '../../overview/overview-drawer';
-import { ACTION_OPTIONS, ConditionDetails, type ConditionDetailsProps, DataCard, ENTITY_TYPES, getActionIcon, NOTIFICATION_TYPE } from '@odigos/ui-components';
+import { ConditionDetails, type ConditionDetailsProps, DataCard } from '@odigos/ui-components';
+import { ACTION_OPTIONS, ENTITY_TYPES, getActionIcon, NOTIFICATION_TYPE } from '@odigos/ui-utils';
 
 interface Props {}
 

--- a/frontend/webapp/containers/main/actions/action-form-body/custom-fields/add-cluster-info.tsx
+++ b/frontend/webapp/containers/main/actions/action-form-body/custom-fields/add-cluster-info.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
+import { safeJsonParse } from '@odigos/ui-utils';
 import type { AddClusterInfoSpec } from '@/types';
-import { KeyValueInputsList, safeJsonParse } from '@odigos/ui-components';
+import { KeyValueInputsList } from '@odigos/ui-components';
 
 type Props = {
   value: string;

--- a/frontend/webapp/containers/main/actions/action-form-body/custom-fields/delete-attributes.tsx
+++ b/frontend/webapp/containers/main/actions/action-form-body/custom-fields/delete-attributes.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
+import { safeJsonParse } from '@odigos/ui-utils';
+import { InputList } from '@odigos/ui-components';
 import type { DeleteAttributesSpec } from '@/types';
-import { InputList, safeJsonParse } from '@odigos/ui-components';
 
 type Props = {
   value: string;

--- a/frontend/webapp/containers/main/actions/action-form-body/custom-fields/error-sampler.tsx
+++ b/frontend/webapp/containers/main/actions/action-form-body/custom-fields/error-sampler.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo } from 'react';
+import { Input } from '@odigos/ui-components';
 import type { ErrorSamplerSpec } from '@/types';
-import { Input, isEmpty, safeJsonParse } from '@odigos/ui-components';
+import { isEmpty, safeJsonParse } from '@odigos/ui-utils';
 
 type Props = {
   value: string;

--- a/frontend/webapp/containers/main/actions/action-form-body/custom-fields/index.tsx
+++ b/frontend/webapp/containers/main/actions/action-form-body/custom-fields/index.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import PiiMasking from './pii-masking';
 import ErrorSampler from './error-sampler';
 import LatencySampler from './latency-sampler';
+import { ACTION_TYPE } from '@odigos/ui-utils';
 import AddClusterInfo from './add-cluster-info';
 import DeleteAttributes from './delete-attributes';
 import RenameAttributes from './rename-attributes';
-import { ACTION_TYPE } from '@odigos/ui-components';
 import ProbabilisticSampler from './probabilistic-sampler';
 
 interface Props {

--- a/frontend/webapp/containers/main/actions/action-form-body/custom-fields/latency-sampler.tsx
+++ b/frontend/webapp/containers/main/actions/action-form-body/custom-fields/latency-sampler.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
+import { safeJsonParse } from '@odigos/ui-utils';
 import type { LatencySamplerSpec } from '@/types';
-import { InputTable, safeJsonParse } from '@odigos/ui-components';
+import { InputTable } from '@odigos/ui-components';
 
 type Props = {
   value: string;

--- a/frontend/webapp/containers/main/actions/action-form-body/custom-fields/pii-masking.tsx
+++ b/frontend/webapp/containers/main/actions/action-form-body/custom-fields/pii-masking.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import type { PiiMaskingSpec } from '@/types';
 import styled, { css } from 'styled-components';
-import { Checkbox, FieldError, FieldLabel, safeJsonParse } from '@odigos/ui-components';
+import { safeJsonParse } from '@odigos/ui-utils';
+import { Checkbox, FieldError, FieldLabel } from '@odigos/ui-components';
 
 type Props = {
   value: string;

--- a/frontend/webapp/containers/main/actions/action-form-body/custom-fields/probabilistic-sampler.tsx
+++ b/frontend/webapp/containers/main/actions/action-form-body/custom-fields/probabilistic-sampler.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo } from 'react';
+import { Input } from '@odigos/ui-components';
 import type { ProbabilisticSamplerSpec } from '@/types';
-import { Input, isEmpty, safeJsonParse } from '@odigos/ui-components';
+import { isEmpty, safeJsonParse } from '@odigos/ui-utils';
 
 type Props = {
   value: string;

--- a/frontend/webapp/containers/main/actions/action-form-body/custom-fields/rename-attributes.tsx
+++ b/frontend/webapp/containers/main/actions/action-form-body/custom-fields/rename-attributes.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
+import { safeJsonParse } from '@odigos/ui-utils';
 import type { RenameAttributesSpec } from '@/types';
-import { KeyValueInputsList, safeJsonParse } from '@odigos/ui-components';
+import { KeyValueInputsList } from '@odigos/ui-components';
 
 type Props = {
   value: string;

--- a/frontend/webapp/containers/main/actions/action-form-body/index.tsx
+++ b/frontend/webapp/containers/main/actions/action-form-body/index.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
+import { Theme } from '@odigos/ui-theme';
 import { type ActionInput } from '@/types';
 import ActionCustomFields from './custom-fields';
 import styled, { useTheme } from 'styled-components';
-import { type ActionOption, CheckCircledIcon, CrossCircledIcon, DocsButton, Input, MonitorsCheckboxes, SectionTitle, Segment, Text, TextArea, Theme } from '@odigos/ui-components';
+import { type ActionOption } from '@odigos/ui-utils';
+import { CheckCircledIcon, CrossCircledIcon } from '@odigos/ui-icons';
+import { DocsButton, Input, MonitorsCheckboxes, SectionTitle, Segment, Text, TextArea } from '@odigos/ui-components';
 
 interface Props {
   isUpdate?: boolean;

--- a/frontend/webapp/containers/main/actions/action-modal/index.tsx
+++ b/frontend/webapp/containers/main/actions/action-modal/index.tsx
@@ -3,7 +3,8 @@ import { ACTION } from '@/utils';
 import { ActionFormBody } from '../';
 import { ModalBody } from '@/styles';
 import { useActionCRUD, useActionFormData } from '@/hooks/actions';
-import { ACTION_OPTIONS, ActionOption, AutocompleteInput, CenterThis, Divider, FadeLoader, Modal, NavigationButtons, SectionTitle, useKeyDown } from '@odigos/ui-components';
+import { ACTION_OPTIONS, useKeyDown, type ActionOption } from '@odigos/ui-utils';
+import { AutocompleteInput, CenterThis, Divider, FadeLoader, Modal, NavigationButtons, SectionTitle } from '@odigos/ui-components';
 
 interface Props {
   isOpen: boolean;

--- a/frontend/webapp/containers/main/destinations/add-destination/configured-destinations-list/index.tsx
+++ b/frontend/webapp/containers/main/destinations/add-destination/configured-destinations-list/index.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { extractMonitors } from '@/utils';
+import { TrashIcon } from '@odigos/ui-icons';
+import { ENTITY_TYPES } from '@odigos/ui-utils';
 import { IAppState, useAppStore } from '@/store';
 import { type ConfiguredDestination } from '@/types';
-import { DataCardFields, DataTab, DeleteWarning, ENTITY_TYPES, IconButton, TrashIcon } from '@odigos/ui-components';
+import { DataCardFields, DataTab, DeleteWarning, IconButton } from '@odigos/ui-components';
 
 const Container = styled.div`
   display: flex;

--- a/frontend/webapp/containers/main/destinations/add-destination/index.tsx
+++ b/frontend/webapp/containers/main/destinations/add-destination/index.tsx
@@ -4,10 +4,12 @@ import { useAppStore } from '@/store';
 import { SetupHeader } from '@/components';
 import { useRouter } from 'next/navigation';
 import styled, { useTheme } from 'styled-components';
+import { NOTIFICATION_TYPE } from '@odigos/ui-utils';
+import { ArrowIcon, PlusIcon } from '@odigos/ui-icons';
 import { DestinationModal } from '../destination-modal';
 import { useDestinationCRUD, useSourceCRUD } from '@/hooks';
 import { ConfiguredDestinationsList } from './configured-destinations-list';
-import { ArrowIcon, Button, CenterThis, FadeLoader, NOTIFICATION_TYPE, NotificationNote, PlusIcon, SectionTitle, Text } from '@odigos/ui-components';
+import { Button, CenterThis, FadeLoader, NotificationNote, SectionTitle, Text } from '@odigos/ui-components';
 
 const ContentWrapper = styled.div`
   width: 640px;

--- a/frontend/webapp/containers/main/destinations/destination-drawer/build-card.ts
+++ b/frontend/webapp/containers/main/destinations/destination-drawer/build-card.ts
@@ -1,6 +1,7 @@
 import { DISPLAY_TITLES } from '@/utils';
+import { compareCondition, safeJsonParse } from '@odigos/ui-utils';
+import { DATA_CARD_FIELD_TYPES, DataCardFieldsProps } from '@odigos/ui-components';
 import type { ActualDestination, DestinationDetailsResponse, ExportedSignals } from '@/types';
-import { compareCondition, DATA_CARD_FIELD_TYPES, DataCardFieldsProps, safeJsonParse } from '@odigos/ui-components';
 
 const buildMonitorsList = (exportedSignals: ExportedSignals): string =>
   Object.keys(exportedSignals)
@@ -26,7 +27,6 @@ const buildCard = (destination: ActualDestination, destinationTypeDetails?: Dest
 
     const shouldHide = !!hideFromReadData?.length
       ? compareCondition(
-          // @ts-ignore
           hideFromReadData,
           (destinationTypeDetails?.fields || []).map((field) => ({ name: field.name, value: parsedFields[field.name] ?? null })),
         )

--- a/frontend/webapp/containers/main/destinations/destination-drawer/index.tsx
+++ b/frontend/webapp/containers/main/destinations/destination-drawer/index.tsx
@@ -7,8 +7,9 @@ import { type ActualDestination } from '@/types';
 import buildDrawerItem from './build-drawer-item';
 import OverviewDrawer from '../../overview/overview-drawer';
 import { DestinationFormBody } from '../destination-form-body';
+import { ENTITY_TYPES, NOTIFICATION_TYPE } from '@odigos/ui-utils';
 import { useDestinationCRUD, useDestinationFormData, useDestinationTypes } from '@/hooks';
-import { ConditionDetails, ConditionDetailsProps, DataCard, ENTITY_TYPES, NOTIFICATION_TYPE } from '@odigos/ui-components';
+import { ConditionDetails, ConditionDetailsProps, DataCard } from '@odigos/ui-components';
 
 interface Props {}
 

--- a/frontend/webapp/containers/main/destinations/destination-form-body/dynamic-fields/index.tsx
+++ b/frontend/webapp/containers/main/destinations/destination-form-body/dynamic-fields/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { INPUT_TYPES } from '@/utils';
 import type { DynamicField } from '@/types';
-import { Checkbox, compareCondition, Dropdown, Input, InputList, KeyValueInputsList, safeJsonParse, TextArea } from '@odigos/ui-components';
+import { compareCondition, safeJsonParse } from '@odigos/ui-utils';
+import { Checkbox, Dropdown, Input, InputList, KeyValueInputsList, TextArea } from '@odigos/ui-components';
 
 interface Props {
   fields: DynamicField[];
@@ -13,11 +14,7 @@ export const DestinationDynamicFields: React.FC<Props> = ({ fields, onChange, fo
   return fields?.map((field) => {
     const { componentType, renderCondition, ...rest } = field;
 
-    const shouldRender = compareCondition(
-      // @ts-ignore
-      renderCondition,
-      fields,
-    );
+    const shouldRender = compareCondition(renderCondition, fields);
     if (!shouldRender) return null;
 
     switch (componentType) {

--- a/frontend/webapp/containers/main/destinations/destination-form-body/index.tsx
+++ b/frontend/webapp/containers/main/destinations/destination-form-body/index.tsx
@@ -1,9 +1,10 @@
 import React, { Dispatch, SetStateAction, useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { DestinationDynamicFields } from './dynamic-fields';
+import { NOTIFICATION_TYPE, SIGNAL_TYPE } from '@odigos/ui-utils';
 import { type ConnectionStatus, TestConnection } from './test-connection';
 import { type DestinationInput, type DestinationTypeItem, type DynamicField } from '@/types';
-import { Divider, Input, MonitorsCheckboxes, NOTIFICATION_TYPE, NotificationNote, SectionTitle, SIGNAL_TYPE } from '@odigos/ui-components';
+import { Divider, Input, MonitorsCheckboxes, NotificationNote, SectionTitle } from '@odigos/ui-components';
 
 interface Props {
   isUpdate?: boolean;

--- a/frontend/webapp/containers/main/destinations/destination-form-body/test-connection/index.tsx
+++ b/frontend/webapp/containers/main/destinations/destination-form-body/test-connection/index.tsx
@@ -2,7 +2,8 @@ import React, { useEffect } from 'react';
 import { useTestConnection } from '@/hooks';
 import { type DestinationInput } from '@/types';
 import styled, { css, useTheme } from 'styled-components';
-import { Button, FadeLoader, getStatusIcon, NOTIFICATION_TYPE, Text } from '@odigos/ui-components';
+import { Button, FadeLoader, Text } from '@odigos/ui-components';
+import { getStatusIcon, NOTIFICATION_TYPE } from '@odigos/ui-utils';
 
 export type ConnectionStatus = NOTIFICATION_TYPE.SUCCESS | NOTIFICATION_TYPE.ERROR;
 

--- a/frontend/webapp/containers/main/destinations/destination-modal/choose-destination-body/destinations-list/index.tsx
+++ b/frontend/webapp/containers/main/destinations/destination-modal/choose-destination-body/destinations-list/index.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import styled from 'styled-components';
 import { IDestinationListItem } from '@/hooks';
 import type { DestinationTypeItem } from '@/types';
+import { capitalizeFirstLetter, SIGNAL_TYPE } from '@odigos/ui-utils';
 import { PotentialDestinationsList } from './potential-destinations-list';
-import { capitalizeFirstLetter, DataTab, NoDataFound, SectionTitle, SIGNAL_TYPE } from '@odigos/ui-components';
+import { DataTab, NoDataFound, SectionTitle } from '@odigos/ui-components';
 
 const Container = styled.div`
   display: flex;

--- a/frontend/webapp/containers/main/destinations/destination-modal/choose-destination-body/destinations-list/potential-destinations-list/index.tsx
+++ b/frontend/webapp/containers/main/destinations/destination-modal/choose-destination-body/destinations-list/potential-destinations-list/index.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import styled from 'styled-components';
+import { OdigosLogo } from '@odigos/ui-icons';
+import { SIGNAL_TYPE } from '@odigos/ui-utils';
 import { usePotentialDestinations } from '@/hooks';
 import { type DestinationTypeItem } from '@/types';
-import { DataTab, OdigosLogo, SectionTitle, SIGNAL_TYPE, SkeletonLoader } from '@odigos/ui-components';
+import { DataTab, SectionTitle, SkeletonLoader } from '@odigos/ui-components';
 
 interface Props {
   setSelectedItems: (item: DestinationTypeItem) => void;

--- a/frontend/webapp/containers/main/destinations/destination-modal/choose-destination-body/index.tsx
+++ b/frontend/webapp/containers/main/destinations/destination-modal/choose-destination-body/index.tsx
@@ -1,9 +1,11 @@
 import React, { useMemo, useState } from 'react';
 import styled from 'styled-components';
 import { useDestinationTypes } from '@/hooks';
+import { SearchIcon } from '@odigos/ui-icons';
+import { SIGNAL_TYPE } from '@odigos/ui-utils';
 import { DestinationsList } from './destinations-list';
 import type { DestinationTypeItem, SupportedSignals } from '@/types';
-import { Divider, Dropdown, Input, MonitorsCheckboxes, SearchIcon, SectionTitle, SIGNAL_TYPE } from '@odigos/ui-components';
+import { Divider, Dropdown, Input, MonitorsCheckboxes, SectionTitle } from '@odigos/ui-components';
 
 interface Props {
   onSelect: (item: DestinationTypeItem) => void;

--- a/frontend/webapp/containers/main/destinations/destination-modal/index.tsx
+++ b/frontend/webapp/containers/main/destinations/destination-modal/index.tsx
@@ -3,12 +3,14 @@ import { ModalBody } from '@/styles';
 import { useAppStore } from '@/store';
 import styled from 'styled-components';
 import { SideMenu } from '@/components';
+import { ArrowIcon } from '@odigos/ui-icons';
+import { useKeyDown } from '@odigos/ui-utils';
 import { ACTION, INPUT_TYPES } from '@/utils';
 import { DestinationFormBody } from '../destination-form-body';
 import { ChooseDestinationBody } from './choose-destination-body';
 import { useDestinationCRUD, useDestinationFormData } from '@/hooks';
 import type { ConfiguredDestination, DestinationTypeItem } from '@/types';
-import { ArrowIcon, Modal, NavigationButtons, NavigationButtonsProps, useKeyDown } from '@odigos/ui-components';
+import { Modal, NavigationButtons, NavigationButtonsProps } from '@odigos/ui-components';
 
 interface AddDestinationModalProps {
   isOnboarding?: boolean;

--- a/frontend/webapp/containers/main/instrumentation-rules/rule-drawer/build-drawer-item.ts
+++ b/frontend/webapp/containers/main/instrumentation-rules/rule-drawer/build-drawer-item.ts
@@ -1,4 +1,4 @@
-import { deriveTypeFromRule } from '@odigos/ui-components';
+import { deriveTypeFromRule } from '@odigos/ui-utils';
 import { type InstrumentationRuleSpec, type InstrumentationRuleInput, PayloadCollectionType, CodeAttributesType } from '@/types';
 
 const buildDrawerItem = (id: string, formData: InstrumentationRuleInput, drawerItem: InstrumentationRuleSpec): InstrumentationRuleSpec => {

--- a/frontend/webapp/containers/main/instrumentation-rules/rule-drawer/index.tsx
+++ b/frontend/webapp/containers/main/instrumentation-rules/rule-drawer/index.tsx
@@ -2,13 +2,14 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { RuleFormBody } from '../';
 import buildCard from './build-card';
 import styled from 'styled-components';
+import { DataCard } from '@odigos/ui-components';
 import buildDrawerItem from './build-drawer-item';
 import { ACTION, DATA_CARDS, FORM_ALERTS } from '@/utils';
 import OverviewDrawer from '../../overview/overview-drawer';
 import { type InstrumentationRuleSpecMapped } from '@/types';
 import { useDrawerStore, useNotificationStore } from '@/store';
 import { useInstrumentationRuleCRUD, useInstrumentationRuleFormData } from '@/hooks';
-import { DataCard, ENTITY_TYPES, getInstrumentationRuleIcon, INSTRUMENTATION_RULE_OPTIONS, NOTIFICATION_TYPE } from '@odigos/ui-components';
+import { ENTITY_TYPES, getInstrumentationRuleIcon, INSTRUMENTATION_RULE_OPTIONS, NOTIFICATION_TYPE } from '@odigos/ui-utils';
 
 interface Props {}
 

--- a/frontend/webapp/containers/main/instrumentation-rules/rule-form-body/custom-fields/index.tsx
+++ b/frontend/webapp/containers/main/instrumentation-rules/rule-form-body/custom-fields/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import CodeAttributes from './code-attributes';
 import PayloadCollection from './payload-collection';
 import { type InstrumentationRuleInput } from '@/types';
-import { INSTRUMENTATION_RULE_TYPE } from '@odigos/ui-components';
+import { INSTRUMENTATION_RULE_TYPE } from '@odigos/ui-utils';
 
 interface Props {
   ruleType?: INSTRUMENTATION_RULE_TYPE;

--- a/frontend/webapp/containers/main/instrumentation-rules/rule-form-body/index.tsx
+++ b/frontend/webapp/containers/main/instrumentation-rules/rule-form-body/index.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
+import { Theme } from '@odigos/ui-theme';
 import RuleCustomFields from './custom-fields';
 import styled, { useTheme } from 'styled-components';
 import type { InstrumentationRuleInput } from '@/types';
-import { CheckCircledIcon, CrossCircledIcon, DocsButton, Input, type InstrumentationRuleOption, SectionTitle, Segment, Text, TextArea, Theme } from '@odigos/ui-components';
+import { InstrumentationRuleOption } from '@odigos/ui-utils';
+import { CheckCircledIcon, CrossCircledIcon } from '@odigos/ui-icons';
+import { DocsButton, Input, SectionTitle, Segment, Text, TextArea } from '@odigos/ui-components';
 
 interface Props {
   isUpdate?: boolean;

--- a/frontend/webapp/containers/main/instrumentation-rules/rule-modal/index.tsx
+++ b/frontend/webapp/containers/main/instrumentation-rules/rule-modal/index.tsx
@@ -3,20 +3,8 @@ import { RuleFormBody } from '../';
 import { ModalBody } from '@/styles';
 import { ACTION, FORM_ALERTS } from '@/utils';
 import { useDescribeOdigos, useInstrumentationRuleCRUD, useInstrumentationRuleFormData } from '@/hooks';
-import {
-  AutocompleteInput,
-  CenterThis,
-  Divider,
-  FadeLoader,
-  INSTRUMENTATION_RULE_OPTIONS,
-  type InstrumentationRuleOption,
-  Modal,
-  NavigationButtons,
-  NOTIFICATION_TYPE,
-  NotificationNote,
-  SectionTitle,
-  useKeyDown,
-} from '@odigos/ui-components';
+import { INSTRUMENTATION_RULE_OPTIONS, NOTIFICATION_TYPE, useKeyDown, type InstrumentationRuleOption } from '@odigos/ui-utils';
+import { AutocompleteInput, CenterThis, Divider, FadeLoader, Modal, NavigationButtons, NotificationNote, SectionTitle } from '@odigos/ui-components';
 
 interface Props {
   isOpen: boolean;

--- a/frontend/webapp/containers/main/overview/multi-source-control/index.tsx
+++ b/frontend/webapp/containers/main/overview/multi-source-control/index.tsx
@@ -1,9 +1,12 @@
 import React, { useMemo, useState } from 'react';
 import { useAppStore } from '@/store';
 import { useSourceCRUD } from '@/hooks';
+import { Theme } from '@odigos/ui-theme';
+import { TrashIcon } from '@odigos/ui-icons';
 import { type K8sActualSource } from '@/types';
 import styled, { useTheme } from 'styled-components';
-import { Badge, Button, DeleteWarning, Divider, ENTITY_TYPES, Text, Theme, TrashIcon, useTransition } from '@odigos/ui-components';
+import { ENTITY_TYPES, useTransition } from '@odigos/ui-utils';
+import { Badge, Button, DeleteWarning, Divider, Text } from '@odigos/ui-components';
 
 const Container = styled.div`
   position: fixed;

--- a/frontend/webapp/containers/main/overview/overview-actions-menu/filters/index.tsx
+++ b/frontend/webapp/containers/main/overview/overview-actions-menu/filters/index.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { FilterIcon } from '@odigos/ui-icons';
 import styled, { useTheme } from 'styled-components';
+import { Button, Toggle } from '@odigos/ui-components';
+import { useKeyDown, useOnClickOutside } from '@odigos/ui-utils';
 import { AbsoluteContainer, RelativeContainer } from '../styled';
 import { type FiltersState, useFilterStore } from '@/store/useFilterStore';
-import { Button, FilterIcon, Toggle, useKeyDown, useOnClickOutside } from '@odigos/ui-components';
 import { ErrorDropdown, LanguageDropdown, MonitorDropdown, NamespaceDropdown, SelectionButton, TypeDropdown } from '@/components';
 
 const FormWrapper = styled.div`

--- a/frontend/webapp/containers/main/overview/overview-actions-menu/index.tsx
+++ b/frontend/webapp/containers/main/overview/overview-actions-menu/index.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import { Search } from './search';
 import { Filters } from './filters';
 import { AddEntity } from '@/components';
+import { Theme } from '@odigos/ui-theme';
+import { OverviewIcon } from '@odigos/ui-icons';
 import styled, { useTheme } from 'styled-components';
-import { Divider, MonitorsIcons, OverviewIcon, Text, Theme, Tooltip } from '@odigos/ui-components';
+import { Divider, MonitorsIcons, Text, Tooltip } from '@odigos/ui-components';
 
 const MenuContainer = styled.div`
   display: flex;

--- a/frontend/webapp/containers/main/overview/overview-actions-menu/search/index.tsx
+++ b/frontend/webapp/containers/main/overview/overview-actions-menu/search/index.tsx
@@ -1,7 +1,9 @@
 import React, { useRef, useState } from 'react';
+import { SearchIcon } from '@odigos/ui-icons';
+import { Input } from '@odigos/ui-components';
 import { RelativeContainer } from '../styled';
 import { SearchResults } from './search-results';
-import { Input, SearchIcon, useKeyDown, useOnClickOutside } from '@odigos/ui-components';
+import { useKeyDown, useOnClickOutside } from '@odigos/ui-utils';
 // import { RecentSearches } from './recent-searches';
 
 const Search = () => {

--- a/frontend/webapp/containers/main/overview/overview-actions-menu/search/search-results/builder.ts
+++ b/frontend/webapp/containers/main/overview/overview-actions-menu/search/search-results/builder.ts
@@ -1,4 +1,4 @@
-import { ENTITY_TYPES } from '@odigos/ui-components';
+import { ENTITY_TYPES } from '@odigos/ui-utils';
 import { type ActionDataParsed, type ActualDestination, type InstrumentationRuleSpec, type K8sActualSource } from '@/types';
 
 export type Category = 'all' | ENTITY_TYPES;

--- a/frontend/webapp/containers/main/overview/overview-actions-menu/search/search-results/index.tsx
+++ b/frontend/webapp/containers/main/overview/overview-actions-menu/search/search-results/index.tsx
@@ -2,8 +2,9 @@ import React, { Fragment, useMemo, useState } from 'react';
 import { SelectionButton } from '@/components';
 import { AbsoluteContainer } from '../../styled';
 import styled, { useTheme } from 'styled-components';
+import { Divider, Text } from '@odigos/ui-components';
 import { buildSearchResults, type Category } from './builder';
-import { Divider, ENTITY_TYPES, getEntityIcon, getEntityId, getEntityLabel, Text } from '@odigos/ui-components';
+import { ENTITY_TYPES, getEntityIcon, getEntityId, getEntityLabel } from '@odigos/ui-utils';
 import { useActionCRUD, useDestinationCRUD, useInstrumentationRuleCRUD, useNodeDataFlowHandlers, useSourceCRUD } from '@/hooks';
 
 interface Props {

--- a/frontend/webapp/containers/main/overview/overview-data-flow/build-action-nodes.ts
+++ b/frontend/webapp/containers/main/overview/overview-data-flow/build-action-nodes.ts
@@ -2,7 +2,7 @@ import { type Node } from '@xyflow/react';
 import nodeConfig from './node-config.json';
 import { type NodePositions } from './get-node-positions';
 import { type ActionDataParsed, NODE_TYPES, OVERVIEW_NODE_TYPES } from '@/types';
-import { ENTITY_TYPES, getActionIcon, getEntityIcon, getEntityLabel, HEALTH_STATUS } from '@odigos/ui-components';
+import { ENTITY_TYPES, getActionIcon, getEntityIcon, getEntityLabel, HEALTH_STATUS } from '@odigos/ui-utils';
 
 interface Params {
   loading: boolean;

--- a/frontend/webapp/containers/main/overview/overview-data-flow/build-destination-nodes.ts
+++ b/frontend/webapp/containers/main/overview/overview-data-flow/build-destination-nodes.ts
@@ -3,7 +3,7 @@ import { extractMonitors } from '@/utils';
 import nodeConfig from './node-config.json';
 import { type NodePositions } from './get-node-positions';
 import { type ActualDestination, NODE_TYPES, OVERVIEW_NODE_TYPES } from '@/types';
-import { ENTITY_TYPES, getEntityIcon, getEntityLabel, getHealthStatus, HEALTH_STATUS } from '@odigos/ui-components';
+import { ENTITY_TYPES, getEntityIcon, getEntityLabel, getHealthStatus, HEALTH_STATUS } from '@odigos/ui-utils';
 
 interface Params {
   loading: boolean;

--- a/frontend/webapp/containers/main/overview/overview-data-flow/build-edges.ts
+++ b/frontend/webapp/containers/main/overview/overview-data-flow/build-edges.ts
@@ -1,7 +1,8 @@
+import { Theme } from '@odigos/ui-theme';
 import nodeConfig from './node-config.json';
 import { type Edge, type Node } from '@xyflow/react';
 import { EDGE_TYPES, NODE_TYPES, type OverviewMetricsResponse } from '@/types';
-import { ENTITY_TYPES, formatBytes, HEALTH_STATUS, Theme, type WorkloadId } from '@odigos/ui-components';
+import { ENTITY_TYPES, formatBytes, HEALTH_STATUS, type WorkloadId } from '@odigos/ui-utils';
 
 interface Params {
   theme: Theme.ITheme;

--- a/frontend/webapp/containers/main/overview/overview-data-flow/build-rule-nodes.ts
+++ b/frontend/webapp/containers/main/overview/overview-data-flow/build-rule-nodes.ts
@@ -2,7 +2,7 @@ import { type Node } from '@xyflow/react';
 import nodeConfig from './node-config.json';
 import { type NodePositions } from './get-node-positions';
 import { type InstrumentationRuleSpecMapped, NODE_TYPES, OVERVIEW_NODE_TYPES } from '@/types';
-import { ENTITY_TYPES, getEntityIcon, getEntityLabel, getInstrumentationRuleIcon, HEALTH_STATUS } from '@odigos/ui-components';
+import { ENTITY_TYPES, getEntityIcon, getEntityLabel, getInstrumentationRuleIcon, HEALTH_STATUS } from '@odigos/ui-utils';
 
 interface Params {
   loading: boolean;

--- a/frontend/webapp/containers/main/overview/overview-data-flow/build-source-nodes.ts
+++ b/frontend/webapp/containers/main/overview/overview-data-flow/build-source-nodes.ts
@@ -3,7 +3,7 @@ import nodeConfig from './node-config.json';
 import { type NodePositions } from './get-node-positions';
 import { type K8sActualSource, NODE_TYPES, OVERVIEW_NODE_TYPES } from '@/types';
 import { getMainContainerLanguage } from '@/utils/constants/programming-languages';
-import { ENTITY_TYPES, getEntityIcon, getEntityLabel, getHealthStatus, getProgrammingLanguageIcon, HEALTH_STATUS } from '@odigos/ui-components';
+import { ENTITY_TYPES, getEntityIcon, getEntityLabel, getHealthStatus, getProgrammingLanguageIcon, HEALTH_STATUS } from '@odigos/ui-utils';
 
 interface Params {
   loading: boolean;

--- a/frontend/webapp/containers/main/overview/overview-data-flow/get-node-positions.ts
+++ b/frontend/webapp/containers/main/overview/overview-data-flow/get-node-positions.ts
@@ -1,5 +1,5 @@
 import nodeConfig from './node-config.json';
-import { ENTITY_TYPES, getValueForRange } from '@odigos/ui-components';
+import { ENTITY_TYPES, getValueForRange } from '@odigos/ui-utils';
 
 const { nodeWidth, nodeHeight } = nodeConfig;
 

--- a/frontend/webapp/containers/main/overview/overview-data-flow/index.tsx
+++ b/frontend/webapp/containers/main/overview/overview-data-flow/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { ENTITY_TYPES, Theme } from '@odigos/ui-components';
+import { Theme } from '@odigos/ui-theme';
+import { ENTITY_TYPES } from '@odigos/ui-utils';
 import styled, { useTheme } from 'styled-components';
 import { MultiSourceControl } from '../multi-source-control';
 import { OverviewActionsMenu } from '../overview-actions-menu';

--- a/frontend/webapp/containers/main/overview/overview-drawer/index.tsx
+++ b/frontend/webapp/containers/main/overview/overview-drawer/index.tsx
@@ -1,8 +1,10 @@
 import { forwardRef, type PropsWithChildren, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { useTheme } from 'styled-components';
 import { useDestinationCRUD, useSourceCRUD } from '@/hooks';
+import { EditIcon, TrashIcon, type SVG } from '@odigos/ui-icons';
+import { ENTITY_TYPES, NOTIFICATION_TYPE, useKeyDown } from '@odigos/ui-utils';
 import { useDrawerStore, useNotificationStore, usePendingStore } from '@/store';
-import { CancelWarning, DeleteWarning, Drawer, DrawerProps, EditIcon, ENTITY_TYPES, Input, NOTIFICATION_TYPE, type SVG, Text, TrashIcon, useKeyDown } from '@odigos/ui-components';
+import { CancelWarning, DeleteWarning, Drawer, DrawerProps, Input, Text } from '@odigos/ui-components';
 
 interface OverviewDrawerProps {
   title: string;

--- a/frontend/webapp/containers/main/sources/choose-sources/choose-source-modal/index.tsx
+++ b/frontend/webapp/containers/main/sources/choose-sources/choose-source-modal/index.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { type IAppState } from '@/store';
+import { useKeyDown } from '@odigos/ui-utils';
 import { useSourceCRUD, useSourceFormData } from '@/hooks';
 import { ChooseSourcesBody } from '../choose-sources-body';
-import { Modal, NavigationButtons, useKeyDown } from '@odigos/ui-components';
+import { Modal, NavigationButtons } from '@odigos/ui-components';
 
 interface Props {
   isOpen: boolean;

--- a/frontend/webapp/containers/main/sources/choose-sources/choose-sources-body/choose-sources-body-fast/source-controls/index.tsx
+++ b/frontend/webapp/containers/main/sources/choose-sources/choose-sources-body/choose-sources-body-fast/source-controls/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
+import { SearchIcon } from '@odigos/ui-icons';
 import { type UseSourceFormDataResponse } from '@/hooks';
-import { Divider, Input, SearchIcon, SectionTitle, Toggle } from '@odigos/ui-components';
+import { Divider, Input, SectionTitle, Toggle } from '@odigos/ui-components';
 
 interface Props extends UseSourceFormDataResponse {
   isModal?: boolean;

--- a/frontend/webapp/containers/main/sources/choose-sources/choose-sources-body/choose-sources-body-fast/sources-list/index.tsx
+++ b/frontend/webapp/containers/main/sources/choose-sources/choose-sources-body/choose-sources-body-fast/sources-list/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { Theme } from '@odigos/ui-theme';
 import styled, { useTheme } from 'styled-components';
 import { type UseSourceFormDataResponse } from '@/hooks';
-import { Checkbox, Divider, ExtendArrow, FadeLoader, FlexRow, NoDataFound, Text, Theme, Toggle } from '@odigos/ui-components';
+import { Checkbox, Divider, ExtendArrow, FadeLoader, FlexRow, NoDataFound, Text, Toggle } from '@odigos/ui-components';
 
 interface Props extends UseSourceFormDataResponse {
   isModal?: boolean;

--- a/frontend/webapp/containers/main/sources/choose-sources/choose-sources-body/choose-sources-body-simple/source-controls/index.tsx
+++ b/frontend/webapp/containers/main/sources/choose-sources/choose-sources-body/choose-sources-body-simple/source-controls/index.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
+import { SearchIcon } from '@odigos/ui-icons';
 import { NamespaceDropdown } from '@/components';
 import { type UseSourceFormDataResponse } from '@/hooks';
-import { Badge, Checkbox, Divider, Input, SearchIcon, SectionTitle, Text, Toggle } from '@odigos/ui-components';
+import { Badge, Checkbox, Divider, Input, SectionTitle, Text, Toggle } from '@odigos/ui-components';
 
 interface Props extends UseSourceFormDataResponse {
   isModal?: boolean;

--- a/frontend/webapp/containers/main/sources/choose-sources/choose-sources-body/choose-sources-body-simple/sources-list/index.tsx
+++ b/frontend/webapp/containers/main/sources/choose-sources/choose-sources-body/choose-sources-body-simple/sources-list/index.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
+import { Theme } from '@odigos/ui-theme';
+import { FolderIcon } from '@odigos/ui-icons';
 import { type UseSourceFormDataResponse } from '@/hooks';
-import { Checkbox, FadeLoader, FolderIcon, IconWrapped, NoDataFound, Text, Theme } from '@odigos/ui-components';
+import { Checkbox, FadeLoader, IconWrapped, NoDataFound, Text } from '@odigos/ui-components';
 
 interface Props extends UseSourceFormDataResponse {
   isModal?: boolean;

--- a/frontend/webapp/containers/main/sources/choose-sources/index.tsx
+++ b/frontend/webapp/containers/main/sources/choose-sources/index.tsx
@@ -4,8 +4,8 @@ import styled from 'styled-components';
 import { SetupHeader } from '@/components';
 import { useRouter } from 'next/navigation';
 import { useSourceFormData } from '@/hooks';
+import { ArrowIcon } from '@odigos/ui-icons';
 import { IAppState, useAppStore } from '@/store';
-import { ArrowIcon } from '@odigos/ui-components';
 import { ChooseSourcesBody } from './choose-sources-body';
 
 const HeaderWrapper = styled.div`

--- a/frontend/webapp/containers/main/sources/source-drawer-container/build-drawer-item.ts
+++ b/frontend/webapp/containers/main/sources/source-drawer-container/build-drawer-item.ts
@@ -1,5 +1,5 @@
 import { type K8sActualSource } from '@/types';
-import { type WorkloadId } from '@odigos/ui-components';
+import { type WorkloadId } from '@odigos/ui-utils';
 
 const buildDrawerItem = (id: WorkloadId, formData: { otelServiceName: string }, drawerItem: K8sActualSource): K8sActualSource => {
   const { namespace, name, kind } = id;

--- a/frontend/webapp/containers/main/sources/source-drawer-container/index.tsx
+++ b/frontend/webapp/containers/main/sources/source-drawer-container/index.tsx
@@ -4,25 +4,13 @@ import styled from 'styled-components';
 import { useDrawerStore } from '@/store';
 import { type K8sActualSource } from '@/types';
 import buildDrawerItem from './build-drawer-item';
+import { CodeIcon, ListIcon } from '@odigos/ui-icons';
 import { UpdateSourceBody } from '../update-source-body';
 import { useDescribeSource, useSourceCRUD } from '@/hooks';
 import OverviewDrawer from '../../overview/overview-drawer';
 import { ACTION, BACKEND_BOOLEAN, DATA_CARDS } from '@/utils';
-import {
-  CodeIcon,
-  ConditionDetails,
-  ConditionDetailsProps,
-  DATA_CARD_FIELD_TYPES,
-  DataCard,
-  type DataCardFieldsProps,
-  ENTITY_TYPES,
-  getEntityIcon,
-  ListIcon,
-  NOTIFICATION_TYPE,
-  safeJsonStringify,
-  Segment,
-  type WorkloadId,
-} from '@odigos/ui-components';
+import { ENTITY_TYPES, getEntityIcon, NOTIFICATION_TYPE, safeJsonStringify, type WorkloadId } from '@odigos/ui-utils';
+import { ConditionDetails, ConditionDetailsProps, DATA_CARD_FIELD_TYPES, DataCard, type DataCardFieldsProps, Segment } from '@odigos/ui-components';
 
 interface Props {}
 

--- a/frontend/webapp/hooks/actions/useActionCRUD.ts
+++ b/frontend/webapp/hooks/actions/useActionCRUD.ts
@@ -6,7 +6,7 @@ import { useFilterStore, useNotificationStore } from '@/store';
 import { ACTION, DISPLAY_TITLES, FORM_ALERTS } from '@/utils';
 import { CREATE_ACTION, DELETE_ACTION, UPDATE_ACTION } from '@/graphql/mutations';
 import { type ActionItem, type ComputePlatform, type ActionInput } from '@/types';
-import { ACTION_TYPE, ENTITY_TYPES, getSseTargetFromId, NOTIFICATION_TYPE, safeJsonParse } from '@odigos/ui-components';
+import { ACTION_TYPE, ENTITY_TYPES, getSseTargetFromId, NOTIFICATION_TYPE, safeJsonParse } from '@odigos/ui-utils';
 
 interface UseActionCrudParams {
   onSuccess?: (type: string) => void;

--- a/frontend/webapp/hooks/actions/useActionFormData.ts
+++ b/frontend/webapp/hooks/actions/useActionFormData.ts
@@ -2,7 +2,7 @@ import { useGenericForm } from '@/hooks';
 import { FORM_ALERTS } from '@/utils';
 import { DrawerItem, useNotificationStore } from '@/store';
 import { LatencySamplerSpec, type ActionDataParsed, type ActionInput } from '@/types';
-import { ACTION_TYPE, isEmpty, NOTIFICATION_TYPE, safeJsonParse } from '@odigos/ui-components';
+import { ACTION_TYPE, isEmpty, NOTIFICATION_TYPE, safeJsonParse } from '@odigos/ui-utils';
 
 const INITIAL: ActionInput = {
   // @ts-ignore (TS complains about empty string because we expect an "ActionsType", but it's fine)

--- a/frontend/webapp/hooks/compute-platform/useComputePlatform.ts
+++ b/frontend/webapp/hooks/compute-platform/useComputePlatform.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@apollo/client';
 import { useNotificationStore } from '@/store';
 import { type ComputePlatform } from '@/types';
 import { GET_COMPUTE_PLATFORM } from '@/graphql';
-import { NOTIFICATION_TYPE } from '@odigos/ui-components';
+import { NOTIFICATION_TYPE } from '@odigos/ui-utils';
 
 export const useComputePlatform = () => {
   const { addNotification } = useNotificationStore();

--- a/frontend/webapp/hooks/compute-platform/useNamespace.ts
+++ b/frontend/webapp/hooks/compute-platform/useNamespace.ts
@@ -1,8 +1,8 @@
 import { ACTION, DISPLAY_TITLES, FORM_ALERTS } from '@/utils';
 import { useConfig } from '../config';
 import { useNotificationStore } from '@/store';
+import { NOTIFICATION_TYPE } from '@odigos/ui-utils';
 import { useMutation, useQuery } from '@apollo/client';
-import { NOTIFICATION_TYPE } from '@odigos/ui-components';
 import { useComputePlatform } from './useComputePlatform';
 import { GET_NAMESPACE, PERSIST_NAMESPACE } from '@/graphql';
 import { type ComputePlatform, type PersistNamespaceItemInput } from '@/types';

--- a/frontend/webapp/hooks/compute-platform/usePaginatedSources.ts
+++ b/frontend/webapp/hooks/compute-platform/usePaginatedSources.ts
@@ -3,7 +3,7 @@ import { ACTION } from '@/utils';
 import { GET_SOURCES } from '@/graphql';
 import { useLazyQuery } from '@apollo/client';
 import { type ComputePlatform } from '@/types';
-import { NOTIFICATION_TYPE } from '@odigos/ui-components';
+import { NOTIFICATION_TYPE } from '@odigos/ui-utils';
 import { useNotificationStore, usePaginatedStore } from '@/store';
 
 export const usePaginatedSources = () => {

--- a/frontend/webapp/hooks/config/useConfig.ts
+++ b/frontend/webapp/hooks/config/useConfig.ts
@@ -5,7 +5,7 @@ import { type Config } from '@/types';
 import { GET_CONFIG } from '@/graphql';
 import { useNotificationStore } from '@/store';
 import { useSuspenseQuery } from '@apollo/client';
-import { NOTIFICATION_TYPE } from '@odigos/ui-components';
+import { NOTIFICATION_TYPE } from '@odigos/ui-utils';
 
 export const useConfig = () => {
   const { addNotification } = useNotificationStore();

--- a/frontend/webapp/hooks/describe/useDescribeOdigos.ts
+++ b/frontend/webapp/hooks/describe/useDescribeOdigos.ts
@@ -1,7 +1,7 @@
 import { isEnterprise } from '@/utils';
 import { useQuery } from '@apollo/client';
 import { DESCRIBE_ODIGOS } from '@/graphql';
-import type { DescribeOdigos } from '@/types';
+import { type DescribeOdigos } from '@/types';
 
 export const useDescribeOdigos = () => {
   const { data, loading, error } = useQuery<DescribeOdigos>(DESCRIBE_ODIGOS, {

--- a/frontend/webapp/hooks/describe/useDescribeSource.ts
+++ b/frontend/webapp/hooks/describe/useDescribeSource.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@apollo/client';
 import { DESCRIBE_SOURCE } from '@/graphql';
 import { type DescribeSource } from '@/types';
-import { type WorkloadId } from '@odigos/ui-components';
+import { type WorkloadId } from '@odigos/ui-utils';
 
 export const useDescribeSource = ({ namespace, name, kind }: WorkloadId) => {
   const { data, loading, error } = useQuery<DescribeSource>(DESCRIBE_SOURCE, {

--- a/frontend/webapp/hooks/destinations/useDestinationCRUD.ts
+++ b/frontend/webapp/hooks/destinations/useDestinationCRUD.ts
@@ -4,7 +4,7 @@ import { GET_DESTINATIONS } from '@/graphql';
 import { useMutation, useQuery } from '@apollo/client';
 import { ACTION, DISPLAY_TITLES, FORM_ALERTS } from '@/utils';
 import { useFilterStore, useNotificationStore, usePendingStore } from '@/store';
-import { ENTITY_TYPES, getSseTargetFromId, NOTIFICATION_TYPE } from '@odigos/ui-components';
+import { ENTITY_TYPES, getSseTargetFromId, NOTIFICATION_TYPE } from '@odigos/ui-utils';
 import { type SupportedSignals, type DestinationInput, type ComputePlatform } from '@/types';
 import { CREATE_DESTINATION, DELETE_DESTINATION, UPDATE_DESTINATION } from '@/graphql/mutations';
 

--- a/frontend/webapp/hooks/destinations/useDestinationFormData.ts
+++ b/frontend/webapp/hooks/destinations/useDestinationFormData.ts
@@ -4,7 +4,7 @@ import { useQuery } from '@apollo/client';
 import { GET_DESTINATION_TYPE_DETAILS } from '@/graphql';
 import { ACTION, FORM_ALERTS, INPUT_TYPES } from '@/utils';
 import { type DrawerItem, useNotificationStore } from '@/store';
-import { ENTITY_TYPES, NOTIFICATION_TYPE, safeJsonParse } from '@odigos/ui-components';
+import { ENTITY_TYPES, NOTIFICATION_TYPE, safeJsonParse } from '@odigos/ui-utils';
 import {
   type DynamicField,
   type DestinationDetailsResponse,

--- a/frontend/webapp/hooks/destinations/usePotentialDestinations.ts
+++ b/frontend/webapp/hooks/destinations/usePotentialDestinations.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useQuery } from '@apollo/client';
-import { safeJsonParse } from '@odigos/ui-components';
+import { safeJsonParse } from '@odigos/ui-utils';
 import { type IAppState, useAppStore } from '@/store';
 import { type GetDestinationTypesResponse } from '@/types';
 import { GET_DESTINATION_TYPE, GET_POTENTIAL_DESTINATIONS } from '@/graphql';

--- a/frontend/webapp/hooks/destinations/useTestConnection.ts
+++ b/frontend/webapp/hooks/destinations/useTestConnection.ts
@@ -3,8 +3,8 @@ import { useMutation } from '@apollo/client';
 import { useNotificationStore } from '@/store';
 import { type DestinationInput } from '@/types';
 import { TEST_CONNECTION_MUTATION } from '@/graphql';
+import { NOTIFICATION_TYPE } from '@odigos/ui-utils';
 import { DISPLAY_TITLES, FORM_ALERTS } from '@/utils';
-import { NOTIFICATION_TYPE } from '@odigos/ui-components';
 
 interface TestConnectionResponse {
   succeeded: boolean;

--- a/frontend/webapp/hooks/instrumentation-rules/useInstrumentationRuleCRUD.ts
+++ b/frontend/webapp/hooks/instrumentation-rules/useInstrumentationRuleCRUD.ts
@@ -5,7 +5,7 @@ import { GET_INSTRUMENTATION_RULES } from '@/graphql';
 import { useMutation, useQuery } from '@apollo/client';
 import { ACTION, DISPLAY_TITLES, FORM_ALERTS } from '@/utils';
 import { type ComputePlatform, type InstrumentationRuleInput } from '@/types';
-import { deriveTypeFromRule, ENTITY_TYPES, getSseTargetFromId, NOTIFICATION_TYPE } from '@odigos/ui-components';
+import { deriveTypeFromRule, ENTITY_TYPES, getSseTargetFromId, NOTIFICATION_TYPE } from '@odigos/ui-utils';
 import { CREATE_INSTRUMENTATION_RULE, UPDATE_INSTRUMENTATION_RULE, DELETE_INSTRUMENTATION_RULE } from '@/graphql/mutations';
 
 interface Params {

--- a/frontend/webapp/hooks/instrumentation-rules/useInstrumentationRuleFormData.ts
+++ b/frontend/webapp/hooks/instrumentation-rules/useInstrumentationRuleFormData.ts
@@ -1,6 +1,6 @@
 import { FORM_ALERTS } from '@/utils';
 import { useGenericForm } from '@/hooks';
-import { NOTIFICATION_TYPE } from '@odigos/ui-components';
+import { NOTIFICATION_TYPE } from '@odigos/ui-utils';
 import { useNotificationStore, type DrawerItem } from '@/store';
 import { CodeAttributesType, PayloadCollectionType, type InstrumentationRuleInput, type InstrumentationRuleSpec } from '@/types';
 

--- a/frontend/webapp/hooks/notification/useClickNotif.ts
+++ b/frontend/webapp/hooks/notification/useClickNotif.ts
@@ -4,7 +4,7 @@ import { type Notification } from '@/types';
 import { useDestinationCRUD } from '../destinations';
 import { useInstrumentationRuleCRUD } from '../instrumentation-rules';
 import { DrawerItem, useDrawerStore, useNotificationStore } from '@/store';
-import { ENTITY_TYPES, getIdFromSseTarget, WorkloadId } from '@odigos/ui-components';
+import { ENTITY_TYPES, getIdFromSseTarget, type WorkloadId } from '@odigos/ui-utils';
 
 export const useClickNotif = () => {
   const { sources } = useSourceCRUD();

--- a/frontend/webapp/hooks/notification/useSSE.ts
+++ b/frontend/webapp/hooks/notification/useSSE.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
+import { NOTIFICATION_TYPE } from '@odigos/ui-utils';
 import { useDestinationCRUD } from '../destinations';
 import { usePaginatedSources } from '../compute-platform';
-import { NOTIFICATION_TYPE } from '@odigos/ui-components';
 import { API, DISPLAY_TITLES, NOTIF_CRD_TYPES } from '@/utils';
 import { type NotifyPayload, useNotificationStore, usePendingStore, useStatusStore } from '@/store';
 

--- a/frontend/webapp/hooks/overview/useNodeDataFlowHandlers.ts
+++ b/frontend/webapp/hooks/overview/useNodeDataFlowHandlers.ts
@@ -5,8 +5,8 @@ import { useActionCRUD } from '../actions';
 import { OVERVIEW_NODE_TYPES } from '@/types';
 import { useDestinationCRUD } from '../destinations';
 import { useDrawerStore, useModalStore } from '@/store';
+import { ENTITY_TYPES, type WorkloadId } from '@odigos/ui-utils';
 import { useInstrumentationRuleCRUD } from '../instrumentation-rules';
-import { ENTITY_TYPES, type WorkloadId } from '@odigos/ui-components';
 
 export const useNodeDataFlowHandlers = () => {
   const { sources } = useSourceCRUD();

--- a/frontend/webapp/hooks/sources/useSourceCRUD.ts
+++ b/frontend/webapp/hooks/sources/useSourceCRUD.ts
@@ -5,7 +5,7 @@ import { useNamespace } from '../compute-platform';
 import { PERSIST_SOURCE, UPDATE_K8S_ACTUAL_SOURCE } from '@/graphql';
 import { type PatchSourceRequestInput, type K8sActualSource } from '@/types';
 import { ACTION, BACKEND_BOOLEAN, DISPLAY_TITLES, FORM_ALERTS } from '@/utils';
-import { ENTITY_TYPES, getSseTargetFromId, K8S_RESOURCE_KIND, NOTIFICATION_TYPE, type WorkloadId } from '@odigos/ui-components';
+import { ENTITY_TYPES, getSseTargetFromId, K8S_RESOURCE_KIND, NOTIFICATION_TYPE, type WorkloadId } from '@odigos/ui-utils';
 import { type PendingItem, useAppStore, useFilterStore, useNotificationStore, usePaginatedStore, usePendingStore } from '@/store';
 
 interface Params {

--- a/frontend/webapp/hooks/tokens/useTokenCRUD.ts
+++ b/frontend/webapp/hooks/tokens/useTokenCRUD.ts
@@ -4,7 +4,7 @@ import { useNotificationStore } from '@/store';
 import { UPDATE_API_TOKEN } from '@/graphql/mutations';
 import { useComputePlatform } from '../compute-platform';
 import { ACTION, DISPLAY_TITLES, FORM_ALERTS } from '@/utils';
-import { ENTITY_TYPES, getSseTargetFromId, NOTIFICATION_TYPE } from '@odigos/ui-components';
+import { ENTITY_TYPES, getSseTargetFromId, NOTIFICATION_TYPE } from '@odigos/ui-utils';
 
 interface UseTokenCrudParams {
   onSuccess?: (type: string) => void;

--- a/frontend/webapp/hooks/tokens/useTokenTracker.ts
+++ b/frontend/webapp/hooks/tokens/useTokenTracker.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { useTokenCRUD } from '.';
 import { DISPLAY_TITLES, SEVEN_DAYS_IN_MS } from '@/utils';
 import { useNotificationStore, useStatusStore } from '@/store';
-import { isOverTime, NOTIFICATION_TYPE, useTimeAgo } from '@odigos/ui-components';
+import { isOverTime, NOTIFICATION_TYPE, useTimeAgo } from '@odigos/ui-utils';
 
 // This hook is responsible for tracking the tokens and their expiration times.
 // When a token is about to expire or has expired, a notification is added to the notification store, and the connection status is updated accordingly.

--- a/frontend/webapp/package.json
+++ b/frontend/webapp/package.json
@@ -13,7 +13,10 @@
   "dependencies": {
     "@apollo/client": "^3.12.8",
     "@apollo/experimental-nextjs-app-support": "^0.11.8",
-    "@odigos/ui-components": "^0.0.32",
+    "@odigos/ui-components": "^0.0.33",
+    "@odigos/ui-icons": "^0.0.2",
+    "@odigos/ui-theme": "^0.0.2",
+    "@odigos/ui-utils": "^0.0.3",
     "@xyflow/react": "^12.4.2",
     "graphql": "^16.10.0",
     "javascript-time-ago": "^2.5.11",

--- a/frontend/webapp/store/useDrawerStore.ts
+++ b/frontend/webapp/store/useDrawerStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { ENTITY_TYPES, type WorkloadId } from '@odigos/ui-components';
+import { ENTITY_TYPES, type WorkloadId } from '@odigos/ui-utils';
 import type { ActionDataParsed, ActualDestination, InstrumentationRuleSpec, K8sActualSource } from '@/types';
 
 export enum DRAWER_OTHER_TYPES {

--- a/frontend/webapp/store/useNotificationStore.ts
+++ b/frontend/webapp/store/useNotificationStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import type { Notification } from '@/types';
-import { isTimeElapsed } from '@odigos/ui-components';
+import { isTimeElapsed } from '@odigos/ui-utils';
 
 export type NotifyPayload = Omit<Notification, 'id' | 'dismissed' | 'seen' | 'time'>;
 

--- a/frontend/webapp/store/usePaginatedStore.ts
+++ b/frontend/webapp/store/usePaginatedStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { type K8sActualSource } from '@/types';
-import { type WorkloadId } from '@odigos/ui-components';
+import { type WorkloadId } from '@odigos/ui-utils';
 
 interface IPaginatedState {
   sources: K8sActualSource[];

--- a/frontend/webapp/store/usePendingStore.ts
+++ b/frontend/webapp/store/usePendingStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { ENTITY_TYPES, type WorkloadId } from '@odigos/ui-components';
+import { ENTITY_TYPES, type WorkloadId } from '@odigos/ui-utils';
 
 // This store is used to keep track of pending items that are being created, updated, or deleted.
 // This is used for entities that require an SSE event to be sent from the backend after a CRUD action.

--- a/frontend/webapp/store/useStatusStore.ts
+++ b/frontend/webapp/store/useStatusStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { NOTIFICATION_TYPE } from '@odigos/ui-components';
+import { NOTIFICATION_TYPE } from '@odigos/ui-utils';
 
 interface StoreValues {
   status: NOTIFICATION_TYPE;

--- a/frontend/webapp/styles/theme-provider.tsx
+++ b/frontend/webapp/styles/theme-provider.tsx
@@ -1,5 +1,5 @@
 import React, { type FC, type PropsWithChildren, useState } from 'react';
-import { Theme } from '@odigos/ui-components';
+import { Theme } from '@odigos/ui-theme';
 import { useServerInsertedHTML } from 'next/navigation';
 import { ServerStyleSheet, StyleSheetManager } from 'styled-components';
 

--- a/frontend/webapp/types/actions.ts
+++ b/frontend/webapp/types/actions.ts
@@ -1,5 +1,5 @@
 import type { Condition } from './common';
-import { ACTION_TYPE, SIGNAL_TYPE } from '@odigos/ui-components';
+import { ACTION_TYPE, SIGNAL_TYPE } from '@odigos/ui-utils';
 
 export type AddClusterInfoSpec = {
   clusterAttributes: {

--- a/frontend/webapp/types/common.ts
+++ b/frontend/webapp/types/common.ts
@@ -1,4 +1,4 @@
-import { NOTIFICATION_TYPE } from '@odigos/ui-components';
+import { NOTIFICATION_TYPE } from '@odigos/ui-utils';
 
 export interface ExportedSignals {
   logs: boolean;

--- a/frontend/webapp/types/destinations.ts
+++ b/frontend/webapp/types/destinations.ts
@@ -1,5 +1,8 @@
 import { type DropdownProps } from '@odigos/ui-components';
 import { type Condition, type ExportedSignals } from './common';
+import { type Condition as CompareCondition } from '@odigos/ui-utils';
+
+type YamlCompareArr = [string, CompareCondition, string] | ['true' | 'false'];
 
 interface ObservabilitySignalSupport {
   supported: boolean;
@@ -40,8 +43,8 @@ export interface DestinationDetailsField {
   componentProperties: string;
   secret: boolean;
   initialValue: string;
-  renderCondition: string[];
-  hideFromReadData: string[];
+  renderCondition: YamlCompareArr;
+  hideFromReadData: YamlCompareArr;
   customReadDataLabels: {
     condition: string;
     title: string;
@@ -58,7 +61,7 @@ export interface DynamicField {
   placeholder?: string;
   required?: boolean;
   options?: DropdownProps['options'];
-  renderCondition: string[];
+  renderCondition: YamlCompareArr;
 }
 
 export interface DestinationDetailsResponse {

--- a/frontend/webapp/types/instrumentation-rules.ts
+++ b/frontend/webapp/types/instrumentation-rules.ts
@@ -1,4 +1,4 @@
-import { INSTRUMENTATION_RULE_TYPE, type WorkloadId } from '@odigos/ui-components';
+import { INSTRUMENTATION_RULE_TYPE, type WorkloadId } from '@odigos/ui-utils';
 
 export enum PayloadCollectionType {
   HTTP_REQUEST = 'httpRequest',

--- a/frontend/webapp/types/sources.ts
+++ b/frontend/webapp/types/sources.ts
@@ -1,5 +1,5 @@
 import { type Condition } from './common';
-import { PROGRAMMING_LANGUAGES, WorkloadId } from '@odigos/ui-components';
+import { PROGRAMMING_LANGUAGES, type WorkloadId } from '@odigos/ui-utils';
 
 export interface SourceContainer {
   containerName: string;

--- a/frontend/webapp/utils/constants/programming-languages.ts
+++ b/frontend/webapp/utils/constants/programming-languages.ts
@@ -1,5 +1,5 @@
 import { K8sActualSource } from '@/types';
-import { PROGRAMMING_LANGUAGES } from '@odigos/ui-components';
+import { PROGRAMMING_LANGUAGES } from '@odigos/ui-utils';
 
 // while odigos lists language per container, we want to aggregate one single language for the workload.
 // the process is mostly heuristic, we iterate over the containers and return the first valid language we find.

--- a/frontend/webapp/utils/functions/extract-monitors/index.ts
+++ b/frontend/webapp/utils/functions/extract-monitors/index.ts
@@ -1,5 +1,5 @@
 import type { ExportedSignals } from '@/types';
-import { SIGNAL_TYPE } from '@odigos/ui-components';
+import { SIGNAL_TYPE } from '@odigos/ui-utils';
 
 export const extractMonitors = (exportedSignals: ExportedSignals) => {
   const filtered = Object.keys(exportedSignals).filter((signal) => exportedSignals[signal as SIGNAL_TYPE] === true) as SIGNAL_TYPE[];

--- a/frontend/webapp/yarn.lock
+++ b/frontend/webapp/yarn.lock
@@ -514,13 +514,44 @@
   resolved "https://registry.yarnpkg.com/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz#3dc35ba0f1e66b403c00b39344f870298ebb1c8e"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
-"@odigos/ui-components@^0.0.32":
-  version "0.0.32"
-  resolved "https://registry.yarnpkg.com/@odigos/ui-components/-/ui-components-0.0.32.tgz#aa20b11c425a22319e0e8322c23755586fd8260b"
-  integrity sha512-n5nM9JlqwzdP/EAowkhmyc35OHeewPQJLtJ49RCLiqqdoZdAmHuvcPGTAf7VOJ/9l+qP3Okaqnq94zLVNAWi9A==
+"@odigos/ui-components@^0.0.33":
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/@odigos/ui-components/-/ui-components-0.0.33.tgz#ede74c18ed070a117ea4cc47530846bb9bfeb3b2"
+  integrity sha512-YYCSkwhNUYcS2CT1HWPbQvuw8oIvClzl9sjXtp7dPfT/13m3QYJ0ZvgcY8Y5samTLQw1zC9sBOrou25Qm+DLEQ==
   dependencies:
-    javascript-time-ago "^2.5.11"
+    "@odigos/ui-icons" "^0.0.2"
+    "@odigos/ui-theme" "^0.0.2"
+    "@odigos/ui-utils" "^0.0.3"
     prism-react-renderer "^2.4.1"
+    react "^19.0.0"
+    react-dom "^19.0.0"
+    styled-components "^6.1.14"
+
+"@odigos/ui-icons@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@odigos/ui-icons/-/ui-icons-0.0.2.tgz#0cdc9867b871971e7487e7728ad762d2a5440a3e"
+  integrity sha512-AqK8YjWxXnENu1/zWR30Xg8tvKeFD50k06a9o6QqNRJkJ1U4pZQkJea/yAe5Fy1Ocx2d1R2eZ8fc32+KnY8N8Q==
+  dependencies:
+    react "^19.0.0"
+    react-dom "^19.0.0"
+    styled-components "^6.1.14"
+
+"@odigos/ui-theme@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@odigos/ui-theme/-/ui-theme-0.0.2.tgz#82b40ac09811ff56f254b61af9e1302c09245cec"
+  integrity sha512-0lxOrJ0vxyS73AA8kDmp34Ev2CeMI8uqE2O9rtGuAhuAvYrKqUPltw3Y6PiYs/A7HjidJK7CZGJyY7CaQacyPQ==
+  dependencies:
+    react "^19.0.0"
+    react-dom "^19.0.0"
+    styled-components "^6.1.14"
+
+"@odigos/ui-utils@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@odigos/ui-utils/-/ui-utils-0.0.3.tgz#f69200442ff1d52322c6c469c5eec3bec98df640"
+  integrity sha512-M1Ys9N5drozQNNIydkwjHK1omr1tszCosDmEVETbjMmIKhm01B8AKfKjY8VmBBILpZQnZN2fjUC/DWAvSUQh5g==
+  dependencies:
+    "@odigos/ui-icons" "^0.0.2"
+    javascript-time-ago "^2.5.11"
     react "^19.0.0"
     react-dom "^19.0.0"
     styled-components "^6.1.14"


### PR DESCRIPTION
This pull request focuses on reorganizing imports across various components in the frontend web application to improve code maintainability and readability. The changes primarily involve moving certain imports to more appropriate packages (`@odigos/ui-theme`, `@odigos/ui-icons`, and `@odigos/ui-utils`).

These changes help in better organization of the codebase by grouping related imports together, making it easier to manage and understand dependencies.