### PR TITLE
refactor: resolve service name in controller instead of webhook

### DIFF
--- a/instrumentor/controllers/agentenabled/pods_webhook.go
+++ b/instrumentor/controllers/agentenabled/pods_webhook.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/go-logr/logr"
 	"github.com/odigos-io/odigos/api/k8sconsts"
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/common"
@@ -16,7 +15,6 @@ import (
 	podutils "github.com/odigos-io/odigos/instrumentor/internal/pod"
 	webhookenvinjector "github.com/odigos-io/odigos/instrumentor/internal/webhook_env_injector"
 	"github.com/odigos-io/odigos/instrumentor/sdks"
-	sourceutils "github.com/odigos-io/odigos/k8sutils/pkg/source"
 	k8sutils "github.com/odigos-io/odigos/k8sutils/pkg/utils"
 	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
 	corev1 "k8s.io/api/core/v1"
@@ -83,8 +81,8 @@ func (p *PodsWebhook) Default(ctx context.Context, obj runtime.Object) error {
 	}
 
 	// this is temporary and should be refactored so the service name and other resource attributes are written to agent config
-	serviceName := p.getServiceNameForEnv(ctx, logger, pw)
-	if serviceName == nil || *serviceName == "" {
+	serviceName := ic.Spec.ServiceName
+	if serviceName == "" {
 		logger.Error(errors.New("failed to get service name for pod"), "Skipping Injection of ODIGOS agent")
 		return nil
 	}
@@ -106,7 +104,7 @@ func (p *PodsWebhook) Default(ctx context.Context, obj runtime.Object) error {
 			continue
 		}
 
-		containerVolumeMounted, err := p.injectOdigosToContainer(containerConfig, podContainerSpec, *pw, *serviceName, *odigosConfig.MountMethod)
+		containerVolumeMounted, err := p.injectOdigosToContainer(containerConfig, podContainerSpec, *pw, serviceName, *odigosConfig.MountMethod)
 		if err != nil {
 			logger.Error(err, "failed to inject ODIGOS agent to container")
 			continue
@@ -229,7 +227,7 @@ func (p *PodsWebhook) injectOdigosToContainer(containerConfig *odigosv1.Containe
 			}
 		}
 		if distroMetadata.RuntimeAgent.K8sAttrsViaEnvVars {
-			podswebhook.InjectOtelResourceAndServerNameEnvVars(existingEnvNames, podContainerSpec, distroName, pw, serviceName)
+			podswebhook.InjectOtelResourceAndServiceNameEnvVars(existingEnvNames, podContainerSpec, distroName, pw, serviceName)
 		}
 		// TODO: once we have a flag to enable/disable device injection, we should check it here.
 		if distroMetadata.RuntimeAgent.Device != nil {
@@ -259,28 +257,6 @@ func (p *PodsWebhook) injectOdigosToContainer(containerConfig *odigosv1.Containe
 	}
 
 	return volumeMounted, nil
-}
-
-// checks for the service name on the annotation, or fallback to the workload name
-func (p *PodsWebhook) getServiceNameForEnv(ctx context.Context, logger logr.Logger, podWorkload *k8sconsts.PodWorkload) *string {
-	workloadObj := workload.ClientObjectFromWorkloadKind(podWorkload.Kind)
-	err := p.Client.Get(ctx, client.ObjectKey{Namespace: podWorkload.Namespace, Name: podWorkload.Name}, workloadObj)
-	if err != nil {
-		logger.Error(err, "failed to get workload object from cache. cannot check for workload source. using workload name as OTEL_SERVICE_NAME")
-		return &podWorkload.Name
-	}
-
-	resolvedServiceName, err := sourceutils.OtelServiceNameBySource(ctx, p.Client, workloadObj)
-	if err != nil {
-		logger.Error(err, "failed to get OTel service name from source. using workload name as OTEL_SERVICE_NAME")
-		return &podWorkload.Name
-	}
-
-	if resolvedServiceName == "" {
-		resolvedServiceName = podWorkload.Name
-	}
-
-	return &resolvedServiceName
 }
 
 func getRelevantOtelSDKs(ctx context.Context, kubeClient client.Client, podWorkload k8sconsts.PodWorkload) (map[common.ProgrammingLanguage]common.OtelSdk, error) {

--- a/instrumentor/controllers/agentenabled/podswebhook/otelresource.go
+++ b/instrumentor/controllers/agentenabled/podswebhook/otelresource.go
@@ -60,7 +60,7 @@ func getResourceAttributesEnvVarValue(ra []resourceAttribute) string {
 	return strings.Join(attrs, ",")
 }
 
-func InjectOtelResourceAndServerNameEnvVars(existingEnvNames EnvVarNamesMap, container *corev1.Container, distroName string, pw k8sconsts.PodWorkload, serviceName string) EnvVarNamesMap {
+func InjectOtelResourceAndServiceNameEnvVars(existingEnvNames EnvVarNamesMap, container *corev1.Container, distroName string, pw k8sconsts.PodWorkload, serviceName string) EnvVarNamesMap {
 
 	// OTEL_SERVICE_NAME
 	existingEnvNames = injectEnvVarToPodContainer(existingEnvNames, container, otelServiceNameEnvVarName, serviceName)

--- a/instrumentor/controllers/instrumentationconfig/source_controller.go
+++ b/instrumentor/controllers/instrumentationconfig/source_controller.go
@@ -45,8 +45,14 @@ func (r *SourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 
-	if instConfig.Spec.ServiceName != source.Spec.OtelServiceName {
-		instConfig.Spec.ServiceName = source.Spec.OtelServiceName
+	currentServiceName := source.Spec.OtelServiceName
+	if currentServiceName == "" {
+		// if the user did not override the service name, we should use the name of the workload
+		currentServiceName = source.Spec.Workload.Name
+	}
+
+	if instConfig.Spec.ServiceName != currentServiceName {
+		instConfig.Spec.ServiceName = currentServiceName
 		logger.Info("Updating InstrumentationConfig service name", "instrumentationConfig", instConfigName, "namespace", req.Namespace, "serviceName", source.Spec.OtelServiceName)
 		err = r.Update(ctx, instConfig)
 		return utils.K8SUpdateErrorHandler(err)

--- a/instrumentor/controllers/sourceinstrumentation/common.go
+++ b/instrumentor/controllers/sourceinstrumentation/common.go
@@ -154,10 +154,7 @@ func createInstrumentationConfigForWorkload(ctx context.Context, k8sClient clien
 	if err != nil {
 		return nil, err
 	}
-
-	if serviceName != "" {
-		instConfig.Spec.ServiceName = serviceName
-	}
+	instConfig.Spec.ServiceName = serviceName
 
 	if err := ctrl.SetControllerReference(obj, &instConfig, scheme); err != nil {
 		logger.Error(err, "Failed to set controller reference", "name", instConfigName, "namespace", namespace)

--- a/tests/e2e/workload-lifecycle/02-assert-ic-service-names.yaml
+++ b/tests/e2e/workload-lifecycle/02-assert-ic-service-names.yaml
@@ -1,0 +1,143 @@
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-nodejs-minimum-version
+  namespace: default
+spec:
+  serviceName: nodejs-minimum-version-reported
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-nodejs-latest-version
+  namespace: default
+spec:
+  serviceName: nodejs-latest-version-reported
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-nodejs-dockerfile-env
+  namespace: default
+spec:
+  serviceName: nodejs-dockerfile-env-reported
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-nodejs-manifest-env
+  namespace: default
+spec:
+  serviceName: nodejs-manifest-env-reported
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-java-supported-version
+  namespace: default
+spec:
+  serviceName: java-supported-version-reported
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-java-azul
+  namespace: default
+spec:
+  serviceName: java-azul-reported
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-java-supported-docker-env
+  namespace: default
+spec:
+  serviceName: java-supported-docker-env-reported
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-java-supported-manifest-env
+  namespace: default
+spec:
+  serviceName: java-supported-manifest-env-reported
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-java-latest-version
+  namespace: default
+spec:
+  serviceName: java-latest-version-reported
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-java-old-version
+  namespace: default
+spec:
+  serviceName: java-old-version-reported
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-python-latest-version
+  namespace: default
+spec:
+  serviceName: python-latest-version-reported
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-python-alpine
+  namespace: default
+spec:
+  serviceName: python-alpine-reported
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-python-not-supported
+  namespace: default
+spec:
+  serviceName: python-not-supported-reported
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-python-min-version
+  namespace: default
+spec:
+  serviceName: python-min-version-reported
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-dotnet8-glibc
+  namespace: default
+spec:
+  serviceName: dotnet8-glibc-reported
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-dotnet8-musl
+  namespace: default
+spec:
+  serviceName: dotnet8-musl-reported
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-dotnet6-glibc
+  namespace: default
+spec:
+  serviceName: dotnet6-glibc-reported
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-dotnet6-musl
+  namespace: default
+spec:
+  serviceName: dotnet6-musl-reported

--- a/tests/e2e/workload-lifecycle/chainsaw-test.yaml
+++ b/tests/e2e/workload-lifecycle/chainsaw-test.yaml
@@ -125,6 +125,9 @@ spec:
       try:
         - apply:
             file: 02-sources-reported-names.yaml
+        - assert:
+            timeout: 1m
+            file: 02-assert-ic-service-names.yaml
         - script:
             content: kubectl rollout restart deployment -l odigos.io/e2e=test-workload
 


### PR DESCRIPTION
## Description

How we calculate the service name to use for each config?

- if the user set this in workload source object - use it
- otherwise - use the workload name as default ("coupon", "membership", etc)

This PR moves this logic from the pods webhooik to the reconcilers, insuring that the right value is always updated in the existing field and is never empty.

Then we can set it only once, and don't need to resolve it downstream in multiple consumers.

## How Has This Been Tested?

- [x] Manual Testing

## Kubernetes Checklist

Reduce work in webhook, and do it only few times in controller instead of again and again for each pod.
This removes a `Get` request to the cache during webhook which is a good improvement 🎉

## User Facing Changes

Internal refactor