### PR TITLE
fix: mount /mnt/var/log into node collector

### DIFF
--- a/autoscaler/controllers/nodecollector/daemonset.go
+++ b/autoscaler/controllers/nodecollector/daemonset.go
@@ -238,6 +238,14 @@ func getDesiredDaemonSet(datacollection *odigosv1.CollectorsGroup,
 							},
 						},
 						{
+							Name: "mntvarlog",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/mnt/var/log",
+								},
+							},
+						},
+						{
 							Name: "varlibdockercontainers",
 							VolumeSource: corev1.VolumeSource{
 								HostPath: &corev1.HostPathVolumeSource{
@@ -272,6 +280,11 @@ func getDesiredDaemonSet(datacollection *odigosv1.CollectorsGroup,
 								{
 									Name:      "varlog",
 									MountPath: "/var/log",
+									ReadOnly:  true,
+								},
+								{ // for clusters where /var/log is not a symlink to /mnt/var/log
+									Name:      "mntvarlog",
+									MountPath: "/mnt/var/log",
 									ReadOnly:  true,
 								},
 								{

--- a/tests/common/assert/pipeline-ready.yaml
+++ b/tests/common/assert/pipeline-ready.yaml
@@ -146,6 +146,9 @@ spec:
             - mountPath: /var/log
               name: varlog
               readOnly: true
+            - mountPath: /mnt/var/log
+              name: mntvarlog
+              readOnly: true
             - mountPath: /hostfs
               name: hostfs
               readOnly: true
@@ -191,6 +194,10 @@ spec:
             path: /var/log
             type: ""
           name: varlog
+        - hostPath:
+            path: /mnt/var/log
+            type: ""
+          name: mntvarlog
         - hostPath:
             path: /var/lib/docker/containers
             type: ""


### PR DESCRIPTION
## Description

Odigos reads logs from k8s node fs in `/var/log`. in some systems, this path is a symlink to `/mnt/var/log`, so we need to mount this as well for the logs collection to work.

This will not cover all possible cases, but the hope is that `/mnt/var/log` is common enough to cover most non-trivial cases.

