### PR TITLE
fix: use vpid in e2e test assert after agent merge

### DIFF
--- a/tests/common/assert/simple-demo-instrumented.yaml
+++ b/tests/common/assert/simple-demo-instrumented.yaml
@@ -252,7 +252,7 @@ status:
       (value != null): true
     - key: telemetry.distro.version
       (value != null): true
-    - key: process.pid
+    - key: process.vpid
       (value != null): true
     - key: k8s.namespace.name
       (value != null): true

--- a/tests/e2e/workload-lifecycle/01-assert-instrumented.yaml
+++ b/tests/e2e/workload-lifecycle/01-assert-instrumented.yaml
@@ -85,7 +85,7 @@ status:
       value: "14.0.0"
     - key: telemetry.distro.version
       value: e2e-test
-    - key: process.pid
+    - key: process.vpid
       (value != null): true
     - key: k8s.namespace.name
       (value != null): true
@@ -135,7 +135,7 @@ status:
       (value != null): true
     - key: telemetry.distro.version
       value: e2e-test
-    - key: process.pid
+    - key: process.vpid
       (value != null): true
     - key: k8s.namespace.name
       (value != null): true
@@ -185,7 +185,7 @@ status:
       value: "20.17.0"
     - key: telemetry.distro.version
       value: e2e-test
-    - key: process.pid
+    - key: process.vpid
       (value != null): true
     - key: k8s.namespace.name
       (value != null): true
@@ -235,7 +235,7 @@ status:
       value: "20.17.0"
     - key: telemetry.distro.version
       value: e2e-test
-    - key: process.pid
+    - key: process.vpid
       (value != null): true
     - key: k8s.namespace.name
       (value != null): true


### PR DESCRIPTION
Updating the tests after merging https://github.com/odigos-io/opentelemetry-node/pull/18