### PR TITLE
fix: go-offsets reapply

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,6 @@
 {
   "version": "0.2.0",
   "configurations": [
-
     {
       "name": "Remote Odiglet",
       "type": "go",
@@ -64,6 +63,16 @@
       "program": "${workspaceFolder}/cli",
       "cwd": "${workspaceFolder}/cli",
       "args": ["uninstall", "--yes"],
+      "buildFlags": "-tags=embed_manifests"
+    },
+    {
+      "name": "cli upgrade",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/cli",
+      "cwd": "${workspaceFolder}/cli",
+      "args": ["upgrade", "--yes", "--version", "v1.0.172"],
       "buildFlags": "-tags=embed_manifests"
     },
     {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,7 @@
 {
   "version": "0.2.0",
   "configurations": [
+
     {
       "name": "Remote Odiglet",
       "type": "go",
@@ -63,16 +64,6 @@
       "program": "${workspaceFolder}/cli",
       "cwd": "${workspaceFolder}/cli",
       "args": ["uninstall", "--yes"],
-      "buildFlags": "-tags=embed_manifests"
-    },
-    {
-      "name": "cli upgrade",
-      "type": "go",
-      "request": "launch",
-      "mode": "debug",
-      "program": "${workspaceFolder}/cli",
-      "cwd": "${workspaceFolder}/cli",
-      "args": ["upgrade", "--yes", "--version", "v1.0.172"],
       "buildFlags": "-tags=embed_manifests"
     },
     {


### PR DESCRIPTION
## Description

This PR fixes a bug in cli upgrade. When the newly introduced `odigos-go-offsets` already exists, the cli upgrade would try to apply the object that is returned from the k8s api, but this is not supported (missing kind, `ERROR metadata.managedFields must be nil` etc).

To fix it, I always create the configmap in the supported manner, and just copy the content.

This does not fail in tests, since the test runs cli-upgrade from a version which does not contain offsets file, thus it's a create not an update to existing object.

## How Has This Been Tested?

- [x] Manual Testing

## Kubernetes Checklist

fix a bug in how cli upgrade is applying changes to an existing cm

## User Facing Changes

no