### PR TITLE
feat: inject some distro env vars from manifest instead of code branching

### DIFF
--- a/common/consts/consts.go
+++ b/common/consts/consts.go
@@ -77,7 +77,6 @@ var (
 	OtelExporterEndpointEnvName = "OTEL_EXPORTER_OTLP_ENDPOINT"
 	// Python related ones
 	OtelPythonConfiguratorEnvName      = "OTEL_PYTHON_CONFIGURATOR"
-	OtelPythonOSSConfiguratorEnvValue  = "odigos-python-configurator"
 	OtelPythonEBPFConfiguratorEnvValue = "ebpf"
 	OpampServerHostEnvName             = "ODIGOS_OPAMP_SERVER_HOST"
 	OpAMPPort                          = 4320

--- a/common/consts/consts.go
+++ b/common/consts/consts.go
@@ -76,8 +76,6 @@ var (
 	OtelTracesExporter          = "OTEL_TRACES_EXPORTER"
 	OtelExporterEndpointEnvName = "OTEL_EXPORTER_OTLP_ENDPOINT"
 	// Python related ones
-	OtelPythonConfiguratorEnvName      = "OTEL_PYTHON_CONFIGURATOR"
-	OtelPythonEBPFConfiguratorEnvValue = "ebpf"
-	OpampServerHostEnvName             = "ODIGOS_OPAMP_SERVER_HOST"
-	OpAMPPort                          = 4320
+	OpampServerHostEnvName = "ODIGOS_OPAMP_SERVER_HOST"
+	OpAMPPort              = 4320
 )

--- a/distros/distro/oteldistribution.go
+++ b/distros/distro/oteldistribution.go
@@ -22,9 +22,33 @@ type Framework struct {
 	FrameworkVersion string `yaml:"frameworkVersion"`
 }
 
+// static name-value environment variable that need to be set in the application runtime.
+type StaticEnvironmentVariable struct {
+	// The name of the environment variable to set.
+	EnvName string `yaml:"envName"`
+
+	// The value of the environment variable to set.
+	EnvValue string `yaml:"envValue"`
+}
+
+type EnvironmentVariables struct {
+
+	// if this distribution runs an opamp client, add the environment variables that configures the server endpoint (local node)
+	OpAmpClientEnvironments bool `yaml:"opAmpClientEnvironments,omitempty"`
+
+	// set to true if this distribution uses the OTLP HTTP protocol to emit telemetry data to node collector.
+	// if `true` the OTEL_EXPORTER_OTLP_ENDPOINT environment variable will be set to LocalTrafficOTLPHttpDataCollectionEndpoint
+	OtlpHttpLocalNode bool `yaml:"otlpHttpLocalNode,omitempty"`
+
+	// list of static environment variables that need to be set in the application runtime.
+	StaticVariables []StaticEnvironmentVariable `yaml:"staticVariables,omitempty"`
+}
+
 // this struct describes environment variables that needs to be set in the application runtime
 // to enable the distribution.
-type EnvironmentVariable struct {
+// This environment variable should be patched with odigos value if it already exists in the manifest.
+// If this value is determined to arrive from Container Runtime during runtime inspection, this value should be set in manifest so not to break the application.
+type RuntimeAgentEnvironmentVariable struct {
 
 	// The name of the environment variable to set or patch.
 	EnvName string `yaml:"envName"`
@@ -61,6 +85,10 @@ type RuntimeAgent struct {
 	// This list contains the full path of the files that need to be opened for the agent to properly start.
 	// All these paths must be contained in one of the directoryNames.
 	FileOpenTriggers []string `yaml:"fileOpenTriggers,omitempty"`
+
+	// List of environment variables that need to be set in the application runtime to enable the distribution.
+	// those are patched if exist in the manifest, and supplemented from runtime inspection when relevant (value from docker runtime).
+	EnvironmentVariables []RuntimeAgentEnvironmentVariable `yaml:"environmentVariables,omitempty"`
 }
 
 // OtelDistro (Short for OpenTelemetry Distribution) is a collection of OpenTelemetry components,
@@ -97,9 +125,9 @@ type OtelDistro struct {
 	// Free text description of the distribution, what it includes, it's use cases, etc.
 	Description string `yaml:"description"`
 
-	// a list of environment variables that needs to be set in the application runtime
+	// categories of environments variables that need to be set in the application runtime
 	// to enable the distribution.
-	EnvironmentVariables []EnvironmentVariable `yaml:"environmentVariables,omitempty"`
+	EnvironmentVariables EnvironmentVariables `yaml:"environmentVariables,omitempty"`
 
 	// Metadata and properties of the runtime agent that is used to enable the distribution.
 	// Can be nil in case no runtime agent is required.

--- a/distros/yamls/java-community.yaml
+++ b/distros/yamls/java-community.yaml
@@ -11,6 +11,11 @@ spec:
   displayName: Java Community Native Instrumentation
   description: |
     This distribution is for JVM-based applications (Java, Scala, Kotlin, etc.) using OpenTelemetry Native SDK and instrumentation libraries from the OpenTelemetry community.
+  runtimeAgent:
+    directoryNames:
+      - "{{ODIGOS_AGENTS_DIR}}/java"
+    k8sAttrsViaEnvVars: true
+    device: 'instrumentation.odigos.io/generic'
   environmentVariables:
     - envName: JAVA_OPTS
       envValue: '-javaagent:{{ODIGOS_AGENTS_DIR}}/java/javaagent.jar'
@@ -18,8 +23,3 @@ spec:
     - envName: JAVA_TOOL_OPTIONS
       envValue: '-javaagent:{{ODIGOS_AGENTS_DIR}}/java/javaagent.jar'
       delimiter: ' '
-  runtimeAgent:
-    directoryNames:
-      - "{{ODIGOS_AGENTS_DIR}}/java"
-    k8sAttrsViaEnvVars: true
-    device: 'instrumentation.odigos.io/generic'

--- a/distros/yamls/java-community.yaml
+++ b/distros/yamls/java-community.yaml
@@ -16,10 +16,10 @@ spec:
       - "{{ODIGOS_AGENTS_DIR}}/java"
     k8sAttrsViaEnvVars: true
     device: 'instrumentation.odigos.io/generic'
-  environmentVariables:
-    - envName: JAVA_OPTS
-      envValue: '-javaagent:{{ODIGOS_AGENTS_DIR}}/java/javaagent.jar'
-      delimiter: ' '
-    - envName: JAVA_TOOL_OPTIONS
-      envValue: '-javaagent:{{ODIGOS_AGENTS_DIR}}/java/javaagent.jar'
-      delimiter: ' '
+    environmentVariables:
+      - envName: JAVA_OPTS
+        envValue: '-javaagent:{{ODIGOS_AGENTS_DIR}}/java/javaagent.jar'
+        delimiter: ' '
+      - envName: JAVA_TOOL_OPTIONS
+        envValue: '-javaagent:{{ODIGOS_AGENTS_DIR}}/java/javaagent.jar'
+        delimiter: ' '

--- a/distros/yamls/java-community.yaml
+++ b/distros/yamls/java-community.yaml
@@ -11,6 +11,8 @@ spec:
   displayName: Java Community Native Instrumentation
   description: |
     This distribution is for JVM-based applications (Java, Scala, Kotlin, etc.) using OpenTelemetry Native SDK and instrumentation libraries from the OpenTelemetry community.
+  environmentVariables:
+    otlpHttpLocalNode: true
   runtimeAgent:
     directoryNames:
       - "{{ODIGOS_AGENTS_DIR}}/java"

--- a/distros/yamls/nodejs-community.yaml
+++ b/distros/yamls/nodejs-community.yaml
@@ -11,6 +11,9 @@ spec:
   displayName: 'Node.js Community Native Instrumentation'
   description: |
     This distribution is for Node.js applications using OpenTelemetry Native SDK and instrumentation libraries from the OpenTelemetry community.
+  environmentVariables:
+    opAmpClientEnvironments: true
+    otlpHttpLocalNode: true
   runtimeAgent:
     directoryNames:
       - "{{ODIGOS_AGENTS_DIR}}/nodejs"

--- a/distros/yamls/nodejs-community.yaml
+++ b/distros/yamls/nodejs-community.yaml
@@ -11,11 +11,11 @@ spec:
   displayName: 'Node.js Community Native Instrumentation'
   description: |
     This distribution is for Node.js applications using OpenTelemetry Native SDK and instrumentation libraries from the OpenTelemetry community.
-  environmentVariables:
-    - envName: NODE_OPTIONS
-      envValue: '--require {{ODIGOS_AGENTS_DIR}}/nodejs/autoinstrumentation.js'
-      delimiter: ' '
   runtimeAgent:
     directoryNames:
       - "{{ODIGOS_AGENTS_DIR}}/nodejs"
     device: 'instrumentation.odigos.io/generic'
+    environmentVariables:
+      - envName: NODE_OPTIONS
+        envValue: '--require {{ODIGOS_AGENTS_DIR}}/nodejs/autoinstrumentation.js'
+        delimiter: ' '

--- a/distros/yamls/python-community.yaml
+++ b/distros/yamls/python-community.yaml
@@ -12,11 +12,17 @@ spec:
   description: |
     This distribution is for Python applications using OpenTelemetry Native SDK and instrumentation libraries from the OpenTelemetry community.
   environmentVariables:
-    - envName: PYTHONPATH
-      envValue: '{{ODIGOS_AGENTS_DIR}}/python:{{ODIGOS_AGENTS_DIR}}/python/opentelemetry/instrumentation/auto_instrumentation'
-      delimiter: ':'
+    opAmpClientEnvironments: true
+    otlpHttpLocalNode: true
+    staticVariables:
+      - envName: OTEL_PYTHON_CONFIGURATOR
+        envValue: 'odigos-python-configurator'
   runtimeAgent:
     directoryNames:
       - "{{ODIGOS_AGENTS_DIR}}/python"
     device: 'instrumentation.odigos.io/generic'
+    environmentVariables:
+      - envName: PYTHONPATH
+        envValue: '{{ODIGOS_AGENTS_DIR}}/python:{{ODIGOS_AGENTS_DIR}}/python/opentelemetry/instrumentation/auto_instrumentation'
+        delimiter: ':'
       

--- a/instrumentor/cmd/main.go
+++ b/instrumentor/cmd/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	"github.com/odigos-io/odigos/distros"
@@ -70,17 +71,20 @@ func main() {
 
 	distrosGetter, err := distros.NewCommunityGetter()
 	if err != nil {
+		fmt.Println("Failed to initialize distro getter", err.Error())
 		setupLog.Error(err, "Failed to initialize distro getter")
 		os.Exit(1)
 	}
 	dp, err := distros.NewProvider(distros.NewCommunityDefaulter(), distrosGetter)
 	if err != nil {
+		fmt.Println("Failed to initialize distro provider", err.Error())
 		setupLog.Error(err, "Failed to initialize distro provider")
 		os.Exit(1)
 	}
 
 	i, err := instrumentor.New(managerOptions, dp)
 	if err != nil {
+		fmt.Println("Failed to initialize instrumentor")
 		setupLog.Error(err, "Failed to initialize instrumentor")
 		os.Exit(1)
 	}

--- a/instrumentor/controllers/agentenabled/pods_webhook.go
+++ b/instrumentor/controllers/agentenabled/pods_webhook.go
@@ -212,6 +212,12 @@ func (p *PodsWebhook) injectOdigosToContainer(containerConfig *odigosv1.Containe
 	for _, envVar := range distroMetadata.EnvironmentVariables.StaticVariables {
 		podswebhook.InjectStaticEnvVar(&existingEnvNames, podContainerSpec, envVar.EnvName, envVar.EnvValue)
 	}
+	if distroMetadata.EnvironmentVariables.OpAmpClientEnvironments {
+		podswebhook.InjectOpampServerEnvVar(&existingEnvNames, podContainerSpec)
+	}
+	if distroMetadata.EnvironmentVariables.OtlpHttpLocalNode {
+		podswebhook.InjectOtlpHttpEndpointEnvVar(&existingEnvNames, podContainerSpec)
+	}
 
 	volumeMounted := false
 	if distroMetadata.RuntimeAgent != nil {

--- a/instrumentor/controllers/agentenabled/pods_webhook.go
+++ b/instrumentor/controllers/agentenabled/pods_webhook.go
@@ -206,7 +206,12 @@ func (p *PodsWebhook) injectOdigosToContainer(containerConfig *odigosv1.Containe
 	for _, envVar := range podContainerSpec.Env {
 		existingEnvNames[envVar.Name] = struct{}{}
 	}
+
+	// inject various kinds of distro environment variables
 	podswebhook.InjectOdigosK8sEnvVars(&existingEnvNames, podContainerSpec, distroName, pw.Namespace)
+	for _, envVar := range distroMetadata.EnvironmentVariables.StaticVariables {
+		podswebhook.InjectStaticEnvVar(&existingEnvNames, podContainerSpec, envVar.EnvName, envVar.EnvValue)
+	}
 
 	volumeMounted := false
 	if distroMetadata.RuntimeAgent != nil {

--- a/instrumentor/controllers/agentenabled/podswebhook/env.go
+++ b/instrumentor/controllers/agentenabled/podswebhook/env.go
@@ -5,14 +5,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func InjectOdigosK8sEnvVars(existingEnvNames *map[string]struct{}, container *corev1.Container, distroName string, ns string) {
-
-	injectEnvVarToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarContainerName, container.Name)
-	injectEnvVarToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarDistroName, distroName)
-	injectEnvVarObjectFieldRefToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarPodName, "metadata.name")
-	injectEnvVarToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarNamespace, ns)
-}
-
 func injectEnvVarObjectFieldRefToPodContainer(existingEnvNames *map[string]struct{}, container *corev1.Container, envVarName, envVarRef string) {
 	if _, exists := (*existingEnvNames)[envVarName]; exists {
 		return
@@ -41,4 +33,15 @@ func injectEnvVarToPodContainer(existingEnvNames *map[string]struct{}, container
 	})
 
 	(*existingEnvNames)[envVarName] = struct{}{}
+}
+
+func InjectOdigosK8sEnvVars(existingEnvNames *map[string]struct{}, container *corev1.Container, distroName string, ns string) {
+	injectEnvVarToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarContainerName, container.Name)
+	injectEnvVarToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarDistroName, distroName)
+	injectEnvVarObjectFieldRefToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarPodName, "metadata.name")
+	injectEnvVarToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarNamespace, ns)
+}
+
+func InjectStaticEnvVar(existingEnvNames *map[string]struct{}, container *corev1.Container, envVarName string, envVarValue string) {
+	injectEnvVarToPodContainer(existingEnvNames, container, envVarName, envVarValue)
 }

--- a/instrumentor/controllers/sourceinstrumentation/common.go
+++ b/instrumentor/controllers/sourceinstrumentation/common.go
@@ -109,7 +109,11 @@ func syncWorkload(ctx context.Context, k8sClient client.Client, scheme *runtime.
 			}
 			ic, err = createInstrumentationConfigForWorkload(ctx, k8sClient, instConfigName, podWorkload.Namespace, obj, scheme)
 			if err != nil {
-				return ctrl.Result{}, err
+				if apierrors.IsAlreadyExists(err) {
+					return ctrl.Result{Requeue: true}, nil
+				} else {
+					return ctrl.Result{}, err
+				}
 			}
 		}
 

--- a/instrumentor/instrumentor.go
+++ b/instrumentor/instrumentor.go
@@ -25,8 +25,10 @@ type Instrumentor struct {
 func New(opts controllers.KubeManagerOptions, dp *distros.Provider) (*Instrumentor, error) {
 	err := feature.Setup()
 	if err != nil {
+		fmt.Println("Setup failed")
 		return nil, err
 	}
+	fmt.Println("Setup successful")
 
 	mgr, err := controllers.CreateManager(opts)
 	if err != nil {

--- a/instrumentor/internal/webhook_env_injector/webhook_env_injector.go
+++ b/instrumentor/internal/webhook_env_injector/webhook_env_injector.go
@@ -233,10 +233,6 @@ func InjectPythonEnvVars(container *corev1.Container) {
 	} else {
 		tierSpecificEnvs = []corev1.EnvVar{
 			{
-				Name:  commonconsts.OtelPythonConfiguratorEnvName,
-				Value: commonconsts.OtelPythonOSSConfiguratorEnvValue,
-			},
-			{
 				Name:  commonconsts.OtelExporterEndpointEnvName,
 				Value: service.LocalTrafficOTLPHttpDataCollectionEndpoint("$(NODE_IP)"),
 			},

--- a/instrumentor/internal/webhook_env_injector/webhook_env_injector.go
+++ b/instrumentor/internal/webhook_env_injector/webhook_env_injector.go
@@ -10,7 +10,6 @@ import (
 	commonconsts "github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/common/envOverwrite"
 	"github.com/odigos-io/odigos/k8sutils/pkg/env"
-	"github.com/odigos-io/odigos/k8sutils/pkg/service"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -153,19 +152,6 @@ func getContainerEnvVarPointer(containerEnv *[]corev1.EnvVar, envVarName string)
 
 func injectJavaCommunityEnvVars(ctx context.Context, logger logr.Logger,
 	container *corev1.Container, client client.Client) {
-
-	container.Env = append(container.Env, corev1.EnvVar{
-		Name: "NODE_IP",
-		ValueFrom: &corev1.EnvVarSource{
-			FieldRef: &corev1.ObjectFieldSelector{
-				FieldPath: "status.hostIP",
-			},
-		},
-	})
-	container.Env = append(container.Env, corev1.EnvVar{
-		Name:  commonconsts.OtelExporterEndpointEnvName,
-		Value: service.LocalTrafficOTLPHttpDataCollectionEndpoint("$(NODE_IP)"),
-	})
 
 	// Set the OTEL signals exporter env vars
 	setOtelSignalsExporterEnvVars(ctx, logger, container, client)


### PR DESCRIPTION
## Description

We want to retire some old code responsible for injecting some env vars, to make the logic sit in the distro manifest instead of being set in code.

This has the benefit of consolidating all the relevant per-distro configurations into one file, and removing some of the tier-aware code which should be migrated to enterprise instrumentor.

## How Has This Been Tested?

- [ ] Updated e2e Tests
- [X] Manual Testing - tested this in my local kind cluster. checked the values in the manifest after rollout with new instrumentor, and made sure all services are running, healthy, and emitting traces.

## Kubernetes Checklist

Just refactor of the code in the pods webhook. no changes in k8s api.

It's notable to mention that the new implementation checks for the presence of an env var before setting it's value in the manifest.

## User Facing Changes

Internal refactors only. no user face change is expected.