### PR TITLE
Replace OpenShift docs URL with Odigos catalog on OpenShift

### DIFF
--- a/docs/setup/system-requirements.mdx
+++ b/docs/setup/system-requirements.mdx
@@ -24,7 +24,7 @@ This allows users to maintain observability on nodes that meet the requirements 
 - [Kind](https://kind.sigs.k8s.io)
 - [Minikube](https://minikube.sigs.k8s.io/docs/start)
 - [K3s](https://k3s.io)
-- [Red Hat OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift) (see [how to install on OpenShift](/setup/installation-options#openshift-installation))
+- [Red Hat OpenShift](https://catalog.redhat.com/software/container-stacks/detail/675201b3ade18c062e2efc0b) (see [how to install on OpenShift](/setup/installation-options#openshift-installation))
 - [Amazon Elastic Kubernetes Service (EKS)](https://aws.amazon.com/eks/)
 - [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine)
 - [Azure Kubernetes Service (AKS)](https://azure.microsoft.com/en-us/products/kubernetes-service)


### PR DESCRIPTION
This pull request includes a minor update to the `docs/setup/system-requirements.mdx` file. The change updates the link for Red Hat OpenShift to point to a more specific container stack detail page.

Documentation update:

* [`docs/setup/system-requirements.mdx`](diffhunk://#diff-dce1fa0a01a33f246fafe30474920046e4a74e42bb49621c59e96063ff04fd44L27-R27): Updated the Red Hat OpenShift link to point to the container stack detail page instead of the general technologies page.