### PR TITLE
Strip binaries to reduce images size

### DIFF
--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -193,6 +193,7 @@ jobs:
             VERSION=${{ env.ODIGOS_TAG }}
             SUMMARY=${{ matrix.summary }}
             DESCRIPTION=${{ matrix.description }}
+            LD_FLAGS="-s -w"
           platforms: linux/amd64,linux/arm64
           file: >-
             ${{ matrix.service == 'odiglet' && format('odiglet/{0}', matrix.dockerfile) ||

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,12 @@ RUN --mount=type=cache,target=/go/pkg \
 COPY $SERVICE_NAME/ .
 # Build for target architecture
 ARG TARGETARCH
+ARG LD_FLAGS=""
 RUN go mod tidy
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
     CGO_ENABLED=0 GOARCH=$TARGETARCH \
-    go build -a -o /workspace/build/$SERVICE_NAME cmd/main.go
+    go build -ldflags="$LD_FLAGS" -a -o /workspace/build/$SERVICE_NAME cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -19,11 +19,12 @@ RUN --mount=type=cache,target=/go/pkg \
 COPY $SERVICE_NAME/ .
 # Build for target architecture
 ARG TARGETARCH
+ARG LD_FLAGS=""
 RUN go mod tidy
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
     CGO_ENABLED=0 GOARCH=$TARGETARCH \
-    go build -a -o /workspace/build/$SERVICE_NAME cmd/main.go
+    go build -ldflags="$LD_FLAGS" -a -o /workspace/build/$SERVICE_NAME cmd/main.go
 RUN make licenses
 
 FROM registry.access.redhat.com/ubi9/ubi-micro:latest

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,8 @@ build-image/%:
 	--build-arg VERSION=$(TAG) \
 	--build-arg RELEASE=$(TAG) \
 	--build-arg SUMMARY="$(SUMMARY)" \
-	--build-arg DESCRIPTION="$(DESCRIPTION)"
+	--build-arg DESCRIPTION="$(DESCRIPTION)" \
+	--build-arg LD_FLAGS="$(LD_FLAGS)"
 
 .PHONY: build-operator-index
 build-operator-index:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,7 +15,8 @@ COPY . .
 COPY --from=builder /webapp/out frontend/webapp/out
 WORKDIR /app/frontend
 ARG TARGETARCH
-RUN CGO_ENABLED=0 GOARCH=$TARGETARCH go build -o odigos-ui
+ARG LD_FLAGS=""
+RUN CGO_ENABLED=0 GOARCH=$TARGETARCH go build -ldflags="$LD_FLAGS" -o odigos-ui
 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /app

--- a/frontend/Dockerfile.rhel
+++ b/frontend/Dockerfile.rhel
@@ -15,7 +15,8 @@ COPY . .
 COPY --from=builder /webapp/out frontend/webapp/out
 WORKDIR /app/frontend
 ARG TARGETARCH
-RUN CGO_ENABLED=0 GOARCH=$TARGETARCH go build -o odigos-ui
+ARG LD_FLAGS=""
+RUN CGO_ENABLED=0 GOARCH=$TARGETARCH go build -ldflags="$LD_FLAGS" -o odigos-ui
 RUN make licenses
 
 FROM registry.access.redhat.com/ubi9/ubi-micro:latest

--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -99,9 +99,10 @@ WORKDIR /go/src/github.com/odigos-io/odigos/odiglet
 COPY odiglet/ .
 
 ARG TARGETARCH
+ARG LD_FLAGS=""
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    GOOS=linux GOARCH=$TARGETARCH make build-odiglet
+    GOOS=linux GOARCH=$TARGETARCH LD_FLAGS=$LD_FLAGS make build-odiglet
 
 WORKDIR /instrumentations
 

--- a/odiglet/Dockerfile.rhel
+++ b/odiglet/Dockerfile.rhel
@@ -99,9 +99,10 @@ WORKDIR /go/src/github.com/odigos-io/odigos/odiglet
 COPY odiglet/ .
 
 ARG TARGETARCH
+ARG LD_FLAGS=""
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    GOOS=linux GOARCH=$TARGETARCH make build-odiglet
+    GOOS=linux GOARCH=$TARGETARCH LD_FLAGS=$LD_FLAGS make build-odiglet
 RUN make licenses
 
 WORKDIR /instrumentations

--- a/odiglet/Makefile
+++ b/odiglet/Makefile
@@ -4,7 +4,7 @@ LIBRARIES := go.opentelemetry.io/auto \
 			github.com/odigos-io/runtime-detector
 
 build-odiglet: generate
-	CGO_ENABLED=0 go build -o odiglet cmd/main.go
+	CGO_ENABLED=0 go build -ldflags="$(LD_FLAGS)" -o odiglet cmd/main.go
 
 debug-build-odiglet: generate
 	go build -o odiglet -gcflags "all=-N -l" cmd/main.go

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -16,12 +16,13 @@ COPY operator/ .
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
+ARG LD_FLAGS=""
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -tags=embed_manifests -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -ldflags="$LD_FLAGS" -tags=embed_manifests -a -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
Add ld_flags as build argument to all of our images.
* When building locally, using the Makefile, the images won't get stripped by default. They can be stripped by running:
```
LD_FLAGS="-s -w" TAG=dummy-instrumentor-slim make build-instrumentor
```
* The release CI is updated to strip the images.
* The collector is stripped by default:  https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder#debug-symbols

Some size comparissions:
```
registry.odigos.io/odigos-instrumentor                            dummy-instrumentor-slim   49728c6d5831   2 seconds ago        46.2MB
registry.odigos.io/odigos-instrumentor                            dummy-instrumentor        c3664c33ce34   About a minute ago   66.3MB
registry.odigos.io/odigos-odiglet                                 dummy-odiglet-slim        eac2f946513a   40 hours ago         283MB
registry.odigos.io/odigos-odiglet                                 dummy-odiglet             6bfcc6e61f09   40 hours ago         310MB
registry.odigos.io/odigos-ui                                      dummy-ui-slim             593b61da34d4   41 hours ago         71MB
registry.odigos.io/odigos-ui                                      dummy-ui                  8c61523a210f   41 hours ago         101MB
```