### PR TITLE
Add release check for open offsets PRs

### DIFF
--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -11,6 +11,20 @@ on:
         required: true
 
 jobs:
+  verify-offsets-merged:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: ['enterprise-go-instrumentation']
+    steps:
+      - name: Verify no open offsets PRs
+        run: |
+          curl -s -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.RELEASE_BOT_TOKEN }}" \
+          "https://api.github.com/repos/odigos-io/${{ matrix.repo }}/pulls?state=open&per_page=100" | \
+          jq '[.[] | select(.labels | any(.name == "offsets"))]' | \
+          jq 'if length > 0 then error("❌ Error: Open PRs with label \"offsets\" found!") else empty end'
+
   print-tag:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

This adds a step at the start of a release to make sure there are no open offsets PRs in our enterprise Go repo. This can be expanded with other languages as well as new labels using the matrix (even though the matrix is currently one value)

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
