### PR TITLE
operator: Update API field documentation

### DIFF
--- a/api/genref-config.yaml
+++ b/api/genref-config.yaml
@@ -63,3 +63,8 @@ apis:
     title: actions.odigos.io/v1alpha1
     package: github.com/odigos-io/odigos
     path: api/actions/v1alpha1
+
+  - name: operator.odigos.io
+    title: operator.odigos.io/v1alpha1
+    package: github.com/odigos-io/odigos/operator
+    path: api/v1alpha1

--- a/common/odigos_config.go
+++ b/common/odigos_config.go
@@ -1,6 +1,8 @@
 package common
 
 type ProfileName string
+
+// +kubebuilder:validation:Enum=normal;readonly
 type UiMode string
 
 const (

--- a/docs/api-reference/operator.odigos.io.v1alpha1.mdx
+++ b/docs/api-reference/operator.odigos.io.v1alpha1.mdx
@@ -1,0 +1,232 @@
+
+
+## Resource Types 
+
+
+  
+    
+    
+
+## `Odigos` <a id="Odigos"></a>
+    
+<p>Odigos is the Schema for the odigos API</p>
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Type</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr>
+<td>
+<code>metadata</code> <B>[Required]</B>
+</td>
+<td>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#objectmeta-v1-meta"><code>meta/v1.ObjectMeta</code></a>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   Refer to the Kubernetes API documentation for the fields of the <code>metadata</code> field.
+   </td>
+</tr>
+<tr>
+<td>
+<code>spec</code> <B>[Required]</B>
+</td>
+<td>
+<a href="#OdigosSpec"><code>OdigosSpec</code></a>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+<tr>
+<td>
+<code>status</code> <B>[Required]</B>
+</td>
+<td>
+<a href="#OdigosStatus"><code>OdigosStatus</code></a>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+</tbody>
+</table>
+
+## `OdigosSpec` <a id="OdigosSpec"></a>
+    
+
+**Appears in:**
+
+- [Odigos](#Odigos)
+
+<p>OdigosSpec defines the desired state of Odigos</p>
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Type</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr>
+<td>
+<code>onPremToken</code> <B>[Required]</B>
+</td>
+<td>
+<code>string</code>
+</td>
+<td>
+   <p>(Optional) OnPremToken is an enterprise token for Odigos Enterprise.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>uiMode</code> <B>[Required]</B>
+</td>
+<td>
+<a href="https://pkg.go.dev/github.com/odigos-io/odigos/common#UiMode"><code>common.UiMode</code></a>
+</td>
+<td>
+   <p>(Optional) UIMode sets the UI mode to either &quot;normal&quot; or &quot;readonly&quot;.
+In &quot;normal&quot; mode the UI is fully interactive, allowing users to view and edit
+Odigos configuration and settings. In &quot;readonly&quot; mode, the UI can only be
+used to view current Odigos configuration and is not interactive.
+Default=normal</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>telemetryEnabled</code> <B>[Required]</B>
+</td>
+<td>
+<code>bool</code>
+</td>
+<td>
+   <p>(Optional) TelemetryEnabled records general telemetry regarding Odigos usage.
+Default=false</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ignoredNamespaces</code> <B>[Required]</B>
+</td>
+<td>
+<code>[]string</code>
+</td>
+<td>
+   <p>(Optional) IgnoredNamespaces is a list of namespaces to not show in the Odigos UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ignoredContainers</code> <B>[Required]</B>
+</td>
+<td>
+<code>[]string</code>
+</td>
+<td>
+   <p>(Optional) IgnoredContainers is a list of container names to exclude from instrumentation (useful for ignoring sidecars).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>profiles</code> <B>[Required]</B>
+</td>
+<td>
+<a href="https://pkg.go.dev/github.com/odigos-io/odigos/common#ProfileName"><code>[]common.ProfileName</code></a>
+</td>
+<td>
+   <p>(Optional) Profiles is a list of preset profiles with a specific configuration.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>skipWebhookIssuerCreation</code> <B>[Required]</B>
+</td>
+<td>
+<code>bool</code>
+</td>
+<td>
+   <p>(Optional) SkipWebhookIssuerCreation skips creating the Issuer and Certificate for the Instrumentor pod webhook if cert-manager is installed.
+Default=false</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>podSecurityPolicy</code> <B>[Required]</B>
+</td>
+<td>
+<code>bool</code>
+</td>
+<td>
+   <p>(Optional) PodSecurityPolicy allows Odigos pods to use a privileged pod security policy.
+Default=false</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imagePrefix</code> <B>[Required]</B>
+</td>
+<td>
+<code>string</code>
+</td>
+<td>
+   <p>(Optional) ImagePrefix is a prefix for all container images.
+This should only be used if you are pulling Odigos images from the non-default registry.
+Default: registry.odigos.io
+Default (OpenShift): registry.connect.redhat.com</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>mountMethod</code> <B>[Required]</B>
+</td>
+<td>
+<a href="https://pkg.go.dev/github.com/odigos-io/odigos/common#MountMethod"><code>common.MountMethod</code></a>
+</td>
+<td>
+   <p>(Optional) MountMethod optionally defines the mechanism for mounting Odigos files into instrumented pods.
+One of &quot;k8s-virtual-device&quot; (default) or &quot;k8s-host-path&quot;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>openshiftEnabled</code> <B>[Required]</B>
+</td>
+<td>
+<code>bool</code>
+</td>
+<td>
+   <p>(Optional) OpenShiftEnabled configures selinux on OpenShift nodes.
+DEPRECATED: OpenShift clusters are auto-detected and this API field will be removed in a future release.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `OdigosStatus` <a id="OdigosStatus"></a>
+    
+
+**Appears in:**
+
+- [Odigos](#Odigos)
+
+<p>OdigosStatus defines the observed state of Odigos</p>
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Type</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr>
+<td>
+<code>conditions</code> <B>[Required]</B>
+</td>
+<td>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#condition-v1-meta"><code>[]meta/v1.Condition</code></a>
+</td>
+<td>
+   <p>Conditions store the status conditions of the Odigos instances</p>
+</td>
+</tr>
+</tbody>
+</table>

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -95,7 +95,8 @@
           "group": "API Reference",
           "pages": [
             "api-reference/odigos.io.v1alpha1",
-            "api-reference/actions.odigos.io.v1alpha1"
+            "api-reference/actions.odigos.io.v1alpha1",
+            "api-reference/operator.odigos.io.v1alpha1"
           ]
         }
       ]

--- a/operator/api/v1alpha1/odigos_types.go
+++ b/operator/api/v1alpha1/odigos_types.go
@@ -24,22 +24,35 @@ import (
 
 // OdigosSpec defines the desired state of Odigos
 type OdigosSpec struct {
+	// OnPremToken is an optional enterprise token for Odigos Enterprise.
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="On-Prem Token"
+	// +operator-sdk:csv:customresourcedefinitions:order=1
+	OnPremToken string `json:"onPremToken,omitempty"`
+
+	// UIMode sets the UI mode (one-of: normal, readonly)
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="UI Mode"
+	// +operator-sdk:csv:customresourcedefinitions:order=2
+	UIMode common.UiMode `json:"uiMode,omitempty"`
+
 	// TelemetryEnabled records general telemetry regarding Odigos usage.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +operator-sdk:csv:customresourcedefinitions:order=2
 	TelemetryEnabled bool `json:"telemetryEnabled,omitempty"`
-
-	// OpenShiftEnabled configures selinux on OpenShift nodes.
-	// DEPRECATED: OpenShift clusters are auto-detected and this API field will be removed in a future release.
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OpenShift Enabled"
-	OpenShiftEnabled bool `json:"openshiftEnabled,omitempty"`
 
 	// IgnoredNamespaces is a list of namespaces to not show in the Odigos UI
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +operator-sdk:csv:customresourcedefinitions:order=2
 	IgnoredNamespaces []string `json:"ignoredNamespaces,omitempty"`
 
 	// IgnoredContainers is a list of container names to exclude from instrumentation (useful for sidecars)
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +operator-sdk:csv:customresourcedefinitions:order=2
 	IgnoredContainers []string `json:"ignoredContainers,omitempty"`
+
+	// Profiles is a list of preset profiles with a specific configuration.
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +operator-sdk:csv:customresourcedefinitions:order=3
+	Profiles []common.ProfileName `json:"profiles,omitempty"`
 
 	// SkipWebhookIssuerCreation skips creating the Issuer and Certificate for the Instrumentor pod webhook if cert-manager is installed.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
@@ -53,22 +66,15 @@ type OdigosSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	ImagePrefix string `json:"imagePrefix,omitempty"`
 
-	// Profiles is a list of preset profiles with a specific configuration.
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	Profiles []common.ProfileName `json:"profiles,omitempty"`
-
-	// UIMode sets the UI mode (one-of: normal, readonly)
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="UI Mode"
-	UIMode common.UiMode `json:"uiMode,omitempty"`
-
-	// OnPremToken is an optional enterprise token for Odigos Enterprise.
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="On-Prem Token"
-	OnPremToken string `json:"onPremToken,omitempty"`
-
 	// MountMethod defines the mechanism for mounting Odigos files into instrumented pods.
 	// Must be one of: (k8s-virtual-device, k8s-host-path)
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Mount Method"
 	MountMethod common.MountMethod `json:"mountMethod,omitempty"`
+
+	// OpenShiftEnabled configures selinux on OpenShift nodes.
+	// DEPRECATED: OpenShift clusters are auto-detected and this API field will be removed in a future release.
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OpenShift Enabled"
+	OpenShiftEnabled bool `json:"openshiftEnabled,omitempty"`
 }
 
 // OdigosStatus defines the observed state of Odigos

--- a/operator/api/v1alpha1/odigos_types.go
+++ b/operator/api/v1alpha1/odigos_types.go
@@ -25,36 +25,30 @@ import (
 // OdigosSpec defines the desired state of Odigos
 type OdigosSpec struct {
 	// OnPremToken is an optional enterprise token for Odigos Enterprise.
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="On-Prem Token"
-	// +operator-sdk:csv:customresourcedefinitions:order=1
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="On-Prem Token",order=1
 	OnPremToken string `json:"onPremToken,omitempty"`
 
 	// UIMode sets the UI mode to either "normal" (default) or "readonly".
 	// In "normal" mode the UI is fully interactive, allowing users to view and edit
 	// Odigos configuration and settings. In "readonly" mode, the UI can only be
 	// used to view current Odigos configuration and is not interactive.
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="UI Mode"
-	// +operator-sdk:csv:customresourcedefinitions:order=2
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="UI Mode",order=2
 	UIMode common.UiMode `json:"uiMode,omitempty"`
 
 	// TelemetryEnabled records general telemetry regarding Odigos usage.
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// +operator-sdk:csv:customresourcedefinitions:order=2
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=2
 	TelemetryEnabled bool `json:"telemetryEnabled,omitempty"`
 
 	// IgnoredNamespaces is an optional list of namespaces to not show in the Odigos UI.
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// +operator-sdk:csv:customresourcedefinitions:order=2
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=2
 	IgnoredNamespaces []string `json:"ignoredNamespaces,omitempty"`
 
 	// IgnoredContainers is an optional list of container names to exclude from instrumentation (useful for ignoring sidecars).
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// +operator-sdk:csv:customresourcedefinitions:order=2
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=2
 	IgnoredContainers []string `json:"ignoredContainers,omitempty"`
 
 	// Profiles is an optional list of preset profiles with a specific configuration.
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// +operator-sdk:csv:customresourcedefinitions:order=3
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=3
 	Profiles []common.ProfileName `json:"profiles,omitempty"`
 
 	// SkipWebhookIssuerCreation optionally skips creating the Issuer and Certificate for the Instrumentor pod webhook if cert-manager is installed.

--- a/operator/api/v1alpha1/odigos_types.go
+++ b/operator/api/v1alpha1/odigos_types.go
@@ -29,7 +29,10 @@ type OdigosSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:order=1
 	OnPremToken string `json:"onPremToken,omitempty"`
 
-	// UIMode sets the UI mode (one-of: normal, readonly)
+	// UIMode sets the UI mode to either "normal" (default) or "readonly".
+	// In "normal" mode the UI is fully interactive, allowing users to view and edit
+	// Odigos configuration and settings. In "readonly" mode, the UI can only be
+	// used to view current Odigos configuration and is not interactive.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="UI Mode"
 	// +operator-sdk:csv:customresourcedefinitions:order=2
 	UIMode common.UiMode `json:"uiMode,omitempty"`
@@ -39,35 +42,38 @@ type OdigosSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:order=2
 	TelemetryEnabled bool `json:"telemetryEnabled,omitempty"`
 
-	// IgnoredNamespaces is a list of namespaces to not show in the Odigos UI
+	// IgnoredNamespaces is an optional list of namespaces to not show in the Odigos UI.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +operator-sdk:csv:customresourcedefinitions:order=2
 	IgnoredNamespaces []string `json:"ignoredNamespaces,omitempty"`
 
-	// IgnoredContainers is a list of container names to exclude from instrumentation (useful for sidecars)
+	// IgnoredContainers is an optional list of container names to exclude from instrumentation (useful for ignoring sidecars).
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +operator-sdk:csv:customresourcedefinitions:order=2
 	IgnoredContainers []string `json:"ignoredContainers,omitempty"`
 
-	// Profiles is a list of preset profiles with a specific configuration.
+	// Profiles is an optional list of preset profiles with a specific configuration.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +operator-sdk:csv:customresourcedefinitions:order=3
 	Profiles []common.ProfileName `json:"profiles,omitempty"`
 
-	// SkipWebhookIssuerCreation skips creating the Issuer and Certificate for the Instrumentor pod webhook if cert-manager is installed.
+	// SkipWebhookIssuerCreation optionally skips creating the Issuer and Certificate for the Instrumentor pod webhook if cert-manager is installed.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	SkipWebhookIssuerCreation bool `json:"skipWebhookIssuerCreation,omitempty"`
 
-	// PodSecurityPolicy enables the pod security policy.
+	// PodSecurityPolicy optionally enables the pod security policy.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	PodSecurityPolicy bool `json:"podSecurityPolicy,omitempty"`
 
-	// ImagePrefix is the prefix for all container images. used when your cluster doesn't have access to docker hub
+	// ImagePrefix is an optional prefix for all container images.
+	// This should only be used if you are pulling Odigos images from the non-default registry.
+	// Default: registry.odigos.io
+	// Default (OpenShift): registry.connect.redhat.com
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	ImagePrefix string `json:"imagePrefix,omitempty"`
 
-	// MountMethod defines the mechanism for mounting Odigos files into instrumented pods.
-	// Must be one of: (k8s-virtual-device, k8s-host-path)
+	// MountMethod optionally defines the mechanism for mounting Odigos files into instrumented pods.
+	// One of "k8s-virtual-device" (default) or "k8s-host-path".
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Mount Method"
 	MountMethod common.MountMethod `json:"mountMethod,omitempty"`
 

--- a/operator/api/v1alpha1/odigos_types.go
+++ b/operator/api/v1alpha1/odigos_types.go
@@ -59,7 +59,7 @@ type OdigosSpec struct {
 
 	// UIMode sets the UI mode (one-of: normal, readonly)
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="UI Mode"
-	UIMode string `json:"uiMode,omitempty"`
+	UIMode common.UiMode `json:"uiMode,omitempty"`
 
 	// OnPremToken is an optional enterprise token for Odigos Enterprise.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="On-Prem Token"

--- a/operator/api/v1alpha1/odigos_types.go
+++ b/operator/api/v1alpha1/odigos_types.go
@@ -24,54 +24,58 @@ import (
 
 // OdigosSpec defines the desired state of Odigos
 type OdigosSpec struct {
-	// OnPremToken is an optional enterprise token for Odigos Enterprise.
+	// (Optional) OnPremToken is an enterprise token for Odigos Enterprise.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="On-Prem Token",order=1
 	OnPremToken string `json:"onPremToken,omitempty"`
 
-	// UIMode sets the UI mode to either "normal" (default) or "readonly".
+	// (Optional) UIMode sets the UI mode to either "normal" or "readonly".
 	// In "normal" mode the UI is fully interactive, allowing users to view and edit
 	// Odigos configuration and settings. In "readonly" mode, the UI can only be
 	// used to view current Odigos configuration and is not interactive.
+	// Default=normal
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="UI Mode",order=2
 	UIMode common.UiMode `json:"uiMode,omitempty"`
 
-	// TelemetryEnabled records general telemetry regarding Odigos usage.
+	// (Optional) TelemetryEnabled records general telemetry regarding Odigos usage.
+	// Default=false
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=2
 	TelemetryEnabled bool `json:"telemetryEnabled,omitempty"`
 
-	// IgnoredNamespaces is an optional list of namespaces to not show in the Odigos UI.
+	// (Optional) IgnoredNamespaces is a list of namespaces to not show in the Odigos UI.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=2
 	IgnoredNamespaces []string `json:"ignoredNamespaces,omitempty"`
 
-	// IgnoredContainers is an optional list of container names to exclude from instrumentation (useful for ignoring sidecars).
+	// (Optional) IgnoredContainers is a list of container names to exclude from instrumentation (useful for ignoring sidecars).
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=2
 	IgnoredContainers []string `json:"ignoredContainers,omitempty"`
 
-	// Profiles is an optional list of preset profiles with a specific configuration.
+	// (Optional) Profiles is a list of preset profiles with a specific configuration.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=3
 	Profiles []common.ProfileName `json:"profiles,omitempty"`
 
-	// SkipWebhookIssuerCreation optionally skips creating the Issuer and Certificate for the Instrumentor pod webhook if cert-manager is installed.
+	// (Optional) SkipWebhookIssuerCreation skips creating the Issuer and Certificate for the Instrumentor pod webhook if cert-manager is installed.
+	// Default=false
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	SkipWebhookIssuerCreation bool `json:"skipWebhookIssuerCreation,omitempty"`
 
-	// PodSecurityPolicy optionally enables the pod security policy.
+	// (Optional) PodSecurityPolicy allows Odigos pods to use a privileged pod security policy.
+	// Default=false
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	PodSecurityPolicy bool `json:"podSecurityPolicy,omitempty"`
 
-	// ImagePrefix is an optional prefix for all container images.
+	// (Optional) ImagePrefix is a prefix for all container images.
 	// This should only be used if you are pulling Odigos images from the non-default registry.
 	// Default: registry.odigos.io
 	// Default (OpenShift): registry.connect.redhat.com
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	ImagePrefix string `json:"imagePrefix,omitempty"`
 
-	// MountMethod optionally defines the mechanism for mounting Odigos files into instrumented pods.
+	// (Optional) MountMethod optionally defines the mechanism for mounting Odigos files into instrumented pods.
 	// One of "k8s-virtual-device" (default) or "k8s-host-path".
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Mount Method"
 	MountMethod common.MountMethod `json:"mountMethod,omitempty"`
 
-	// OpenShiftEnabled configures selinux on OpenShift nodes.
+	// (Optional) OpenShiftEnabled configures selinux on OpenShift nodes.
 	// DEPRECATED: OpenShift clusters are auto-detected and this API field will be removed in a future release.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OpenShift Enabled"
 	OpenShiftEnabled bool `json:"openshiftEnabled,omitempty"`

--- a/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
     capabilities: Basic Install
     categories: Logging & Tracing
     containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d
-    createdAt: "2025-04-15T18:49:24Z"
+    createdAt: "2025-04-15T18:56:30Z"
     description: Odigos enables automatic distributed tracing with OpenTelemetry and eBPF.
     features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "true"
@@ -44,18 +44,22 @@ spec:
         kind: Odigos
         name: odigos.operator.odigos.io
         specDescriptors:
-          - description: IgnoredContainers is a list of container names to exclude from instrumentation (useful for sidecars)
+          - description: IgnoredContainers is an optional list of container names to exclude from instrumentation (useful for ignoring sidecars).
             displayName: Ignored Containers
             path: ignoredContainers
-          - description: IgnoredNamespaces is a list of namespaces to not show in the Odigos UI
+          - description: IgnoredNamespaces is an optional list of namespaces to not show in the Odigos UI.
             displayName: Ignored Namespaces
             path: ignoredNamespaces
-          - description: ImagePrefix is the prefix for all container images. used when your cluster doesn't have access to docker hub
+          - description: |-
+              ImagePrefix is an optional prefix for all container images.
+              This should only be used if you are pulling Odigos images from the non-default registry.
+              Default: registry.odigos.io
+              Default (OpenShift): registry.connect.redhat.com
             displayName: Image Prefix
             path: imagePrefix
           - description: |-
-              MountMethod defines the mechanism for mounting Odigos files into instrumented pods.
-              Must be one of: (k8s-virtual-device, k8s-host-path)
+              MountMethod optionally defines the mechanism for mounting Odigos files into instrumented pods.
+              One of "k8s-virtual-device" (default) or "k8s-host-path".
             displayName: Mount Method
             path: mountMethod
           - description: OnPremToken is an optional enterprise token for Odigos Enterprise.
@@ -66,19 +70,23 @@ spec:
               DEPRECATED: OpenShift clusters are auto-detected and this API field will be removed in a future release.
             displayName: OpenShift Enabled
             path: openshiftEnabled
-          - description: PodSecurityPolicy enables the pod security policy.
+          - description: PodSecurityPolicy optionally enables the pod security policy.
             displayName: Pod Security Policy
             path: podSecurityPolicy
-          - description: Profiles is a list of preset profiles with a specific configuration.
+          - description: Profiles is an optional list of preset profiles with a specific configuration.
             displayName: Profiles
             path: profiles
-          - description: SkipWebhookIssuerCreation skips creating the Issuer and Certificate for the Instrumentor pod webhook if cert-manager is installed.
+          - description: SkipWebhookIssuerCreation optionally skips creating the Issuer and Certificate for the Instrumentor pod webhook if cert-manager is installed.
             displayName: Skip Webhook Issuer Creation
             path: skipWebhookIssuerCreation
           - description: TelemetryEnabled records general telemetry regarding Odigos usage.
             displayName: Telemetry Enabled
             path: telemetryEnabled
-          - description: 'UIMode sets the UI mode (one-of: normal, readonly)'
+          - description: |-
+              UIMode sets the UI mode to either "normal" (default) or "readonly".
+              In "normal" mode the UI is fully interactive, allowing users to view and edit
+              Odigos configuration and settings. In "readonly" mode, the UI can only be
+              used to view current Odigos configuration and is not interactive.
             displayName: UI Mode
             path: uiMode
         statusDescriptors:
@@ -533,28 +541,28 @@ spec:
     name: Odigos
     url: https://odigos.io
   relatedImages:
+    - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:f25a35e65a0706e616ab32b9a5bfb94206978c6767bb8beff20504cecd39bd62
+      name: collector
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:06dcf548aaeb4d32c1e8d30f1d0440c91f696d9f94807d983c366e3ee124310e
+      name: enterprise-odiglet
+    - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:4d213af27d432665bf72caffbafa33a7991cb627bad9c2d894c4f8931e14d27b
+      name: scheduler
+    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d
+      name: manager
     - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:3297a0997597a5dcced94e0efe12f218d6af40773e736305f8d0dfcd1ebf902e
       name: enterprise_instrumentor
     - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d
       name: odigos-certified-operator-ubi9-487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d-annotation
+    - image: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:51d62c00c2aa4515543830a88fc27d63e1970f885d9fc3f1da8711d53b9aa68d
+      name: autoscaler
+    - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:fc7afc383cd35657b899ecdd1ea3a9851fa4c6cf49c309a20356dd246453e281
+      name: frontend
     - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:54a4075fdd861c43b13f50861a4f82b7cb2f6146660b023ca4afa4e9e27bce02
       name: instrumentor
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:3297a0997597a5dcced94e0efe12f218d6af40773e736305f8d0dfcd1ebf902e
+      name: enterprise-instrumentor
     - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:40aaece592d75ebacc636153dfbf96452984100b563c31f773c88988182cefe0
       name: odiglet
     - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:06dcf548aaeb4d32c1e8d30f1d0440c91f696d9f94807d983c366e3ee124310e
-      name: enterprise-odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d
-      name: manager
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:06dcf548aaeb4d32c1e8d30f1d0440c91f696d9f94807d983c366e3ee124310e
       name: enterprise_odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:51d62c00c2aa4515543830a88fc27d63e1970f885d9fc3f1da8711d53b9aa68d
-      name: autoscaler
-    - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:f25a35e65a0706e616ab32b9a5bfb94206978c6767bb8beff20504cecd39bd62
-      name: collector
-    - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:fc7afc383cd35657b899ecdd1ea3a9851fa4c6cf49c309a20356dd246453e281
-      name: frontend
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:3297a0997597a5dcced94e0efe12f218d6af40773e736305f8d0dfcd1ebf902e
-      name: enterprise-instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:4d213af27d432665bf72caffbafa33a7991cb627bad9c2d894c4f8931e14d27b
-      name: scheduler
   version: 1.0.170

--- a/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
     capabilities: Basic Install
     categories: Logging & Tracing
     containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d
-    createdAt: "2025-04-11T15:32:16Z"
+    createdAt: "2025-04-15T18:45:11Z"
     description: Odigos enables automatic distributed tracing with OpenTelemetry and eBPF.
     features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "true"
@@ -533,28 +533,28 @@ spec:
     name: Odigos
     url: https://odigos.io
   relatedImages:
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:3297a0997597a5dcced94e0efe12f218d6af40773e736305f8d0dfcd1ebf902e
+      name: enterprise-instrumentor
+    - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:40aaece592d75ebacc636153dfbf96452984100b563c31f773c88988182cefe0
+      name: odiglet
     - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:06dcf548aaeb4d32c1e8d30f1d0440c91f696d9f94807d983c366e3ee124310e
       name: enterprise-odiglet
     - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:4d213af27d432665bf72caffbafa33a7991cb627bad9c2d894c4f8931e14d27b
       name: scheduler
     - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:3297a0997597a5dcced94e0efe12f218d6af40773e736305f8d0dfcd1ebf902e
       name: enterprise_instrumentor
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:06dcf548aaeb4d32c1e8d30f1d0440c91f696d9f94807d983c366e3ee124310e
+      name: enterprise_odiglet
     - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d
       name: odigos-certified-operator-ubi9-487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d-annotation
     - image: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:51d62c00c2aa4515543830a88fc27d63e1970f885d9fc3f1da8711d53b9aa68d
       name: autoscaler
-    - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:f25a35e65a0706e616ab32b9a5bfb94206978c6767bb8beff20504cecd39bd62
-      name: collector
     - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:fc7afc383cd35657b899ecdd1ea3a9851fa4c6cf49c309a20356dd246453e281
       name: frontend
     - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:54a4075fdd861c43b13f50861a4f82b7cb2f6146660b023ca4afa4e9e27bce02
       name: instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:3297a0997597a5dcced94e0efe12f218d6af40773e736305f8d0dfcd1ebf902e
-      name: enterprise-instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:40aaece592d75ebacc636153dfbf96452984100b563c31f773c88988182cefe0
-      name: odiglet
     - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d
       name: manager
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:06dcf548aaeb4d32c1e8d30f1d0440c91f696d9f94807d983c366e3ee124310e
-      name: enterprise_odiglet
+    - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:f25a35e65a0706e616ab32b9a5bfb94206978c6767bb8beff20504cecd39bd62
+      name: collector
   version: 1.0.170

--- a/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
     capabilities: Basic Install
     categories: Logging & Tracing
     containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d
-    createdAt: "2025-04-15T18:56:30Z"
+    createdAt: "2025-04-15T19:06:41Z"
     description: Odigos enables automatic distributed tracing with OpenTelemetry and eBPF.
     features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "true"
@@ -44,12 +44,28 @@ spec:
         kind: Odigos
         name: odigos.operator.odigos.io
         specDescriptors:
+          - description: OnPremToken is an optional enterprise token for Odigos Enterprise.
+            displayName: On-Prem Token
+            path: onPremToken
           - description: IgnoredContainers is an optional list of container names to exclude from instrumentation (useful for ignoring sidecars).
             displayName: Ignored Containers
             path: ignoredContainers
           - description: IgnoredNamespaces is an optional list of namespaces to not show in the Odigos UI.
             displayName: Ignored Namespaces
             path: ignoredNamespaces
+          - description: TelemetryEnabled records general telemetry regarding Odigos usage.
+            displayName: Telemetry Enabled
+            path: telemetryEnabled
+          - description: |-
+              UIMode sets the UI mode to either "normal" (default) or "readonly".
+              In "normal" mode the UI is fully interactive, allowing users to view and edit
+              Odigos configuration and settings. In "readonly" mode, the UI can only be
+              used to view current Odigos configuration and is not interactive.
+            displayName: UI Mode
+            path: uiMode
+          - description: Profiles is an optional list of preset profiles with a specific configuration.
+            displayName: Profiles
+            path: profiles
           - description: |-
               ImagePrefix is an optional prefix for all container images.
               This should only be used if you are pulling Odigos images from the non-default registry.
@@ -62,9 +78,6 @@ spec:
               One of "k8s-virtual-device" (default) or "k8s-host-path".
             displayName: Mount Method
             path: mountMethod
-          - description: OnPremToken is an optional enterprise token for Odigos Enterprise.
-            displayName: On-Prem Token
-            path: onPremToken
           - description: |-
               OpenShiftEnabled configures selinux on OpenShift nodes.
               DEPRECATED: OpenShift clusters are auto-detected and this API field will be removed in a future release.
@@ -73,22 +86,9 @@ spec:
           - description: PodSecurityPolicy optionally enables the pod security policy.
             displayName: Pod Security Policy
             path: podSecurityPolicy
-          - description: Profiles is an optional list of preset profiles with a specific configuration.
-            displayName: Profiles
-            path: profiles
           - description: SkipWebhookIssuerCreation optionally skips creating the Issuer and Certificate for the Instrumentor pod webhook if cert-manager is installed.
             displayName: Skip Webhook Issuer Creation
             path: skipWebhookIssuerCreation
-          - description: TelemetryEnabled records general telemetry regarding Odigos usage.
-            displayName: Telemetry Enabled
-            path: telemetryEnabled
-          - description: |-
-              UIMode sets the UI mode to either "normal" (default) or "readonly".
-              In "normal" mode the UI is fully interactive, allowing users to view and edit
-              Odigos configuration and settings. In "readonly" mode, the UI can only be
-              used to view current Odigos configuration and is not interactive.
-            displayName: UI Mode
-            path: uiMode
         statusDescriptors:
           - description: Conditions store the status conditions of the Odigos instances
             displayName: Conditions
@@ -541,28 +541,28 @@ spec:
     name: Odigos
     url: https://odigos.io
   relatedImages:
-    - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:f25a35e65a0706e616ab32b9a5bfb94206978c6767bb8beff20504cecd39bd62
-      name: collector
     - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:06dcf548aaeb4d32c1e8d30f1d0440c91f696d9f94807d983c366e3ee124310e
       name: enterprise-odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:4d213af27d432665bf72caffbafa33a7991cb627bad9c2d894c4f8931e14d27b
-      name: scheduler
     - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d
       name: manager
     - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:3297a0997597a5dcced94e0efe12f218d6af40773e736305f8d0dfcd1ebf902e
       name: enterprise_instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d
-      name: odigos-certified-operator-ubi9-487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d-annotation
     - image: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:51d62c00c2aa4515543830a88fc27d63e1970f885d9fc3f1da8711d53b9aa68d
       name: autoscaler
+    - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:f25a35e65a0706e616ab32b9a5bfb94206978c6767bb8beff20504cecd39bd62
+      name: collector
     - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:fc7afc383cd35657b899ecdd1ea3a9851fa4c6cf49c309a20356dd246453e281
       name: frontend
-    - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:54a4075fdd861c43b13f50861a4f82b7cb2f6146660b023ca4afa4e9e27bce02
-      name: instrumentor
     - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:3297a0997597a5dcced94e0efe12f218d6af40773e736305f8d0dfcd1ebf902e
       name: enterprise-instrumentor
     - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:40aaece592d75ebacc636153dfbf96452984100b563c31f773c88988182cefe0
       name: odiglet
+    - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:4d213af27d432665bf72caffbafa33a7991cb627bad9c2d894c4f8931e14d27b
+      name: scheduler
     - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:06dcf548aaeb4d32c1e8d30f1d0440c91f696d9f94807d983c366e3ee124310e
       name: enterprise_odiglet
+    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d
+      name: odigos-certified-operator-ubi9-487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d-annotation
+    - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:54a4075fdd861c43b13f50861a4f82b7cb2f6146660b023ca4afa4e9e27bce02
+      name: instrumentor
   version: 1.0.170

--- a/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
     capabilities: Basic Install
     categories: Logging & Tracing
     containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d
-    createdAt: "2025-04-15T19:06:41Z"
+    createdAt: "2025-04-16T14:22:10Z"
     description: Odigos enables automatic distributed tracing with OpenTelemetry and eBPF.
     features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "true"
@@ -44,49 +44,56 @@ spec:
         kind: Odigos
         name: odigos.operator.odigos.io
         specDescriptors:
-          - description: OnPremToken is an optional enterprise token for Odigos Enterprise.
+          - description: (Optional) OnPremToken is an enterprise token for Odigos Enterprise.
             displayName: On-Prem Token
             path: onPremToken
-          - description: IgnoredContainers is an optional list of container names to exclude from instrumentation (useful for ignoring sidecars).
+          - description: (Optional) IgnoredContainers is a list of container names to exclude from instrumentation (useful for ignoring sidecars).
             displayName: Ignored Containers
             path: ignoredContainers
-          - description: IgnoredNamespaces is an optional list of namespaces to not show in the Odigos UI.
+          - description: (Optional) IgnoredNamespaces is a list of namespaces to not show in the Odigos UI.
             displayName: Ignored Namespaces
             path: ignoredNamespaces
-          - description: TelemetryEnabled records general telemetry regarding Odigos usage.
+          - description: |-
+              (Optional) TelemetryEnabled records general telemetry regarding Odigos usage.
+              Default=false
             displayName: Telemetry Enabled
             path: telemetryEnabled
           - description: |-
-              UIMode sets the UI mode to either "normal" (default) or "readonly".
+              (Optional) UIMode sets the UI mode to either "normal" or "readonly".
               In "normal" mode the UI is fully interactive, allowing users to view and edit
               Odigos configuration and settings. In "readonly" mode, the UI can only be
               used to view current Odigos configuration and is not interactive.
+              Default=normal
             displayName: UI Mode
             path: uiMode
-          - description: Profiles is an optional list of preset profiles with a specific configuration.
+          - description: (Optional) Profiles is a list of preset profiles with a specific configuration.
             displayName: Profiles
             path: profiles
           - description: |-
-              ImagePrefix is an optional prefix for all container images.
+              (Optional) ImagePrefix is a prefix for all container images.
               This should only be used if you are pulling Odigos images from the non-default registry.
               Default: registry.odigos.io
               Default (OpenShift): registry.connect.redhat.com
             displayName: Image Prefix
             path: imagePrefix
           - description: |-
-              MountMethod optionally defines the mechanism for mounting Odigos files into instrumented pods.
+              (Optional) MountMethod optionally defines the mechanism for mounting Odigos files into instrumented pods.
               One of "k8s-virtual-device" (default) or "k8s-host-path".
             displayName: Mount Method
             path: mountMethod
           - description: |-
-              OpenShiftEnabled configures selinux on OpenShift nodes.
+              (Optional) OpenShiftEnabled configures selinux on OpenShift nodes.
               DEPRECATED: OpenShift clusters are auto-detected and this API field will be removed in a future release.
             displayName: OpenShift Enabled
             path: openshiftEnabled
-          - description: PodSecurityPolicy optionally enables the pod security policy.
+          - description: |-
+              (Optional) PodSecurityPolicy allows Odigos pods to use a privileged pod security policy.
+              Default=false
             displayName: Pod Security Policy
             path: podSecurityPolicy
-          - description: SkipWebhookIssuerCreation optionally skips creating the Issuer and Certificate for the Instrumentor pod webhook if cert-manager is installed.
+          - description: |-
+              (Optional) SkipWebhookIssuerCreation skips creating the Issuer and Certificate for the Instrumentor pod webhook if cert-manager is installed.
+              Default=false
             displayName: Skip Webhook Issuer Creation
             path: skipWebhookIssuerCreation
         statusDescriptors:
@@ -541,28 +548,28 @@ spec:
     name: Odigos
     url: https://odigos.io
   relatedImages:
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:06dcf548aaeb4d32c1e8d30f1d0440c91f696d9f94807d983c366e3ee124310e
-      name: enterprise-odiglet
     - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d
-      name: manager
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:3297a0997597a5dcced94e0efe12f218d6af40773e736305f8d0dfcd1ebf902e
-      name: enterprise_instrumentor
+      name: odigos-certified-operator-ubi9-487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d-annotation
     - image: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:51d62c00c2aa4515543830a88fc27d63e1970f885d9fc3f1da8711d53b9aa68d
       name: autoscaler
-    - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:f25a35e65a0706e616ab32b9a5bfb94206978c6767bb8beff20504cecd39bd62
-      name: collector
-    - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:fc7afc383cd35657b899ecdd1ea3a9851fa4c6cf49c309a20356dd246453e281
-      name: frontend
+    - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:54a4075fdd861c43b13f50861a4f82b7cb2f6146660b023ca4afa4e9e27bce02
+      name: instrumentor
     - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:3297a0997597a5dcced94e0efe12f218d6af40773e736305f8d0dfcd1ebf902e
       name: enterprise-instrumentor
     - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:40aaece592d75ebacc636153dfbf96452984100b563c31f773c88988182cefe0
       name: odiglet
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:06dcf548aaeb4d32c1e8d30f1d0440c91f696d9f94807d983c366e3ee124310e
+      name: enterprise-odiglet
     - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:4d213af27d432665bf72caffbafa33a7991cb627bad9c2d894c4f8931e14d27b
       name: scheduler
+    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d
+      name: manager
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:3297a0997597a5dcced94e0efe12f218d6af40773e736305f8d0dfcd1ebf902e
+      name: enterprise_instrumentor
+    - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:f25a35e65a0706e616ab32b9a5bfb94206978c6767bb8beff20504cecd39bd62
+      name: collector
+    - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:fc7afc383cd35657b899ecdd1ea3a9851fa4c6cf49c309a20356dd246453e281
+      name: frontend
     - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:06dcf548aaeb4d32c1e8d30f1d0440c91f696d9f94807d983c366e3ee124310e
       name: enterprise_odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d
-      name: odigos-certified-operator-ubi9-487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d-annotation
-    - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:54a4075fdd861c43b13f50861a4f82b7cb2f6146660b023ca4afa4e9e27bce02
-      name: instrumentor
   version: 1.0.170

--- a/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
     capabilities: Basic Install
     categories: Logging & Tracing
     containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d
-    createdAt: "2025-04-15T18:45:11Z"
+    createdAt: "2025-04-15T18:49:24Z"
     description: Odigos enables automatic distributed tracing with OpenTelemetry and eBPF.
     features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "true"
@@ -534,27 +534,27 @@ spec:
     url: https://odigos.io
   relatedImages:
     - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:3297a0997597a5dcced94e0efe12f218d6af40773e736305f8d0dfcd1ebf902e
-      name: enterprise-instrumentor
+      name: enterprise_instrumentor
+    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d
+      name: odigos-certified-operator-ubi9-487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d-annotation
+    - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:54a4075fdd861c43b13f50861a4f82b7cb2f6146660b023ca4afa4e9e27bce02
+      name: instrumentor
     - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:40aaece592d75ebacc636153dfbf96452984100b563c31f773c88988182cefe0
       name: odiglet
     - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:06dcf548aaeb4d32c1e8d30f1d0440c91f696d9f94807d983c366e3ee124310e
       name: enterprise-odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:4d213af27d432665bf72caffbafa33a7991cb627bad9c2d894c4f8931e14d27b
-      name: scheduler
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:3297a0997597a5dcced94e0efe12f218d6af40773e736305f8d0dfcd1ebf902e
-      name: enterprise_instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:06dcf548aaeb4d32c1e8d30f1d0440c91f696d9f94807d983c366e3ee124310e
-      name: enterprise_odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d
-      name: odigos-certified-operator-ubi9-487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d-annotation
-    - image: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:51d62c00c2aa4515543830a88fc27d63e1970f885d9fc3f1da8711d53b9aa68d
-      name: autoscaler
-    - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:fc7afc383cd35657b899ecdd1ea3a9851fa4c6cf49c309a20356dd246453e281
-      name: frontend
-    - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:54a4075fdd861c43b13f50861a4f82b7cb2f6146660b023ca4afa4e9e27bce02
-      name: instrumentor
     - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d
       name: manager
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:06dcf548aaeb4d32c1e8d30f1d0440c91f696d9f94807d983c366e3ee124310e
+      name: enterprise_odiglet
+    - image: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:51d62c00c2aa4515543830a88fc27d63e1970f885d9fc3f1da8711d53b9aa68d
+      name: autoscaler
     - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:f25a35e65a0706e616ab32b9a5bfb94206978c6767bb8beff20504cecd39bd62
       name: collector
+    - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:fc7afc383cd35657b899ecdd1ea3a9851fa4c6cf49c309a20356dd246453e281
+      name: frontend
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:3297a0997597a5dcced94e0efe12f218d6af40773e736305f8d0dfcd1ebf902e
+      name: enterprise-instrumentor
+    - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:4d213af27d432665bf72caffbafa33a7991cb627bad9c2d894c4f8931e14d27b
+      name: scheduler
   version: 1.0.170

--- a/operator/bundle/manifests/operator.odigos.io_odigos.yaml
+++ b/operator/bundle/manifests/operator.odigos.io_odigos.yaml
@@ -40,25 +40,28 @@ spec:
             description: OdigosSpec defines the desired state of Odigos
             properties:
               ignoredContainers:
-                description: IgnoredContainers is a list of container names to exclude
-                  from instrumentation (useful for sidecars)
+                description: IgnoredContainers is an optional list of container names
+                  to exclude from instrumentation (useful for ignoring sidecars).
                 items:
                   type: string
                 type: array
               ignoredNamespaces:
-                description: IgnoredNamespaces is a list of namespaces to not show
-                  in the Odigos UI
+                description: IgnoredNamespaces is an optional list of namespaces to
+                  not show in the Odigos UI.
                 items:
                   type: string
                 type: array
               imagePrefix:
-                description: ImagePrefix is the prefix for all container images. used
-                  when your cluster doesn't have access to docker hub
+                description: |-
+                  ImagePrefix is an optional prefix for all container images.
+                  This should only be used if you are pulling Odigos images from the non-default registry.
+                  Default: registry.odigos.io
+                  Default (OpenShift): registry.connect.redhat.com
                 type: string
               mountMethod:
                 description: |-
-                  MountMethod defines the mechanism for mounting Odigos files into instrumented pods.
-                  Must be one of: (k8s-virtual-device, k8s-host-path)
+                  MountMethod optionally defines the mechanism for mounting Odigos files into instrumented pods.
+                  One of "k8s-virtual-device" (default) or "k8s-host-path".
                 enum:
                 - k8s-virtual-device
                 - k8s-host-path
@@ -73,25 +76,30 @@ spec:
                   DEPRECATED: OpenShift clusters are auto-detected and this API field will be removed in a future release.
                 type: boolean
               podSecurityPolicy:
-                description: PodSecurityPolicy enables the pod security policy.
+                description: PodSecurityPolicy optionally enables the pod security
+                  policy.
                 type: boolean
               profiles:
-                description: Profiles is a list of preset profiles with a specific
-                  configuration.
+                description: Profiles is an optional list of preset profiles with
+                  a specific configuration.
                 items:
                   type: string
                 type: array
               skipWebhookIssuerCreation:
-                description: SkipWebhookIssuerCreation skips creating the Issuer and
-                  Certificate for the Instrumentor pod webhook if cert-manager is
-                  installed.
+                description: SkipWebhookIssuerCreation optionally skips creating the
+                  Issuer and Certificate for the Instrumentor pod webhook if cert-manager
+                  is installed.
                 type: boolean
               telemetryEnabled:
                 description: TelemetryEnabled records general telemetry regarding
                   Odigos usage.
                 type: boolean
               uiMode:
-                description: 'UIMode sets the UI mode (one-of: normal, readonly)'
+                description: |-
+                  UIMode sets the UI mode to either "normal" (default) or "readonly".
+                  In "normal" mode the UI is fully interactive, allowing users to view and edit
+                  Odigos configuration and settings. In "readonly" mode, the UI can only be
+                  used to view current Odigos configuration and is not interactive.
                 enum:
                 - normal
                 - readonly

--- a/operator/bundle/manifests/operator.odigos.io_odigos.yaml
+++ b/operator/bundle/manifests/operator.odigos.io_odigos.yaml
@@ -60,8 +60,8 @@ spec:
                   MountMethod defines the mechanism for mounting Odigos files into instrumented pods.
                   Must be one of: (k8s-virtual-device, k8s-host-path)
                 enum:
-                - virtual-device
-                - host-path
+                - k8s-virtual-device
+                - k8s-host-path
                 type: string
               onPremToken:
                 description: OnPremToken is an optional enterprise token for Odigos
@@ -92,6 +92,9 @@ spec:
                 type: boolean
               uiMode:
                 description: 'UIMode sets the UI mode (one-of: normal, readonly)'
+                enum:
+                - normal
+                - readonly
                 type: string
             type: object
           status:

--- a/operator/bundle/manifests/operator.odigos.io_odigos.yaml
+++ b/operator/bundle/manifests/operator.odigos.io_odigos.yaml
@@ -40,66 +40,69 @@ spec:
             description: OdigosSpec defines the desired state of Odigos
             properties:
               ignoredContainers:
-                description: IgnoredContainers is an optional list of container names
+                description: (Optional) IgnoredContainers is a list of container names
                   to exclude from instrumentation (useful for ignoring sidecars).
                 items:
                   type: string
                 type: array
               ignoredNamespaces:
-                description: IgnoredNamespaces is an optional list of namespaces to
-                  not show in the Odigos UI.
+                description: (Optional) IgnoredNamespaces is a list of namespaces
+                  to not show in the Odigos UI.
                 items:
                   type: string
                 type: array
               imagePrefix:
                 description: |-
-                  ImagePrefix is an optional prefix for all container images.
+                  (Optional) ImagePrefix is a prefix for all container images.
                   This should only be used if you are pulling Odigos images from the non-default registry.
                   Default: registry.odigos.io
                   Default (OpenShift): registry.connect.redhat.com
                 type: string
               mountMethod:
                 description: |-
-                  MountMethod optionally defines the mechanism for mounting Odigos files into instrumented pods.
+                  (Optional) MountMethod optionally defines the mechanism for mounting Odigos files into instrumented pods.
                   One of "k8s-virtual-device" (default) or "k8s-host-path".
                 enum:
                 - k8s-virtual-device
                 - k8s-host-path
                 type: string
               onPremToken:
-                description: OnPremToken is an optional enterprise token for Odigos
+                description: (Optional) OnPremToken is an enterprise token for Odigos
                   Enterprise.
                 type: string
               openshiftEnabled:
                 description: |-
-                  OpenShiftEnabled configures selinux on OpenShift nodes.
+                  (Optional) OpenShiftEnabled configures selinux on OpenShift nodes.
                   DEPRECATED: OpenShift clusters are auto-detected and this API field will be removed in a future release.
                 type: boolean
               podSecurityPolicy:
-                description: PodSecurityPolicy optionally enables the pod security
-                  policy.
+                description: |-
+                  (Optional) PodSecurityPolicy allows Odigos pods to use a privileged pod security policy.
+                  Default=false
                 type: boolean
               profiles:
-                description: Profiles is an optional list of preset profiles with
+                description: (Optional) Profiles is a list of preset profiles with
                   a specific configuration.
                 items:
                   type: string
                 type: array
               skipWebhookIssuerCreation:
-                description: SkipWebhookIssuerCreation optionally skips creating the
-                  Issuer and Certificate for the Instrumentor pod webhook if cert-manager
-                  is installed.
+                description: |-
+                  (Optional) SkipWebhookIssuerCreation skips creating the Issuer and Certificate for the Instrumentor pod webhook if cert-manager is installed.
+                  Default=false
                 type: boolean
               telemetryEnabled:
-                description: TelemetryEnabled records general telemetry regarding
-                  Odigos usage.
+                description: |-
+                  (Optional) TelemetryEnabled records general telemetry regarding Odigos usage.
+                  Default=false
                 type: boolean
               uiMode:
                 description: |-
-                  UIMode sets the UI mode to either "normal" (default) or "readonly".
+                  (Optional) UIMode sets the UI mode to either "normal" or "readonly".
                   In "normal" mode the UI is fully interactive, allowing users to view and edit
                   Odigos configuration and settings. In "readonly" mode, the UI can only be
                   used to view current Odigos configuration and is not interactive.
+                  Default=normal
                 enum:
                 - normal
                 - readonly

--- a/operator/config/crd/bases/operator.odigos.io_odigos.yaml
+++ b/operator/config/crd/bases/operator.odigos.io_odigos.yaml
@@ -40,25 +40,28 @@ spec:
             description: OdigosSpec defines the desired state of Odigos
             properties:
               ignoredContainers:
-                description: IgnoredContainers is a list of container names to exclude
-                  from instrumentation (useful for sidecars)
+                description: IgnoredContainers is an optional list of container names
+                  to exclude from instrumentation (useful for ignoring sidecars).
                 items:
                   type: string
                 type: array
               ignoredNamespaces:
-                description: IgnoredNamespaces is a list of namespaces to not show
-                  in the Odigos UI
+                description: IgnoredNamespaces is an optional list of namespaces to
+                  not show in the Odigos UI.
                 items:
                   type: string
                 type: array
               imagePrefix:
-                description: ImagePrefix is the prefix for all container images. used
-                  when your cluster doesn't have access to docker hub
+                description: |-
+                  ImagePrefix is an optional prefix for all container images.
+                  This should only be used if you are pulling Odigos images from the non-default registry.
+                  Default: registry.odigos.io
+                  Default (OpenShift): registry.connect.redhat.com
                 type: string
               mountMethod:
                 description: |-
-                  MountMethod defines the mechanism for mounting Odigos files into instrumented pods.
-                  Must be one of: (k8s-virtual-device, k8s-host-path)
+                  MountMethod optionally defines the mechanism for mounting Odigos files into instrumented pods.
+                  One of "k8s-virtual-device" (default) or "k8s-host-path".
                 enum:
                 - k8s-virtual-device
                 - k8s-host-path
@@ -73,25 +76,30 @@ spec:
                   DEPRECATED: OpenShift clusters are auto-detected and this API field will be removed in a future release.
                 type: boolean
               podSecurityPolicy:
-                description: PodSecurityPolicy enables the pod security policy.
+                description: PodSecurityPolicy optionally enables the pod security
+                  policy.
                 type: boolean
               profiles:
-                description: Profiles is a list of preset profiles with a specific
-                  configuration.
+                description: Profiles is an optional list of preset profiles with
+                  a specific configuration.
                 items:
                   type: string
                 type: array
               skipWebhookIssuerCreation:
-                description: SkipWebhookIssuerCreation skips creating the Issuer and
-                  Certificate for the Instrumentor pod webhook if cert-manager is
-                  installed.
+                description: SkipWebhookIssuerCreation optionally skips creating the
+                  Issuer and Certificate for the Instrumentor pod webhook if cert-manager
+                  is installed.
                 type: boolean
               telemetryEnabled:
                 description: TelemetryEnabled records general telemetry regarding
                   Odigos usage.
                 type: boolean
               uiMode:
-                description: 'UIMode sets the UI mode (one-of: normal, readonly)'
+                description: |-
+                  UIMode sets the UI mode to either "normal" (default) or "readonly".
+                  In "normal" mode the UI is fully interactive, allowing users to view and edit
+                  Odigos configuration and settings. In "readonly" mode, the UI can only be
+                  used to view current Odigos configuration and is not interactive.
                 enum:
                 - normal
                 - readonly

--- a/operator/config/crd/bases/operator.odigos.io_odigos.yaml
+++ b/operator/config/crd/bases/operator.odigos.io_odigos.yaml
@@ -60,8 +60,8 @@ spec:
                   MountMethod defines the mechanism for mounting Odigos files into instrumented pods.
                   Must be one of: (k8s-virtual-device, k8s-host-path)
                 enum:
-                - virtual-device
-                - host-path
+                - k8s-virtual-device
+                - k8s-host-path
                 type: string
               onPremToken:
                 description: OnPremToken is an optional enterprise token for Odigos
@@ -92,6 +92,9 @@ spec:
                 type: boolean
               uiMode:
                 description: 'UIMode sets the UI mode (one-of: normal, readonly)'
+                enum:
+                - normal
+                - readonly
                 type: string
             type: object
           status:

--- a/operator/config/crd/bases/operator.odigos.io_odigos.yaml
+++ b/operator/config/crd/bases/operator.odigos.io_odigos.yaml
@@ -40,66 +40,69 @@ spec:
             description: OdigosSpec defines the desired state of Odigos
             properties:
               ignoredContainers:
-                description: IgnoredContainers is an optional list of container names
+                description: (Optional) IgnoredContainers is a list of container names
                   to exclude from instrumentation (useful for ignoring sidecars).
                 items:
                   type: string
                 type: array
               ignoredNamespaces:
-                description: IgnoredNamespaces is an optional list of namespaces to
-                  not show in the Odigos UI.
+                description: (Optional) IgnoredNamespaces is a list of namespaces
+                  to not show in the Odigos UI.
                 items:
                   type: string
                 type: array
               imagePrefix:
                 description: |-
-                  ImagePrefix is an optional prefix for all container images.
+                  (Optional) ImagePrefix is a prefix for all container images.
                   This should only be used if you are pulling Odigos images from the non-default registry.
                   Default: registry.odigos.io
                   Default (OpenShift): registry.connect.redhat.com
                 type: string
               mountMethod:
                 description: |-
-                  MountMethod optionally defines the mechanism for mounting Odigos files into instrumented pods.
+                  (Optional) MountMethod optionally defines the mechanism for mounting Odigos files into instrumented pods.
                   One of "k8s-virtual-device" (default) or "k8s-host-path".
                 enum:
                 - k8s-virtual-device
                 - k8s-host-path
                 type: string
               onPremToken:
-                description: OnPremToken is an optional enterprise token for Odigos
+                description: (Optional) OnPremToken is an enterprise token for Odigos
                   Enterprise.
                 type: string
               openshiftEnabled:
                 description: |-
-                  OpenShiftEnabled configures selinux on OpenShift nodes.
+                  (Optional) OpenShiftEnabled configures selinux on OpenShift nodes.
                   DEPRECATED: OpenShift clusters are auto-detected and this API field will be removed in a future release.
                 type: boolean
               podSecurityPolicy:
-                description: PodSecurityPolicy optionally enables the pod security
-                  policy.
+                description: |-
+                  (Optional) PodSecurityPolicy allows Odigos pods to use a privileged pod security policy.
+                  Default=false
                 type: boolean
               profiles:
-                description: Profiles is an optional list of preset profiles with
+                description: (Optional) Profiles is a list of preset profiles with
                   a specific configuration.
                 items:
                   type: string
                 type: array
               skipWebhookIssuerCreation:
-                description: SkipWebhookIssuerCreation optionally skips creating the
-                  Issuer and Certificate for the Instrumentor pod webhook if cert-manager
-                  is installed.
+                description: |-
+                  (Optional) SkipWebhookIssuerCreation skips creating the Issuer and Certificate for the Instrumentor pod webhook if cert-manager is installed.
+                  Default=false
                 type: boolean
               telemetryEnabled:
-                description: TelemetryEnabled records general telemetry regarding
-                  Odigos usage.
+                description: |-
+                  (Optional) TelemetryEnabled records general telemetry regarding Odigos usage.
+                  Default=false
                 type: boolean
               uiMode:
                 description: |-
-                  UIMode sets the UI mode to either "normal" (default) or "readonly".
+                  (Optional) UIMode sets the UI mode to either "normal" or "readonly".
                   In "normal" mode the UI is fully interactive, allowing users to view and edit
                   Odigos configuration and settings. In "readonly" mode, the UI can only be
                   used to view current Odigos configuration and is not interactive.
+                  Default=normal
                 enum:
                 - normal
                 - readonly

--- a/operator/config/manifests/bases/odigos-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/odigos-operator.clusterserviceversion.yaml
@@ -30,21 +30,24 @@ spec:
       kind: Odigos
       name: odigos.operator.odigos.io
       specDescriptors:
-      - description: IgnoredContainers is a list of container names to exclude from
-          instrumentation (useful for sidecars)
+      - description: IgnoredContainers is an optional list of container names to exclude
+          from instrumentation (useful for ignoring sidecars).
         displayName: Ignored Containers
         path: ignoredContainers
-      - description: IgnoredNamespaces is a list of namespaces to not show in the
-          Odigos UI
+      - description: IgnoredNamespaces is an optional list of namespaces to not show
+          in the Odigos UI.
         displayName: Ignored Namespaces
         path: ignoredNamespaces
-      - description: ImagePrefix is the prefix for all container images. used when
-          your cluster doesn't have access to docker hub
+      - description: |-
+          ImagePrefix is an optional prefix for all container images.
+          This should only be used if you are pulling Odigos images from the non-default registry.
+          Default: registry.odigos.io
+          Default (OpenShift): registry.connect.redhat.com
         displayName: Image Prefix
         path: imagePrefix
       - description: |-
-          MountMethod defines the mechanism for mounting Odigos files into instrumented pods.
-          Must be one of: (k8s-virtual-device, k8s-host-path)
+          MountMethod optionally defines the mechanism for mounting Odigos files into instrumented pods.
+          One of "k8s-virtual-device" (default) or "k8s-host-path".
         displayName: Mount Method
         path: mountMethod
       - description: OnPremToken is an optional enterprise token for Odigos Enterprise.
@@ -55,20 +58,25 @@ spec:
           DEPRECATED: OpenShift clusters are auto-detected and this API field will be removed in a future release.
         displayName: OpenShift Enabled
         path: openshiftEnabled
-      - description: PodSecurityPolicy enables the pod security policy.
+      - description: PodSecurityPolicy optionally enables the pod security policy.
         displayName: Pod Security Policy
         path: podSecurityPolicy
-      - description: Profiles is a list of preset profiles with a specific configuration.
+      - description: Profiles is an optional list of preset profiles with a specific
+          configuration.
         displayName: Profiles
         path: profiles
-      - description: SkipWebhookIssuerCreation skips creating the Issuer and Certificate
-          for the Instrumentor pod webhook if cert-manager is installed.
+      - description: SkipWebhookIssuerCreation optionally skips creating the Issuer
+          and Certificate for the Instrumentor pod webhook if cert-manager is installed.
         displayName: Skip Webhook Issuer Creation
         path: skipWebhookIssuerCreation
       - description: TelemetryEnabled records general telemetry regarding Odigos usage.
         displayName: Telemetry Enabled
         path: telemetryEnabled
-      - description: 'UIMode sets the UI mode (one-of: normal, readonly)'
+      - description: |-
+          UIMode sets the UI mode to either "normal" (default) or "readonly".
+          In "normal" mode the UI is fully interactive, allowing users to view and edit
+          Odigos configuration and settings. In "readonly" mode, the UI can only be
+          used to view current Odigos configuration and is not interactive.
         displayName: UI Mode
         path: uiMode
       statusDescriptors:

--- a/operator/config/manifests/bases/odigos-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/odigos-operator.clusterserviceversion.yaml
@@ -30,53 +30,59 @@ spec:
       kind: Odigos
       name: odigos.operator.odigos.io
       specDescriptors:
-      - description: OnPremToken is an optional enterprise token for Odigos Enterprise.
+      - description: (Optional) OnPremToken is an enterprise token for Odigos Enterprise.
         displayName: On-Prem Token
         path: onPremToken
-      - description: IgnoredContainers is an optional list of container names to exclude
-          from instrumentation (useful for ignoring sidecars).
+      - description: (Optional) IgnoredContainers is a list of container names to
+          exclude from instrumentation (useful for ignoring sidecars).
         displayName: Ignored Containers
         path: ignoredContainers
-      - description: IgnoredNamespaces is an optional list of namespaces to not show
+      - description: (Optional) IgnoredNamespaces is a list of namespaces to not show
           in the Odigos UI.
         displayName: Ignored Namespaces
         path: ignoredNamespaces
-      - description: TelemetryEnabled records general telemetry regarding Odigos usage.
+      - description: |-
+          (Optional) TelemetryEnabled records general telemetry regarding Odigos usage.
+          Default=false
         displayName: Telemetry Enabled
         path: telemetryEnabled
       - description: |-
-          UIMode sets the UI mode to either "normal" (default) or "readonly".
+          (Optional) UIMode sets the UI mode to either "normal" or "readonly".
           In "normal" mode the UI is fully interactive, allowing users to view and edit
           Odigos configuration and settings. In "readonly" mode, the UI can only be
           used to view current Odigos configuration and is not interactive.
+          Default=normal
         displayName: UI Mode
         path: uiMode
-      - description: Profiles is an optional list of preset profiles with a specific
+      - description: (Optional) Profiles is a list of preset profiles with a specific
           configuration.
         displayName: Profiles
         path: profiles
       - description: |-
-          ImagePrefix is an optional prefix for all container images.
+          (Optional) ImagePrefix is a prefix for all container images.
           This should only be used if you are pulling Odigos images from the non-default registry.
           Default: registry.odigos.io
           Default (OpenShift): registry.connect.redhat.com
         displayName: Image Prefix
         path: imagePrefix
       - description: |-
-          MountMethod optionally defines the mechanism for mounting Odigos files into instrumented pods.
+          (Optional) MountMethod optionally defines the mechanism for mounting Odigos files into instrumented pods.
           One of "k8s-virtual-device" (default) or "k8s-host-path".
         displayName: Mount Method
         path: mountMethod
       - description: |-
-          OpenShiftEnabled configures selinux on OpenShift nodes.
+          (Optional) OpenShiftEnabled configures selinux on OpenShift nodes.
           DEPRECATED: OpenShift clusters are auto-detected and this API field will be removed in a future release.
         displayName: OpenShift Enabled
         path: openshiftEnabled
-      - description: PodSecurityPolicy optionally enables the pod security policy.
+      - description: |-
+          (Optional) PodSecurityPolicy allows Odigos pods to use a privileged pod security policy.
+          Default=false
         displayName: Pod Security Policy
         path: podSecurityPolicy
-      - description: SkipWebhookIssuerCreation optionally skips creating the Issuer
-          and Certificate for the Instrumentor pod webhook if cert-manager is installed.
+      - description: |-
+          (Optional) SkipWebhookIssuerCreation skips creating the Issuer and Certificate for the Instrumentor pod webhook if cert-manager is installed.
+          Default=false
         displayName: Skip Webhook Issuer Creation
         path: skipWebhookIssuerCreation
       statusDescriptors:

--- a/operator/config/manifests/bases/odigos-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/odigos-operator.clusterserviceversion.yaml
@@ -30,6 +30,9 @@ spec:
       kind: Odigos
       name: odigos.operator.odigos.io
       specDescriptors:
+      - description: OnPremToken is an optional enterprise token for Odigos Enterprise.
+        displayName: On-Prem Token
+        path: onPremToken
       - description: IgnoredContainers is an optional list of container names to exclude
           from instrumentation (useful for ignoring sidecars).
         displayName: Ignored Containers
@@ -38,6 +41,20 @@ spec:
           in the Odigos UI.
         displayName: Ignored Namespaces
         path: ignoredNamespaces
+      - description: TelemetryEnabled records general telemetry regarding Odigos usage.
+        displayName: Telemetry Enabled
+        path: telemetryEnabled
+      - description: |-
+          UIMode sets the UI mode to either "normal" (default) or "readonly".
+          In "normal" mode the UI is fully interactive, allowing users to view and edit
+          Odigos configuration and settings. In "readonly" mode, the UI can only be
+          used to view current Odigos configuration and is not interactive.
+        displayName: UI Mode
+        path: uiMode
+      - description: Profiles is an optional list of preset profiles with a specific
+          configuration.
+        displayName: Profiles
+        path: profiles
       - description: |-
           ImagePrefix is an optional prefix for all container images.
           This should only be used if you are pulling Odigos images from the non-default registry.
@@ -50,9 +67,6 @@ spec:
           One of "k8s-virtual-device" (default) or "k8s-host-path".
         displayName: Mount Method
         path: mountMethod
-      - description: OnPremToken is an optional enterprise token for Odigos Enterprise.
-        displayName: On-Prem Token
-        path: onPremToken
       - description: |-
           OpenShiftEnabled configures selinux on OpenShift nodes.
           DEPRECATED: OpenShift clusters are auto-detected and this API field will be removed in a future release.
@@ -61,24 +75,10 @@ spec:
       - description: PodSecurityPolicy optionally enables the pod security policy.
         displayName: Pod Security Policy
         path: podSecurityPolicy
-      - description: Profiles is an optional list of preset profiles with a specific
-          configuration.
-        displayName: Profiles
-        path: profiles
       - description: SkipWebhookIssuerCreation optionally skips creating the Issuer
           and Certificate for the Instrumentor pod webhook if cert-manager is installed.
         displayName: Skip Webhook Issuer Creation
         path: skipWebhookIssuerCreation
-      - description: TelemetryEnabled records general telemetry regarding Odigos usage.
-        displayName: Telemetry Enabled
-        path: telemetryEnabled
-      - description: |-
-          UIMode sets the UI mode to either "normal" (default) or "readonly".
-          In "normal" mode the UI is fully interactive, allowing users to view and edit
-          Odigos configuration and settings. In "readonly" mode, the UI can only be
-          used to view current Odigos configuration and is not interactive.
-        displayName: UI Mode
-        path: uiMode
       statusDescriptors:
       - description: Conditions store the status conditions of the Odigos instances
         displayName: Conditions


### PR DESCRIPTION
## Description

This updates the Operator CRD fields to have clearer explanations of what they are for, which ones are optional, and what are the defaults.

This also changes the `UIMode` in the operator CR to use the UIMode type (instead of string), and adds an `enum` to the UIMode type for API validation.

The API fields are re-ordered to be presented in a general level of importance.

The Operator API is added to the main docs.odigos.io site

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [x] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
