### PR TITLE
feat: make every path segment without letters template

### DIFF
--- a/collector/processors/odigosurltemplateprocessor/README.md
+++ b/collector/processors/odigosurltemplateprocessor/README.md
@@ -120,7 +120,7 @@ The templatization process should be monitored and adjusted according to the val
 
 By default, the processor will split the path to segment (e.g. "/user/1234" -> ["user", "1234"]) and replace the segments with the following rules:
 
-- only digits - `^\d+$` -> `{id}` (`1234`, `328962358623904`, `0`)
+- only digits or special characters - ```^[\d_\-!@#$%^&*()=+{}\[\]:;"'<>,.?/\\|`~]+$``` -> `{id}` (`1234`, `123_456`, `0`)
 - uuids - `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` -> `{id}` (`123e4567-e89b-12d3-a456-426614174000`). They can appear as either prefix or suffix of the segment (for example `/process/PROCESS_123e4567-e89b-12d3-a456-42661bd74000`)
 - hex-encoded strings - `[0-9a-f]{2}([0-9a-f]{2})*` -> `{id}` (`6f2a9cdeab34f01e`)
 - long numbers anywhere - `\d{7,}` -> `{id}` (`1234567`, `INC328962358623904`, `sb_12345678901234567890_us`)

--- a/collector/processors/odigosurltemplateprocessor/templatize.go
+++ b/collector/processors/odigosurltemplateprocessor/templatize.go
@@ -8,7 +8,10 @@ import (
 )
 
 var (
-	onlyDigitsRegex = regexp.MustCompile(`^\d+$`)
+
+	// matches any string that contains only digits or special characters
+	// will catch things like "1234_567" but not anything that contains a letter
+	noLettersRegex = regexp.MustCompile(`^[\d_\-!@#$%^&*()=+{}\[\]:;"'<>,.?/\\|` + "`" + `~]+$`)
 
 	// matches UUIDs in the format 123e4567-e89b-12d3-a456-426614174000
 	// these UUIDs are common in cloud systems and are often used as ids
@@ -185,12 +188,12 @@ func attemptTemplateWithRule(pathSegments []string, ruleSegments TemplatizationR
 // as {id} / {date} etc
 // empty string as return value means that the segment is not a templated id
 func getSegmentTemplatizationString(segment string, customIdsRegexp []regexp.Regexp) string {
-	// check if the segment is a number or uuid
-	if onlyDigitsRegex.MatchString(segment) ||
-		longNumberAnywhereRegex.MatchString(segment) ||
-		uuidRegex.MatchString(segment) ||
-		hexEncodedRegex.MatchString(segment) {
-		return "id"
+
+	// check if the segment matches any of the custom ids regexp
+	for _, customRegexp := range customIdsRegexp {
+		if customRegexp.MatchString(segment) {
+			return "id"
+		}
 	}
 
 	if datesRegex.MatchString(segment) {
@@ -201,11 +204,12 @@ func getSegmentTemplatizationString(segment string, customIdsRegexp []regexp.Reg
 		return "email"
 	}
 
-	// check if the segment matches any of the custom ids regexp
-	for _, customRegexp := range customIdsRegexp {
-		if customRegexp.MatchString(segment) {
-			return "id"
-		}
+	// check if the segment is a number or uuid
+	if noLettersRegex.MatchString(segment) ||
+		longNumberAnywhereRegex.MatchString(segment) ||
+		uuidRegex.MatchString(segment) ||
+		hexEncodedRegex.MatchString(segment) {
+		return "id"
 	}
 
 	return ""


### PR DESCRIPTION
## Description

There is a templatization rule that automatically templatize path segments which are numbers (only digits).

This PR extends it to cover digits or special character, which is targeted to also match things like `123_456` which are currently not templated.

## How Has This Been Tested?

- [x] Added Unit Tests

## Kubernetes Checklist

No

## User Facing Changes

Cover more id cases by default