### PR TITLE
fix: dependabot yarn -> npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,7 +49,7 @@ updates:
       day: sunday
       interval: weekly
 
-  - package-ecosystem: yarn
+  - package-ecosystem: npm
     directories:
       - /frontend/webapp
       - /docs


### PR DESCRIPTION
According to the [docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#package-ecosystem-), `yarn` should be defined with `npm`.