### PR TITLE
ci: Add 'odigos-test' namespace for CLI installation

### DIFF
--- a/frontend/webapp/cypress/constants/index.ts
+++ b/frontend/webapp/cypress/constants/index.ts
@@ -21,6 +21,7 @@ export const CRD_IDS = {
 
 export const NAMESPACES = {
   DEFAULT: 'default',
+  ODIGOS_TEST: 'odigos-test',
   ODIGOS_SYSTEM: 'odigos-system',
 };
 

--- a/frontend/webapp/cypress/e2e/04-destinations.cy.ts
+++ b/frontend/webapp/cypress/e2e/04-destinations.cy.ts
@@ -5,7 +5,7 @@ import { BUTTONS, CRD_NAMES, DATA_IDS, NAMESPACES, ROUTES, SELECTED_ENTITIES, TE
 // Tests will fail if you have existing CRDs in the cluster.
 // If you have to run tests locally, make sure to clean up the cluster before running the tests.
 
-const namespace = NAMESPACES.ODIGOS_SYSTEM;
+const namespace = NAMESPACES.ODIGOS_TEST;
 const crdName = CRD_NAMES.DESTINATION;
 
 describe('Destinations CRUD', () => {

--- a/frontend/webapp/cypress/e2e/05-actions.cy.ts
+++ b/frontend/webapp/cypress/e2e/05-actions.cy.ts
@@ -5,7 +5,7 @@ import { BUTTONS, CRD_NAMES, DATA_IDS, INPUTS, NAMESPACES, ROUTES, SELECTED_ENTI
 // Tests will fail if you have existing CRDs in the cluster.
 // If you have to run tests locally, make sure to clean up the cluster before running the tests.
 
-const namespace = NAMESPACES.ODIGOS_SYSTEM;
+const namespace = NAMESPACES.ODIGOS_TEST;
 const crdName = CRD_NAMES.ACTION;
 
 describe('Actions CRUD', () => {

--- a/frontend/webapp/cypress/e2e/06-rules.cy.ts
+++ b/frontend/webapp/cypress/e2e/06-rules.cy.ts
@@ -5,7 +5,7 @@ import { BUTTONS, CRD_NAMES, DATA_IDS, INPUTS, MOCKED_DESCRIBE, NAMESPACES, ROUT
 // Tests will fail if you have existing CRDs in the cluster.
 // If you have to run tests locally, make sure to clean up the cluster before running the tests.
 
-const namespace = NAMESPACES.ODIGOS_SYSTEM;
+const namespace = NAMESPACES.ODIGOS_TEST;
 const crdName = CRD_NAMES.INSTRUMENTATION_RULE;
 
 describe('Instrumentation Rules CRUD', () => {

--- a/tests/e2e/ui/chainsaw-test.yaml
+++ b/tests/e2e/ui/chainsaw-test.yaml
@@ -11,7 +11,7 @@ spec:
         - script:
             timeout: 60s
             content: |
-              ../../../cli/odigos install --version e2e-test
+              ../../../cli/odigos install --namespace odigos-test --version e2e-test
 
     - name: Install App - Simple Demo
       try:


### PR DESCRIPTION
This pull request includes changes to the Cypress tests and an E2E test configuration to use a new namespace for testing. The most important changes include updating the namespace in various test files and the E2E test configuration.

Changes to Cypress tests:

* [`frontend/webapp/cypress/constants/index.ts`](diffhunk://#diff-ffe3e5bc9ff7bba75f2007551dd3e69fa93e9638a7fb62ceec23414f8333f491R24): Added `ODIGOS_TEST` to the `NAMESPACES` export.
* [`frontend/webapp/cypress/e2e/04-destinations.cy.ts`](diffhunk://#diff-6f34bd7eb1cce2b4683938973757c4b0e80921234633a259cd17674c0805ca1bL8-R8): Changed the namespace from `ODIGOS_SYSTEM` to `ODIGOS_TEST` for the Destinations CRUD tests.
* [`frontend/webapp/cypress/e2e/05-actions.cy.ts`](diffhunk://#diff-adc830d3310d3ba00c598b867a2b4f782e4fc6d3147fdb7af3f6346eb6d2f79fL8-R8): Changed the namespace from `ODIGOS_SYSTEM` to `ODIGOS_TEST` for the Actions CRUD tests.
* [`frontend/webapp/cypress/e2e/06-rules.cy.ts`](diffhunk://#diff-aba373cc082245b95ade17d84a085f3f05f6feccbc7d9ee511cb3cc6b4927dd6L8-R8): Changed the namespace from `ODIGOS_SYSTEM` to `ODIGOS_TEST` for the Instrumentation Rules CRUD tests.

Changes to E2E test configuration:

* [`tests/e2e/ui/chainsaw-test.yaml`](diffhunk://#diff-755f1b6537d52a2a2e4be3c1e17d296567f0b9e43c396b3c552a8dff9851a2bbL14-R14): Updated the `odigos install` command to include the `--namespace odigos-test` flag.