### PR TITLE
Add suggested-namespace and supported arch labels to Operator CSV

### DIFF
--- a/operator/config/manifests/bases/odigos-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/odigos-operator.clusterserviceversion.yaml
@@ -16,6 +16,10 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
+    operatorframework.io/suggested-namespace: "odigos-operator-system"
+    operatorframework.io/os.linux: supported
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
     operators.openshift.io/valid-subscription: Odigos Enterprise subscription (for
       enterprise features)
     support: Odigos


### PR DESCRIPTION
## Description

Add the following labels to the Operator's base CSV to define a default namespace and supported architectures:

```
    operatorframework.io/suggested-namespace: "odigos-operator-system"
    operatorframework.io/os.linux: supported
    operatorframework.io/arch.amd64: supported
    operatorframework.io/arch.arm64: supported
```

See:

* https://docs.openshift.com/container-platform/4.18/operators/operator_sdk/osdk-generating-csvs.html#olm-enabling-operator-for-multi-arch_osdk-generating-csvs
* https://docs.openshift.com/container-platform/4.18/operators/operator_sdk/osdk-generating-csvs.html#osdk-suggested-namespace_osdk-generating-csvs

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
