### PR TITLE
Switch to ubi9-micro images

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     go build -a -o /workspace/build/$SERVICE_NAME cmd/main.go
 RUN make licenses
 
-FROM registry.access.redhat.com/ubi9:9.5-1736404036
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 ARG SERVICE_NAME
 ARG VERSION
 ARG RELEASE

--- a/collector/Dockerfile.rhel
+++ b/collector/Dockerfile.rhel
@@ -6,7 +6,7 @@ ARG TARGETARCH
 RUN GOOS=linux GOARCH=$TARGETARCH make build-odigoscol
 RUN make licenses
 
-FROM registry.access.redhat.com/ubi9:9.5-1736404036
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 ARG VERSION
 ARG RELEASE
 ARG SUMMARY

--- a/frontend/Dockerfile.rhel
+++ b/frontend/Dockerfile.rhel
@@ -18,7 +18,7 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 GOARCH=$TARGETARCH go build -o odigos-ui
 RUN make licenses
 
-FROM registry.access.redhat.com/ubi9:9.5-1736404036
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 ARG VERSION
 ARG RELEASE
 ARG SUMMARY

--- a/odiglet/Dockerfile.rhel
+++ b/odiglet/Dockerfile.rhel
@@ -120,7 +120,7 @@ COPY --from=nodejs-agent-native-community-builder /repos/odigos/agents/nodejs-na
 # .NET
 COPY --from=dotnet-builder /dotnet-instrumentation /instrumentations/dotnet
 
-FROM registry.access.redhat.com/ubi9:9.5-1736404036
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 ARG VERSION
 ARG RELEASE
 ARG SUMMARY


### PR DESCRIPTION
This switches RHEL Dockerfiles from the main [ubi9 image](https://catalog.redhat.com/software/containers/ubi9/ubi/615bcf606feffc5384e8452e?container-tabs=overview) to the smaller [ubi9-micro image](https://catalog.redhat.com/software/containers/ubi9/ubi/615bcf606feffc5384e8452e?container-tabs=overview)

Size comparison:

```
registry.access.redhat.com/ubi9/ubi 356MB
registry.access.redhat.com/ubi9/ubi-micro 33MB

registry.odigos.io/odigos-ui-ubi9 611MB
registry.odigos.io/odigos-ui-ubi9-micro 207MB

registry.odigos.io/odigos-collector-ubi9 761MB
registry.odigos.io/odigos-collector-ubi9-micro 357MB

registry.odigos.io/odigos-instrumentor-ubi9 567MB
registry.odigos.io/odigos-instrumentor-ubi9-micro 163MB

registry.odigos.io/odigos-odiglet-ubi9 979MB
registry.odigos.io/odigos-odiglet-ubi9-micro 575MB

registry.odigos.io/odigos-scheduler-ubi9 565MB
registry.odigos.io/odigos-scheduler-ubi9-micro 161MB

registry.odigos.io/odigos-autoscaler-ubi9 569MB
registry.odigos.io/odigos-autoscaler-ubi9-micro 165MB
```

Will open a similar PR for enterprise

This also minimizes the security risk surface for each image by reducing unnecessary dependencies