### PR TITLE
Let cli Artifact Registry release run from a different tag

### DIFF
--- a/.github/workflows/release-artifactregistry.yml
+++ b/.github/workflows/release-artifactregistry.yml
@@ -90,15 +90,6 @@ jobs:
         with:
           node-version: 18
 
-      - uses: goreleaser/goreleaser-action@v5
-        with:
-          distribution: goreleaser
-          version: latest
-          args: release --rm-dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
-
       - uses: ko-build/setup-ko@v0.8
 
       - name: publish cli image to docker registries
@@ -126,39 +117,3 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
           curl -X POST -H 'Content-type: application/json' --data '{"link":"https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}", "description":"ERROR: failed to publish odigos CLI", "tag":"${{ env.TAG }}"}' ${{ env.SLACK_WEBHOOK_URL }}
-
-  release-helm:
-    needs: [release-cli]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Determine Tag Value
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "TAG=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
-          elif [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-            echo "TAG=${{ github.event.client_payload.tag }}" >> $GITHUB_ENV
-          else
-            echo "Unknown event type"
-            echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-            exit 1
-          fi
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Configure Git
-        run: |
-          git config --global user.email "bot@odigos.io"
-          git config --global user.name "Odigos Release Bot"
-
-      - name: Install Helm
-        uses: azure/setup-helm@v4.2.0
-        with:
-          version: v3.15.2
-
-      - name: Release Helm charts
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: bash ./scripts/release-charts.sh

--- a/.github/workflows/release-artifactregistry.yml
+++ b/.github/workflows/release-artifactregistry.yml
@@ -36,7 +36,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ env.TAG }}
 
       - name: Set env
         id: vars


### PR DESCRIPTION
Trying to run the release workflow after https://github.com/odigos-io/odigos/pull/2484, but the action only checks out the repo at the given tag.

So, trying to tag `v1.0.155` from `main` (where the creds files are gitignore'd), still ends up just cloning the repo at `1.0.155`

This also removes redundant steps from the current main release flow. These will soon be merged into one workflow once we permanently drop dockerhub builds