### PR TITLE
e2e: increase Odigos installed assertion timeout

### DIFF
--- a/tests/e2e/helm-chart/chainsaw-test.yaml
+++ b/tests/e2e/helm-chart/chainsaw-test.yaml
@@ -50,6 +50,7 @@ spec:
               fi
 
         - assert:
+            timeout: 1m
             file: ../../common/assert/odigos-installed.yaml  # ✅ Moved outside `catch`
 
       catch:


### PR DESCRIPTION
## Description

Been seeing failures like [this one](https://github.com/odigos-io/odigos/actions/runs/14621198252/job/41026869724?pr=2764) where the odiglet is still pending/initializing. Maybe there is something actually blocking it, but possibly it just needs a little more time than the default which appears to be 30s. Opening this as a test to see

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [x] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
