### PR TITLE
test: parallelize cli-upgrade steps for faster run

### DIFF
--- a/tests/e2e/cli-upgrade/chainsaw-test.yaml
+++ b/tests/e2e/cli-upgrade/chainsaw-test.yaml
@@ -6,10 +6,17 @@ spec:
   description: Check successful upgrade from latest version of CLI
   skipDelete: true
   steps:
+
     - name: Prepare destination
       try:
         - apply: 
             file: ../../common/apply/simple-trace-db-deployment.yaml
+
+    - name: Install Demo App
+      try:
+        - apply:
+            file: ../../common/apply/install-simple-demo.yaml
+
     - name: Install Odigos latest release from GitHub for pre upgrade setup
       try:
         - script:
@@ -50,62 +57,36 @@ spec:
               # cleanup any existing installation of odigos the might be left over from previous runs while developing
               ./odigos uninstall --yes
               # Run the Odigos CLI installation
-              ./odigos install --namespace odigos-test
-        - assert:
-            file: ../../common/assert/odigos-installed.yaml
-    - name: Assert Trace DB is up
+              ./odigos install --namespace odigos-test --nowait
+
+    - name: Instrument Cluster
+      try:
+        - apply:
+            file: ../../common/apply/add-simple-trace-db-destination.yaml
+        - apply:
+            file: ../../common/apply/instrument-default-ns.yaml
+
+    - name: Assert Setup Ready
       try:
         - assert:
             timeout: 1m
             file: ../../common/assert/simple-trace-db-running.yaml
-    - name: Install Demo App
-      try:
-        - script:
-            timeout: 5m
-            content: |
-              docker pull registry.odigos.io/odigos-demo-inventory:v0.1
-              docker pull registry.odigos.io/odigos-demo-membership:v0.1
-              docker pull registry.odigos.io/odigos-demo-coupon:v0.1
-              docker pull registry.odigos.io/odigos-demo-pricing:v0.1
-              docker pull registry.odigos.io/odigos-demo-frontend:v0.2
-              kind load docker-image registry.odigos.io/odigos-demo-inventory:v0.1
-              kind load docker-image registry.odigos.io/odigos-demo-membership:v0.1
-              kind load docker-image registry.odigos.io/odigos-demo-coupon:v0.1
-              kind load docker-image registry.odigos.io/odigos-demo-pricing:v0.1
-              kind load docker-image registry.odigos.io/odigos-demo-frontend:v0.2
-        - apply:
-            file: ../../common/apply/install-simple-demo.yaml
         - assert:
+            timeout: 1m
             file: ../../common/assert/simple-demo-installed.yaml
-
-    - name: Instrument Namespace
-      try:
-        - apply:
-            file: ../../common/apply/instrument-default-ns.yaml
-
-    - name: Assert Runtime Detected
-      try:
+        - assert:
+            timeout: 1m 
+            file: ../../common/assert/odigos-installed.yaml
         - assert:
             timeout: 4m
             file: ../../common/assert/simple-demo-runtime-detected.yaml
-
-    - name: Add Destination
-      try:
-        - apply:
-            file: ../../common/apply/add-simple-trace-db-destination.yaml
-
-    - name: Odigos pipeline pods ready
-    # We make sure that the pipeline pods are ready before proceeding with the next steps
-    # This is intentionally different from pipeline-ready.yaml, which checks for the pipeline CRDs
-    # When adding a feature related to the pipeline, if we would use the same assert before the upgrade, the test would fail.
-    # Since the version installed here is latest official one.
-      try:
         - script:
+            # We make sure that the pipeline pods are ready before proceeding with the next steps
+            # This is intentionally different from pipeline-ready.yaml, which checks for the pipeline CRDs
+            # When adding a feature related to the pipeline, if we would use the same assert before the upgrade, the test would fail.
+            # Since the version installed here is latest official one.
             content: ../../common/assert_pipeline_pods_ready.sh
             timeout: 5m
-
-    - name: Simple-demo instrumented after destination added
-      try:
         - assert:
             file: ../../common/assert/simple-demo-instrumented.yaml
 


### PR DESCRIPTION
This PR aims to parallelize some steps in the `cli-upgrade` e2e test to make it run faster and stay correct