### PR TITLE
feat: enhance url-template processor with more default templatization patterns

### DIFF
--- a/collector/processors/odigosurltemplateprocessor/README.md
+++ b/collector/processors/odigosurltemplateprocessor/README.md
@@ -46,7 +46,7 @@ The templatization process should be monitored and adjusted according to the val
 By default, the processor will split the path to segment (e.g. "/user/1234" -> ["user", "1234"]) and replace the segments with the following rules:
 
 - numbers - `\d+` -> `{id}` (`1234`, `328962358623904`, `0`)
-- uuids - `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` -> `{id}` (`123e4567-e89b-12d3-a456-426614174000`)
+- uuids - `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` -> `{id}` (`123e4567-e89b-12d3-a456-426614174000`). They can appear as either prefix or suffix of the segment (for example `/process/PROCESS_123e4567-e89b-12d3-a456-426614174000`)
 - hex-encoded strings - `[0-9a-f]{2}([0-9a-f]{2})*` -> `{id}` (`6f2a9cdeab34f01e`)
 
 These default rules will not templatize paths like `/user/john` or `/user/s111222333` which will be copied as is into the span name and attribute with potentially high cardinality.

--- a/collector/processors/odigosurltemplateprocessor/README.md
+++ b/collector/processors/odigosurltemplateprocessor/README.md
@@ -48,8 +48,9 @@ By default, the processor will split the path to segment (e.g. "/user/1234" -> [
 - numbers - `\d+` -> `{id}` (`1234`, `328962358623904`, `0`)
 - uuids - `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` -> `{id}` (`123e4567-e89b-12d3-a456-426614174000`). They can appear as either prefix or suffix of the segment (for example `/process/PROCESS_123e4567-e89b-12d3-a456-426614174000`)
 - hex-encoded strings - `[0-9a-f]{2}([0-9a-f]{2})*` -> `{id}` (`6f2a9cdeab34f01e`)
+- long numbers - `\d{9,}` -> `{id}` (`123456789`, `INC328962358623904`, `sb_12345678901234567890_us`)
 
-These default rules will not templatize paths like `/user/john` or `/user/s111222333` which will be copied as is into the span name and attribute with potentially high cardinality.
+These default rules will not templatize paths like `/user/john` or `/user/s11112222` which will be copied as is into the span name and attribute with potentially high cardinality.
 
 ## Custom Templatization
 

--- a/collector/processors/odigosurltemplateprocessor/README.md
+++ b/collector/processors/odigosurltemplateprocessor/README.md
@@ -45,10 +45,11 @@ The templatization process should be monitored and adjusted according to the val
 
 By default, the processor will split the path to segment (e.g. "/user/1234" -> ["user", "1234"]) and replace the segments with the following rules:
 
-- numbers - `\d+` -> `{id}`
-- uuids - `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` -> `{uuid}`
+- numbers - `\d+` -> `{id}` (`1234`, `328962358623904`, `0`)
+- uuids - `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` -> `{id}` (`123e4567-e89b-12d3-a456-426614174000`)
+- hex-encoded strings - `[0-9a-f]{2}([0-9a-f]{2})*` -> `{id}` (`6f2a9cdeab34f01e`)
 
-This will address paths like `/user/1234` and `/user/123e4567-e89b-12d3-a456-426614174000`, but will not templatize paths like `/user/john` or `/user/s111222333` which will be copied as is into the span name and attribute with potentially high cardinality.
+These default rules will not templatize paths like `/user/john` or `/user/s111222333` which will be copied as is into the span name and attribute with potentially high cardinality.
 
 ## Custom Templatization
 

--- a/collector/processors/odigosurltemplateprocessor/README.md
+++ b/collector/processors/odigosurltemplateprocessor/README.md
@@ -45,10 +45,10 @@ The templatization process should be monitored and adjusted according to the val
 
 By default, the processor will split the path to segment (e.g. "/user/1234" -> ["user", "1234"]) and replace the segments with the following rules:
 
-- numbers - `\d+` -> `{id}` (`1234`, `328962358623904`, `0`)
-- uuids - `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` -> `{id}` (`123e4567-e89b-12d3-a456-426614174000`). They can appear as either prefix or suffix of the segment (for example `/process/PROCESS_123e4567-e89b-12d3-a456-426614174000`)
+- only digits - `^\d+$` -> `{id}` (`1234`, `328962358623904`, `0`)
+- uuids - `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` -> `{id}` (`123e4567-e89b-12d3-a456-426614174000`). They can appear as either prefix or suffix of the segment (for example `/process/PROCESS_123e4567-e89b-12d3-a456-42661bd74000`)
 - hex-encoded strings - `[0-9a-f]{2}([0-9a-f]{2})*` -> `{id}` (`6f2a9cdeab34f01e`)
-- long numbers - `\d{9,}` -> `{id}` (`123456789`, `INC328962358623904`, `sb_12345678901234567890_us`)
+- long numbers anywhere - `\d{9,}` -> `{id}` (`123456789`, `INC328962358623904`, `sb_12345678901234567890_us`)
 
 These default rules will not templatize paths like `/user/john` or `/user/s11112222` which will be copied as is into the span name and attribute with potentially high cardinality.
 

--- a/collector/processors/odigosurltemplateprocessor/processor_test.go
+++ b/collector/processors/odigosurltemplateprocessor/processor_test.go
@@ -269,6 +269,71 @@ func TestProcessor_Traces(t *testing.T) {
 			expectedAttrKey:   "http.route",
 			expectedAttrValue: "/products",
 		},
+		{
+			name:          "mixed-numbers-and-text",
+			serviceName:   "mixed-numbers-and-text",
+			spanKind:      ptrace.SpanKindServer,
+			inputSpanName: "GET",
+			inputSpanAttrs: map[string]any{
+				"http.request.method": "GET",
+				"url.path":            "/api/v1",
+			},
+			expectedSpanName:  "GET /api/v1",
+			expectedAttrKey:   "http.route",
+			expectedAttrValue: "/api/v1",
+		},
+		{
+			name:          "hexencoded id",
+			serviceName:   "hexencoded-id",
+			spanKind:      ptrace.SpanKindServer,
+			inputSpanName: "GET",
+			inputSpanAttrs: map[string]any{
+				"http.request.method": "GET",
+				"url.path":            "/user/6f2a9cdeab34f01e",
+			},
+			expectedSpanName:  "GET /user/{id}",
+			expectedAttrKey:   "http.route",
+			expectedAttrValue: "/user/{id}",
+		},
+		{
+			name:          "short looking like hexencoded id",
+			serviceName:   "short-looking-like-hexencoded-id",
+			spanKind:      ptrace.SpanKindServer,
+			inputSpanName: "GET",
+			inputSpanAttrs: map[string]any{
+				"http.request.method": "GET",
+				"url.path":            "/user/feed12",
+			},
+			expectedSpanName:  "GET /user/feed12", // should not be templated as the string contains hex chars, but it's too short
+			expectedAttrKey:   "http.route",
+			expectedAttrValue: "/user/feed12",
+		},
+		{
+			name:          "long text",
+			serviceName:   "long-text",
+			spanKind:      ptrace.SpanKindServer,
+			inputSpanName: "GET",
+			inputSpanAttrs: map[string]any{
+				"http.request.method": "GET",
+				"url.path":            "/user/CamelCaseLongTextThatShouldNotBeTemplated",
+			},
+			expectedSpanName:  "GET /user/CamelCaseLongTextThatShouldNotBeTemplated", // should not be templated as chars are not hex
+			expectedAttrKey:   "http.route",
+			expectedAttrValue: "/user/CamelCaseLongTextThatShouldNotBeTemplated",
+		},
+		{
+			name:          "non-even length hex",
+			serviceName:   "non-even-length-hex",
+			spanKind:      ptrace.SpanKindServer,
+			inputSpanName: "GET",
+			inputSpanAttrs: map[string]any{
+				"http.request.method": "GET",
+				"url.path":            "/user/abcdefabcdefabcde", // contains 17 chars
+			},
+			expectedSpanName:  "GET /user/abcdefabcdefabcde", // should not be templated as the string contains hex chars, but it's too short
+			expectedAttrKey:   "http.route",
+			expectedAttrValue: "/user/abcdefabcdefabcde",
+		},
 	}
 
 	for _, tc := range tt {

--- a/collector/processors/odigosurltemplateprocessor/processor_test.go
+++ b/collector/processors/odigosurltemplateprocessor/processor_test.go
@@ -373,6 +373,33 @@ func TestProcessor_Traces(t *testing.T) {
 			expectedAttrKey:   "http.route",
 			expectedAttrValue: "/user/abcdefabcdefabcde",
 		},
+		{
+			name:          "long number with text",
+			serviceName:   "long-number-with-text",
+			spanKind:      ptrace.SpanKindServer,
+			inputSpanName: "GET",
+			inputSpanAttrs: map[string]any{
+				"http.request.method": "GET",
+				"url.path":            "/user/INC001268637", // contains 9 digits number
+			},
+			expectedSpanName:  "GET /user/{id}", // should be templated as the number is long
+			expectedAttrKey:   "http.route",
+			expectedAttrValue: "/user/{id}",
+		},
+		{
+			name: "long number in middle of text",
+			// this is a corner case where the number is long, but it is not at the beginning or end of the string
+			serviceName:   "long-number-in-middle-of-text",
+			spanKind:      ptrace.SpanKindServer,
+			inputSpanName: "GET",
+			inputSpanAttrs: map[string]any{
+				"http.request.method": "GET",
+				"url.path":            "/user/INC001268637US", // contains 9 digits number
+			},
+			expectedSpanName:  "GET /user/{id}",
+			expectedAttrKey:   "http.route",
+			expectedAttrValue: "/user/{id}",
+		},
 	}
 
 	for _, tc := range tt {

--- a/collector/processors/odigosurltemplateprocessor/processor_test.go
+++ b/collector/processors/odigosurltemplateprocessor/processor_test.go
@@ -75,8 +75,8 @@ func TestProcessor_Traces(t *testing.T) {
 			expectedAttrValue: "/user/{id}",
 		},
 		{
-			name:          "guid in url path",
-			serviceName:   "guid-templated-string",
+			name:          "uuid in url path",
+			serviceName:   "uuid-templated-string",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -86,6 +86,32 @@ func TestProcessor_Traces(t *testing.T) {
 			expectedSpanName:  "GET /user/{id}",
 			expectedAttrKey:   "http.route",
 			expectedAttrValue: "/user/{id}",
+		},
+		{
+			name:          "uuid with any suffix",
+			serviceName:   "uuid-templated-string-with-suffix",
+			spanKind:      ptrace.SpanKindServer,
+			inputSpanName: "GET",
+			inputSpanAttrs: map[string]any{
+				"http.request.method": "GET",
+				"url.path":            "/processes/PROCESS_123e4567-e89b-12d3-a456-426614174000",
+			},
+			expectedSpanName:  "GET /processes/{id}",
+			expectedAttrKey:   "http.route",
+			expectedAttrValue: "/processes/{id}",
+		},
+		{
+			name:          "uuid with any prefix",
+			serviceName:   "uuid-templated-string-with-prefix",
+			spanKind:      ptrace.SpanKindServer,
+			inputSpanName: "GET",
+			inputSpanAttrs: map[string]any{
+				"http.request.method": "GET",
+				"url.path":            "/processes/123e4567-e89b-12d3-a456-426614174000_PROCESS",
+			},
+			expectedSpanName:  "GET /processes/{id}",
+			expectedAttrKey:   "http.route",
+			expectedAttrValue: "/processes/{id}",
 		},
 		{
 			name:          "multiple numeric ids in url path",

--- a/collector/processors/odigosurltemplateprocessor/processor_test.go
+++ b/collector/processors/odigosurltemplateprocessor/processor_test.go
@@ -322,6 +322,19 @@ func TestProcessor_Traces(t *testing.T) {
 			expectedAttrValue: "/user/{id}",
 		},
 		{
+			name:          "long hexencoded id",
+			serviceName:   "long-hexencoded-id",
+			spanKind:      ptrace.SpanKindServer,
+			inputSpanName: "GET",
+			inputSpanAttrs: map[string]any{
+				"http.request.method": "GET",
+				"url.path":            "/user/6f2a9cdeab34f01e1234567890abcdef", // 32 chars
+			},
+			expectedSpanName:  "GET /user/{id}",
+			expectedAttrKey:   "http.route",
+			expectedAttrValue: "/user/{id}",
+		},
+		{
 			name:          "short looking like hexencoded id",
 			serviceName:   "short-looking-like-hexencoded-id",
 			spanKind:      ptrace.SpanKindServer,

--- a/collector/processors/odigosurltemplateprocessor/templatize.go
+++ b/collector/processors/odigosurltemplateprocessor/templatize.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	numberRegex = regexp.MustCompile(`^\d+$`)
+	onlyDigitsRegex = regexp.MustCompile(`^\d+$`)
 
 	// matches UUIDs in the format 123e4567-e89b-12d3-a456-426614174000
 	// these UUIDs are common in cloud systems and are often used as ids
@@ -42,7 +42,7 @@ var (
 	// assume that long numbers (more than 8 digits) are ids.
 	// even if they are found with some text (for example "INC001268637") they are treated as ids
 	// it is very unlikely for a a number with so many digits to be static and meaningful.
-	longNumberRegex = regexp.MustCompile(`\d{9,}`)
+	longNumberAnywhereRegex = regexp.MustCompile(`\d{9,}`)
 )
 
 type RulePathSegment struct {
@@ -165,10 +165,10 @@ func defaultTemplatizeURLPath(pathSegments []string) (string, bool) {
 	// avoid modifying the original segments slice
 	templatizedSegments := make([]string, len(pathSegments))
 	for i, segment := range pathSegments {
-		if uuidRegex.MatchString(segment) ||
-			numberRegex.MatchString(segment) ||
-			hexEncodedRegex.MatchString(segment) ||
-			longNumberRegex.MatchString(segment) {
+		if onlyDigitsRegex.MatchString(segment) ||
+			longNumberAnywhereRegex.MatchString(segment) ||
+			uuidRegex.MatchString(segment) ||
+			hexEncodedRegex.MatchString(segment) {
 
 			templatizedSegments[i] = "{id}"
 			templated = true

--- a/collector/processors/odigosurltemplateprocessor/templatize.go
+++ b/collector/processors/odigosurltemplateprocessor/templatize.go
@@ -8,17 +8,25 @@ import (
 )
 
 var (
-	uuidRegex   = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 	numberRegex = regexp.MustCompile(`^\d+$`)
 
+	// matches UUIDs in the format 123e4567-e89b-12d3-a456-426614174000
+	// these UUIDs are common in cloud systems and are often used as ids
+	// they are 36 characters long and are made up of 5 groups of hexadecimal characters
+	// separated by hyphens.
+	// this regexp will allow any prefix OR suffix of the UUID to be matched
+	// so for example: "PROCESS_123e4567-e89b-12d3-a456-426614174000" will also be matched
+	uuidRegex = regexp.MustCompile(`(^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})|([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)`)
+
+	// Covers hex encoded values like (for example) span/trace IDs.
+	// These are common as ids in cloud systems.
+	//
 	// To enforce the following conditions in a single Go regular expression:
 	// - Only lowercase hexadecimal characters (0-9 and a-f),
 	// - More than 16 characters,
 	// - An even number of characters
 	//
-	// covers hex encoded values like (for example) span/trace IDs.
-	// these are common as ids in cloud systems.
-	// it is considered safe as:
+	// It is considered safe as:
 	// - letters are only limited to lowercase a-f, which any real word with 16 chars or more will fail.
 	// - the regex will not match if the string is less than 16 chars, so things like "feed12" (all letters a-f) will not match.
 	// - the regex will not match if the string is odd length (indicating it's not hex encoded) so another filter for extreme corner cases.

--- a/collector/processors/odigosurltemplateprocessor/templatize.go
+++ b/collector/processors/odigosurltemplateprocessor/templatize.go
@@ -38,6 +38,11 @@ var (
 	// 	 - 8 × 2 = 16 characters minimum
 	// 	 - Each repetition is of 2 characters → ensures even length.
 	hexEncodedRegex = regexp.MustCompile(`^(?:[0-9a-f]{2}){8,}$`)
+
+	// assume that long numbers (more than 8 digits) are ids.
+	// even if they are found with some text (for example "INC001268637") they are treated as ids
+	// it is very unlikely for a a number with so many digits to be static and meaningful.
+	longNumberRegex = regexp.MustCompile(`\d{9,}`)
 )
 
 type RulePathSegment struct {
@@ -160,7 +165,11 @@ func defaultTemplatizeURLPath(pathSegments []string) (string, bool) {
 	// avoid modifying the original segments slice
 	templatizedSegments := make([]string, len(pathSegments))
 	for i, segment := range pathSegments {
-		if uuidRegex.MatchString(segment) || numberRegex.MatchString(segment) || hexEncodedRegex.MatchString(segment) {
+		if uuidRegex.MatchString(segment) ||
+			numberRegex.MatchString(segment) ||
+			hexEncodedRegex.MatchString(segment) ||
+			longNumberRegex.MatchString(segment) {
+
 			templatizedSegments[i] = "{id}"
 			templated = true
 		} else {


### PR DESCRIPTION
## Description

<!-- Short summary of the changes -->

templatize ids that looks like:

- `6f2a9cdeab34f01e` (hex encoded string)
- `INC0032534534` (long number with text)
- `PROCESS_123e4567-e89b-12d3-a456-426614bd4000` (uuid with prefix or suffix)

## Testing

- [x] Added Unit Tests

## Kubernetes Checklist

Not affecting k8s

## User Facing Changes

Less cases of high cardinality when using this processor
