### PR TITLE
fix: avoid adding the mount paths multiple times

### DIFF
--- a/instrumentor/controllers/agentenabled/podswebhook/mount.go
+++ b/instrumentor/controllers/agentenabled/podswebhook/mount.go
@@ -8,22 +8,17 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func checkIfMountDirectoryExists(containerSpec *corev1.Container, dir string) bool {
-	for _, volumeMount := range containerSpec.VolumeMounts {
-		if volumeMount.SubPath == dir {
-			return true
-		}
-	}
-	return false
-}
-
 func MountDirectory(containerSpec *corev1.Container, dir string) {
 	// TODO: assuming the directory always starts with {{ODIGOS_AGENTS_DIR}}. This should be validated.
 	// Should we return errors here to validate static values?
 	relativePath := strings.TrimPrefix(dir, distro.AgentPlaceholderDirectory+"/")
-	if checkIfMountDirectoryExists(containerSpec, dir) {
-		// avoid adding the directory volume twice to the container
-		return
+
+	// make sure we are idempotent, not adding ourselves multiple times
+	for _, volumeMount := range containerSpec.VolumeMounts {
+		if volumeMount.SubPath == dir {
+			// the volume is already mounted, do not add it again
+			return
+		}
 	}
 
 	absolutePath := strings.ReplaceAll(dir, distro.AgentPlaceholderDirectory, k8sconsts.OdigosAgentsDirectory)
@@ -35,20 +30,14 @@ func MountDirectory(containerSpec *corev1.Container, dir string) {
 	})
 }
 
-func checkIfVolumExists(pod *corev1.Pod) bool {
-	for _, volume := range pod.Spec.Volumes {
-		if volume.Name == k8sconsts.OdigosAgentMountVolumeName {
-			return true
-		}
-	}
-	return false
-}
-
 func MountPodVolume(pod *corev1.Pod) {
 
-	if checkIfVolumExists(pod) {
-		// avoid adding the volume twice to the pod
-		return
+	// make sure we are idempotent, not adding ourselves multiple times
+	for _, volume := range pod.Spec.Volumes {
+		if volume.Name == k8sconsts.OdigosAgentMountVolumeName {
+			// the volume is already mounted, do not add it again
+			return
+		}
 	}
 
 	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{

--- a/instrumentor/controllers/agentenabled/podswebhook/mount.go
+++ b/instrumentor/controllers/agentenabled/podswebhook/mount.go
@@ -8,10 +8,24 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+func checkIfMountDirectoryExists(containerSpec *corev1.Container, dir string) bool {
+	for _, volumeMount := range containerSpec.VolumeMounts {
+		if volumeMount.SubPath == dir {
+			return true
+		}
+	}
+	return false
+}
+
 func MountDirectory(containerSpec *corev1.Container, dir string) {
 	// TODO: assuming the directory always starts with {{ODIGOS_AGENTS_DIR}}. This should be validated.
 	// Should we return errors here to validate static values?
 	relativePath := strings.TrimPrefix(dir, distro.AgentPlaceholderDirectory+"/")
+	if checkIfMountDirectoryExists(containerSpec, dir) {
+		// avoid adding the directory volume twice to the container
+		return
+	}
+
 	absolutePath := strings.ReplaceAll(dir, distro.AgentPlaceholderDirectory, k8sconsts.OdigosAgentsDirectory)
 	containerSpec.VolumeMounts = append(containerSpec.VolumeMounts, corev1.VolumeMount{
 		Name:      k8sconsts.OdigosAgentMountVolumeName,
@@ -21,7 +35,22 @@ func MountDirectory(containerSpec *corev1.Container, dir string) {
 	})
 }
 
+func checkIfVolumExists(pod *corev1.Pod) bool {
+	for _, volume := range pod.Spec.Volumes {
+		if volume.Name == k8sconsts.OdigosAgentMountVolumeName {
+			return true
+		}
+	}
+	return false
+}
+
 func MountPodVolume(pod *corev1.Pod) {
+
+	if checkIfVolumExists(pod) {
+		// avoid adding the volume twice to the pod
+		return
+	}
+
 	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
 		Name: k8sconsts.OdigosAgentMountVolumeName,
 		VolumeSource: corev1.VolumeSource{


### PR DESCRIPTION
In case the webhook is triggered more than once