### PR TITLE
Update Operator to v1.0.177

### DIFF
--- a/operator/DEVELOPMENT.md
+++ b/operator/DEVELOPMENT.md
@@ -76,3 +76,16 @@ Clean up with:
 ```
 operator-sdk cleanup odigos-operator  --delete-all
 ```
+
+## Preparing a new release
+
+Once a new version of Odigos has been released, and the components have all passed OpenShift certification, do the following:
+
+1. Update the `VERSION` variable at the top of the `Makefile`
+2. Update the tag for each `RELATED_IMAGE_*` environment variable in `config/manager/manager.yaml`
+3. In `config/manifests/bases/odigos-operator.clusterserviceversion.yaml`, update the following:
+    1. The `version` in the `alm-examples` annotation
+    2. The tag on the `containerImage` annotation
+    3. The `metadata.name` version
+    4. The `spec.version` value
+4. Run `USE_IMAGE_DIGESTS=true make generate manifests bundle` to update the generated bundle and commit the results.

--- a/operator/DEVELOPMENT.md
+++ b/operator/DEVELOPMENT.md
@@ -89,3 +89,19 @@ Once a new version of Odigos has been released, and the components have all pass
     3. The `metadata.name` version
     4. The `spec.version` value
 4. Run `USE_IMAGE_DIGESTS=true make generate manifests bundle` to update the generated bundle and commit the results.
+
+### Publishing the release to OpenShift
+
+When you have verified the new version, open a pull request to https://github.com/redhat-openshift-ecosystem/certified-operators
+
+Example: https://github.com/redhat-openshift-ecosystem/certified-operators/pull/5535
+
+Do the following in your PR:
+
+1. Create a new folder called `operators/odigos-operator/v<VERSION>`
+2. Create 2 sub-folders in `operators/odigos-operator/v<VERSION>`:
+    1. `manifests`
+    2. `metadata`
+3. Copy everything from `config/bundle/manifests` (in this repo) to your new `operators/odigos-operator/v<VERSION>/manifests` folder
+4. Copy the `annotations.yaml` from a previous version of `operators/odigos-operator` to your new `metadata` folder
+5. Open a pull request to the Red Hat repo with the title format: `operator odigos-operator (v<VERSION>)`

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.0.170
+VERSION ?= 1.0.177
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/operator/bundle/manifests/odigos-operator-odigos-version-t9g2c28b4f_v1_configmap.yaml
+++ b/operator/bundle/manifests/odigos-operator-odigos-version-t9g2c28b4f_v1_configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+data:
+  ODIGOS_VERSION: 1.0.177
+kind: ConfigMap
+metadata:
+  name: odigos-operator-odigos-version-t9g2c28b4f

--- a/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
@@ -33,7 +33,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     support: Odigos
-  name: odigos-operator.v1.0.170
+  name: odigos-operator.v1.0.177
   namespace: odigos-operator-system
 spec:
   apiservicedefinitions: {}

--- a/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
@@ -19,8 +19,8 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Logging & Tracing
-    containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d
-    createdAt: "2025-04-16T14:22:10Z"
+    containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:74d91e9553811696292bf0cfdf2dc37cba397106233310ed36472e8b4e82228e
+    createdAt: "2025-04-23T14:22:21Z"
     description: Odigos enables automatic distributed tracing with OpenTelemetry and eBPF.
     features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "true"
@@ -433,24 +433,24 @@ spec:
                         valueFrom:
                           configMapKeyRef:
                             key: ODIGOS_VERSION
-                            name: odigos-operator-odigos-version-mk99cdcf27
+                            name: odigos-operator-odigos-version-t9g2c28b4f
                       - name: RELATED_IMAGE_AUTOSCALER
-                        value: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:51d62c00c2aa4515543830a88fc27d63e1970f885d9fc3f1da8711d53b9aa68d
+                        value: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:5a47e5b95dca436dbaa5db5c2f656fff1de127a4cbc38ed42d469ccaa55aedb1
                       - name: RELATED_IMAGE_COLLECTOR
-                        value: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:f25a35e65a0706e616ab32b9a5bfb94206978c6767bb8beff20504cecd39bd62
+                        value: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:10b5e23fa624fc66c077851fb982539e193fca622f89e0655986acf82d61ad1b
                       - name: RELATED_IMAGE_FRONTEND
-                        value: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:fc7afc383cd35657b899ecdd1ea3a9851fa4c6cf49c309a20356dd246453e281
+                        value: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:ad6b64008a454e99e10f8ed6e17d7fffba677e3086b44101b3e281d16159aec1
                       - name: RELATED_IMAGE_INSTRUMENTOR
-                        value: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:54a4075fdd861c43b13f50861a4f82b7cb2f6146660b023ca4afa4e9e27bce02
+                        value: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:2ef5136c48902930db1bd8a0a9a82d7dd0fd06d6f814bc985aa412356163c203
                       - name: RELATED_IMAGE_ENTERPRISE_INSTRUMENTOR
-                        value: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:3297a0997597a5dcced94e0efe12f218d6af40773e736305f8d0dfcd1ebf902e
+                        value: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:2342e872344a4b4500b6bdc2762f60efdb2667765b880d6d274e5d6d683cccc2
                       - name: RELATED_IMAGE_ODIGLET
-                        value: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:40aaece592d75ebacc636153dfbf96452984100b563c31f773c88988182cefe0
+                        value: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:75b6d405bd2f083cbcb10b9cda45119f8a9b478f97723cfa156a59a58b930439
                       - name: RELATED_IMAGE_ENTERPRISE_ODIGLET
-                        value: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:06dcf548aaeb4d32c1e8d30f1d0440c91f696d9f94807d983c366e3ee124310e
+                        value: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:c4956e4884e1d62337884d0991a346990260a251115d73cf7698eb4284f6123b
                       - name: RELATED_IMAGE_SCHEDULER
-                        value: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:4d213af27d432665bf72caffbafa33a7991cb627bad9c2d894c4f8931e14d27b
-                    image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d
+                        value: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:dd6d4ad278d050328cb5a2fbbc78522489a3cfacdb1f1c70d336e8c810d44281
+                    image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:74d91e9553811696292bf0cfdf2dc37cba397106233310ed36472e8b4e82228e
                     livenessProbe:
                       httpGet:
                         path: /healthz
@@ -548,28 +548,28 @@ spec:
     name: Odigos
     url: https://odigos.io
   relatedImages:
-    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d
-      name: odigos-certified-operator-ubi9-487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d-annotation
-    - image: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:51d62c00c2aa4515543830a88fc27d63e1970f885d9fc3f1da8711d53b9aa68d
-      name: autoscaler
-    - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:54a4075fdd861c43b13f50861a4f82b7cb2f6146660b023ca4afa4e9e27bce02
-      name: instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:3297a0997597a5dcced94e0efe12f218d6af40773e736305f8d0dfcd1ebf902e
-      name: enterprise-instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:40aaece592d75ebacc636153dfbf96452984100b563c31f773c88988182cefe0
-      name: odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:06dcf548aaeb4d32c1e8d30f1d0440c91f696d9f94807d983c366e3ee124310e
-      name: enterprise-odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:4d213af27d432665bf72caffbafa33a7991cb627bad9c2d894c4f8931e14d27b
-      name: scheduler
-    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:487394779173baf86ef6425100c61c153a2163c579f01870aeb5e3b709b3e23d
-      name: manager
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:3297a0997597a5dcced94e0efe12f218d6af40773e736305f8d0dfcd1ebf902e
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:2342e872344a4b4500b6bdc2762f60efdb2667765b880d6d274e5d6d683cccc2
       name: enterprise_instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:f25a35e65a0706e616ab32b9a5bfb94206978c6767bb8beff20504cecd39bd62
-      name: collector
-    - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:fc7afc383cd35657b899ecdd1ea3a9851fa4c6cf49c309a20356dd246453e281
-      name: frontend
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:06dcf548aaeb4d32c1e8d30f1d0440c91f696d9f94807d983c366e3ee124310e
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:c4956e4884e1d62337884d0991a346990260a251115d73cf7698eb4284f6123b
       name: enterprise_odiglet
-  version: 1.0.170
+    - image: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:5a47e5b95dca436dbaa5db5c2f656fff1de127a4cbc38ed42d469ccaa55aedb1
+      name: autoscaler
+    - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:ad6b64008a454e99e10f8ed6e17d7fffba677e3086b44101b3e281d16159aec1
+      name: frontend
+    - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:2ef5136c48902930db1bd8a0a9a82d7dd0fd06d6f814bc985aa412356163c203
+      name: instrumentor
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:2342e872344a4b4500b6bdc2762f60efdb2667765b880d6d274e5d6d683cccc2
+      name: enterprise-instrumentor
+    - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:75b6d405bd2f083cbcb10b9cda45119f8a9b478f97723cfa156a59a58b930439
+      name: odiglet
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:c4956e4884e1d62337884d0991a346990260a251115d73cf7698eb4284f6123b
+      name: enterprise-odiglet
+    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:74d91e9553811696292bf0cfdf2dc37cba397106233310ed36472e8b4e82228e
+      name: manager
+    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:74d91e9553811696292bf0cfdf2dc37cba397106233310ed36472e8b4e82228e
+      name: odigos-certified-operator-ubi9-74d91e9553811696292bf0cfdf2dc37cba397106233310ed36472e8b4e82228e-annotation
+    - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:10b5e23fa624fc66c077851fb982539e193fca622f89e0655986acf82d61ad1b
+      name: collector
+    - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:dd6d4ad278d050328cb5a2fbbc78522489a3cfacdb1f1c70d336e8c810d44281
+      name: scheduler
+  version: 1.0.177

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -5,32 +5,32 @@ kind: Kustomization
 images:
 - name: autoscaler
   newName: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9
-  newTag: v1.0.170
+  newTag: v1.0.177
 - name: collector
   newName: registry.connect.redhat.com/odigos/odigos-collector-ubi9
-  newTag: v1.0.170
+  newTag: v1.0.177
 - name: controller
   newName: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9
-  newTag: v1.0.170
+  newTag: v1.0.177
 - name: enterprise-instrumentor
   newName: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9
-  newTag: v1.0.170
+  newTag: v1.0.177
 - name: enterprise-odiglet
   newName: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9
-  newTag: v1.0.170
+  newTag: v1.0.177
 - name: frontend
   newName: registry.connect.redhat.com/odigos/odigos-ui-ubi9
-  newTag: v1.0.170
+  newTag: v1.0.177
 - name: instrumentor
   newName: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9
-  newTag: v1.0.170
+  newTag: v1.0.177
 - name: odiglet
   newName: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9
-  newTag: v1.0.170
+  newTag: v1.0.177
 - name: scheduler
   newName: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9
-  newTag: v1.0.170
+  newTag: v1.0.177
 configMapGenerator:
 - literals:
-  - ODIGOS_VERSION=1.0.170
+  - ODIGOS_VERSION=1.0.177
   name: odigos-version

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -78,21 +78,21 @@ spec:
               name: odigos-version
               key: ODIGOS_VERSION
         - name: RELATED_IMAGE_AUTOSCALER
-          value: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9:v1.0.170
+          value: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9:v1.0.177
         - name: RELATED_IMAGE_COLLECTOR
-          value: registry.connect.redhat.com/odigos/odigos-collector-ubi9:v1.0.170
+          value: registry.connect.redhat.com/odigos/odigos-collector-ubi9:v1.0.177
         - name: RELATED_IMAGE_FRONTEND
-          value: registry.connect.redhat.com/odigos/odigos-ui-ubi9:v1.0.170
+          value: registry.connect.redhat.com/odigos/odigos-ui-ubi9:v1.0.177
         - name: RELATED_IMAGE_INSTRUMENTOR
-          value: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9:v1.0.170
+          value: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9:v1.0.177
         - name: RELATED_IMAGE_ENTERPRISE_INSTRUMENTOR
-          value: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9:v1.0.170
+          value: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9:v1.0.177
         - name: RELATED_IMAGE_ODIGLET
-          value: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9:v1.0.170
+          value: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9:v1.0.177
         - name: RELATED_IMAGE_ENTERPRISE_ODIGLET
-          value: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9:v1.0.170
+          value: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9:v1.0.177
         - name: RELATED_IMAGE_SCHEDULER
-          value: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9:v1.0.170
+          value: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9:v1.0.177
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/operator/config/manifests/bases/odigos-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/odigos-operator.clusterserviceversion.yaml
@@ -3,10 +3,10 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     alm-examples: '[{"apiVersion":"operator.odigos.io/v1alpha1", "kind":"Odigos",
-      "metadata":{"name":"odigos","namespace":"odigos-operator-system"}, "spec":{"version":"v1.0.170"}}]'
+      "metadata":{"name":"odigos","namespace":"odigos-operator-system"}, "spec":{"version":"v1.0.177"}}]'
     capabilities: Basic Install
     categories: Logging & Tracing
-    containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9:v1.0.170
+    containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9:v1.0.177
     description: Odigos enables automatic distributed tracing with OpenTelemetry and
       eBPF.
     features.operators.openshift.io/disconnected: "false"
@@ -19,7 +19,7 @@ metadata:
     operators.openshift.io/valid-subscription: Odigos Enterprise subscription (for
       enterprise features)
     support: Odigos
-  name: odigos-operator.v1.0.170
+  name: odigos-operator.v1.0.177
   namespace: odigos-operator-system
 spec:
   apiservicedefinitions: {}
@@ -142,4 +142,4 @@ spec:
   provider:
     name: Odigos
     url: https://odigos.io
-  version: 1.0.170
+  version: 1.0.177


### PR DESCRIPTION
## Description

This updates the operator to the latest v1.0.177 images and adds more documentation on releasing the operator

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [x] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
