### PR TITLE
perf: separate instrumentation-instances from paginated-sources query

### DIFF
--- a/frontend/graph/schema.resolvers.go
+++ b/frontend/graph/schema.resolvers.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/odigos-io/odigos/api/k8sconsts"
 	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
@@ -24,7 +23,6 @@ import (
 	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	"github.com/odigos-io/odigos/k8sutils/pkg/pro"
 	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
-	"golang.org/x/sync/errgroup"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -118,60 +116,31 @@ func (r *computePlatformResolver) K8sActualNamespace(ctx context.Context, obj *m
 
 // Sources is the resolver for the sources field.
 func (r *computePlatformResolver) Sources(ctx context.Context, obj *model.ComputePlatform, nextPage string) (*model.PaginatedSources, error) {
-	startTime := time.Now()
 	limit, _ := services.GetPageLimit(ctx)
-
 	list, err := kube.DefaultClient.OdigosClient.InstrumentationConfigs("").List(ctx, metav1.ListOptions{
 		Limit:    int64(limit),
 		Continue: nextPage,
 	})
 
-	r.Logger.Info("listed instrumentation configs", "count", len(list.Items), "duration", time.Since(startTime).String())
-	prevTime := time.Now()
-
 	if err != nil {
 		if strings.Contains(err.Error(), "The provided continue parameter is too old") {
-			r.Logger.Info("the provided continue parameter is too old, re-paginating from scratch")
-
 			// Retry without the continue token
 			list, err = kube.DefaultClient.OdigosClient.InstrumentationConfigs("").List(ctx, metav1.ListOptions{
 				Limit: int64(limit),
 			})
+
 			if err != nil {
 				return nil, err
 			}
-
-			r.Logger.Info("listed instrumentation configs", "count", len(list.Items), "duration", time.Since(prevTime).String())
-			prevTime = time.Now()
 		} else {
 			return nil, err
 		}
 	}
 
-	g, ctx := errgroup.WithContext(ctx)
-	g.SetLimit(limit)
-	ch := make(chan *model.K8sActualSource, len(list.Items))
-
-	for _, ic := range list.Items {
-		g.Go(func() error {
-			src := instrumentationConfigToActualSource(ic)
-			services.AddHealthyInstrumentationInstancesCondition(ctx, &ic, src)
-			ch <- src
-			return nil
-		})
-	}
-
-	g.Wait()
-	close(ch)
-
-	r.Logger.Info("listed instrumentation instances", "count", len(ch), "duration", time.Since(prevTime).String())
-
 	var actualSources []*model.K8sActualSource
-	for src := range ch {
-		actualSources = append(actualSources, src)
+	for _, ic := range list.Items {
+		actualSources = append(actualSources, instrumentationConfigToActualSource(ic))
 	}
-
-	r.Logger.Info("resolved sources query", "count", len(list.Items), "duration", time.Since(startTime).String())
 
 	return &model.PaginatedSources{
 		NextPage: list.GetContinue(),
@@ -194,7 +163,9 @@ func (r *computePlatformResolver) Source(ctx context.Context, obj *model.Compute
 	}
 
 	src := instrumentationConfigToActualSource(*ic)
+	// note: the following is done only for fetch-by-id, we removed this from paginate-all due to peformance issues
 	services.AddHealthyInstrumentationInstancesCondition(ctx, ic, src)
+
 	return src, nil
 }
 


### PR DESCRIPTION
Previously, when paginating sources in the UI, we would list the `InstrumentationConfigs`, and for each config we would get the `InstrumentationInstances` (just to add a "health| condition message to the config).

Unfortunately, this approach costs a lot of time in some production clusters. When fetching a batch of 10 apps, it would take less than 20ms to list the configs, and it would take up to 20s to get the instances.

---

This PR improves the UI load-time, by separating instrumentation-instances from the paginated-sources-query.

The new approach paginates sources much quicker, displaying them in the UI - and allowing the user to work with them. Once all the sources are there, we’ll fetch & update each source in the list with it's instances-health condition message.

So the UI will have all sources - the sources will keep updating their conditions, until we processed the last source in list, then we stop the loop completely and listen to Server Sent Events (any modified event, we refetch that source by ID - getting the updated data, including it’s instances).