### PR TITLE
fix: node collector resolve signals from cluster cg instead of destinations

### DIFF
--- a/autoscaler/controllers/nodecollector/daemonset.go
+++ b/autoscaler/controllers/nodecollector/daemonset.go
@@ -44,7 +44,7 @@ type DelayManager struct {
 }
 
 // RunSyncDaemonSetWithDelayAndSkipNewCalls runs the function with the specified delay and skips new calls until the function execution is finished
-func (dm *DelayManager) RunSyncDaemonSetWithDelayAndSkipNewCalls(delay time.Duration, retries int, dests *odigosv1.DestinationList,
+func (dm *DelayManager) RunSyncDaemonSetWithDelayAndSkipNewCalls(delay time.Duration, retries int,
 	collection *odigosv1.CollectorsGroup, ctx context.Context, c client.Client, scheme *runtime.Scheme, secrets []string, version string) {
 	dm.mu.Lock()
 	defer dm.mu.Unlock()
@@ -74,7 +74,7 @@ func (dm *DelayManager) RunSyncDaemonSetWithDelayAndSkipNewCalls(delay time.Dura
 		}()
 
 		for i := 0; i < retries; i++ {
-			_, err = syncDaemonSet(ctx, dests, collection, c, scheme, secrets, version)
+			_, err = syncDaemonSet(ctx, collection, c, scheme, secrets, version)
 			if err == nil {
 				return
 			}
@@ -88,7 +88,7 @@ func (dm *DelayManager) finishProgress() {
 	dm.inProgress = false
 }
 
-func syncDaemonSet(ctx context.Context, dests *odigosv1.DestinationList, datacollection *odigosv1.CollectorsGroup,
+func syncDaemonSet(ctx context.Context, datacollection *odigosv1.CollectorsGroup,
 	c client.Client, scheme *runtime.Scheme, imagePullSecrets []string, odigosVersion string) (*appsv1.DaemonSet, error) {
 	logger := log.FromContext(ctx)
 

--- a/autoscaler/controllers/nodecollector/manager.go
+++ b/autoscaler/controllers/nodecollector/manager.go
@@ -7,8 +7,57 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
+
+type receiverSignalsChangedPredicate struct {
+}
+
+func (o receiverSignalsChangedPredicate) Create(e event.CreateEvent) bool {
+	if e.Object == nil {
+		return false
+	}
+
+	return true
+}
+
+func (i receiverSignalsChangedPredicate) Update(e event.UpdateEvent) bool {
+	if e.ObjectNew == nil || e.ObjectOld == nil {
+		return false
+	}
+
+	oldCollectorGroup, ok := e.ObjectOld.(*odigosv1.CollectorsGroup)
+	if !ok {
+		return false
+	}
+	newCollectorGroup, ok := e.ObjectNew.(*odigosv1.CollectorsGroup)
+	if !ok {
+		return false
+	}
+
+	// check if the receiver signals array has changed (len or content)
+	if len(oldCollectorGroup.Status.ReceiverSignals) != len(newCollectorGroup.Status.ReceiverSignals) {
+		return true
+	}
+	for i := 0; i < len(oldCollectorGroup.Status.ReceiverSignals); i++ {
+		if oldCollectorGroup.Status.ReceiverSignals[i] != newCollectorGroup.Status.ReceiverSignals[i] {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (i receiverSignalsChangedPredicate) Delete(e event.DeleteEvent) bool {
+	return false
+}
+
+func (i receiverSignalsChangedPredicate) Generic(e event.GenericEvent) bool {
+	return false
+}
+
+var _ predicate.Predicate = &receiverSignalsChangedPredicate{}
 
 func SetupWithManager(mgr ctrl.Manager, imagePullSecrets []string, odigosVersion string) error {
 	err := builder.
@@ -19,7 +68,11 @@ func SetupWithManager(mgr ctrl.Manager, imagePullSecrets []string, odigosVersion
 		Owns(&corev1.ConfigMap{}). // in case the configmap of the node-collector is deleted or modified for any reason, this will reconcile and recreate it
 		// we assume everything in the collectorsgroup spec is the configuration for the collectors to generate.
 		// thus, we need to monitor any change to the spec which is what the generation field is for.
-		WithEventFilter(predicate.And(&odigospredicate.OdigosCollectorsGroupNodePredicate, &predicate.GenerationChangedPredicate{})).
+		WithEventFilter(
+			predicate.Or(
+				predicate.And(&odigospredicate.OdigosCollectorsGroupNodePredicate, &predicate.GenerationChangedPredicate{}),
+				predicate.And(&odigospredicate.OdigosCollectorsGroupClusterPredicate, &receiverSignalsChangedPredicate{}),
+			)).
 		Complete(&CollectorsGroupReconciler{
 			Client:           mgr.GetClient(),
 			Scheme:           mgr.GetScheme(),


### PR DESCRIPTION

## Description

When auto scaler reconciled node collector configmap and daemonset, it would use destinations for that.

Fixed:

- Destinations reconciler was not triggering the node reconciler, which caused the cm not to update when a new destination is created that should enable a new signal to be collected.
- exceptions for "span-to-metrics" were calculated from dest which might not be in sync with actual pipeline (this was the case in victoria metrics)
- remove unused parameter `dest` in sync daemonset function.

## How Has This Been Tested?

- [x] Manual Testing

## Kubernetes Checklist

Added another event filter for the collectors group reconciler which should not have any meaningful overhead.

## User Facing Changes

Fix bug - if there is a tracing destination and one adds a logging destination, it would apply the `filelog` receiver immediately. due to current bug, users restart autoscaler as a workaround due to this bug
