### PR TITLE
remove liveness probe from e2e test in simple-demo

### DIFF
--- a/tests/common/apply/install-simple-demo.yaml
+++ b/tests/common/apply/install-simple-demo.yaml
@@ -74,12 +74,6 @@ spec:
               port: 8080
             initialDelaySeconds: 5
             periodSeconds: 5
-          livenessProbe:
-            httpGet:
-              path: /actuator/health/liveness
-              port: 8080
-            initialDelaySeconds: 5
-            periodSeconds: 5
 ---
 kind: Service
 apiVersion: v1


### PR DESCRIPTION
The liveness probe generated a lot of not relevant traffic during the e2e test