### PR TITLE
fix: otlphttp URL with path parse

### DIFF
--- a/common/config/otlphttp_test.go
+++ b/common/config/otlphttp_test.go
@@ -57,7 +57,7 @@ func TestParseOtlpHttpEndpoint(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "path not allowed",
+			name: "path mismatch not allowed",
 			args: args{
 				rawURL: "http://localhost:4318/some-path",
 				port:   "4318",
@@ -65,6 +65,16 @@ func TestParseOtlpHttpEndpoint(t *testing.T) {
 			},
 			want:    "",
 			wantErr: true,
+		},
+		{
+			name: "path in URL allowed",
+			args: args{
+				rawURL: "http://localhost:4318/some-path",
+				port:   "4318",
+				path:   "",
+			},
+			want:    "http://localhost:4318/some-path",
+			wantErr: false,
 		},
 		{
 			name: "ipv4",

--- a/common/config/utils.go
+++ b/common/config/utils.go
@@ -104,7 +104,7 @@ func parseOtlpHttpEndpoint(rawUrl string, defaultPort string, requiredPath strin
 	if parsedUrl.Path == "" {
 		// Path is empty, append the required path
 		parsedUrl.Path = requiredPath
-	} else if parsedUrl.Path != requiredPath {
+	} else if requiredPath != "" && parsedUrl.Path != requiredPath {
 		// Path already exists, and is not equal to the required path
 		return "", fmt.Errorf("invalid otlp http endpoint path: %s", parsedUrl.Path)
 	}


### PR DESCRIPTION
## Description

Following #2673 , this PR fixes the parsing ot otlpHttp endpoint that contains a path in the URL

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [x] Added Unit Tests

