### PR TITLE
fix: deletion error

### DIFF
--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -107,6 +107,13 @@ func UninstallOdigosResources(ctx context.Context, client *kube.Client, ns strin
 		client, ns, uninstallRBAC)
 	createKubeResourceWithLogging(ctx, "Uninstalling Odigos Secrets",
 		client, ns, uninstallSecrets)
+	// Without deleting the mutating and validating webhook configurations, the CRDs cannot be deleted.
+	// E.g deleting "Sources" at later stage will fail as the CRD is still in use.
+	createKubeResourceWithLogging(ctx, "Uninstalling Odigos MutatingWebhookConfigurations",
+		client, ns, uninstallMutatingWebhookConfigs)
+
+	createKubeResourceWithLogging(ctx, "Uninstalling Odigos ValidatingWebhookConfigurations",
+		client, ns, uninstallValidatingWebhookConfigs)
 }
 
 // UninstallClusterResources removes cluster-wide Odigos resources, such as node labels,
@@ -134,11 +141,6 @@ func UninstallClusterResources(ctx context.Context, client *kube.Client, ns stri
 	createKubeResourceWithLogging(ctx, "Uninstalling Odigos CRDs",
 		client, ns, uninstallCRDs)
 
-	createKubeResourceWithLogging(ctx, "Uninstalling Odigos MutatingWebhookConfigurations",
-		client, ns, uninstallMutatingWebhookConfigs)
-
-	createKubeResourceWithLogging(ctx, "Uninstalling Odigos ValidatingWebhookConfigurations",
-		client, ns, uninstallValidatingWebhookConfigs)
 }
 
 func waitForNamespaceDeletion(ctx context.Context, client *kube.Client, ns string) {


### PR DESCRIPTION
## Description

This PR fixes the failure that occurs during deletion:

```
ERROR Internal error occurred: failed calling webhook "source-mutating-webhook.odigos.io": failed to call webhook: Post "https://odigos-instrumentor.odigos-system.svc:9443/mutate-odigos-io-v1alpha1-source?timeout=10s": service "odigos-instrumentor" not found
exit status 255
```

The error happens because the odigos-instrumentor service is deleted before the mutating webhook, so when attempting to delete a Source, it tries to reach the now non-existent service.

To resolve this, I reordered the deletion steps so that the source mutating and validating webhooks are removed before the actual resource.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [X] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
