### PR TITLE
Handle empty JAVA env vars as if they are not defined

### DIFF
--- a/instrumentor/internal/webhook_env_injector/webhook_env_injector.go
+++ b/instrumentor/internal/webhook_env_injector/webhook_env_injector.go
@@ -72,7 +72,7 @@ func getEnvVarNamesForLanguage(pl common.ProgrammingLanguage) []string {
 // Return false if the env was not processed using the manifest value and requires further handling by other methods.
 func handleManifestEnvVar(container *corev1.Container, envVarName string, otelsdk common.OtelSdk, logger logr.Logger) bool {
 	manifestEnvVar := getContainerEnvVarPointer(&container.Env, envVarName)
-	if manifestEnvVar == nil || manifestEnvVar.Value == "" {
+	if manifestEnvVar == nil || (manifestEnvVar.ValueFrom == nil && manifestEnvVar.Value == "") {
 		return false // Not found in manifest. further process it
 	}
 
@@ -163,6 +163,14 @@ func applyOdigosEnvDefaults(container *corev1.Container, envVarsPerLanguage []st
 
 		valueToInject, ok := odigosValueForOtelSdk[otelsdk]
 		if !ok { // No Odigos value for this SDK
+			continue
+		}
+
+		existingEnv := getContainerEnvVarPointer(&container.Env, envVarName)
+		if existingEnv != nil && existingEnv.ValueFrom == nil {
+			if existingEnv.Value == "" {
+				existingEnv.Value = valueToInject
+			}
 			continue
 		}
 

--- a/instrumentor/internal/webhook_env_injector/webhook_env_injector.go
+++ b/instrumentor/internal/webhook_env_injector/webhook_env_injector.go
@@ -72,7 +72,7 @@ func getEnvVarNamesForLanguage(pl common.ProgrammingLanguage) []string {
 // Return false if the env was not processed using the manifest value and requires further handling by other methods.
 func handleManifestEnvVar(container *corev1.Container, envVarName string, otelsdk common.OtelSdk, logger logr.Logger) bool {
 	manifestEnvVar := getContainerEnvVarPointer(&container.Env, envVarName)
-	if manifestEnvVar == nil {
+	if manifestEnvVar == nil || manifestEnvVar.Value == "" {
 		return false // Not found in manifest. further process it
 	}
 
@@ -136,6 +136,14 @@ func processEnvVarsFromRuntimeDetails(runtimeDetails *odigosv1.RuntimeDetailsByC
 
 		// Get the relevant envVar that we're iterating over
 		if envVar.Name != envVarName {
+			continue
+		}
+
+		if envVar.Value == "" {
+			// if the value is empty, treat it as it's not existing.
+			// from the env appending perspective, this is the same as not having it at all
+			// we want to set it to the odigos value
+			// this will be done at the last step
 			continue
 		}
 

--- a/tests/e2e/env-injection/01-assert-apps-installed.yaml
+++ b/tests/e2e/env-injection/01-assert-apps-installed.yaml
@@ -30,6 +30,20 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
+    app: java-supported-empty-manifest-env
+  namespace: default
+status:
+  containerStatuses:
+    - name: java-supported-empty-manifest-env
+      ready: true
+      restartCount: 0
+      started: true
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
     app: java-latest-version
   namespace: default
 status:

--- a/tests/e2e/env-injection/01-assert-env-vars.yaml
+++ b/tests/e2e/env-injection/01-assert-env-vars.yaml
@@ -27,9 +27,25 @@ spec:
       name: java-supported-manifest-env
       (env[?name=='JAVA_TOOL_OPTIONS']):
       - value: "-Dnot.work=true -javaagent:/var/odigos/java/javaagent.jar"
-    # JAVA_TOOL_OPTIONS is not set in the manifest of java-supported-manifest-env,
+    # JAVA_OPTS is not set in the manifest of java-supported-manifest-env,
     # so we need to ensure it is also not set in the pod spec.
       (env[?name=='JAVA_OPTS']): []
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: java-supported-empty-manifest-env
+  namespace: default
+spec:
+  containers:
+    - image: public.ecr.aws/odigos/java-supported-manifest-env:v0.0.1
+      # JAVA_OPTS is defined in the manifest but it is empty,
+      # so we expect here to have our value in both env vars.
+      (env[?name=='JAVA_OPTS']):
+       - value: "-javaagent:/var/odigos/java/javaagent.jar"
+      (env[?name=='JAVA_TOOL_OPTIONS']):
+       - value: "-javaagent:/var/odigos/java/javaagent.jar"
 ---
 apiVersion: v1
 kind: Pod

--- a/tests/e2e/env-injection/01-assert-runtime-detected.yaml
+++ b/tests/e2e/env-injection/01-assert-runtime-detected.yaml
@@ -35,6 +35,21 @@ apiVersion: odigos.io/v1alpha1
 kind: InstrumentationConfig
 metadata:
   namespace: default
+  name: deployment-java-supported-empty-manifest-env
+status:
+  runtimeDetailsByContainer:
+  - containerName: ava-supported-empty-manifest-env
+    (!envFromContainerRuntime): true
+    envVars:
+    - name: JAVA_OPTS
+      value: ""
+    (envVars[?name=='JAVA_TOOL_OPTIONS']): []
+    language: java
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  namespace: default
   name: deployment-java-latest-version
 status:
   runtimeDetailsByContainer:

--- a/tests/e2e/env-injection/01-assert-runtime-detected.yaml
+++ b/tests/e2e/env-injection/01-assert-runtime-detected.yaml
@@ -38,7 +38,7 @@ metadata:
   name: deployment-java-supported-empty-manifest-env
 status:
   runtimeDetailsByContainer:
-  - containerName: ava-supported-empty-manifest-env
+  - containerName: java-supported-empty-manifest-env
     (!envFromContainerRuntime): true
     envVars:
     - name: JAVA_OPTS

--- a/tests/e2e/env-injection/01-install-test-apps.yaml
+++ b/tests/e2e/env-injection/01-install-test-apps.yaml
@@ -82,6 +82,48 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: java-supported-empty-manifest-env
+  namespace: default
+  labels:
+    app: java-supported-empty-manifest-env
+spec:
+  selector:
+    matchLabels:
+      app: java-supported-empty-manifest-env
+  template:
+    metadata:
+      labels:
+        app: java-supported-empty-manifest-env
+    spec:
+      containers:
+        - name: java-supported-empty-manifest-env
+          image: public.ecr.aws/odigos/java-supported-manifest-env:v0.0.1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+          env:
+            - name: JAVA_OPTS
+              value: ""
+          readinessProbe:
+            tcpSocket:
+              port: 3000
+            initialDelaySeconds: 20
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: java-supported-empty-manifest-env
+  namespace: default
+spec:
+  selector:
+    app: java-supported-empty-manifest-env
+  ports:
+    - protocol: TCP
+      port: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: java-latest-version
   namespace: default
   labels:


### PR DESCRIPTION
## Description

Following https://github.com/odigos-io/odigos/pull/2667, we append our value only to one env var if we detect a user defined value. That PR also covers the case where the env var (for example JAVA_OPTS) is declared by the user and have an empty value. For that case, we'll add our value only to the JAVA_OPTS. Most (if not all) the JDKs don't looks for the JAVA_OPTS env var for agent injecting - hence this results in the agent not being injected.
We should completely remove JAVA_OPTS in a future PR, this is done as a quick fix.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [x] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ v ] Changes how Odigos interacts with Kubernetes

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

Only the described case above will affect the pod webhook operation and will result in different pod spec.
