### PR TITLE
Fix mount method value enum

### DIFF
--- a/common/mount.go
+++ b/common/mount.go
@@ -5,7 +5,7 @@ package common
 // We should revisit this decision later on and consider if the config should be k8s specific,
 // then move it to the api module.
 
-// +kubebuilder:validation:Enum=virtual-device;host-path
+// +kubebuilder:validation:Enum=k8s-virtual-device;k8s-host-path
 type MountMethod string
 
 const (


### PR DESCRIPTION
## Description

The mountMethod must be one of `k8s-virtual-device` or `k8s-host-path`, but our API validation only has `virtual-device` or `host-path`. This updates the validation

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
