### PR TITLE
add test connection for OTLP gRPC and OTLP HTTP destinations

### DIFF
--- a/destinations/data/otlp.yaml
+++ b/destinations/data/otlp.yaml
@@ -22,3 +22,4 @@ spec:
         required: true
         placeholder: 'host:port'
         tooltip: The format is `host:port`, host is required, port is optional and defaults to the default OTLP gRPC port `4317`.
+  testConnectionSupported: true

--- a/destinations/data/otlphttp.yaml
+++ b/destinations/data/otlphttp.yaml
@@ -21,7 +21,7 @@ spec:
         type: text
         required: true
         placeholder: 'http://host:port'
-        tooltip: The format is `host:port`, host is required, port is optional and defaults to the default OTLP gRPC port `4317`.
+        tooltip: The format is `host:port`, host is required, port is optional and defaults to the default OTLP HTTP port `4318`.
 
     - name: OTLP_HTTP_BASIC_AUTH_USERNAME
       displayName: Basic Auth Username
@@ -41,3 +41,4 @@ spec:
         placeholder: 'password'
         tooltip: in case the otlp receiver requires basic auth, this is the password
       secret: true
+  testConnectionSupported: true

--- a/docs/backends/otlphttp.mdx
+++ b/docs/backends/otlphttp.mdx
@@ -53,7 +53,7 @@ To configure basic authentication, use the optional config options `Basic Auth U
   ✅ Logs
 </Accordion>
 
-- **OTLP_HTTP_ENDPOINT** `string` : OTLP http Endpoint. The format is `host:port`, host is required, port is optional and defaults to the default OTLP gRPC port `4317`.
+- **OTLP_HTTP_ENDPOINT** `string` : OTLP http Endpoint. The format is `host:port`, host is required, port is optional and defaults to the default OTLP HTTP port `4318`.
   - This field is required
   - Example: `http://host:port`
 - **OTLP_HTTP_BASIC_AUTH_USERNAME** `string` : Basic Auth Username. in case the otlp receiver requires basic auth, this is the username


### PR DESCRIPTION
## Description

Add the test connection button for the OTLP HTTP and OTLP gRPC destinations

## How Has This Been Tested?

manually tested with both destinations
