### PR TITLE
Url templatization more cases

### DIFF
--- a/collector/processors/odigosurltemplateprocessor/README.md
+++ b/collector/processors/odigosurltemplateprocessor/README.md
@@ -50,6 +50,7 @@ By default, the processor will split the path to segment (e.g. "/user/1234" -> [
 - hex-encoded strings - `[0-9a-f]{2}([0-9a-f]{2})*` -> `{id}` (`6f2a9cdeab34f01e`)
 - long numbers anywhere - `\d{7,}` -> `{id}` (`1234567`, `INC328962358623904`, `sb_12345678901234567890_us`)
 - common [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) date-time formats - `^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}(?::\d{2})?)?(?:Z|[+-]\d{4})?$` -> `{date}` (`2023-10-01T12:00:00+0000`)
+- emails - `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$` like `foo@bar.io` -> `{email}`
 
 These default rules will not templatize paths like `/user/john`, `/user/s111222`, `/users/123456_789` which will be copied as is into the span name and attribute with potentially high cardinality.
 

--- a/collector/processors/odigosurltemplateprocessor/README.md
+++ b/collector/processors/odigosurltemplateprocessor/README.md
@@ -48,9 +48,9 @@ By default, the processor will split the path to segment (e.g. "/user/1234" -> [
 - only digits - `^\d+$` -> `{id}` (`1234`, `328962358623904`, `0`)
 - uuids - `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` -> `{id}` (`123e4567-e89b-12d3-a456-426614174000`). They can appear as either prefix or suffix of the segment (for example `/process/PROCESS_123e4567-e89b-12d3-a456-42661bd74000`)
 - hex-encoded strings - `[0-9a-f]{2}([0-9a-f]{2})*` -> `{id}` (`6f2a9cdeab34f01e`)
-- long numbers anywhere - `\d{9,}` -> `{id}` (`123456789`, `INC328962358623904`, `sb_12345678901234567890_us`)
+- long numbers anywhere - `\d{7,}` -> `{id}` (`1234567`, `INC328962358623904`, `sb_12345678901234567890_us`)
 
-These default rules will not templatize paths like `/user/john` or `/user/s11112222` which will be copied as is into the span name and attribute with potentially high cardinality.
+These default rules will not templatize paths like `/user/john`, `/user/s111222`, `/users/123456_789` which will be copied as is into the span name and attribute with potentially high cardinality.
 
 ## Custom Templatization
 

--- a/collector/processors/odigosurltemplateprocessor/README.md
+++ b/collector/processors/odigosurltemplateprocessor/README.md
@@ -49,6 +49,7 @@ By default, the processor will split the path to segment (e.g. "/user/1234" -> [
 - uuids - `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` -> `{id}` (`123e4567-e89b-12d3-a456-426614174000`). They can appear as either prefix or suffix of the segment (for example `/process/PROCESS_123e4567-e89b-12d3-a456-42661bd74000`)
 - hex-encoded strings - `[0-9a-f]{2}([0-9a-f]{2})*` -> `{id}` (`6f2a9cdeab34f01e`)
 - long numbers anywhere - `\d{7,}` -> `{id}` (`1234567`, `INC328962358623904`, `sb_12345678901234567890_us`)
+- common [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) date-time formats - `^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}(?::\d{2})?)?(?:Z|[+-]\d{4})?$` -> `{date}` (`2023-10-01T12:00:00+0000`)
 
 These default rules will not templatize paths like `/user/john`, `/user/s111222`, `/users/123456_789` which will be copied as is into the span name and attribute with potentially high cardinality.
 

--- a/collector/processors/odigosurltemplateprocessor/processor_test.go
+++ b/collector/processors/odigosurltemplateprocessor/processor_test.go
@@ -380,7 +380,7 @@ func TestProcessor_Traces(t *testing.T) {
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
 				"http.request.method": "GET",
-				"url.path":            "/user/INC001268637", // contains 9 digits number
+				"url.path":            "/user/INC0012686", // contains 7 digits number
 			},
 			expectedSpanName:  "GET /user/{id}", // should be templated as the number is long
 			expectedAttrKey:   "http.route",
@@ -394,11 +394,25 @@ func TestProcessor_Traces(t *testing.T) {
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
 				"http.request.method": "GET",
-				"url.path":            "/user/INC001268637US", // contains 9 digits number
+				"url.path":            "/user/INC0012637US", // contains 7 digits number
 			},
 			expectedSpanName:  "GET /user/{id}",
 			expectedAttrKey:   "http.route",
 			expectedAttrValue: "/user/{id}",
+		},
+		{
+			name: "6 digits number should not be templated",
+			// this is a corner case where the number is under the limit of digits (7)
+			serviceName:   "6-digits-number-should-not-be-templated",
+			spanKind:      ptrace.SpanKindServer,
+			inputSpanName: "GET",
+			inputSpanAttrs: map[string]any{
+				"http.request.method": "GET",
+				"url.path":            "/user/123456_654321", // contains 6 digits number twice
+			},
+			expectedSpanName:  "GET /user/123456_654321", // should not be templated as the number is under the limit
+			expectedAttrKey:   "http.route",
+			expectedAttrValue: "/user/123456_654321",
 		},
 	}
 

--- a/collector/processors/odigosurltemplateprocessor/processor_test.go
+++ b/collector/processors/odigosurltemplateprocessor/processor_test.go
@@ -45,25 +45,40 @@ func assertSpanNameAndAttribute(t *testing.T, span ptrace.Span, expectedName str
 	}
 }
 
+type processorTestManifest struct {
+	name              string
+	spanKind          ptrace.SpanKind
+	inputSpanName     string
+	inputSpanAttrs    map[string]any
+	expectedSpanName  string
+	expectedAttrKey   string
+	expectedAttrValue string
+}
+
+func runProcessorTests(t *testing.T, tt []processorTestManifest, processor *urlTemplateProcessor) {
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			traces := generateTraceData(tc.inputSpanName, tc.inputSpanName, tc.spanKind, tc.inputSpanAttrs)
+
+			ctx := context.Background()
+			processedTraces, err := processor.processTraces(ctx, traces)
+			require.NoError(t, err)
+
+			processedSpan := processedTraces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+			assertSpanNameAndAttribute(t, processedSpan, tc.expectedSpanName, tc.expectedAttrKey, tc.expectedAttrValue)
+		})
+	}
+}
+
 func TestProcessor_Traces(t *testing.T) {
 	set := processortest.NewNopSettings(processortest.NopType)
 
 	processor, err := newUrlTemplateProcessor(set, &Config{})
 	require.NoError(t, err)
 
-	tt := []struct {
-		name              string
-		serviceName       string
-		spanKind          ptrace.SpanKind
-		inputSpanName     string
-		inputSpanAttrs    map[string]any
-		expectedSpanName  string
-		expectedAttrKey   string
-		expectedAttrValue string
-	}{
+	tt := []processorTestManifest{
 		{
 			name:          "numeric id in url path",
-			serviceName:   "numeric-templated-string",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -76,7 +91,6 @@ func TestProcessor_Traces(t *testing.T) {
 		},
 		{
 			name:          "uuid in url path",
-			serviceName:   "uuid-templated-string",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -89,7 +103,6 @@ func TestProcessor_Traces(t *testing.T) {
 		},
 		{
 			name:          "uuid with any suffix",
-			serviceName:   "uuid-templated-string-with-suffix",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -102,7 +115,6 @@ func TestProcessor_Traces(t *testing.T) {
 		},
 		{
 			name:          "uuid with any prefix",
-			serviceName:   "uuid-with-any-prefix",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -115,7 +127,6 @@ func TestProcessor_Traces(t *testing.T) {
 		},
 		{
 			name:          "multiple numeric ids in url path",
-			serviceName:   "multiple-numeric-templated-string",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -128,7 +139,6 @@ func TestProcessor_Traces(t *testing.T) {
 		},
 		{
 			name:          "deprecated method attribute",
-			serviceName:   "deprecated-method-attribute",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -141,7 +151,6 @@ func TestProcessor_Traces(t *testing.T) {
 		},
 		{
 			name:          "deprecated http.target attribute",
-			serviceName:   "deprecated-http-target-attribute",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -154,7 +163,6 @@ func TestProcessor_Traces(t *testing.T) {
 		},
 		{
 			name:          "http.target with query params",
-			serviceName:   "http-target-with-query-params",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -167,7 +175,6 @@ func TestProcessor_Traces(t *testing.T) {
 		},
 		{
 			name:          "with url.full attribute",
-			serviceName:   "url-full-attribute",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -180,7 +187,6 @@ func TestProcessor_Traces(t *testing.T) {
 		},
 		{
 			name:          "with deprecated http.url attribute",
-			serviceName:   "http-url-attribute",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -193,7 +199,6 @@ func TestProcessor_Traces(t *testing.T) {
 		},
 		{
 			name:          "client span",
-			serviceName:   "client-span",
 			spanKind:      ptrace.SpanKindClient,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -206,7 +211,6 @@ func TestProcessor_Traces(t *testing.T) {
 		},
 		{
 			name:          "span name is not the method",
-			serviceName:   "span-name-not-the-method",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "some-other-name",
 			inputSpanAttrs: map[string]any{
@@ -219,7 +223,6 @@ func TestProcessor_Traces(t *testing.T) {
 		},
 		{
 			name:          "ignore internal span",
-			serviceName:   "ignore-internal-span",
 			spanKind:      ptrace.SpanKindInternal,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -232,7 +235,6 @@ func TestProcessor_Traces(t *testing.T) {
 		},
 		{
 			name:          "ignore span without any path",
-			serviceName:   "ignore-span-without-path",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -244,7 +246,6 @@ func TestProcessor_Traces(t *testing.T) {
 		},
 		{
 			name:          "ignore span without any method",
-			serviceName:   "ignore-span-without-method",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -256,7 +257,6 @@ func TestProcessor_Traces(t *testing.T) {
 		},
 		{
 			name:          "ignore server span with templated attribute",
-			serviceName:   "ignore-server-span-with-templated-attribute",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -270,7 +270,6 @@ func TestProcessor_Traces(t *testing.T) {
 		},
 		{
 			name:          "ignore client span with templated attribute",
-			serviceName:   "ignore-client-span-with-templated-attribute",
 			spanKind:      ptrace.SpanKindClient,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -284,7 +283,6 @@ func TestProcessor_Traces(t *testing.T) {
 		},
 		{
 			name:          "static url path",
-			serviceName:   "static-url-path",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -297,7 +295,6 @@ func TestProcessor_Traces(t *testing.T) {
 		},
 		{
 			name:          "mixed-numbers-and-text",
-			serviceName:   "mixed-numbers-and-text",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -310,7 +307,6 @@ func TestProcessor_Traces(t *testing.T) {
 		},
 		{
 			name:          "hexencoded id",
-			serviceName:   "hexencoded-id",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -323,7 +319,6 @@ func TestProcessor_Traces(t *testing.T) {
 		},
 		{
 			name:          "long hexencoded id",
-			serviceName:   "long-hexencoded-id",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -336,7 +331,6 @@ func TestProcessor_Traces(t *testing.T) {
 		},
 		{
 			name:          "short looking like hexencoded id",
-			serviceName:   "short-looking-like-hexencoded-id",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -349,7 +343,6 @@ func TestProcessor_Traces(t *testing.T) {
 		},
 		{
 			name:          "long text",
-			serviceName:   "long-text",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -362,7 +355,6 @@ func TestProcessor_Traces(t *testing.T) {
 		},
 		{
 			name:          "non-even length hex",
-			serviceName:   "non-even-length-hex",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -375,7 +367,6 @@ func TestProcessor_Traces(t *testing.T) {
 		},
 		{
 			name:          "long number with text",
-			serviceName:   "long-number-with-text",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -389,7 +380,6 @@ func TestProcessor_Traces(t *testing.T) {
 		{
 			name: "long number in middle of text",
 			// this is a corner case where the number is long, but it is not at the beginning or end of the string
-			serviceName:   "long-number-in-middle-of-text",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -403,7 +393,6 @@ func TestProcessor_Traces(t *testing.T) {
 		{
 			name: "6 digits number should not be templated",
 			// this is a corner case where the number is under the limit of digits (7)
-			serviceName:   "6-digits-number-should-not-be-templated",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "GET",
 			inputSpanAttrs: map[string]any{
@@ -416,18 +405,128 @@ func TestProcessor_Traces(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
-			traces := generateTraceData(tc.serviceName, tc.inputSpanName, tc.spanKind, tc.inputSpanAttrs)
+	runProcessorTests(t, tt, processor)
+}
 
-			ctx := context.Background()
-			processedTraces, err := processor.processTraces(ctx, traces)
-			require.NoError(t, err)
-
-			processedSpan := processedTraces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
-			assertSpanNameAndAttribute(t, processedSpan, tc.expectedSpanName, tc.expectedAttrKey, tc.expectedAttrValue)
-		})
+func TestDefaultDateTemplatization(t *testing.T) {
+	tt := []processorTestManifest{
+		{
+			name:          "date in url path",
+			spanKind:      ptrace.SpanKindServer,
+			inputSpanName: "GET",
+			inputSpanAttrs: map[string]any{
+				"http.request.method": "GET",
+				"url.path":            "/user/2025-12-04T14:55:04+0000",
+			},
+			expectedSpanName:  "GET /user/{date}",
+			expectedAttrKey:   "http.route",
+			expectedAttrValue: "/user/{date}",
+		},
+		{
+			name:          "plain date",
+			spanKind:      ptrace.SpanKindServer,
+			inputSpanName: "GET",
+			inputSpanAttrs: map[string]any{
+				"http.request.method": "GET",
+				"url.path":            "/user/2025-12-04",
+			},
+			expectedSpanName:  "GET /user/{date}",
+			expectedAttrKey:   "http.route",
+			expectedAttrValue: "/user/{date}",
+		},
+		{
+			name:          "date with hour minute",
+			spanKind:      ptrace.SpanKindServer,
+			inputSpanName: "GET",
+			inputSpanAttrs: map[string]any{
+				"http.request.method": "GET",
+				"url.path":            "/user/2025-12-04T14:55",
+			},
+			expectedSpanName:  "GET /user/{date}",
+			expectedAttrKey:   "http.route",
+			expectedAttrValue: "/user/{date}",
+		},
+		{
+			name:          "date with hour minute second",
+			spanKind:      ptrace.SpanKindServer,
+			inputSpanName: "GET",
+			inputSpanAttrs: map[string]any{
+				"http.request.method": "GET",
+				"url.path":            "/user/2025-12-04T14:55:22",
+			},
+			expectedSpanName:  "GET /user/{date}",
+			expectedAttrKey:   "http.route",
+			expectedAttrValue: "/user/{date}",
+		},
+		{
+			name:          "date with UCT timezone",
+			spanKind:      ptrace.SpanKindServer,
+			inputSpanName: "GET",
+			inputSpanAttrs: map[string]any{
+				"http.request.method": "GET",
+				"url.path":            "/user/2025-12-04T14:55:22Z",
+			},
+			expectedSpanName:  "GET /user/{date}",
+			expectedAttrKey:   "http.route",
+			expectedAttrValue: "/user/{date}",
+		},
+		{
+			name:          "date with timezone as offset",
+			spanKind:      ptrace.SpanKindServer,
+			inputSpanName: "GET",
+			inputSpanAttrs: map[string]any{
+				"http.request.method": "GET",
+				"url.path":            "/user/2025-12-04T14:55:22+0000",
+			},
+			expectedSpanName:  "GET /user/{date}",
+			expectedAttrKey:   "http.route",
+			expectedAttrValue: "/user/{date}",
+		},
+		{
+			name: "no prefix",
+			// this is a corner case where the date is not at the beginning or end of the string
+			spanKind:      ptrace.SpanKindServer,
+			inputSpanName: "GET",
+			inputSpanAttrs: map[string]any{
+				"http.request.method": "GET",
+				"url.path":            "/user/ent_2025-12-04T14:55:22+0000",
+			},
+			expectedSpanName:  "GET /user/ent_2025-12-04T14:55:22+0000",
+			expectedAttrKey:   "http.route",
+			expectedAttrValue: "/user/ent_2025-12-04T14:55:22+0000",
+		},
+		{
+			name: "no suffix",
+			// this is a corner case where the date is not at the beginning or end of the string
+			spanKind:      ptrace.SpanKindServer,
+			inputSpanName: "GET",
+			inputSpanAttrs: map[string]any{
+				"http.request.method": "GET",
+				"url.path":            "/user/2025-12-04T14:55:22+0000_ent",
+			},
+			expectedSpanName:  "GET /user/2025-12-04T14:55:22+0000_ent",
+			expectedAttrKey:   "http.route",
+			expectedAttrValue: "/user/2025-12-04T14:55:22+0000_ent",
+		},
+		{
+			name:          "not matching day first",
+			spanKind:      ptrace.SpanKindServer,
+			inputSpanName: "GET",
+			inputSpanAttrs: map[string]any{
+				"http.request.method": "GET",
+				"url.path":            "04-12-2025",
+			},
+			expectedSpanName:  "GET 04-12-2025",
+			expectedAttrKey:   "http.route",
+			expectedAttrValue: "04-12-2025",
+		},
 	}
+
+	set := processortest.NewNopSettings(processortest.NopType)
+	processor, err := newUrlTemplateProcessor(set, &Config{})
+	require.NoError(t, err)
+
+	runProcessorTests(t, tt, processor)
 }
 
 func TestProcessor_TemplatizationRules(t *testing.T) {

--- a/collector/processors/odigosurltemplateprocessor/templatize.go
+++ b/collector/processors/odigosurltemplateprocessor/templatize.go
@@ -39,10 +39,10 @@ var (
 	// 	 - Each repetition is of 2 characters → ensures even length.
 	hexEncodedRegex = regexp.MustCompile(`^(?:[0-9a-f]{2}){8,}$`)
 
-	// assume that long numbers (more than 8 digits) are ids.
-	// even if they are found with some text (for example "INC001268637") they are treated as ids
+	// assume that long numbers (7 continues digits or more) are ids.
+	// even if they are found with some text (for example "INC0012686") they are treated as ids
 	// it is very unlikely for a a number with so many digits to be static and meaningful.
-	longNumberAnywhereRegex = regexp.MustCompile(`\d{9,}`)
+	longNumberAnywhereRegex = regexp.MustCompile(`\d{7,}`)
 )
 
 type RulePathSegment struct {

--- a/collector/processors/odigosurltemplateprocessor/templatize.go
+++ b/collector/processors/odigosurltemplateprocessor/templatize.go
@@ -62,6 +62,9 @@ var (
 	// 2025-12-04T14:55:04.123Z (milliseconds)
 	// 2025-12-04T14:55:04.123+0000 (millis with offset)
 	datesRegex = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}(?::\d{2})?)?(?:Z|[+-]\d{4})?$`)
+
+	// matches email addresses
+	emailRegex = regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
 )
 
 type RulePathSegment struct {
@@ -192,6 +195,10 @@ func getSegmentTemplatizationString(segment string, customIdsRegexp []regexp.Reg
 
 	if datesRegex.MatchString(segment) {
 		return "date"
+	}
+
+	if emailRegex.MatchString(segment) {
+		return "email"
 	}
 
 	// check if the segment matches any of the custom ids regexp


### PR DESCRIPTION
## Description

Add 3 changes for url-templatization processor:

- capture any number with >= 7 digits (instead of 9)
- date / date-time like "2025-30-04T13:14:15+0000"
- emails

## How Has This Been Tested?

- [x] Added Unit Tests

## Kubernetes Checklist

## User Facing Changes

More cases automatically covered by the processor