### PR TITLE
delete ebpf instrumentation instances once odiglet shuts down

### DIFF
--- a/instrumentation/manager.go
+++ b/instrumentation/manager.go
@@ -21,7 +21,7 @@ var (
 )
 
 const (
-	shutdownCleanupTimeout = 5 * time.Second
+	shutdownCleanupTimeout = 10 * time.Second
 )
 
 // ConfigUpdate is used to send a configuration update request to the manager.
@@ -152,7 +152,7 @@ func (m *manager[ProcessDetails, ConfigGroup]) runEventLoop(ctx context.Context)
 		for pid, details := range m.detailsByPid {
 			select {
 			case <-ctx.Done():
-				m.logger.Error(ctx.Err(), "failed to cleanup instrumentation resources", "pid", pid)
+				m.logger.Error(ctx.Err(), "context canceled while cleaning up instrumentations before shutdown")
 				return
 			default:
 				if details.inst == nil {


### PR DESCRIPTION
Once the Odiglet is shutting down, call the `reporter.OnExit` callback from the ebpf instrumentation manager.
When the odiglet is doing a rollout (in an upgrade for example) the ebpf probes are unloaded and loaded - this creates a time period when there is not active instrumentation - hence this change will remove the instrumentation instances corresponding to these instrumentations in that time period.