### PR TITLE
feat: add queue retry and timeout to mock exporter

### DIFF
--- a/collector/exporters/mockdestinationexporter/config.go
+++ b/collector/exporters/mockdestinationexporter/config.go
@@ -5,6 +5,9 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configretry"
+	"go.opentelemetry.io/collector/exporter/exporterbatcher"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
 // Config contains the main configuration options for the mockdestination exporter
@@ -18,6 +21,13 @@ type Config struct {
 	// Set to 0 to disable rejection, and to 1 to reject all exports.
 	// Can be used to simulate destinations that are back-pressuring the collector.
 	RejectFraction float64 `mapstructure:"reject_fraction"`
+
+	// these configs controls configures the various export options.
+	// default values (when not set) are used just like the otlp exporter.
+	TimeoutConfig exporterhelper.TimeoutConfig `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
+	QueueConfig   exporterhelper.QueueConfig   `mapstructure:"sending_queue"`
+	RetryConfig   configretry.BackOffConfig    `mapstructure:"retry_on_failure"`
+	BatcherConfig exporterbatcher.Config       `mapstructure:"batcher"`
 }
 
 func (c *Config) Validate() error {

--- a/collector/exporters/mockdestinationexporter/factory.go
+++ b/collector/exporters/mockdestinationexporter/factory.go
@@ -5,9 +5,12 @@ import (
 	"time"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/odigos/exporter/mockdestinationexporter/internal/metadata"
+	"go.opentelemetry.io/collector/config/configretry"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/exporter/exporterbatcher"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
@@ -25,6 +28,10 @@ func createDefaultConfig() component.Config {
 	return &Config{
 		ResponseDuration: time.Millisecond * 100,
 		RejectFraction:   0,
+		TimeoutConfig:    exporterhelper.NewDefaultTimeoutConfig(),
+		RetryConfig:      configretry.NewDefaultBackOffConfig(),
+		QueueConfig:      exporterhelper.NewDefaultQueueConfig(),
+		BatcherConfig:    exporterbatcher.NewDefaultConfig(),
 	}
 }
 
@@ -43,7 +50,13 @@ func createLogsExporter(
 		ctx,
 		set,
 		cfg,
-		gcsExporter.ConsumeLogs)
+		gcsExporter.ConsumeLogs,
+		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
+		exporterhelper.WithTimeout(pCfg.TimeoutConfig),
+		exporterhelper.WithRetry(pCfg.RetryConfig),
+		exporterhelper.WithQueue(pCfg.QueueConfig),
+		exporterhelper.WithBatcher(pCfg.BatcherConfig),
+	)
 }
 
 func createTracesExporter(
@@ -62,6 +75,11 @@ func createTracesExporter(
 		set,
 		cfg,
 		gcsExporter.ConsumeTraces,
+		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
+		exporterhelper.WithTimeout(pCfg.TimeoutConfig),
+		exporterhelper.WithRetry(pCfg.RetryConfig),
+		exporterhelper.WithQueue(pCfg.QueueConfig),
+		exporterhelper.WithBatcher(pCfg.BatcherConfig),
 	)
 }
 
@@ -81,5 +99,10 @@ func createMetricsExporter(
 		set,
 		cfg,
 		gcsExporter.ConsumeMetrics,
+		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
+		exporterhelper.WithTimeout(pCfg.TimeoutConfig),
+		exporterhelper.WithRetry(pCfg.RetryConfig),
+		exporterhelper.WithQueue(pCfg.QueueConfig),
+		exporterhelper.WithBatcher(pCfg.BatcherConfig),
 	)
 }

--- a/collector/exporters/mockdestinationexporter/go.mod
+++ b/collector/exporters/mockdestinationexporter/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.27.0
 	go.opentelemetry.io/collector/component/componenttest v0.121.0
+	go.opentelemetry.io/collector/config/configretry v1.27.0
 	go.opentelemetry.io/collector/confmap v1.27.0
 	go.opentelemetry.io/collector/consumer v1.27.0
 	go.opentelemetry.io/collector/exporter v0.121.0
@@ -36,7 +37,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/config/configretry v1.27.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.121.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.121.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.121.0 // indirect


### PR DESCRIPTION
This PR adds more capabilities to the mock destination exporter in the odigos collector which is used for debug.

It makes the exporter behave like otlp exporter, as well as use the default values that otlp exporter uses.