### PR TITLE
feat: add PHP language detection

### DIFF
--- a/api/config/crd/bases/odigos.io_instrumentationconfigs.yaml
+++ b/api/config/crd/bases/odigos.io_instrumentationconfigs.yaml
@@ -382,6 +382,7 @@ spec:
                       - go
                       - dotnet
                       - javascript
+                      - php
                       - mysql
                       - nginx
                       - unknown
@@ -588,6 +589,7 @@ spec:
                       - go
                       - dotnet
                       - javascript
+                      - php
                       - mysql
                       - nginx
                       - unknown

--- a/api/config/crd/bases/odigos.io_instrumentationrules.yaml
+++ b/api/config/crd/bases/odigos.io_instrumentationrules.yaml
@@ -99,6 +99,7 @@ spec:
                       - go
                       - dotnet
                       - javascript
+                      - php
                       - mysql
                       - nginx
                       - unknown

--- a/api/config/crd/bases/odigos.io_instrumentedapplications.yaml
+++ b/api/config/crd/bases/odigos.io_instrumentedapplications.yaml
@@ -136,6 +136,7 @@ spec:
                       - go
                       - dotnet
                       - javascript
+                      - php
                       - mysql
                       - nginx
                       - unknown

--- a/common/lang_detection.go
+++ b/common/lang_detection.go
@@ -10,7 +10,7 @@ type ProgramLanguageDetails struct {
 	RuntimeVersion *version.Version
 }
 
-// +kubebuilder:validation:Enum=java;python;go;dotnet;javascript;mysql;nginx;unknown;ignored
+// +kubebuilder:validation:Enum=java;python;go;dotnet;javascript;php;mysql;nginx;unknown;ignored
 type ProgrammingLanguage string
 
 const (
@@ -19,6 +19,7 @@ const (
 	GoProgrammingLanguage         ProgrammingLanguage = "go"
 	DotNetProgrammingLanguage     ProgrammingLanguage = "dotnet"
 	JavascriptProgrammingLanguage ProgrammingLanguage = "javascript"
+	PhpProgrammingLanguage        ProgrammingLanguage = "php"
 	// This is an experimental feature, It is not a language
 	// but in order to avoid huge refactoring we are adding it here for now
 	MySQLProgrammingLanguage ProgrammingLanguage = "mysql"

--- a/helm/odigos/templates/crds/odigos.io_instrumentationconfigs.yaml
+++ b/helm/odigos/templates/crds/odigos.io_instrumentationconfigs.yaml
@@ -382,6 +382,7 @@ spec:
                       - go
                       - dotnet
                       - javascript
+                      - php
                       - mysql
                       - nginx
                       - unknown
@@ -588,6 +589,7 @@ spec:
                       - go
                       - dotnet
                       - javascript
+                      - php
                       - mysql
                       - nginx
                       - unknown

--- a/helm/odigos/templates/crds/odigos.io_instrumentationrules.yaml
+++ b/helm/odigos/templates/crds/odigos.io_instrumentationrules.yaml
@@ -99,6 +99,7 @@ spec:
                       - go
                       - dotnet
                       - javascript
+                      - php
                       - mysql
                       - nginx
                       - unknown

--- a/helm/odigos/templates/crds/odigos.io_instrumentedapplications.yaml
+++ b/helm/odigos/templates/crds/odigos.io_instrumentedapplications.yaml
@@ -136,6 +136,7 @@ spec:
                       - go
                       - dotnet
                       - javascript
+                      - php
                       - mysql
                       - nginx
                       - unknown

--- a/procdiscovery/pkg/inspectors/langdetect.go
+++ b/procdiscovery/pkg/inspectors/langdetect.go
@@ -13,6 +13,7 @@ import (
 	"github.com/odigos-io/odigos/procdiscovery/pkg/inspectors/mysql"
 	"github.com/odigos-io/odigos/procdiscovery/pkg/inspectors/nginx"
 	"github.com/odigos-io/odigos/procdiscovery/pkg/inspectors/nodejs"
+	"github.com/odigos-io/odigos/procdiscovery/pkg/inspectors/php"
 	"github.com/odigos-io/odigos/procdiscovery/pkg/inspectors/python"
 	"github.com/odigos-io/odigos/procdiscovery/pkg/process"
 )
@@ -44,6 +45,7 @@ var inspectorsByLanguage = map[common.ProgrammingLanguage]Inspector{
 	common.GoProgrammingLanguage:         &golang.GolangInspector{},
 	common.PythonProgrammingLanguage:     &python.PythonInspector{},
 	common.JavascriptProgrammingLanguage: &nodejs.NodejsInspector{},
+	common.PhpProgrammingLanguage:        &php.PhpInspector{},
 	common.MySQLProgrammingLanguage:      &mysql.MySQLInspector{},
 	common.NginxProgrammingLanguage:      &nginx.NginxInspector{},
 }

--- a/procdiscovery/pkg/inspectors/php/php.go
+++ b/procdiscovery/pkg/inspectors/php/php.go
@@ -1,0 +1,38 @@
+package php
+
+import (
+	"path/filepath"
+
+	"github.com/odigos-io/odigos/common"
+	"github.com/odigos-io/odigos/procdiscovery/pkg/inspectors/utils"
+	"github.com/odigos-io/odigos/procdiscovery/pkg/process"
+)
+
+type PhpInspector struct{}
+
+const processName = "php"
+
+func (n *PhpInspector) QuickScan(pcx *process.ProcessContext) (common.ProgrammingLanguage, bool) {
+	proc := pcx.Details
+
+	baseExe := filepath.Base(proc.ExePath)
+
+	// Check if baseExe starts with "php"
+	if len(baseExe) >= 3 && baseExe[:3] == processName {
+		// If it's exactly "php", return true
+		if len(baseExe) == 3 {
+			return common.PhpProgrammingLanguage, true
+		}
+
+		// Use the helper function to check remaining characters
+		if utils.IsDigitsOnly(baseExe[3:]) {
+			return common.PhpProgrammingLanguage, true
+		}
+	}
+
+	return "", false
+}
+
+func (n *PhpInspector) DeepScan(pcx *process.ProcessContext) (common.ProgrammingLanguage, bool) {
+	return "", false
+}


### PR DESCRIPTION
## Description

This adds support for PHP language detection.
Runtime Version not included, not available via envs, must use leveraged permissions to `nsenter` and run `php -v`.
<img width="661" alt="Screenshot 2025-04-14 at 21 16 01" src="https://github.com/user-attachments/assets/5631ae66-8f3d-4563-84dd-71f0580bbc72" />

## How Has This Been Tested?

- [x] Manual Testing

## Kubernetes Checklist

- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
