### PR TITLE
Update Operator bundle to v1.0.159

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.0.154
+VERSION ?= 1.0.159
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -50,7 +50,7 @@ endif
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
 OPERATOR_SDK_VERSION ?= v1.39.1
 # Image URL to use all building/pushing image targets
-IMG ?= registry.connect.redhat.com/odigos/odigos-operator-ubi9:v$(VERSION)
+IMG ?= registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9:v$(VERSION)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.31.0
 

--- a/operator/bundle/manifests/odigos-operator-odigos-version-55dgk4kht7_v1_configmap.yaml
+++ b/operator/bundle/manifests/odigos-operator-odigos-version-55dgk4kht7_v1_configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+data:
+  ODIGOS_VERSION: 1.0.159
+kind: ConfigMap
+metadata:
+  name: odigos-operator-odigos-version-55dgk4kht7

--- a/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
@@ -19,8 +19,8 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Logging & Tracing
-    containerImage: registry.connect.redhat.com/odigos/odigos-operator-ubi9@sha256:be543164c22b5f2e7762a73a854d6bdb122babd042b6747fec0283d3b101c04f
-    createdAt: "2025-02-27T19:20:12Z"
+    containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:5e5d0d43080c2402504ecb2227feaa8f6210f77d60c6b846657857fe4967d188
+    createdAt: "2025-03-03T20:42:45Z"
     description: Odigos enables automatic distributed tracing with OpenTelemetry and eBPF.
     features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "true"
@@ -33,7 +33,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.39.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     support: Odigos
-  name: odigos-operator.v1.0.154
+  name: odigos-operator.v1.0.159
   namespace: odigos-operator-system
 spec:
   apiservicedefinitions: {}
@@ -84,7 +84,18 @@ spec:
             displayName: Conditions
             path: conditions
         version: v1alpha1
-  description: The Odigos Operator installs Odigos
+  description: |-
+    The Odigos Operator provides options for installing and configuring Odigos.
+
+    Upon creation of an Odigos resource, the Odigos Operator installs the following Odigos components:
+
+    - Instrumentor
+    - Odiglet
+    - Autoscaler
+    - Scheduler
+    - Frontend UI
+
+    With Odigos installed, follow the Odigos docs at docs.odigos.io for instructions on instrumenting applications and configuring destinations.
   displayName: Odigos Operator
   icon:
     - base64data: iVBORw0KGgoAAAANSUhEUgAAASwAAAEsBAMAAACLU5NGAAAAMFBMVEUkICP5+fn9/f0hHSD7+/s5NjhPTE/b2tvp6em/vr+RjpD19fWlpKV3dHZoZmiDgYO0KM89AAAF7UlEQVR42u2cXWgUVxTHBy67D6FdGLmQ0C0Un6ylDwND8lAw5ZaBbE0fFkJTLJgVRKMiipDU2hQlsDQRQz8gWiG1SdFGSqEQWBqVtM2DTQIFSRFrpbQIxWo/HoR+Yx+aiK1x7jmzM3JmJ8L/95jM7v525s6ZM+ecHccBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACIg/JZMpRynucph7fORWyrJK16Ptg/xDE8Ed76+n6WAxfKclqFsYBnzWxY60t2WxN0HuqSsmr9wrg82tL6JmJrt3hM6hDujLJKqqXXXRXaWaOuoJarX/JEtB4yolrusyKrXt1wZbWKv4rsrfPCWm6/yNLqk9b6VGJxtU9Ja22U2FtPu9Jaz0loPWWktdaLaK2FFrSgBS1oQQtaD7AWcZ+4CrR0y6KV/AeZa+npSesV+XmdsZY+e4koduRP1zLVCg5fo+pIfu5KLUMt8+oW5iam9ZeqyUqr8xXOyvG9XftMNlqdJ8pRN3yVMZOBli5d6KpTqztuGq6lm+dUnYKj4gJFelp6+o8YVVAmUKSmpQ9filObVXSgSEsrGLlqL3bf960/KjJQpKRl7MCg/Fz3nu3bnHBwVVSgSEerc9wKDCr309vDR4aH3vlKefUDRSpapRNdllXPfC1wjXaDM3YsWwoUQepaS+HKWuyqMhbcjfx2ZTS/oFPW0s2TtlXhnsNE9ANCgUJcS5/93Q4MuXu7CZ3H6gUKaS1N5jHXQyu6Y7FORiGsZUaojOHhajiqnauTUchqGTqP+cuKS8XZ6IxCVIsIV+TOWmKGzij+85LU0oe6yOzqBpG9FCdIr8Jb8lozW8n/tlHNBP06nR++WJXWKr1Pf9ImMtVbR38H77KR1dJvMInMrXgFgDuHsb1PVqvlphP/GPJtHb/XiGqdY/7J9RrXl+ntC4OSWvook37u4HqGF5l3e09Si1nCjnOKKwK8yXyP5VNETOsR5n98r/E15hayfVBOS/czH1Jge41PcG83Kqg1kXDF831y9bOcVguztNQLrFaJW41LL5HSYr/6Dr59f5HfwVJaXBd3+Yhwp+JJ5jUbpsS0PmFWvPotfqH3/+vCoJgWOyFwit9bTOBycn1iWlwQipjc4K4LWWv184Erda3R1anF7601R/nrlZTWx/dxEBuw5O8jQDzTgACxUTCctsuFU/Z9+IuPy118mkzql2qHv1SzL9kkp+WeTJzYNDcgsWHTwA1TiWe0zgsmzY/xZ3vCQbu8YNLsdmxNGLjYS6LoLYY7m/RUZE5EdUv09vWzhGu+g1nx7VXZm/3v+aVCwVwXlPDNvj4YcZccf2m1jUoXkhaTFJK4YNorXEhy9Qzd1CxUKS16KapKVb52epD08skCF3niqvyd4qmoVvFdsnjaRAT6R7tIqwWTRgGcKTV/aGt9Tmzn321dC7cL1pKF+SZrdVHL0Ns8llK7YLnreo3wuhw6GR8nqr/eroHUmivMSE0+1MckQpy3e2UPNoXGHdHRV5W+FZ+pR6xDqFp/rKbdfW2es/fXijYT0a5Sub9rqTeFdckOFN7e4/q2WECM3aj8aZ1RC93v/uflI7p45sBHdqs63BJObeDA3iVKed17vv3uh7IfEa4yGc9Q5E8VPWouKc1hlli/lqSnuNIb/QmmJ2MM2Xj0zFua81tUoAiHqyvVDMbK6IxiRbj6s5bJEN545BCeFa4aNbJo+JFFR/UsBJkNeFJzXFYe0/hxWG7qzds7YDKc0tUBPSO4e5/JeAK8ec4umESN6DZqML10M7zad9Ywxo/fYkALWtCCFrSgBa34yD944UkJrVX6mIq21flQD/FHoLC93ESIPzDGnZDYWeKP1+mQeXhTrk9UixsPT0yvkdQqLcpYOW1jRk6LbZgmX/SVgcDI3CdqMyL2WDDH2zw/zBM+sdTX/LZD41s8MS3Hz3VvZymHt47YdpsStHJu//ow7gP6In58qsSf5sdJeZ4DAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAHmX8B0ce8wxI6b2MAAAAASUVORK5CYII=
@@ -404,8 +415,8 @@ spec:
                         valueFrom:
                           configMapKeyRef:
                             key: ODIGOS_VERSION
-                            name: odigos-operator-odigos-version-46f47t59fb
-                    image: registry.connect.redhat.com/odigos/odigos-operator-ubi9@sha256:be543164c22b5f2e7762a73a854d6bdb122babd042b6747fec0283d3b101c04f
+                            name: odigos-operator-odigos-version-55dgk4kht7
+                    image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:5e5d0d43080c2402504ecb2227feaa8f6210f77d60c6b846657857fe4967d188
                     livenessProbe:
                       httpGet:
                         path: /healthz
@@ -490,6 +501,8 @@ spec:
   links:
     - name: Odigos
       url: https://odigos.io
+    - name: Odigos Documentation
+      url: https://docs.odigos.io
     - name: Odigos on Github
       url: https://github.com/odigos-io/odigos
   maintainers:
@@ -501,8 +514,8 @@ spec:
     name: Odigos
     url: https://odigos.io
   relatedImages:
-    - image: registry.connect.redhat.com/odigos/odigos-operator-ubi9@sha256:be543164c22b5f2e7762a73a854d6bdb122babd042b6747fec0283d3b101c04f
+    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:5e5d0d43080c2402504ecb2227feaa8f6210f77d60c6b846657857fe4967d188
       name: manager
-    - image: registry.connect.redhat.com/odigos/odigos-operator-ubi9@sha256:be543164c22b5f2e7762a73a854d6bdb122babd042b6747fec0283d3b101c04f
-      name: odigos-operator-ubi9-be543164c22b5f2e7762a73a854d6bdb122babd042b6747fec0283d3b101c04f-annotation
-  version: 1.0.154
+    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:5e5d0d43080c2402504ecb2227feaa8f6210f77d60c6b846657857fe4967d188
+      name: odigos-certified-operator-ubi9-5e5d0d43080c2402504ecb2227feaa8f6210f77d60c6b846657857fe4967d188-annotation
+  version: 1.0.159

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -4,9 +4,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: registry.connect.redhat.com/odigos/odigos-operator-ubi9
-  newTag: v1.0.154
+  newName: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9
+  newTag: v1.0.159
 configMapGenerator:
 - literals:
-  - ODIGOS_VERSION=1.0.154
+  - ODIGOS_VERSION=1.0.159
   name: odigos-version

--- a/operator/config/manifests/bases/odigos-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/odigos-operator.clusterserviceversion.yaml
@@ -3,10 +3,10 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     alm-examples: '[{"apiVersion":"operator.odigos.io/v1alpha1", "kind":"Odigos",
-      "metadata":{"name":"odigos","namespace":"odigos-operator-system"}, "spec":{"version":"v1.0.144"}}]'
+      "metadata":{"name":"odigos","namespace":"odigos-operator-system"}, "spec":{"version":"v1.0.159"}}]'
     capabilities: Basic Install
     categories: Logging & Tracing
-    containerImage: registry.connect.redhat.com/odigos/odigos-operator-ubi9:v1.0.154
+    containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9:v1.0.159
     description: Odigos enables automatic distributed tracing with OpenTelemetry and
       eBPF.
     features.operators.openshift.io/disconnected: "false"
@@ -74,7 +74,18 @@ spec:
         displayName: Conditions
         path: conditions
       version: v1alpha1
-  description: The Odigos Operator installs Odigos
+  description: |-
+    The Odigos Operator provides options for installing and configuring Odigos.
+
+    Upon creation of an Odigos resource, the Odigos Operator installs the following Odigos components:
+
+    - Instrumentor
+    - Odiglet
+    - Autoscaler
+    - Scheduler
+    - Frontend UI
+
+    With Odigos installed, follow the Odigos docs at docs.odigos.io for instructions on instrumenting applications and configuring destinations.
   displayName: Odigos Operator
   icon:
   - base64data: iVBORw0KGgoAAAANSUhEUgAAASwAAAEsBAMAAACLU5NGAAAAMFBMVEUkICP5+fn9/f0hHSD7+/s5NjhPTE/b2tvp6em/vr+RjpD19fWlpKV3dHZoZmiDgYO0KM89AAAF7UlEQVR42u2cXWgUVxTHBy67D6FdGLmQ0C0Un6ylDwND8lAw5ZaBbE0fFkJTLJgVRKMiipDU2hQlsDQRQz8gWiG1SdFGSqEQWBqVtM2DTQIFSRFrpbQIxWo/HoR+Yx+aiK1x7jmzM3JmJ8L/95jM7v525s6ZM+ecHccBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACIg/JZMpRynucph7fORWyrJK16Ptg/xDE8Ed76+n6WAxfKclqFsYBnzWxY60t2WxN0HuqSsmr9wrg82tL6JmJrt3hM6hDujLJKqqXXXRXaWaOuoJarX/JEtB4yolrusyKrXt1wZbWKv4rsrfPCWm6/yNLqk9b6VGJxtU9Ja22U2FtPu9Jaz0loPWWktdaLaK2FFrSgBS1oQQtaD7AWcZ+4CrR0y6KV/AeZa+npSesV+XmdsZY+e4koduRP1zLVCg5fo+pIfu5KLUMt8+oW5iam9ZeqyUqr8xXOyvG9XftMNlqdJ8pRN3yVMZOBli5d6KpTqztuGq6lm+dUnYKj4gJFelp6+o8YVVAmUKSmpQ9filObVXSgSEsrGLlqL3bf960/KjJQpKRl7MCg/Fz3nu3bnHBwVVSgSEerc9wKDCr309vDR4aH3vlKefUDRSpapRNdllXPfC1wjXaDM3YsWwoUQepaS+HKWuyqMhbcjfx2ZTS/oFPW0s2TtlXhnsNE9ANCgUJcS5/93Q4MuXu7CZ3H6gUKaS1N5jHXQyu6Y7FORiGsZUaojOHhajiqnauTUchqGTqP+cuKS8XZ6IxCVIsIV+TOWmKGzij+85LU0oe6yOzqBpG9FCdIr8Jb8lozW8n/tlHNBP06nR++WJXWKr1Pf9ImMtVbR38H77KR1dJvMInMrXgFgDuHsb1PVqvlphP/GPJtHb/XiGqdY/7J9RrXl+ntC4OSWvook37u4HqGF5l3e09Si1nCjnOKKwK8yXyP5VNETOsR5n98r/E15hayfVBOS/czH1Jge41PcG83Kqg1kXDF831y9bOcVguztNQLrFaJW41LL5HSYr/6Dr59f5HfwVJaXBd3+Yhwp+JJ5jUbpsS0PmFWvPotfqH3/+vCoJgWOyFwit9bTOBycn1iWlwQipjc4K4LWWv184Erda3R1anF7601R/nrlZTWx/dxEBuw5O8jQDzTgACxUTCctsuFU/Z9+IuPy118mkzql2qHv1SzL9kkp+WeTJzYNDcgsWHTwA1TiWe0zgsmzY/xZ3vCQbu8YNLsdmxNGLjYS6LoLYY7m/RUZE5EdUv09vWzhGu+g1nx7VXZm/3v+aVCwVwXlPDNvj4YcZccf2m1jUoXkhaTFJK4YNorXEhy9Qzd1CxUKS16KapKVb52epD08skCF3niqvyd4qmoVvFdsnjaRAT6R7tIqwWTRgGcKTV/aGt9Tmzn321dC7cL1pKF+SZrdVHL0Ns8llK7YLnreo3wuhw6GR8nqr/eroHUmivMSE0+1MckQpy3e2UPNoXGHdHRV5W+FZ+pR6xDqFp/rKbdfW2es/fXijYT0a5Sub9rqTeFdckOFN7e4/q2WECM3aj8aZ1RC93v/uflI7p45sBHdqs63BJObeDA3iVKed17vv3uh7IfEa4yGc9Q5E8VPWouKc1hlli/lqSnuNIb/QmmJ2MM2Xj0zFua81tUoAiHqyvVDMbK6IxiRbj6s5bJEN545BCeFa4aNbJo+JFFR/UsBJkNeFJzXFYe0/hxWG7qzds7YDKc0tUBPSO4e5/JeAK8ec4umESN6DZqML10M7zad9Ywxo/fYkALWtCCFrSgBa34yD944UkJrVX6mIq21flQD/FHoLC93ESIPzDGnZDYWeKP1+mQeXhTrk9UixsPT0yvkdQqLcpYOW1jRk6LbZgmX/SVgcDI3CdqMyL2WDDH2zw/zBM+sdTX/LZD41s8MS3Hz3VvZymHt47YdpsStHJu//ow7gP6In58qsSf5sdJeZ4DAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAHmX8B0ce8wxI6b2MAAAAASUVORK5CYII=
@@ -103,6 +114,8 @@ spec:
   links:
   - name: Odigos
     url: https://odigos.io
+  - name: Odigos Documentation
+    url: https://docs.odigos.io
   - name: Odigos on Github
     url: https://github.com/odigos-io/odigos
   maintainers:
@@ -113,4 +126,4 @@ spec:
   provider:
     name: Odigos
     url: https://odigos.io
-  version: 1.0.144
+  version: 1.0.159


### PR DESCRIPTION
The Operator image is now available at `registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9`, updating the bundle to use this and point to v1.0.159. This will be automated in the future

These changes pushed to the OpenShift operatorhub via https://github.com/redhat-openshift-ecosystem/certified-operators/pull/5295