### PR TITLE
feat: record profile source on resources auto created from profile

### DIFF
--- a/api/k8sconsts/resources.go
+++ b/api/k8sconsts/resources.go
@@ -1,9 +1,9 @@
 package k8sconsts
 
 const (
-         // OdigosAgentsMetaHashLabel is used to label pods being instrumented.
-         // It can be used to count the number of instrumented pods for a workload and whether they are up to date
-         // with the expected agents.
+	// OdigosAgentsMetaHashLabel is used to label pods being instrumented.
+	// It can be used to count the number of instrumented pods for a workload and whether they are up to date
+	// with the expected agents.
 	OdigosAgentsMetaHashLabel = "odigos.io/agents-meta-hash"
 
 	// OdigosCollectorRoleLabel is the label used to identify the role of the Odigos collector.
@@ -21,5 +21,9 @@ const (
 
 	// for resources auto created by a profile, this annotation will record
 	// the name of the profile that created them.
-	OdigosProfileAnnotation = "odigos.io/profile"
+	OdigosProfileAnnotation = "odigos.io/profile-name"
+
+	OdigosProfileSourceAnnotation  = "odigos.io/profile-source"
+	OdigosProfileSourceConfig      = "config"
+	OdigosProfileSourceOnPremToken = "onprem-token"
 )


### PR DESCRIPTION
## Description

When user adds profiles, odigos will create various resources from it (actions, rules).
the resource already contains the name of the profile that manages this resource, but it does not say if the profile is from token or from config.

This is important, so if multiple conflicting profiles exists (for example, one from token, and one that user sets explicitly), we are able to apply them in the right order and guarantee that the result is deterministic.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [x] Manual Testing

## Kubernetes Checklist

One more annotations on each resource generated from profiles (very few)

## User Facing Changes

No