### PR TITLE
odiglet: Initialize clientset at startup and do OpenShift selinux changes last

### DIFF
--- a/k8sutils/pkg/node/node.go
+++ b/k8sutils/pkg/node/node.go
@@ -6,27 +6,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 
 	"github.com/odigos-io/odigos/api/k8sconsts"
 	"github.com/odigos-io/odigos/common"
 	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 )
 
-func AddLabelToNode(nodeName string, labelKey string, labelValue string) error {
+func AddLabelToNode(clientset *kubernetes.Clientset, nodeName string, labelKey string, labelValue string) error {
 	// Add odiglet installed label to node
-	cfg, err := rest.InClusterConfig()
-	if err != nil {
-		return err
-	}
-
-	clientset, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		return err
-	}
-
 	patch := []byte(`{"metadata": {"labels": {"` + labelKey + `": "` + labelValue + `"}}}`)
-	_, err = clientset.CoreV1().Nodes().Patch(context.Background(), nodeName, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+	_, err := clientset.CoreV1().Nodes().Patch(context.Background(), nodeName, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
 	if err != nil {
 		return err
 	}

--- a/odiglet/odiglet.go
+++ b/odiglet/odiglet.go
@@ -205,5 +205,12 @@ func OdigletInitPhase() {
 		os.Exit(-1)
 	}
 
+	// SELinux settings should be applied last. This function chroot's to use the host's PATH for
+	// executing selinux commands to make agents readable by pods.
+	if err := fs.ApplyOpenShiftSELinuxSettings(); err != nil {
+		log.Logger.Error(err, "Failed to apply SELinux settings on RHEL host")
+		os.Exit(-1)
+	}
+
 	os.Exit(0)
 }

--- a/odiglet/pkg/instrumentation/fs/agents.go
+++ b/odiglet/pkg/instrumentation/fs/agents.go
@@ -55,37 +55,6 @@ func CopyAgentsDirectoryToHost() error {
 		return err
 	}
 
-	// Check if the semanage command exists when running on RHEL/CoreOS
-	_, err = exec.LookPath(filepath.Join(chrootDir, semanagePath))
-	if err == nil {
-		// Run the semanage command to add the new directory to the container_ro_file_t context
-		// semanage writes SELinux config to host
-		syscall.Chroot(chrootDir)
-		cmd := exec.Command(semanagePath, "fcontext", "-a", "-t", "container_ro_file_t", "/var/odigos(/.*)?")
-		err = cmd.Run()
-		if err != nil {
-			log.Logger.Error(err, "Error running semanage command")
-		}
-
-		// Check if the restorecon command exists when running on RHEL/CoreOS
-		// restorecon applies the SELinux settings we just created to the host
-		// And we are already chrooted to the host path, so we can just look for restoreconPath now
-		_, err = exec.LookPath(restoreconPath)
-		if err == nil {
-			// Run the restorecon command to apply the new context
-			cmd := exec.Command(restoreconPath, "-r", k8sconsts.OdigosAgentsDirectory)
-			err = cmd.Run()
-			if err != nil {
-				log.Logger.Error(err, "Error running restorecon command")
-			}
-		} else {
-			log.Logger.Error(err, "Unable to find restorecon path")
-		}
-
-	} else {
-		log.Logger.Error(err, "Unable to find semanage path")
-	}
-
 	return nil
 }
 
@@ -172,4 +141,43 @@ func calculateFileHash(filePath string) (string, error) {
 	}
 
 	return fmt.Sprintf("%x", hasher.Sum(nil)), nil
+}
+
+// ApplyOpenShiftSELinuxSettings makes auto-instrumentation agents readable by containers on RHEL hosts.
+// Note: This function calls chroot to use the host's PATH to execute selinux commands. Calling it will
+// affect the odiglet running process's apparent filesystem.
+func ApplyOpenShiftSELinuxSettings() error {
+	// Check if the semanage command exists when running on RHEL/CoreOS
+	_, err := exec.LookPath(filepath.Join(chrootDir, semanagePath))
+	if err == nil {
+		// Run the semanage command to add the new directory to the container_ro_file_t context
+		// semanage writes SELinux config to host
+		syscall.Chroot(chrootDir)
+		cmd := exec.Command(semanagePath, "fcontext", "-a", "-t", "container_ro_file_t", "/var/odigos(/.*)?")
+		err = cmd.Run()
+		if err != nil {
+			log.Logger.Error(err, "Error running semanage command")
+			return err
+		}
+
+		// Check if the restorecon command exists when running on RHEL/CoreOS
+		// restorecon applies the SELinux settings we just created to the host
+		// And we are already chrooted to the host path, so we can just look for restoreconPath now
+		_, err = exec.LookPath(restoreconPath)
+		if err == nil {
+			// Run the restorecon command to apply the new context
+			cmd := exec.Command(restoreconPath, "-r", k8sconsts.OdigosAgentsDirectory)
+			err = cmd.Run()
+			if err != nil {
+				log.Logger.Error(err, "Error running restorecon command")
+				return err
+			}
+		} else {
+			log.Logger.Error(err, "Unable to find restorecon path")
+			return err
+		}
+	} else {
+		log.Logger.Info("Unable to find semanage path, possibly not on RHEL host")
+	}
+	return nil
 }


### PR DESCRIPTION
This does 2 things in the Odiglet:

* **Make SELinux calls for openshift last in the init phase.** These functions `chroot` to the host directory to run selinux commands that update the agent permissions, so they are readable by pods. This `chroot` was preventing the k8s client from initializing with `open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory`. Moved last so the `chroot` doesn't mess up future changes.
* **Initializes the k8s clientset in the main odiglet function.** This allows the same clientset to be passed through to the init phase (which uses it to apply labels to nodes) and the odiglet controller. Doing so makes `clientset` an argument to functions like `odiglet.New` and `k8snode.AddLabelToNode`, the latter of which is just a helper which should not be initializing its own clientset every call anyway.

Technically, either one of these changes would have fixed the issue. But doing both is even better to help prevent future issues like this.