### PR TITLE
feat: add items per seconds for debug destination

### DIFF
--- a/common/config/testdata/debugexporter.yaml
+++ b/common/config/testdata/debugexporter.yaml
@@ -12,6 +12,8 @@ receivers:
         endpoint: 0.0.0.0:4318
 exporters:
   debug/d1:
+    sampling_initial: 1
+    sampling_thereafter: 1
     verbosity: basic
 processors:
   memory_limiter: {}

--- a/tests/debug-exporter.yaml
+++ b/tests/debug-exporter.yaml
@@ -6,8 +6,11 @@ metadata:
 spec:
   data:
     VERBOSITY: detailed
+    # uncomment next line to only sample 1 item (batch to export) per second
+    # ITEMS_PER_SECOND: '1'
   destinationName: debug
   signals:
+  # comment the ones you don't want to 
   - TRACES
   - METRICS
   - LOGS


### PR DESCRIPTION
## Description

The debug destination currently logs all the telemetry items passing in the pipeline.
For production environments with a lot of data, this can overwhelmed the collector.

This PR adds an option to set lower volume for logging. for example one item per second, protecting us from flooding the logs.

## How Has This Been Tested?

- [x] Manual Testing

## Kubernetes Checklist

No

## User Facing Changes

New feature in exporter allowing users to debug issues in pipeline