### PR TITLE
feat: set only 1 envvar in java in case one of the options defined + …

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -76,6 +76,7 @@ jobs:
           - 'workload-lifecycle'
           - 'source'
           - 'source-webhooks'
+          - 'env-injection'
         include:
           - kube-version: '1.20.15'
             kind-image: 'kindest/node:v1.20.15@sha256:a32bf55309294120616886b5338f95dd98a2f7231519c7dedcec32ba29699394'

--- a/instrumentor/internal/webhook_env_injector/webhook_env_injector.go
+++ b/instrumentor/internal/webhook_env_injector/webhook_env_injector.go
@@ -29,15 +29,30 @@ func InjectOdigosAgentEnvVars(ctx context.Context, logger logr.Logger, podWorklo
 		return
 	}
 
+	// Odigos appends necessary environment variables to enable its agent.
+	// It handles this in the following ways:
+	// 1. Appends Odigos-specific values to environment variables already defined by the user in the manifest.
+	// 2. Appends Odigos-specific values to environment variables already defined by the user at runtime.
+	// 3. Sets environment variables with Odigos defaults when they are not defined in either the manifest or the runtime.
+
+	isOdigosAgentEnvAppended := false
 	for _, envVarName := range envVarsPerLanguage {
+		// 1.
 		if handleManifestEnvVar(container, envVarName, otelsdk, logger) {
+			isOdigosAgentEnvAppended = true
 			continue
 		}
 
-		err := injectEnvVarsFromRuntime(logger, container, envVarName, otelsdk, runtimeDetails)
-		if err != nil {
-			logger.Error(err, "failed to inject environment variables for container", "container", container.Name)
+		// 2.
+		if injectEnvVarsFromRuntime(logger, container, envVarName, otelsdk, runtimeDetails) {
+			isOdigosAgentEnvAppended = true
+			continue
 		}
+	}
+
+	// 3.
+	if !isOdigosAgentEnvAppended {
+		applyOdigosEnvDefaults(container, envVarsPerLanguage, otelsdk)
 	}
 }
 
@@ -74,16 +89,19 @@ func handleManifestEnvVar(container *corev1.Container, envVarName string, otelsd
 }
 
 func injectEnvVarsFromRuntime(logger logr.Logger, container *corev1.Container, envVarName string,
-	otelsdk common.OtelSdk, runtimeDetails *odigosv1.RuntimeDetailsByContainer) error {
+	otelsdk common.OtelSdk, runtimeDetails *odigosv1.RuntimeDetailsByContainer) bool {
 	logger.Info("Inject Odigos values based on runtime details", "envVarName", envVarName, "container", container.Name)
 
 	if !shouldInject(runtimeDetails, logger, container.Name) {
-		return nil
+		return false
 	}
 
 	envVarsToInject := processEnvVarsFromRuntimeDetails(runtimeDetails, envVarName, otelsdk)
-	container.Env = append(container.Env, envVarsToInject...)
-	return nil
+	if len(envVarsToInject) > 0 {
+		container.Env = append(container.Env, envVarsToInject...)
+		return true
+	}
+	return false
 }
 
 func processEnvVarsFromRuntimeDetails(runtimeDetails *odigosv1.RuntimeDetailsByContainer, envVarName string, otelsdk common.OtelSdk) []corev1.EnvVar {
@@ -97,26 +115,37 @@ func processEnvVarsFromRuntimeDetails(runtimeDetails *odigosv1.RuntimeDetailsByC
 	if !ok { // No odigos value for this SDK
 		return envVars
 	}
+	for _, envVar := range runtimeDetails.EnvFromContainerRuntime {
 
-	if runtimeDetails.EnvFromContainerRuntime == nil {
-		envVars = append(envVars, corev1.EnvVar{Name: envVarName, Value: valueToInject})
-	} else {
-		for _, envVar := range runtimeDetails.EnvFromContainerRuntime {
-
-			// Get the relevant envVar that we're iterating over
-			if envVar.Name != envVarName {
-				continue
-			}
-
-			patchedEnvVarValue := envOverwrite.AppendOdigosAdditionsToEnvVar(envVarName, envVar.Value, valueToInject)
-			envVars = append(envVars, corev1.EnvVar{Name: envVarName, Value: *patchedEnvVarValue})
+		// Get the relevant envVar that we're iterating over
+		if envVar.Name != envVarName {
+			continue
 		}
-		// If EnvFromContainerRuntime does not include the relevant envVar (e.g., JAVA_OPTS), it should still be added with the Odigos value.
-		if len(envVars) == 0 {
-			envVars = append(envVars, corev1.EnvVar{Name: envVarName, Value: valueToInject})
-		}
+
+		patchedEnvVarValue := envOverwrite.AppendOdigosAdditionsToEnvVar(envVarName, envVar.Value, valueToInject)
+		envVars = append(envVars, corev1.EnvVar{Name: envVarName, Value: *patchedEnvVarValue})
 	}
+
 	return envVars
+}
+
+func applyOdigosEnvDefaults(container *corev1.Container, envVarsPerLanguage []string, otelsdk common.OtelSdk) {
+	for _, envVarName := range envVarsPerLanguage {
+		odigosValueForOtelSdk := envOverwrite.GetPossibleValuesPerEnv(envVarName)
+		if odigosValueForOtelSdk == nil { // No Odigos values for this env var
+			continue
+		}
+
+		valueToInject, ok := odigosValueForOtelSdk[otelsdk]
+		if !ok { // No Odigos value for this SDK
+			continue
+		}
+
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  envVarName,
+			Value: valueToInject,
+		})
+	}
 }
 
 func shouldInject(runtimeDetails *odigosv1.RuntimeDetailsByContainer, logger logr.Logger, containerName string) bool {

--- a/tests/e2e/env-injection/01-assert-apps-installed.yaml
+++ b/tests/e2e/env-injection/01-assert-apps-installed.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: java-supported-docker-env
+  namespace: default
+status:
+  containerStatuses:
+    - name: java-supported-docker-env
+      ready: true
+      restartCount: 0
+      started: true
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: java-supported-manifest-env
+  namespace: default
+status:
+  containerStatuses:
+    - name: java-supported-manifest-env
+      ready: true
+      restartCount: 0
+      started: true
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: java-latest-version
+  namespace: default
+status:
+  containerStatuses:
+    - name: java-latest-version
+      ready: true
+      restartCount: 0
+      started: true
+  phase: Running

--- a/tests/e2e/env-injection/01-assert-env-vars.yaml
+++ b/tests/e2e/env-injection/01-assert-env-vars.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: java-latest-version
+  namespace: default
+spec:
+  containers:
+    - image: public.ecr.aws/odigos/java-latest-version:v0.0.1
+      name: java-latest-version
+      (env[?name=='JAVA_OPTS']):
+       - value: "-javaagent:/var/odigos/java/javaagent.jar"
+      (env[?name=='JAVA_TOOL_OPTIONS']):        
+       - value: "-javaagent:/var/odigos/java/javaagent.jar"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: java-supported-manifest-env
+  namespace: default
+spec:
+  containers:
+    - image: public.ecr.aws/odigos/java-supported-manifest-env:v0.0.1
+      name: java-supported-manifest-env
+      (env[?name=='JAVA_OPTS']):
+      - value: "-Dnot.work=true -javaagent:/var/odigos/java/javaagent.jar"
+      (env[?name=='JAVA_TOOL_OPTIONS']): []
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: java-supported-docker-env
+  namespace: default
+spec:
+  containers:
+    - image: public.ecr.aws/odigos/java-supported-docker-env:v0.0.1
+      name: java-supported-docker-env
+      (env[?name=='JAVA_OPTS']):
+      - value: -Dthis.does.not.exist=true -javaagent:/var/odigos/java/javaagent.jar
+      (env[?name=='JAVA_TOOL_OPTIONS']): []

--- a/tests/e2e/env-injection/01-assert-runtime-detected.yaml
+++ b/tests/e2e/env-injection/01-assert-runtime-detected.yaml
@@ -1,0 +1,44 @@
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  namespace: default
+  name: deployment-java-supported-docker-env
+status:
+  runtimeDetailsByContainer:
+  - containerName: java-supported-docker-env
+    envFromContainerRuntime:
+    - name: JAVA_OPTS
+      value: -Dthis.does.not.exist=true
+    (envFromContainerRuntime[?name=='JAVA_TOOL_OPTIONS']): []           
+    envVars:
+    - name: JAVA_OPTS
+      value: -Dthis.does.not.exist=true
+    (envVars[?name=='JAVA_TOOL_OPTIONS']): []           
+    language: java
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  namespace: default
+  name: deployment-java-supported-manifest-env
+status:
+  runtimeDetailsByContainer:
+  - containerName: java-supported-manifest-env
+    (!envFromContainerRuntime): true
+    envVars:
+    - name: JAVA_OPTS
+      value: "-Dnot.work=true"
+    (envVars[?name=='JAVA_TOOL_OPTIONS']): []      
+    language: java
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  namespace: default
+  name: deployment-java-latest-version
+status:
+  runtimeDetailsByContainer:
+    - containerName: java-latest-version
+      (!envVars): true
+      (!envFromContainerRuntime): true
+      language: java

--- a/tests/e2e/env-injection/01-install-test-apps.yaml
+++ b/tests/e2e/env-injection/01-install-test-apps.yaml
@@ -1,0 +1,119 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: java-supported-docker-env
+  namespace: default
+  labels:
+    app: java-supported-docker-env
+spec:
+  selector:
+    matchLabels:
+      app: java-supported-docker-env
+  template:
+    metadata:
+      labels:
+        app: java-supported-docker-env
+    spec:
+      containers:
+        - name: java-supported-docker-env
+          image: public.ecr.aws/odigos/java-supported-docker-env:v0.0.1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+          readinessProbe:
+            tcpSocket:
+              port: 3000
+            initialDelaySeconds: 20
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: java-supported-docker-env
+  namespace: default
+spec:
+  selector:
+    app: java-supported-docker-env
+  ports:
+    - protocol: TCP
+      port: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: java-supported-manifest-env
+  namespace: default
+  labels:
+    app: java-supported-manifest-env
+spec:
+  selector:
+    matchLabels:
+      app: java-supported-manifest-env
+  template:
+    metadata:
+      labels:
+        app: java-supported-manifest-env
+    spec:
+      containers:
+        - name: java-supported-manifest-env
+          image: public.ecr.aws/odigos/java-supported-manifest-env:v0.0.1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+          env:
+            - name: JAVA_OPTS
+              value: "-Dnot.work=true"
+          readinessProbe:
+            tcpSocket:
+              port: 3000
+            initialDelaySeconds: 20
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: java-supported-manifest-env
+  namespace: default
+spec:
+  selector:
+    app: java-supported-manifest-env
+  ports:
+    - protocol: TCP
+      port: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: java-latest-version
+  namespace: default
+  labels:
+    app: java-latest-version
+spec:
+  selector:
+    matchLabels:
+      app: java-latest-version
+  template:
+    metadata:
+      labels:
+        app: java-latest-version
+    spec:
+      containers:
+        - name: java-latest-version
+          image: public.ecr.aws/odigos/java-latest-version:v0.0.1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+          readinessProbe:
+            tcpSocket:
+              port: 3000
+            initialDelaySeconds: 20
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: java-latest-version
+  namespace: default
+spec:
+  selector:
+    app: java-latest-version
+  ports:
+    - protocol: TCP
+      port: 3000

--- a/tests/e2e/env-injection/chainsaw-test.yaml
+++ b/tests/e2e/env-injection/chainsaw-test.yaml
@@ -1,0 +1,66 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: multi-apps
+spec:
+  description: This e2e test runs a multi-apps scenario
+  skipDelete: true
+  steps:
+    - name: Prepare destination
+      try:
+        - apply: 
+            file: ../../common/apply/simple-trace-db-deployment.yaml
+    - name: Install Odigos
+      try:
+        - script:
+            timeout: 3m
+            content: ../../../cli/odigos install --namespace odigos-test --version e2e-test
+        - assert:
+            file: ../../common/assert/odigos-installed.yaml
+    - name: Verify Node Odiglet label has been added
+      try:
+        - assert:
+            file: ../../common/assert/node-odiglet-label.yaml
+  
+    - name: Assert Trace DB is up
+      try:
+        - assert:
+            timeout: 1m
+            file: ../../common/assert/simple-trace-db-running.yaml
+    - name: '01 - Install Test Apps'
+      try:
+        - apply:
+            file: 01-install-test-apps.yaml
+    - name: '01 - Assert Apps installed'
+      try:
+        - assert:
+            timeout: 150s
+            file: 01-assert-apps-installed.yaml
+
+    - name: Instrument Namespace
+      try:
+        - apply:
+            file: ../../common/apply/instrument-default-ns.yaml
+
+    - name: Assert Runtime Detected
+      try:
+        - assert:
+            timeout: 3m
+            file: 01-assert-runtime-detected.yaml
+
+    - name: Add Destination
+      try:
+        - apply:
+            file: ../../common/apply/add-simple-trace-db-destination.yaml
+
+    - name: Odigos pipeline ready
+      try:
+        - assert:
+            file:  ../../common/assert/pipeline-ready.yaml
+
+    - name: Assert Environment Variables
+      try:
+        - assert:
+            file: 01-assert-env-vars.yaml
+
+    


### PR DESCRIPTION
…create test for it

## Description

This PR addresses the issue observed in `appsDynamic` and improves the overall reliability of environment variable injection.

Specifically:

If either `JAVA_OPTS` or `JAVA_TOOL_OPTIONS` is already defined (in the manifest or at runtime), we avoid setting the other to prevent conflicts.

If neither is defined, we set both environment variables with the appropriate Odigos values.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [X] Updated e2e Tests
- [X] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [X] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
