### PR TITLE
feat: auto add logs processors to the node collector pipeline

### DIFF
--- a/autoscaler/controllers/nodecollector/configmap.go
+++ b/autoscaler/controllers/nodecollector/configmap.go
@@ -142,7 +142,7 @@ func updateOrCreateK8sAttributesForLogs(cfg *config.Config) error {
 			return fmt.Errorf("failed to cast k8s attributes processor extract config to GenericMap")
 		}
 		if _, exists := extract["metadata"]; !exists {
-			extract["metadata"] = []string{}
+			extract["metadata"] = []interface{}{}
 		}
 		metadata, ok := extract["metadata"].([]interface{})
 		if !ok {
@@ -392,6 +392,13 @@ func calculateConfigMapData(nodeCG *odigosv1.CollectorsGroup, sources *odigosv1.
 		err := updateOrCreateK8sAttributesForLogs(&cfg)
 		if err != nil {
 			return "", err
+		}
+		// remove logs processors from CRD logsProcessors in case it is there so not to add it twice
+		for i, processor := range logsProcessors {
+			if processor == K8sAttributesProcessorName {
+				logsProcessors = append(logsProcessors[:i], logsProcessors[i+1:]...)
+				break
+			}
 		}
 
 		cfg.Service.Pipelines["logs"] = config.Pipeline{


### PR DESCRIPTION
## Description

Add or update existing `k8sattributes` processor to also collect workload names attributes (`k8s.deployment.name` etc).
Also add a processor to transform these resource attributes to `service.name` if found.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [x] Manual Testing

## Kubernetes Checklist

No changes in k8s (other than adding a new consumer to `k8sattributes` processor which we want).

## User Facing Changes

Each logs user will now automatically get workload names attributes and `service.name` if possible.
