### PR TITLE
refactor: migrate otel resource env to distro

### DIFF
--- a/distros/distro/oteldistribution.go
+++ b/distros/distro/oteldistribution.go
@@ -40,11 +40,18 @@ type EnvironmentVariable struct {
 	Delimiter string `yaml:"delimiter"`
 }
 
-type AgentDirectory struct {
+type RuntimeAgent struct {
 	// The name of a directory where odigos agent files can be found.
 	// The special value {{ODIGOS_AGENTS_DIR}} is replaced with the actual value at this platform.
-	// K8s will mount this directory from the node fs to the container, but other platforms may have different ways for handling this.
-	DirectoryName string `yaml:"directoryName"`
+	// K8s will mount this directory from the node fs to the container. other platforms may have different ways to make the directory accessible.
+	DirectoryNames []string `yaml:"directoryNames"`
+
+	// This field indicates that the agent populates k8s resource attributes via environment variables.
+	// It targets distros odigos uses without wrapper or customization.
+	// For eBPF, the resource attributes are set in code.
+	// For opamp distros, the resource attributes are set in the opamp server.
+	// We will eventually remove this field once all distros upgrade to dynamic resource attributes.
+	K8sAttrsViaEnvVars bool `yaml:"k8sAttrsViaEnvVars,omitempty"`
 }
 
 // OtelDistro (Short for OpenTelemetry Distribution) is a collection of OpenTelemetry components,
@@ -88,8 +95,7 @@ type OtelDistro struct {
 	// to enable the distribution.
 	EnvironmentVariables []EnvironmentVariable `yaml:"environmentVariables,omitempty"`
 
-	// Directories on the FS where the agent files can be consumed from.
-	// this can be empty if the distribution does not require agent files,
-	// or contain more than one directory if the distribution requires it.
-	AgentDirectories []AgentDirectory `yaml:"agentDirectories,omitempty"`
+	// Metadata and properties of the runtime agent that is used to enable the distribution.
+	// Can be nil in case no runtime agent is required.
+	RuntimeAgent *RuntimeAgent `yaml:"runtimeAgent,omitempty"`
 }

--- a/distros/yamls/dotnet-community.yaml
+++ b/distros/yamls/dotnet-community.yaml
@@ -19,5 +19,7 @@ spec:
   tiers: 
     - community
     - onprem
-  agentDirectories:
-    - directoryName: "{{ODIGOS_AGENTS_DIR}}/dotnet"
+  runtimeAgent:
+    directoryNames:
+      - "{{ODIGOS_AGENTS_DIR}}/dotnet"
+    k8sAttrsViaEnvVars: true

--- a/distros/yamls/dotnet-legacy.yaml
+++ b/distros/yamls/dotnet-legacy.yaml
@@ -13,5 +13,7 @@ spec:
     This distribution is for Dotnet applications running on old runtimes, using OpenTelemetry Native SDK and instrumentation libraries from the OpenTelemetry community.
   tiers: 
     - onprem
-  agentDirectories:
-    - directoryName: "{{ODIGOS_AGENTS_DIR}}/legacy-dotnet"
+  runtimeAgent:
+    directoryNames:
+      - "{{ODIGOS_AGENTS_DIR}}/legacy-dotnet"
+    k8sAttrsViaEnvVars: true

--- a/distros/yamls/java-community.yaml
+++ b/distros/yamls/java-community.yaml
@@ -20,5 +20,7 @@ spec:
     - envName: JAVA_TOOL_OPTIONS
       envValue: '-javaagent:{{ODIGOS_AGENTS_DIR}}/java/javaagent.jar'
       delimiter: ' '
-  agentDirectories:
-    - directoryName: "{{ODIGOS_AGENTS_DIR}}/java"    
+  runtimeAgent:
+    directoryNames:
+      - "{{ODIGOS_AGENTS_DIR}}/java"
+    k8sAttrsViaEnvVars: true

--- a/distros/yamls/java-ebpf-instrumentations.yaml
+++ b/distros/yamls/java-ebpf-instrumentations.yaml
@@ -20,5 +20,6 @@ spec:
     - envName: JAVA_TOOL_OPTIONS
       envValue: '-javaagent:{{ODIGOS_AGENTS_DIR}}/java-ebpf/dtrace-injector.jar'
       delimiter: ' '
-  agentDirectories:
-    - directoryName: "{{ODIGOS_AGENTS_DIR}}/java-ebpf"
+  runtimeAgent:
+    directoryNames:
+      - "{{ODIGOS_AGENTS_DIR}}/java-ebpf"

--- a/distros/yamls/java-enterprise.yaml
+++ b/distros/yamls/java-enterprise.yaml
@@ -20,5 +20,6 @@ spec:
     - envName: JAVA_TOOL_OPTIONS
       envValue: "-javaagent:{{ODIGOS_AGENTS_DIR}}/java-ext-ebpf/javaagent.jar -Dotel.javaagent.extensions={{ODIGOS_AGENTS_DIR}}/java-ext-ebpf/otel_agent_extension.jar"
       delimiter: ' '
-  agentDirectories:
-    - directoryName: "{{ODIGOS_AGENTS_DIR}}/java-ext-ebpf"
+  runtimeAgent:
+    directoryNames:
+      - "{{ODIGOS_AGENTS_DIR}}/java-ext-ebpf"

--- a/distros/yamls/nodejs-community.yaml
+++ b/distros/yamls/nodejs-community.yaml
@@ -17,5 +17,6 @@ spec:
     - envName: NODE_OPTIONS
       envValue: '--require {{ODIGOS_AGENTS_DIR}}/nodejs/autoinstrumentation.js'
       delimiter: ' '
-  agentDirectories:
-    - directoryName: "{{ODIGOS_AGENTS_DIR}}/nodejs"
+  runtimeAgent:
+    directoryNames:
+      - "{{ODIGOS_AGENTS_DIR}}/nodejs"

--- a/distros/yamls/nodejs-enterprise.yaml
+++ b/distros/yamls/nodejs-enterprise.yaml
@@ -17,5 +17,6 @@ spec:
     - envName: NODE_OPTIONS
       envValue: '--require {{ODIGOS_AGENTS_DIR}}/nodejs-ebpf/autoinstrumentation.js'
       delimiter: ' '
-  agentDirectories:
-    - directoryName: "{{ODIGOS_AGENTS_DIR}}/nodejs-ebpf"
+  runtimeAgent:
+    directoryNames:
+      - "{{ODIGOS_AGENTS_DIR}}/nodejs-ebpf"

--- a/distros/yamls/python-community.yaml
+++ b/distros/yamls/python-community.yaml
@@ -17,5 +17,7 @@ spec:
     - envName: PYTHONPATH
       envValue: '{{ODIGOS_AGENTS_DIR}}/python:{{ODIGOS_AGENTS_DIR}}/python/opentelemetry/instrumentation/auto_instrumentation'
       delimiter: ':'
-  agentDirectories:
-    - directoryName: "{{ODIGOS_AGENTS_DIR}}/python"
+  runtimeAgent:
+    directoryNames:
+      - "{{ODIGOS_AGENTS_DIR}}/python"
+      

--- a/distros/yamls/python-enterprise.yaml
+++ b/distros/yamls/python-enterprise.yaml
@@ -17,6 +17,7 @@ spec:
     - envName: PYTHONPATH
       envValue: '{{ODIGOS_AGENTS_DIR}}/python-ebpf:{{ODIGOS_AGENTS_DIR}}/python/opentelemetry/instrumentation/auto_instrumentation:{{ODIGOS_AGENTS_DIR}}/python'
       delimiter: ':'
-  agentDirectories:
-    - directoryName: "{{ODIGOS_AGENTS_DIR}}/python-ebpf"
-    - directoryName: "{{ODIGOS_AGENTS_DIR}}/python"
+  runtimeAgent:
+    directoryNames:
+      - "{{ODIGOS_AGENTS_DIR}}/python"
+      - "{{ODIGOS_AGENTS_DIR}}/python-ebpf"

--- a/instrumentor/controllers/agentenabled/podswebhook/env.go
+++ b/instrumentor/controllers/agentenabled/podswebhook/env.go
@@ -5,18 +5,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func InjectOdigosK8sEnvVars(container *corev1.Container, distroName string, ns string) {
+func InjectOdigosK8sEnvVars(existingEnvNames *map[string]struct{}, container *corev1.Container, distroName string, ns string) {
 
-	// check for existing env vars so we don't introduce them again
-	existingEnvNames := make(map[string]struct{})
-	for _, envVar := range container.Env {
-		existingEnvNames[envVar.Name] = struct{}{}
-	}
-
-	injectEnvVarToPodContainer(&existingEnvNames, container, k8sconsts.OdigosEnvVarContainerName, container.Name)
-	injectEnvVarToPodContainer(&existingEnvNames, container, k8sconsts.OdigosEnvVarDistroName, distroName)
-	injectEnvVarObjectFieldRefToPodContainer(&existingEnvNames, container, k8sconsts.OdigosEnvVarPodName, "metadata.name")
-	injectEnvVarToPodContainer(&existingEnvNames, container, k8sconsts.OdigosEnvVarNamespace, ns)
+	injectEnvVarToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarContainerName, container.Name)
+	injectEnvVarToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarDistroName, distroName)
+	injectEnvVarObjectFieldRefToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarPodName, "metadata.name")
+	injectEnvVarToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarNamespace, ns)
 }
 
 func injectEnvVarObjectFieldRefToPodContainer(existingEnvNames *map[string]struct{}, container *corev1.Container, envVarName, envVarRef string) {

--- a/instrumentor/controllers/agentenabled/podswebhook/otelresource.go
+++ b/instrumentor/controllers/agentenabled/podswebhook/otelresource.go
@@ -1,0 +1,68 @@
+package podswebhook
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/odigos-io/odigos/api/k8sconsts"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const otelServiceNameEnvVarName = "OTEL_SERVICE_NAME"
+const otelResourceAttributesEnvVarName = "OTEL_RESOURCE_ATTRIBUTES"
+
+type resourceAttribute struct {
+	Key   attribute.Key
+	Value string
+}
+
+func getResourceAttributes(podWorkload k8sconsts.PodWorkload, containerName string) []resourceAttribute {
+	workloadKindKey := getWorkloadKindAttributeKey(podWorkload.Kind)
+	return []resourceAttribute{
+		{
+			Key:   semconv.K8SContainerNameKey,
+			Value: containerName,
+		},
+		{
+			Key:   semconv.K8SNamespaceNameKey,
+			Value: podWorkload.Namespace,
+		},
+		{
+			Key:   workloadKindKey,
+			Value: podWorkload.Name,
+		},
+	}
+}
+
+func getWorkloadKindAttributeKey(workloadKind k8sconsts.WorkloadKind) attribute.Key {
+	switch workloadKind {
+	case k8sconsts.WorkloadKindDeployment:
+		return semconv.K8SDeploymentNameKey
+	case k8sconsts.WorkloadKindStatefulSet:
+		return semconv.K8SStatefulSetNameKey
+	case k8sconsts.WorkloadKindDaemonSet:
+		return semconv.K8SDaemonSetNameKey
+	}
+	return attribute.Key("")
+}
+
+func getResourceAttributesEnvVarValue(ra []resourceAttribute) string {
+	var attrs []string
+	for _, a := range ra {
+		attrs = append(attrs, fmt.Sprintf("%s=%s", a.Key, a.Value))
+	}
+	return strings.Join(attrs, ",")
+}
+
+func InjectOtelResourceAndServerNameEnvVars(existingEnvNames *map[string]struct{}, container *corev1.Container, distroName string, pw k8sconsts.PodWorkload, serviceName string) {
+
+	// OTEL_SERVICE_NAME
+	injectEnvVarToPodContainer(existingEnvNames, container, otelServiceNameEnvVarName, serviceName)
+
+	// OTEL_RESOURCE_ATTRIBUTES
+	resourceAttributes := getResourceAttributes(pw, container.Name)
+	resourceAttributesEnvValue := getResourceAttributesEnvVarValue(resourceAttributes)
+	injectEnvVarToPodContainer(existingEnvNames, container, otelResourceAttributesEnvVarName, resourceAttributesEnvValue)
+}


### PR DESCRIPTION
This PR migrate the code in webhook that injects OTEL_RESOURCE_ATTRIBUTE and OTEL_SERVICE_NAME to the 3 relevant distributions.

It moves code from the main pods_webhook.go file to internal files for better organization