### PR TITLE
Disable provenance in image builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,6 +25,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: false
           tags: autoscaler:pr-${{ github.event.number }}
+          provenance: false
           build-args: SERVICE_NAME=autoscaler
           file: ${{ matrix.dockerfile }}
 
@@ -44,6 +45,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: false
           tags: scheduler:pr-${{ github.event.number }}
+          provenance: false
           build-args: SERVICE_NAME=scheduler
           file: ${{ matrix.dockerfile }}
 
@@ -66,6 +68,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: false
           tags: instrumentor:pr-${{ github.event.number }}
+          provenance: false
           build-args: SERVICE_NAME=instrumentor
           file: ${{ matrix.dockerfile }}
       - name: run tests
@@ -89,6 +92,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: false
           tags: odigos-collector:pr-${{ github.event.number }}
+          provenance: false
           context: ./collector
           file: ${{ matrix.dockerfile }}
       - name: run tests
@@ -116,6 +120,7 @@ jobs:
           context: .
           push: false
           tags: odiglet:pr-${{ github.event.number }}
+          provenance: false
       - name: Install build dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y clang llvm libbpf-dev
@@ -142,6 +147,7 @@ jobs:
           context: .
           push: false
           tags: frontend:pr-${{ github.event.number }}
+          provenance: false
 
   build-operator:
     name: build-operator
@@ -161,6 +167,7 @@ jobs:
           context: .
           push: false
           tags: operator:pr-${{ github.event.number }}
+          provenance: false
 
   build-cli:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-modules-artifactregistry.yml
+++ b/.github/workflows/publish-modules-artifactregistry.yml
@@ -85,6 +85,7 @@ jobs:
           ODIGOS_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || steps.extract_tag.outputs.tag}}
         with:
           push: true
+          provenance: false
           tags: us-central1-docker.pkg.dev/odigos-cloud/components/odigos-${{ matrix.service }}${{ matrix.dockerfile == 'Dockerfile.rhel' && '-ubi9' || '' }}:${{ env.ODIGOS_TAG }}
           build-args: |
             SERVICE_NAME=${{ matrix.service }}


### PR DESCRIPTION
## Description

By default the docker build action includes provenance attestations in our builds. These are the `"architecuture": "unknown"` and `"os": "unknown"` in the example manifest output below.

However, OpenShift's oc-mirror tool does not support provenance attestations. This causes oc-mirror to try pulling the attestation manifests as if they are real images, because it can't tell the difference. Fortunately, we aren't using them for anything, so we can remove them to handle this lack of support in OpenShift.

Example manifest:

```
$ crane manifest registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:5e5d0d43080c2402504ecb2227feaa8f6210f77d60c6b846657857fe4967d188
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:47e9ce892aa96cfbd31a8121f4042a637f3d7aa3186cdd215c11206dcc509e3c",
      "size": 1241,
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:7994ba6f97c7b2f2108cae1d10d8060c1ea21cafe387dea5147f8b1f1557a682",
      "size": 1241,
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:441ab35447c5996003be3fae7b12bbdd6c3a8c5b2273be631d3f34bf13b49559",
      "size": 567,
      "annotations": {
        "vnd.docker.reference.digest": "sha256:47e9ce892aa96cfbd31a8121f4042a637f3d7aa3186cdd215c11206dcc509e3c",
        "vnd.docker.reference.type": "attestation-manifest"
      },
      "platform": {
        "architecture": "unknown",
        "os": "unknown"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:3e3edcd619162f2a8863f2f49fd066a0adfa3e7d1fa0ffeef7e4d2f3e289c850",
      "size": 567,
      "annotations": {
        "vnd.docker.reference.digest": "sha256:7994ba6f97c7b2f2108cae1d10d8060c1ea21cafe387dea5147f8b1f1557a682",
        "vnd.docker.reference.type": "attestation-manifest"
      },
      "platform": {
        "architecture": "unknown",
        "os": "unknown"
      }
    }
  ]
}
```

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
