### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Description
+
+<!-- Short summary of the changes -->
+
+## How Has This Been Tested?
+
+<!-- Describe the tests you ran and how you verified your changes. -->
+
+- [ ] Unit Tests
+- [ ] Update e2e Tests
+- [ ] Manually
+- [ ] Load Test
+
+## Kubernetes Checklist
+
+<!-- If this PR includes changes to how Odigos interacts with Kubernetes, please check the boxes below -->
+
+- [ ] This PR includes changes to how Odigos interacts with Kubernetes
+- [ ] Introduces more calls to API Server that might affect performance and number of requests
+- [ ] Old Kubernetes versions supported
+
+## User Facing Changes
+
+<!-- Any changes that users will notice or need to be aware of -->
+
+- [ ] Users might need to actively take action before upgrading to this version
+- [ ] Automatic migration will modify existing objects in a way that is backwards compatible
+- [ ] This PR changes some aspect of the UI, CLI, or K8s Manifests that users needs to be aware of
+- [ ] Add relevant documentation


### PR DESCRIPTION
This PR introduce a pull request template. It can be used to remind both the PR author and reviewer of common points that require attention to guarantee the stability and quality of odigos.
