### PR TITLE
fix: handle update error on agent enable controller

### DIFF
--- a/instrumentor/controllers/agentenabled/sync.go
+++ b/instrumentor/controllers/agentenabled/sync.go
@@ -2,7 +2,6 @@ package agentenabled
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/hashicorp/go-version"
@@ -105,7 +104,10 @@ func reconcileWorkload(ctx context.Context, c client.Client, icName string, name
 
 	if rolloutChanged || agentEnabledChanged {
 		updateErr := c.Status().Update(ctx, &ic)
-		err = errors.Join(err, updateErr)
+		if updateErr != nil {
+			// if the update fails, we should not return an error, but rather log it and retry later.
+			return utils.K8SUpdateErrorHandler(updateErr)
+		}
 	}
 
 	return res, err


### PR DESCRIPTION
## Description

Get rid of errors in instruomentor logs that looks like:

```
2025-04-18T13:45:52Z    ERROR    Reconciler error    {"controller": "agentenabled-instrumentationconfig", "controllerGroup": "odigos.io", "controllerKind": "InstrumentationConfig", "InstrumentationConfig": {"name":"deployment-demo-php","namespace":"demo-php"}, "namespace": "demo-php", "name": "deployment-demo-php", "reconcileID": "93ec2c15-8c72-4e32-896d-60ba0a5d3241", "error": "Operation cannot be fulfilled on instrumentationconfigs.odigos.io \"deployment-demo-php\": the object has been modified; please apply your changes to the latest version and try again"}           ││ sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler                                                           /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.3/pkg/internal/controller/controller.go:341                                                 ││ sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem                                                    ││     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.3/pkg/internal/controller/controller.go:288                                                 ││ sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2                                                          ││     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.3/pkg/internal/controller/controller.go:249  
```
