### PR TITLE
fix: release --rm-dist has been deprecated in favor of --clean

### DIFF
--- a/.github/workflows/release-artifactregistry.yml
+++ b/.github/workflows/release-artifactregistry.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}


### PR DESCRIPTION
https://goreleaser.com/deprecations/#-rm-dist

```
--rm-dist has been deprecated in favor of --clean.
```