### PR TITLE
fix: introduce k8s.pod.name resource attribute to java and dotnet community

### DIFF
--- a/instrumentor/controllers/agentenabled/pods_webhook.go
+++ b/instrumentor/controllers/agentenabled/pods_webhook.go
@@ -206,6 +206,7 @@ func (p *PodsWebhook) injectOdigosToContainer(containerConfig *odigosv1.Containe
 	for _, envVar := range podContainerSpec.Env {
 		existingEnvNames[envVar.Name] = struct{}{}
 	}
+	podswebhook.InjectOdigosK8sEnvVars(&existingEnvNames, podContainerSpec, distroName, pw.Namespace)
 
 	volumeMounted := false
 	if distroMetadata.RuntimeAgent != nil {
@@ -245,7 +246,6 @@ func (p *PodsWebhook) injectOdigosToContainer(containerConfig *odigosv1.Containe
 			}
 		}
 	}
-	podswebhook.InjectOdigosK8sEnvVars(&existingEnvNames, podContainerSpec, distroName, pw.Namespace)
 
 	return volumeMounted, nil
 }

--- a/instrumentor/controllers/agentenabled/podswebhook/otelresource.go
+++ b/instrumentor/controllers/agentenabled/podswebhook/otelresource.go
@@ -22,6 +22,10 @@ func getResourceAttributes(podWorkload k8sconsts.PodWorkload, containerName stri
 	workloadKindKey := getWorkloadKindAttributeKey(podWorkload.Kind)
 	return []resourceAttribute{
 		{
+			Key:   semconv.K8SPodNameKey,
+			Value: "$(ODIGOS_POD_NAME)",
+		},
+		{
 			Key:   semconv.K8SContainerNameKey,
 			Value: containerName,
 		},


### PR DESCRIPTION
## Description

Java and dotnet community were lacking the `k8s.pod.name` resource attribute.
This PR add it to the pod in the webhook.

## How Has This Been Tested?

- [x] Manual Testing

Currently - the e2e tests assert this value, but it didn't work in practice.

## User Facing Changes

Users who use OSS with java/dotnet, will now see this resource attribute in the generated traces.

<img width="755" alt="image" src="https://github.com/user-attachments/assets/5bee8281-48a7-4fc8-9651-b79c7a9114e8" />


