### PR TITLE
Fix waiting for runtime detection when no running pods

### DIFF
--- a/.github/workflows/cross-cloud-tests.yaml
+++ b/.github/workflows/cross-cloud-tests.yaml
@@ -214,10 +214,10 @@ jobs:
           path: odigos_debug*.tar.gz
         continue-on-error: true
 
-      # - name: Destroy Resources
-      #   if: always()
-      #   run: |
-      #     tofu -chdir=$TF_DIR destroy -auto-approve
+      - name: Destroy Resources
+        if: always()
+        run: |
+          tofu -chdir=$TF_DIR destroy -auto-approve
 
       - name: Extract Tag
         id: extract_tag

--- a/.github/workflows/cross-cloud-tests.yaml
+++ b/.github/workflows/cross-cloud-tests.yaml
@@ -214,10 +214,10 @@ jobs:
           path: odigos_debug*.tar.gz
         continue-on-error: true
 
-      - name: Destroy Resources
-        if: always()
-        run: |
-          tofu -chdir=$TF_DIR destroy -auto-approve
+      # - name: Destroy Resources
+      #   if: always()
+      #   run: |
+      #     tofu -chdir=$TF_DIR destroy -auto-approve
 
       - name: Extract Tag
         id: extract_tag

--- a/instrumentor/controllers/sourceinstrumentation/common.go
+++ b/instrumentor/controllers/sourceinstrumentation/common.go
@@ -115,7 +115,12 @@ func syncWorkload(ctx context.Context, k8sClient client.Client, scheme *runtime.
 
 		markedForInstChanged := meta.SetStatusCondition(&ic.Status.Conditions, markedForInstrumentationCondition)
 		runtimeDetailsChanged := initiateRuntimeDetailsConditionIfMissing(ic, workloadObj)
-		agentEnabledChanged := initiateAgentEnabledConditionIfMissing(ic)
+
+		// Set agent enabled condition only if replicas are available to prevent infinite UI loading.
+		agentEnabledChanged := false
+		if workloadObj.AvailableReplicas() > 0 {
+			agentEnabledChanged = initiateAgentEnabledConditionIfMissing(ic)
+		}
 
 		if markedForInstChanged || runtimeDetailsChanged || agentEnabledChanged {
 			ic.Status.Conditions = sortIcConditionsByLogicalOrder(ic.Status.Conditions)


### PR DESCRIPTION
## Description

Fixes an issue where instrumenting a new workload (e.g., a deployment) with no running pods gets stuck in an infinite loading state in the UI.
## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [X] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
