### PR TITLE
Version bump python agent - Added a fix for elasticsearch instrumenta…

### DIFF
--- a/agents/python/setup.py
+++ b/agents/python/setup.py
@@ -3,10 +3,10 @@ from setuptools import setup, find_packages
 index_url = None
 
 # DEV - Local Uncomment to develop locally \/
-# index_url = 'http://host.docker.internal:8080/packages/odigos_opentelemetry_python-1.0.40-py3-none-any.whl'
+# index_url = 'http://host.docker.internal:8080/packages/odigos_opentelemetry_python-1.0.41-py3-none-any.whl'
 
 install_requires = [
-    f"odigos-opentelemetry-python @ {index_url}" if index_url else "odigos-opentelemetry-python==1.0.40"
+    f"odigos-opentelemetry-python @ {index_url}" if index_url else "odigos-opentelemetry-python==1.0.41"
 ]
 
 setup(


### PR DESCRIPTION
Version bump python agent - Added a fix for elasticsearch instrumentation high cardinality 64 byte uuids

## Description

<!-- Short summary of the changes -->

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
