### PR TITLE
chore: migrate ebpf manager from device to distro name env

### DIFF
--- a/api/k8sconsts/envvars.go
+++ b/api/k8sconsts/envvars.go
@@ -4,6 +4,7 @@ const (
 	OdigosEnvVarNamespace     = "ODIGOS_WORKLOAD_NAMESPACE"
 	OdigosEnvVarContainerName = "ODIGOS_CONTAINER_NAME"
 	OdigosEnvVarPodName       = "ODIGOS_POD_NAME"
+	OdigosEnvVarDistroName    = "ODIGOS_DISTRO_NAME"
 )
 
 func OdigosInjectedEnvVars() []string {
@@ -11,5 +12,6 @@ func OdigosInjectedEnvVars() []string {
 		OdigosEnvVarNamespace,
 		OdigosEnvVarContainerName,
 		OdigosEnvVarPodName,
+		OdigosEnvVarDistroName,
 	}
 }

--- a/distros/yamls/python-enterprise.yaml
+++ b/distros/yamls/python-enterprise.yaml
@@ -19,3 +19,4 @@ spec:
       delimiter: ':'
   agentDirectories:
     - directoryName: "{{ODIGOS_AGENTS_DIR}}/python-ebpf"
+    - directoryName: "{{ODIGOS_AGENTS_DIR}}/python"

--- a/instrumentor/controllers/agentenabled/pods_webhook.go
+++ b/instrumentor/controllers/agentenabled/pods_webhook.go
@@ -222,7 +222,7 @@ func injectOdigosToContainer(containerConfig *odigosv1.ContainerAgentConfig, pod
 	volumeMounted := false
 	for _, agentDirectory := range distroMetadata.AgentDirectories {
 		podswebhook.MountDirectory(podContainerSpec, agentDirectory.DirectoryName)
-		podswebhook.InjectK8sEnvVars(podContainerSpec, distroName, pw)
+		podswebhook.InjectOdigosK8sEnvVars(podContainerSpec, distroName, pw.Namespace)
 		volumeMounted = true
 	}
 

--- a/instrumentor/controllers/agentenabled/pods_webhook.go
+++ b/instrumentor/controllers/agentenabled/pods_webhook.go
@@ -181,7 +181,8 @@ func (p *PodsWebhook) injectOdigosInstrumentation(ctx context.Context, pod *core
 		// amir: 07 feb 2025. hard-coded temporary list which is removed once all distros migrate away from device
 		if (runtimeDetails.Language == common.JavascriptProgrammingLanguage && otelSdk == common.OtelSdkEbpfEnterprise) ||
 			(runtimeDetails.Language == common.GoProgrammingLanguage && otelSdk == common.OtelSdkEbpfCommunity) ||
-			(runtimeDetails.Language == common.JavaProgrammingLanguage && otelSdk == common.OtelSdkEbpfEnterprise) {
+			(runtimeDetails.Language == common.JavaProgrammingLanguage && otelSdk == common.OtelSdkEbpfEnterprise) ||
+			(runtimeDetails.Language == common.MySQLProgrammingLanguage && otelSdk == common.OtelSdkEbpfEnterprise) {
 			// Skip device injection for distros that no longer use it
 		} else {
 			webhookdeviceinjector.InjectOdigosInstrumentationDevice(*pw, container, otelSdk, runtimeDetails)

--- a/instrumentor/controllers/agentenabled/podswebhook/env.go
+++ b/instrumentor/controllers/agentenabled/podswebhook/env.go
@@ -5,7 +5,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func InjectK8sEnvVars(container *corev1.Container, distroName string, pw k8sconsts.PodWorkload) {
+func InjectOdigosK8sEnvVars(container *corev1.Container, distroName string, ns string) {
 
 	// check for existing env vars so we don't introduce them again
 	existingEnvNames := make(map[string]struct{})
@@ -15,8 +15,25 @@ func InjectK8sEnvVars(container *corev1.Container, distroName string, pw k8scons
 
 	injectEnvVarToPodContainer(&existingEnvNames, container, k8sconsts.OdigosEnvVarContainerName, container.Name)
 	injectEnvVarToPodContainer(&existingEnvNames, container, k8sconsts.OdigosEnvVarDistroName, distroName)
-	injectEnvVarToPodContainer(&existingEnvNames, container, k8sconsts.OdigosEnvVarPodName, pw.Name)
-	injectEnvVarToPodContainer(&existingEnvNames, container, k8sconsts.OdigosEnvVarNamespace, pw.Namespace)
+	injectEnvVarObjectFieldRefToPodContainer(&existingEnvNames, container, k8sconsts.OdigosEnvVarPodName, "metadata.name")
+	injectEnvVarToPodContainer(&existingEnvNames, container, k8sconsts.OdigosEnvVarNamespace, ns)
+}
+
+func injectEnvVarObjectFieldRefToPodContainer(existingEnvNames *map[string]struct{}, container *corev1.Container, envVarName, envVarRef string) {
+	if _, exists := (*existingEnvNames)[envVarName]; exists {
+		return
+	}
+
+	container.Env = append(container.Env, corev1.EnvVar{
+		Name: envVarName,
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: envVarRef,
+			},
+		},
+	})
+
+	(*existingEnvNames)[envVarName] = struct{}{}
 }
 
 func injectEnvVarToPodContainer(existingEnvNames *map[string]struct{}, container *corev1.Container, envVarName, envVarValue string) {

--- a/instrumentor/controllers/agentenabled/podswebhook/env.go
+++ b/instrumentor/controllers/agentenabled/podswebhook/env.go
@@ -1,0 +1,33 @@
+package podswebhook
+
+import (
+	"github.com/odigos-io/odigos/api/k8sconsts"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func InjectK8sEnvVars(container *corev1.Container, distroName string, pw k8sconsts.PodWorkload) {
+
+	// check for existing env vars so we don't introduce them again
+	existingEnvNames := make(map[string]struct{})
+	for _, envVar := range container.Env {
+		existingEnvNames[envVar.Name] = struct{}{}
+	}
+
+	injectEnvVarToPodContainer(&existingEnvNames, container, k8sconsts.OdigosEnvVarContainerName, container.Name)
+	injectEnvVarToPodContainer(&existingEnvNames, container, k8sconsts.OdigosEnvVarDistroName, distroName)
+	injectEnvVarToPodContainer(&existingEnvNames, container, k8sconsts.OdigosEnvVarPodName, pw.Name)
+	injectEnvVarToPodContainer(&existingEnvNames, container, k8sconsts.OdigosEnvVarNamespace, pw.Namespace)
+}
+
+func injectEnvVarToPodContainer(existingEnvNames *map[string]struct{}, container *corev1.Container, envVarName, envVarValue string) {
+	if _, exists := (*existingEnvNames)[envVarName]; exists {
+		return
+	}
+
+	container.Env = append(container.Env, corev1.EnvVar{
+		Name:  envVarName,
+		Value: envVarValue,
+	})
+
+	(*existingEnvNames)[envVarName] = struct{}{}
+}

--- a/instrumentor/controllers/agentenabled/podswebhook/mount.go
+++ b/instrumentor/controllers/agentenabled/podswebhook/mount.go
@@ -1,0 +1,33 @@
+package podswebhook
+
+import (
+	"strings"
+
+	"github.com/odigos-io/odigos/api/k8sconsts"
+	"github.com/odigos-io/odigos/distros/distro"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func MountDirectory(containerSpec *corev1.Container, dir string) {
+	// TODO: assuming the directory always starts with {{ODIGOS_AGENTS_DIR}}. This should be validated.
+	// Should we return errors here to validate static values?
+	relativePath := strings.TrimPrefix(dir, distro.AgentPlaceholderDirectory+"/")
+	absolutePath := strings.ReplaceAll(dir, distro.AgentPlaceholderDirectory, k8sconsts.OdigosAgentsDirectory)
+	containerSpec.VolumeMounts = append(containerSpec.VolumeMounts, corev1.VolumeMount{
+		Name:      k8sconsts.OdigosAgentMountVolumeName,
+		SubPath:   relativePath,
+		MountPath: absolutePath,
+		ReadOnly:  true,
+	})
+}
+
+func MountPodVolume(pod *corev1.Pod) {
+	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+		Name: k8sconsts.OdigosAgentMountVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: k8sconsts.OdigosAgentsDirectory,
+			},
+		},
+	})
+}

--- a/k8sutils/pkg/container/container.go
+++ b/k8sutils/pkg/container/container.go
@@ -14,6 +14,34 @@ var (
 	ErrContainerNotInPodSpec = errors.New("container not found in pod spec")
 )
 
+func LanguageAndSdk(pod *v1.Pod, containerName string, distroName string) (common.ProgrammingLanguage, common.OtelSdk, error) {
+	if distroName != "" {
+		// TODO: so we can remove the device slowly while having backward compatibility,
+		// we map here the distroNames one by one.
+		// this is temporary, and should be refactored once device is removed
+		switch distroName {
+		case "golang-community":
+			return common.GoProgrammingLanguage, common.OtelSdkEbpfCommunity, nil
+		case "golang-enterprise":
+			return common.GoProgrammingLanguage, common.OtelSdkEbpfEnterprise, nil
+		case "java-enterprise":
+			return common.JavaProgrammingLanguage, common.OtelSdkNativeEnterprise, nil
+		case "java-ebpf-instrumentations":
+			return common.JavaProgrammingLanguage, common.OtelSdkEbpfEnterprise, nil
+		case "python-enterprise":
+			return common.PythonProgrammingLanguage, common.OtelSdkEbpfEnterprise, nil
+		case "nodejs-enterprise":
+			return common.JavascriptProgrammingLanguage, common.OtelSdkEbpfEnterprise, nil
+		case "mysql-enterprise":
+			return common.MySQLProgrammingLanguage, common.OtelSdkEbpfEnterprise, nil
+		}
+	}
+
+	// TODO: this is fallback for migration from device (so that we can handle pods that have not been updated yet)
+	// remove this once device is removed
+	return LanguageSdkFromPodContainer(pod, containerName)
+}
+
 func LanguageSdkFromPodContainer(pod *v1.Pod, containerName string) (common.ProgrammingLanguage, common.OtelSdk, error) {
 	for i := range pod.Spec.Containers {
 		container := pod.Spec.Containers[i]

--- a/odiglet/pkg/ebpf/distribution_matcher.go
+++ b/odiglet/pkg/ebpf/distribution_matcher.go
@@ -15,7 +15,7 @@ type podDeviceDistributionMatcher struct{}
 func (dm *podDeviceDistributionMatcher) Distribution(ctx context.Context, e K8sProcessDetails) (instrumentation.OtelDistribution, error) {
 	// get the language and sdk for this process event
 	// based on the pod spec and the container name from the process event
-	lang, sdk, err := odgiosK8s.LanguageSdkFromPodContainer(e.pod, e.containerName)
+	lang, sdk, err := odgiosK8s.LanguageAndSdk(e.pod, e.containerName, e.distroName)
 	if err != nil {
 		return instrumentation.OtelDistribution{}, fmt.Errorf("failed to get language and sdk: %w", err)
 	}

--- a/odiglet/pkg/ebpf/reporter.go
+++ b/odiglet/pkg/ebpf/reporter.go
@@ -20,6 +20,7 @@ import (
 type K8sProcessDetails struct {
 	pod           *corev1.Pod
 	containerName string
+	distroName    string
 	pw            *k8sconsts.PodWorkload
 	procEvent     detector.ProcessEvent
 }

--- a/odiglet/pkg/ebpf/resolvers.go
+++ b/odiglet/pkg/ebpf/resolvers.go
@@ -27,6 +27,11 @@ func (dr *k8sDetailsResolver) Resolve(ctx context.Context, event detector.Proces
 		return K8sProcessDetails{}, errContainerNameNotReported
 	}
 
+	distroName, found := distroNameFromProcEvent(event)
+	if !found {
+		// TODO: this is ok for migration period. Once device is removed, this should be an error
+	}
+
 	podWorkload, err := workload.PodWorkloadObjectOrError(ctx, pod)
 	if err != nil {
 		return K8sProcessDetails{}, fmt.Errorf("failed to find workload object from pod manifest owners references: %w", err)
@@ -35,6 +40,7 @@ func (dr *k8sDetailsResolver) Resolve(ctx context.Context, event detector.Proces
 	return K8sProcessDetails{
 		pod:           pod,
 		containerName: containerName,
+		distroName:    distroName,
 		pw:            podWorkload,
 		procEvent:     event,
 	}, nil
@@ -65,6 +71,11 @@ func (dr *k8sDetailsResolver) podFromProcEvent(ctx context.Context, e detector.P
 func containerNameFromProcEvent(event detector.ProcessEvent) (string, bool) {
 	containerName, ok := event.ExecDetails.Environments[k8sconsts.OdigosEnvVarContainerName]
 	return containerName, ok
+}
+
+func distroNameFromProcEvent(event detector.ProcessEvent) (string, bool) {
+	distronName, ok := event.ExecDetails.Environments[k8sconsts.OdigosEnvVarDistroName]
+	return distronName, ok
 }
 
 type k8sConfigGroupResolver struct{}

--- a/tests/common/assert/simple-demo-instrumented.yaml
+++ b/tests/common/assert/simple-demo-instrumented.yaml
@@ -110,11 +110,6 @@ spec:
                   - "true"
   containers:
     - name: membership
-      resources:
-        limits:
-          instrumentation.odigos.io/go-ebpf-community: "1"
-        requests:
-          instrumentation.odigos.io/go-ebpf-community: "1"
 status:
   containerStatuses:
     - name: membership


### PR DESCRIPTION
As part of the effort to remove instrumentation device, this PR:

- add environment variable to containers, `ODIGOS_DISTRO_NAME` to describe the name of the distro injected to the pod.
- migrate ebpf manager to match distribution based on the new environment variable with fallback to device so not to break existing users.
- fix missing agent directory needed in python
- remove device from 4 distros that do not inject any env variables - only need the `/var/odigos` mount, or not.
