### PR TITLE
feat: add config option for mount method hostpath or virtual device

### DIFF
--- a/api/k8sconsts/device.go
+++ b/api/k8sconsts/device.go
@@ -1,0 +1,9 @@
+package k8sconsts
+
+const (
+	// the name of the device that only mounts the odigos agents root directory,
+	// allowing any agent to be access it's files.
+	// it would be more ideal to only mount what is needed,
+	// but it's not desirable to have tons of different devices for each case.
+	OdigosGenericDeviceName = "instrumentation.odigos.io/generic"
+)

--- a/common/mount.go
+++ b/common/mount.go
@@ -1,0 +1,14 @@
+package common
+
+// Note: this configuration is currently only relevant for k8s,
+// but is used in odigosconfig which is declared in the common package.
+// We should revisit this decision later on and consider if the config should be k8s specific,
+// then move it to the api module.
+
+// +kubebuilder:validation:Enum=virtual-device;host-path
+type MountMethod string
+
+const (
+	K8sVirtualDeviceMountMethod MountMethod = "k8s-virtual-device"
+	K8sHostPathMountMethod      MountMethod = "k8s-host-path"
+)

--- a/common/odigos_config.go
+++ b/common/odigos_config.go
@@ -112,4 +112,5 @@ type OdigosConfiguration struct {
 	AllowConcurrentAgents     *bool                          `json:"allowConcurrentAgents,omitempty"`
 	UiMode                    UiMode                         `json:"uiMode,omitempty"`
 	CentralBackendURL         string                         `json:"centralBackendURL,omitempty"`
+	MountMethod               *MountMethod                   `json:"mountMethod,omitempty"`
 }

--- a/docs/instrumentations/configuration/mount-method.mdx
+++ b/docs/instrumentations/configuration/mount-method.mdx
@@ -1,0 +1,94 @@
+---
+title: "Agent Mount Method"
+sidebarTitle: "Mount Method"
+---
+
+## Mount Method
+
+For odigos agents to run in the instrumented pod containers, some files need to be mounted to the container.
+
+In Kubernetes, these files are mounted under `/var/odigos` directory, with subdirectories for each agent.
+
+<Warning>
+This section is for advanced users and odigos administrators.
+
+It is recommended to use the default settings, unless you have specific requirements or run into an issue.
+</Warning>
+
+## Supported Mount Methods
+
+Odigos supports 2 mount methods, which can be used depending on the user preference, cluster policies, integration with existing tools, etc.
+
+It is recommended to use `HostPath` unless it does not work, in this case fallback to `VirtualDevice`.
+
+### HostPath
+
+This is the default and the recommended method.
+
+#### Pod Manifest Additions
+
+For agents and languages that requires fs mounts, odigos webhook will add the following:
+
+- Volume to the pod spec, under the `spec.volumes` field:
+
+```yaml
+  - hostPath:
+      path: /var/odigos
+      type: ""
+    name: odigos-agent
+```
+
+- VolumeMount to the instrumented container specs, under the `spec.containers[].volumeMounts` field:
+
+```yaml
+    - mountPath: /var/odigos/{agent_sub_dir}
+      name: odigos-agent
+      readOnly: true
+      subPath: {agent_sub_dir}
+```
+
+#### Caveats
+
+The "host path" option should be enabled in the cluster. Some policy tools may block this option, like: 
+
+- [Open Policy Agent](https://www.openpolicyagent.org/)
+- [Kyverno](https://kyverno.io/)
+
+If you cluster has such policies, you can:
+
+- use the `VirtualDevice` method, or
+- ask the cluster admin to whitelist the odigos agent host path in the policy tool.
+
+
+### VirtualDevice
+
+This method is useful when the `HostPath` method is blocked by cluster policies.
+
+#### Enabling VirtualDevice
+
+- Profile: `odigos profile add mount-method-k8s-virtual-device`
+
+- Odigos CLI: `odigos config set mount-method mount-method-k8s-virtual-device`
+
+- Helm Chart: in your values file, set `instrumentor.mountMethod` to `k8s-virtual-device`, or use helm cli `--set instrumentor.mountMethod=k8s-virtual-device` flag with helm upgrade.
+
+- Kubernetes Manifest: under the `odigos-config` ConfigMap in odigos namespace, set the value in the `mountMethod` field of `config.yaml` to `k8s-virtual-device`.
+
+#### Pod Manifest Additions
+
+For agents and languages that requires fs mounts, odigos webhook will add the following:
+
+- For each instrumented container in the pod spec, odigos will add a resource requirement under the `spec.containers[].resources` field:
+
+```yaml
+    resources:
+      limits:
+        instrumentation.odigos.io/generic: "1"
+      requests:
+        instrumentation.odigos.io/generic: "1"
+```
+
+### Caveats
+
+- May sometimes not integrate well with node auto-scaling tools like [Karpenter](https://karpenter.sh/).
+- Odiglet daemonset needs to be running on a node for instrumented pods to be scheduled on that node.

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -145,6 +145,12 @@
             "instrumentations/dotnet/native",
             "instrumentations/dotnet/enrichment"
           ]
+        },
+        {
+          "group": "Advanced",
+          "pages": [
+            "instrumentations/configuration/mount-method"
+          ]
         }
       ]
     },

--- a/helm/odigos/templates/odigos-config-cm.yaml
+++ b/helm/odigos/templates/odigos-config-cm.yaml
@@ -89,3 +89,9 @@ data:
       {{- toYaml .Values.ignoredNamespaces | nindent 8 }}
     ignoredContainers:
       {{- toYaml .Values.ignoredContainers | nindent 8 }}
+    {{- if and .Values.instrumentor.mountMethod (has .Values.instrumentor.mountMethod (list "k8s-host-path" "k8s-virtual-device")) }}
+    mountMethod: {{ .Values.instrumentor.mountMethod }}
+    {{- else }}
+    {{- fail "Error: Invalid mountMethod. Supported values are 'k8s-host-path' and 'k8s-virtual-device'." }}
+    {{- end }}
+    

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -127,6 +127,10 @@ ui:
   centralBackendURL: ''
 
 instrumentor:
+  # which mount method to use for odigos agent directory
+  # k8s-host-path: use hostPath volume (default and recommended, requires hostPath volume to be enabled in the cluster)
+  # k8s-virtual-device: fallback using a virtual device (recommended as fallback only)
+  mountMethod: 'k8s-host-path'
   deleteLangDetectionPods: true
   image:
     repository: keyval/odigos-instrumentor

--- a/profiles/aggregators/greatwall.go
+++ b/profiles/aggregators/greatwall.go
@@ -9,9 +9,10 @@ var GreatwallProfile = profile.Profile{
 	ProfileName: common.ProfileName("greatwall"),
 	MinimumTier: common.OnPremOdigosTier,
 	ShortDescription: "Bundle profile that includes " +
-		"java-ebpf-instrumentations and legacy-dotnet-instrumentation",
+		"specific preset of profiles for on-premises installations.",
 	Dependencies: []common.ProfileName{
 		"java-ebpf-instrumentations",
 		"legacy-dotnet-instrumentation",
+		"mount-method-k8s-virtual-device",
 	},
 }

--- a/profiles/allprofiles.go
+++ b/profiles/allprofiles.go
@@ -28,6 +28,8 @@ var AllProfiles = []profile.Profile{
 	instrumentation.JavaEbpfInstrumentationsProfile,
 	instrumentation.JavaNativeInstrumentationsProfile,
 	instrumentation.LegacyDotNetProfile,
+	instrumentation.MountMethodK8sHostPathProfile,
+	instrumentation.MountMethodK8sVirtualDevice,
 
 	pipeline.DisableNameProcessorProfile,
 	pipeline.SmallBatchesProfile,

--- a/profiles/instrumentation/mount-method.go
+++ b/profiles/instrumentation/mount-method.go
@@ -1,0 +1,31 @@
+package instrumentation
+
+import (
+	"github.com/odigos-io/odigos/common"
+	"github.com/odigos-io/odigos/profiles/profile"
+)
+
+var MountMethodK8sHostPathProfile = profile.Profile{
+	ProfileName:      common.ProfileName("mount-method-k8s-host-path"),
+	MinimumTier:      common.CommunityOdigosTier,
+	ShortDescription: "Mount odigos agents files to pod container filesystem using k8s host path volume. this is recommended, but requires this option to be enabled in the cluster. tools like OpenPolicyAgent or Kyverno can enforce policies to reject pods that use this option.",
+	ModifyConfigFunc: func(config *common.OdigosConfiguration) {
+		// avoid overriding user's choice if it was already set
+		// TODO: this implies semantics of first setter wins, which is not ideal
+		// and not consistent with yaml profiles (where the later one overrides)
+		if config.MountMethod == nil {
+			hostPath := common.K8sHostPathMountMethod
+			config.MountMethod = &hostPath
+		}
+	},
+}
+
+var MountMethodK8sVirtualDevice = profile.Profile{
+	ProfileName:      common.ProfileName("mount-method-k8s-virtual-device"),
+	MinimumTier:      common.CommunityOdigosTier,
+	ShortDescription: "Mount odigos agents files to pod container filesystem using k8s virtual device. this option is recommended only as fallback when host-path fails to work in the cluster. it can sometimes conflict with node autoscaling tools like Karpenter.",
+	ModifyConfigFunc: func(config *common.OdigosConfiguration) {
+		virtualDevice := common.K8sVirtualDeviceMountMethod
+		config.MountMethod = &virtualDevice
+	},
+}

--- a/scheduler/controllers/odigosconfig/odigosconfig_controller.go
+++ b/scheduler/controllers/odigosconfig/odigosconfig_controller.go
@@ -84,6 +84,11 @@ func (r *odigosConfigController) Reconcile(ctx context.Context, _ ctrl.Request) 
 	// if the values were already set (by user or profile) this is a no-op
 	sizing.SizeSProfile.ModifyConfigFunc(odigosConfig)
 
+	// TODO: revisit doing this here, might be nicer to maintain in a more generic way
+	// and have it on the config object itself.
+	// I want to preserve that user input (specific request or empty), and persist the resolved value in effective config.
+	verifyAndResolveEffectiveMountMethod(odigosConfig)
+
 	err = r.persistEffectiveConfig(ctx, odigosConfig)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -258,5 +263,25 @@ func modifyConfigWithEffectiveProfiles(effectiveProfiles []common.ProfileName, o
 		if p.ModifyConfigFunc != nil {
 			p.ModifyConfigFunc(odigosConfig)
 		}
+	}
+}
+
+func verifyAndResolveEffectiveMountMethod(odigosConfig *common.OdigosConfiguration) {
+	defaultMountMethod := common.K8sHostPathMountMethod
+
+	if odigosConfig.MountMethod == nil {
+		odigosConfig.MountMethod = &defaultMountMethod
+		return
+	}
+
+	switch *odigosConfig.MountMethod {
+	case common.K8sHostPathMountMethod:
+		return
+	case common.K8sVirtualDeviceMountMethod:
+		return
+	default:
+		// any illegal value will be defaulted to host-path
+		// TODO: emit some error here and think how to handle it
+		odigosConfig.MountMethod = &defaultMountMethod
 	}
 }


### PR DESCRIPTION
This allows the user to choose how to apply the mount.

- `k8s-host-path` will add volume to the pod with "host-path".
- `k8s-virtual-device` will add the "instrumentation.odigos.io/generic" device to the resource part of relevant containers.

This allows control of how the mounting is achieved.

Future work: auto detect if hostpath may fail and automatically fallback to virtual device.