### PR TITLE
Configure dependabot for Red Hat UBI image updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,3 +58,15 @@ updates:
     schedule:
       day: sunday
       interval: weekly
+
+  - package-ecosystem: docker
+    directories:
+      - /
+      - /collector
+      - /frontend
+      - /odiglet
+    schedule:
+      day: sunday
+      interval: weekly
+    allow:
+      - dependency-name: 'registry.access.redhat.com/ubi9*'


### PR DESCRIPTION
To keep RHEL images up to date