### PR TITLE
fix: recreate autoscaler resources if deleted or modified

### DIFF
--- a/autoscaler/controllers/collectorsgroup_controller.go
+++ b/autoscaler/controllers/collectorsgroup_controller.go
@@ -26,6 +26,8 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/version"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -61,6 +63,9 @@ func (r *CollectorsGroupReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 func (r *CollectorsGroupReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&odigosv1.CollectorsGroup{}).
+		Owns(&appsv1.DaemonSet{}).  // in case the ds is deleted or modified for any reason, this will reconcile and recreate it
+		Owns(&appsv1.Deployment{}). // in case the deployment is deleted or modified for any reason, this will reconcile and recreate it
+		Owns(&corev1.ConfigMap{}).  // in case the configmap is deleted or modified for any reason, this will reconcile and recreate it
 		// we assume everything in the collectorsgroup spec is the configuration for the collectors to generate.
 		// thus, we need to monitor any change to the spec which is what the generation field is for.
 		WithEventFilter(&predicate.GenerationChangedPredicate{}).


### PR DESCRIPTION
If for any reason, the data-collection daemonset, gateway deployment, or one of the config maps is deleted, then it's not re-created at the moment.

This PR makes it so they are.

We had a bug where the collectors group would get deleted, and it also deleted the daemonset. then if the collectors group is re-created immediately, the daemonset would stay deleted and odigos would not work