### PR TITLE
cli: Add simple enable/disable Source commands

### DIFF
--- a/docs/cli/odigos_sources.mdx
+++ b/docs/cli/odigos_sources.mdx
@@ -43,5 +43,7 @@ odigos sources delete --group mygroup --all-namespaces
 * [odigos](/cli/odigos)	 - Automate OpenTelemetry Observability in Kubernetes
 * [odigos sources create](/cli/odigos_sources_create)	 - Create an Odigos Source
 * [odigos sources delete](/cli/odigos_sources_delete)	 - Delete Odigos Sources
+* [odigos sources disable](/cli/odigos_sources_disable)	 - Disable a source for Odigos instrumentation.
+* [odigos sources enable](/cli/odigos_sources_enable)	 - Enable a source for Odigos instrumentation.
 * [odigos sources status](/cli/odigos_sources_status)	 - Show the status of all Odigos Sources
 * [odigos sources update](/cli/odigos_sources_update)	 - Update Odigos Sources

--- a/docs/cli/odigos_sources_disable.mdx
+++ b/docs/cli/odigos_sources_disable.mdx
@@ -1,0 +1,49 @@
+---
+title: "odigos sources disable"
+sidebarTitle: "odigos sources disable"
+---
+## odigos sources disable
+
+Disable a source for Odigos instrumentation.
+
+### Synopsis
+
+This command disables the given workload for Odigos instrumentation. It will create a Source object (if one does not already exist)
+
+### Examples
+
+```
+
+# Disable deployment "foo" in namespace "default"
+odigos sources disable deployment foo
+
+# Disable namespace "bar" in namespace "default"
+odigos sources disable namespace bar
+
+# Disable statefulset "foo" in namespace "bar"
+odigos sources disable statefulset foo -n bar
+
+```
+
+### Options
+
+```
+  -h, --help               help for disable
+  -n, --namespace string   Kubernetes Namespace for Source (default "default")
+```
+
+### Options inherited from parent commands
+
+```
+      --kube-context string   (optional) name of the kubeconfig context to use
+      --kubeconfig string     (optional) absolute path to the kubeconfig file (default "KUBECONFIG")
+  -v, --verbose               enable verbose output
+```
+
+### SEE ALSO
+
+* [odigos sources](/cli/odigos_sources)	 - Manage Odigos Sources in a cluster
+* [odigos sources disable daemonset](/cli/odigos_sources_disable_daemonset)	 - disable a DaemonSet for Odigos instrumentation
+* [odigos sources disable deployment](/cli/odigos_sources_disable_deployment)	 - disable a Deployment for Odigos instrumentation
+* [odigos sources disable namespace](/cli/odigos_sources_disable_namespace)	 - disable a Namespace for Odigos instrumentation
+* [odigos sources disable statefulset](/cli/odigos_sources_disable_statefulset)	 - disable a StatefulSet for Odigos instrumentation

--- a/docs/cli/odigos_sources_disable.mdx
+++ b/docs/cli/odigos_sources_disable.mdx
@@ -17,7 +17,7 @@ This command disables the given workload for Odigos instrumentation. It will cre
 # Disable deployment "foo" in namespace "default"
 odigos sources disable deployment foo
 
-# Disable namespace "bar" in namespace "default"
+# Disable namespace "bar"
 odigos sources disable namespace bar
 
 # Disable statefulset "foo" in namespace "bar"
@@ -28,8 +28,7 @@ odigos sources disable statefulset foo -n bar
 ### Options
 
 ```
-  -h, --help               help for disable
-  -n, --namespace string   Kubernetes Namespace for Source (default "default")
+  -h, --help   help for disable
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/odigos_sources_disable_daemonset.mdx
+++ b/docs/cli/odigos_sources_disable_daemonset.mdx
@@ -17,7 +17,8 @@ odigos sources disable daemonset [name] [flags]
 ### Options
 
 ```
-  -h, --help   help for daemonset
+  -h, --help               help for daemonset
+  -n, --namespace string   Kubernetes Namespace for Source (default "default")
 ```
 
 ### Options inherited from parent commands
@@ -25,7 +26,6 @@ odigos sources disable daemonset [name] [flags]
 ```
       --kube-context string   (optional) name of the kubeconfig context to use
       --kubeconfig string     (optional) absolute path to the kubeconfig file (default "KUBECONFIG")
-  -n, --namespace string      Kubernetes Namespace for Source (default "default")
   -v, --verbose               enable verbose output
 ```
 

--- a/docs/cli/odigos_sources_disable_daemonset.mdx
+++ b/docs/cli/odigos_sources_disable_daemonset.mdx
@@ -1,0 +1,34 @@
+---
+title: "odigos sources disable daemonset"
+sidebarTitle: "odigos sources disable daemonset"
+---
+## odigos sources disable daemonset
+
+disable a DaemonSet for Odigos instrumentation
+
+### Synopsis
+
+This command disables the provided DaemonSet for Odigos instrumentatin. It will create a Source object if one does not already exists, or update the existing one if it does.
+
+```
+odigos sources disable daemonset [name] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for daemonset
+```
+
+### Options inherited from parent commands
+
+```
+      --kube-context string   (optional) name of the kubeconfig context to use
+      --kubeconfig string     (optional) absolute path to the kubeconfig file (default "KUBECONFIG")
+  -n, --namespace string      Kubernetes Namespace for Source (default "default")
+  -v, --verbose               enable verbose output
+```
+
+### SEE ALSO
+
+* [odigos sources disable](/cli/odigos_sources_disable)	 - Disable a source for Odigos instrumentation.

--- a/docs/cli/odigos_sources_disable_deployment.mdx
+++ b/docs/cli/odigos_sources_disable_deployment.mdx
@@ -17,7 +17,8 @@ odigos sources disable deployment [name] [flags]
 ### Options
 
 ```
-  -h, --help   help for deployment
+  -h, --help               help for deployment
+  -n, --namespace string   Kubernetes Namespace for Source (default "default")
 ```
 
 ### Options inherited from parent commands
@@ -25,7 +26,6 @@ odigos sources disable deployment [name] [flags]
 ```
       --kube-context string   (optional) name of the kubeconfig context to use
       --kubeconfig string     (optional) absolute path to the kubeconfig file (default "KUBECONFIG")
-  -n, --namespace string      Kubernetes Namespace for Source (default "default")
   -v, --verbose               enable verbose output
 ```
 

--- a/docs/cli/odigos_sources_disable_deployment.mdx
+++ b/docs/cli/odigos_sources_disable_deployment.mdx
@@ -1,0 +1,34 @@
+---
+title: "odigos sources disable deployment"
+sidebarTitle: "odigos sources disable deployment"
+---
+## odigos sources disable deployment
+
+disable a Deployment for Odigos instrumentation
+
+### Synopsis
+
+This command disables the provided Deployment for Odigos instrumentatin. It will create a Source object if one does not already exists, or update the existing one if it does.
+
+```
+odigos sources disable deployment [name] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for deployment
+```
+
+### Options inherited from parent commands
+
+```
+      --kube-context string   (optional) name of the kubeconfig context to use
+      --kubeconfig string     (optional) absolute path to the kubeconfig file (default "KUBECONFIG")
+  -n, --namespace string      Kubernetes Namespace for Source (default "default")
+  -v, --verbose               enable verbose output
+```
+
+### SEE ALSO
+
+* [odigos sources disable](/cli/odigos_sources_disable)	 - Disable a source for Odigos instrumentation.

--- a/docs/cli/odigos_sources_disable_namespace.mdx
+++ b/docs/cli/odigos_sources_disable_namespace.mdx
@@ -25,7 +25,6 @@ odigos sources disable namespace [name] [flags]
 ```
       --kube-context string   (optional) name of the kubeconfig context to use
       --kubeconfig string     (optional) absolute path to the kubeconfig file (default "KUBECONFIG")
-  -n, --namespace string      Kubernetes Namespace for Source (default "default")
   -v, --verbose               enable verbose output
 ```
 

--- a/docs/cli/odigos_sources_disable_namespace.mdx
+++ b/docs/cli/odigos_sources_disable_namespace.mdx
@@ -1,0 +1,34 @@
+---
+title: "odigos sources disable namespace"
+sidebarTitle: "odigos sources disable namespace"
+---
+## odigos sources disable namespace
+
+disable a Namespace for Odigos instrumentation
+
+### Synopsis
+
+This command disables the provided Namespace for Odigos instrumentatin. It will create a Source object if one does not already exists, or update the existing one if it does.
+
+```
+odigos sources disable namespace [name] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for namespace
+```
+
+### Options inherited from parent commands
+
+```
+      --kube-context string   (optional) name of the kubeconfig context to use
+      --kubeconfig string     (optional) absolute path to the kubeconfig file (default "KUBECONFIG")
+  -n, --namespace string      Kubernetes Namespace for Source (default "default")
+  -v, --verbose               enable verbose output
+```
+
+### SEE ALSO
+
+* [odigos sources disable](/cli/odigos_sources_disable)	 - Disable a source for Odigos instrumentation.

--- a/docs/cli/odigos_sources_disable_statefulset.mdx
+++ b/docs/cli/odigos_sources_disable_statefulset.mdx
@@ -17,7 +17,8 @@ odigos sources disable statefulset [name] [flags]
 ### Options
 
 ```
-  -h, --help   help for statefulset
+  -h, --help               help for statefulset
+  -n, --namespace string   Kubernetes Namespace for Source (default "default")
 ```
 
 ### Options inherited from parent commands
@@ -25,7 +26,6 @@ odigos sources disable statefulset [name] [flags]
 ```
       --kube-context string   (optional) name of the kubeconfig context to use
       --kubeconfig string     (optional) absolute path to the kubeconfig file (default "KUBECONFIG")
-  -n, --namespace string      Kubernetes Namespace for Source (default "default")
   -v, --verbose               enable verbose output
 ```
 

--- a/docs/cli/odigos_sources_disable_statefulset.mdx
+++ b/docs/cli/odigos_sources_disable_statefulset.mdx
@@ -1,0 +1,34 @@
+---
+title: "odigos sources disable statefulset"
+sidebarTitle: "odigos sources disable statefulset"
+---
+## odigos sources disable statefulset
+
+disable a StatefulSet for Odigos instrumentation
+
+### Synopsis
+
+This command disables the provided StatefulSet for Odigos instrumentatin. It will create a Source object if one does not already exists, or update the existing one if it does.
+
+```
+odigos sources disable statefulset [name] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for statefulset
+```
+
+### Options inherited from parent commands
+
+```
+      --kube-context string   (optional) name of the kubeconfig context to use
+      --kubeconfig string     (optional) absolute path to the kubeconfig file (default "KUBECONFIG")
+  -n, --namespace string      Kubernetes Namespace for Source (default "default")
+  -v, --verbose               enable verbose output
+```
+
+### SEE ALSO
+
+* [odigos sources disable](/cli/odigos_sources_disable)	 - Disable a source for Odigos instrumentation.

--- a/docs/cli/odigos_sources_enable.mdx
+++ b/docs/cli/odigos_sources_enable.mdx
@@ -1,0 +1,49 @@
+---
+title: "odigos sources enable"
+sidebarTitle: "odigos sources enable"
+---
+## odigos sources enable
+
+Enable a source for Odigos instrumentation.
+
+### Synopsis
+
+This command enables the given workload for Odigos instrumentation. It will create a Source object (if one does not already exist)
+
+### Examples
+
+```
+
+# Enable deployment "foo" in namespace "default"
+odigos sources enable deployment foo
+
+# Enable namespace "bar" in namespace "default"
+odigos sources enable namespace bar
+
+# Enable statefulset "foo" in namespace "bar"
+odigos sources enable statefulset foo -n bar
+
+```
+
+### Options
+
+```
+  -h, --help               help for enable
+  -n, --namespace string   Kubernetes Namespace for Source (default "default")
+```
+
+### Options inherited from parent commands
+
+```
+      --kube-context string   (optional) name of the kubeconfig context to use
+      --kubeconfig string     (optional) absolute path to the kubeconfig file (default "KUBECONFIG")
+  -v, --verbose               enable verbose output
+```
+
+### SEE ALSO
+
+* [odigos sources](/cli/odigos_sources)	 - Manage Odigos Sources in a cluster
+* [odigos sources enable daemonset](/cli/odigos_sources_enable_daemonset)	 - enable a DaemonSet for Odigos instrumentation
+* [odigos sources enable deployment](/cli/odigos_sources_enable_deployment)	 - enable a Deployment for Odigos instrumentation
+* [odigos sources enable namespace](/cli/odigos_sources_enable_namespace)	 - enable a Namespace for Odigos instrumentation
+* [odigos sources enable statefulset](/cli/odigos_sources_enable_statefulset)	 - enable a StatefulSet for Odigos instrumentation

--- a/docs/cli/odigos_sources_enable.mdx
+++ b/docs/cli/odigos_sources_enable.mdx
@@ -17,7 +17,7 @@ This command enables the given workload for Odigos instrumentation. It will crea
 # Enable deployment "foo" in namespace "default"
 odigos sources enable deployment foo
 
-# Enable namespace "bar" in namespace "default"
+# Enable namespace "bar"
 odigos sources enable namespace bar
 
 # Enable statefulset "foo" in namespace "bar"
@@ -28,8 +28,7 @@ odigos sources enable statefulset foo -n bar
 ### Options
 
 ```
-  -h, --help               help for enable
-  -n, --namespace string   Kubernetes Namespace for Source (default "default")
+  -h, --help   help for enable
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/odigos_sources_enable_daemonset.mdx
+++ b/docs/cli/odigos_sources_enable_daemonset.mdx
@@ -1,0 +1,34 @@
+---
+title: "odigos sources enable daemonset"
+sidebarTitle: "odigos sources enable daemonset"
+---
+## odigos sources enable daemonset
+
+enable a DaemonSet for Odigos instrumentation
+
+### Synopsis
+
+This command enables the provided DaemonSet for Odigos instrumentatin. It will create a Source object if one does not already exists, or update the existing one if it does.
+
+```
+odigos sources enable daemonset [name] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for daemonset
+```
+
+### Options inherited from parent commands
+
+```
+      --kube-context string   (optional) name of the kubeconfig context to use
+      --kubeconfig string     (optional) absolute path to the kubeconfig file (default "KUBECONFIG")
+  -n, --namespace string      Kubernetes Namespace for Source (default "default")
+  -v, --verbose               enable verbose output
+```
+
+### SEE ALSO
+
+* [odigos sources enable](/cli/odigos_sources_enable)	 - Enable a source for Odigos instrumentation.

--- a/docs/cli/odigos_sources_enable_daemonset.mdx
+++ b/docs/cli/odigos_sources_enable_daemonset.mdx
@@ -17,7 +17,8 @@ odigos sources enable daemonset [name] [flags]
 ### Options
 
 ```
-  -h, --help   help for daemonset
+  -h, --help               help for daemonset
+  -n, --namespace string   Kubernetes Namespace for Source (default "default")
 ```
 
 ### Options inherited from parent commands
@@ -25,7 +26,6 @@ odigos sources enable daemonset [name] [flags]
 ```
       --kube-context string   (optional) name of the kubeconfig context to use
       --kubeconfig string     (optional) absolute path to the kubeconfig file (default "KUBECONFIG")
-  -n, --namespace string      Kubernetes Namespace for Source (default "default")
   -v, --verbose               enable verbose output
 ```
 

--- a/docs/cli/odigos_sources_enable_deployment.mdx
+++ b/docs/cli/odigos_sources_enable_deployment.mdx
@@ -17,7 +17,8 @@ odigos sources enable deployment [name] [flags]
 ### Options
 
 ```
-  -h, --help   help for deployment
+  -h, --help               help for deployment
+  -n, --namespace string   Kubernetes Namespace for Source (default "default")
 ```
 
 ### Options inherited from parent commands
@@ -25,7 +26,6 @@ odigos sources enable deployment [name] [flags]
 ```
       --kube-context string   (optional) name of the kubeconfig context to use
       --kubeconfig string     (optional) absolute path to the kubeconfig file (default "KUBECONFIG")
-  -n, --namespace string      Kubernetes Namespace for Source (default "default")
   -v, --verbose               enable verbose output
 ```
 

--- a/docs/cli/odigos_sources_enable_deployment.mdx
+++ b/docs/cli/odigos_sources_enable_deployment.mdx
@@ -1,0 +1,34 @@
+---
+title: "odigos sources enable deployment"
+sidebarTitle: "odigos sources enable deployment"
+---
+## odigos sources enable deployment
+
+enable a Deployment for Odigos instrumentation
+
+### Synopsis
+
+This command enables the provided Deployment for Odigos instrumentatin. It will create a Source object if one does not already exists, or update the existing one if it does.
+
+```
+odigos sources enable deployment [name] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for deployment
+```
+
+### Options inherited from parent commands
+
+```
+      --kube-context string   (optional) name of the kubeconfig context to use
+      --kubeconfig string     (optional) absolute path to the kubeconfig file (default "KUBECONFIG")
+  -n, --namespace string      Kubernetes Namespace for Source (default "default")
+  -v, --verbose               enable verbose output
+```
+
+### SEE ALSO
+
+* [odigos sources enable](/cli/odigos_sources_enable)	 - Enable a source for Odigos instrumentation.

--- a/docs/cli/odigos_sources_enable_namespace.mdx
+++ b/docs/cli/odigos_sources_enable_namespace.mdx
@@ -25,7 +25,6 @@ odigos sources enable namespace [name] [flags]
 ```
       --kube-context string   (optional) name of the kubeconfig context to use
       --kubeconfig string     (optional) absolute path to the kubeconfig file (default "KUBECONFIG")
-  -n, --namespace string      Kubernetes Namespace for Source (default "default")
   -v, --verbose               enable verbose output
 ```
 

--- a/docs/cli/odigos_sources_enable_namespace.mdx
+++ b/docs/cli/odigos_sources_enable_namespace.mdx
@@ -1,0 +1,34 @@
+---
+title: "odigos sources enable namespace"
+sidebarTitle: "odigos sources enable namespace"
+---
+## odigos sources enable namespace
+
+enable a Namespace for Odigos instrumentation
+
+### Synopsis
+
+This command enables the provided Namespace for Odigos instrumentatin. It will create a Source object if one does not already exists, or update the existing one if it does.
+
+```
+odigos sources enable namespace [name] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for namespace
+```
+
+### Options inherited from parent commands
+
+```
+      --kube-context string   (optional) name of the kubeconfig context to use
+      --kubeconfig string     (optional) absolute path to the kubeconfig file (default "KUBECONFIG")
+  -n, --namespace string      Kubernetes Namespace for Source (default "default")
+  -v, --verbose               enable verbose output
+```
+
+### SEE ALSO
+
+* [odigos sources enable](/cli/odigos_sources_enable)	 - Enable a source for Odigos instrumentation.

--- a/docs/cli/odigos_sources_enable_statefulset.mdx
+++ b/docs/cli/odigos_sources_enable_statefulset.mdx
@@ -17,7 +17,8 @@ odigos sources enable statefulset [name] [flags]
 ### Options
 
 ```
-  -h, --help   help for statefulset
+  -h, --help               help for statefulset
+  -n, --namespace string   Kubernetes Namespace for Source (default "default")
 ```
 
 ### Options inherited from parent commands
@@ -25,7 +26,6 @@ odigos sources enable statefulset [name] [flags]
 ```
       --kube-context string   (optional) name of the kubeconfig context to use
       --kubeconfig string     (optional) absolute path to the kubeconfig file (default "KUBECONFIG")
-  -n, --namespace string      Kubernetes Namespace for Source (default "default")
   -v, --verbose               enable verbose output
 ```
 

--- a/docs/cli/odigos_sources_enable_statefulset.mdx
+++ b/docs/cli/odigos_sources_enable_statefulset.mdx
@@ -1,0 +1,34 @@
+---
+title: "odigos sources enable statefulset"
+sidebarTitle: "odigos sources enable statefulset"
+---
+## odigos sources enable statefulset
+
+enable a StatefulSet for Odigos instrumentation
+
+### Synopsis
+
+This command enables the provided StatefulSet for Odigos instrumentatin. It will create a Source object if one does not already exists, or update the existing one if it does.
+
+```
+odigos sources enable statefulset [name] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for statefulset
+```
+
+### Options inherited from parent commands
+
+```
+      --kube-context string   (optional) name of the kubeconfig context to use
+      --kubeconfig string     (optional) absolute path to the kubeconfig file (default "KUBECONFIG")
+  -n, --namespace string      Kubernetes Namespace for Source (default "default")
+  -v, --verbose               enable verbose output
+```
+
+### SEE ALSO
+
+* [odigos sources enable](/cli/odigos_sources_enable)	 - Enable a source for Odigos instrumentation.

--- a/docs/pipeline/sources/delete.mdx
+++ b/docs/pipeline/sources/delete.mdx
@@ -10,6 +10,27 @@ icon: "trash"
   If a workload is deleted without deleting the Source, the Source will resume its effects if the workload is re-created later.
 </Info>
 
+## With Odigos CLI
+
+The Odigos CLI supports instrumenting and uninstrumenting workloads with the [`odigos sources enable`](/cli/odigos_sources_enable)
+and [`odigos sources disable`](/cli/odigos_sources_disable) commands.
+
+Each of these commands accepts a source type, name, and namespace.
+
+For example, to remove a source from odigos, run:
+
+```shell
+odigos sources disable deployment <deployment-name> -n <deployment-namespace>
+```
+
+This command will rollout existing pods to restart without any odigos additions.
+
+It can be undone (re-instrumented) by running: "
+
+```shell
+odigos sources enable deployment <deployment-name> -n <deployment-namespace>
+```
+
 ## With Odigos UI
 
 The easiest way to remove a source from Odigos is to use the Odigos UI.<br />

--- a/k8sutils/pkg/workload/workloadkinds.go
+++ b/k8sutils/pkg/workload/workloadkinds.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/odigos-io/odigos/api/k8sconsts"
@@ -42,6 +43,8 @@ func WorkloadKindLowerCaseFromKind(pascalCase k8sconsts.WorkloadKind) k8sconsts.
 		return k8sconsts.WorkloadKindLowerCaseDaemonSet
 	case k8sconsts.WorkloadKindStatefulSet:
 		return k8sconsts.WorkloadKindLowerCaseStatefulSet
+	case k8sconsts.WorkloadKindNamespace:
+		return k8sconsts.WorkloadKindLowerCaseNamespace
 	}
 	return ""
 }
@@ -94,6 +97,8 @@ func ClientObjectFromWorkloadKind(kind k8sconsts.WorkloadKind) client.Object {
 		return &v1.DaemonSet{}
 	case k8sconsts.WorkloadKindStatefulSet:
 		return &v1.StatefulSet{}
+	case k8sconsts.WorkloadKindNamespace:
+		return &corev1.Namespace{}
 	default:
 		return nil
 	}


### PR DESCRIPTION
## Description

This adds new commands to the CLI for enabling/disabling Sources: `odigos sources <enable/disable> <type> <name>`

These commands are essentially shorthand for the more explicit (and less user-friendly) `odigos sources create/update` commands.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [x] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [x] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [x] Documentation updated accordingly
