### PR TITLE
feat: urltmeplate processor allow to set template name for customid

### DIFF
--- a/collector/processors/odigosurltemplateprocessor/README.md
+++ b/collector/processors/odigosurltemplateprocessor/README.md
@@ -82,7 +82,7 @@ processors:
     # but regexp like "^ap" is too permissive and will also catch "/api".
     # compatible with golang regexp module https://pkg.go.dev/regexp
     # for performance reasons, avoid using compute-intensive expressions or adding too many values here.
-    custom_ids_regexp:
+    custom_ids:
       - regexp: "^inc_\d+$"
         name: "incidentId"
 ```

--- a/collector/processors/odigosurltemplateprocessor/README.md
+++ b/collector/processors/odigosurltemplateprocessor/README.md
@@ -83,7 +83,8 @@ processors:
     # compatible with golang regexp module https://pkg.go.dev/regexp
     # for performance reasons, avoid using compute-intensive expressions or adding too many values here.
     custom_ids_regexp:
-      - "^inc_\d+$"
+      - regexp: "^inc_\d+$"
+        name: "incidentId"
 ```
 
 ## Include/Exclude Filters
@@ -143,11 +144,9 @@ This rule, when applied to the path `/user/john/friends/1234`, will result in th
 
 To denote a template path segment, use `{}` brackets with name and optional regexp: `{name:regexp}`. name will be used to generate the templated path (e.g `/user/{foo})` will result in this template value when matched against `/user/john`).
 
-### Custom Ids Regexp
+### Custom Ids
 
-The default rule will match various common ids as described above. Systems can and do use a variety of ids conventions and formats. The processor allows you to set custom regexp for the id matching that will be used in addition to the default id templatization regexps.
-
-Custom Templatization takes precedence over the custom id regexp. If any custom custom rule matches a path, it will be taken the the custom ids regexp will not take effect for that path.
+The default rule will match various common ids as described above. Systems can and do use a variety of ids conventions and formats. if you system is using a custom id that is not matched by the default rules, you can set a custom regexp to match these ids.
 
 For example, if your system uses `id`s in format `id-1234`, you can set the regexp `^id-\d+$` to match this format, so that `/user/id-1234` will be templatized to `/user/{id}`.
 
@@ -160,7 +159,7 @@ Few more examples for ids that will not be catched by default but can be configu
 - `svc_auth_xyz123TOKEN` - `^svc_[a-z]+_[a-zA-Z0-9]+$` (Keys)
 - `svc-us-west-2-db12` - `^svc-[a-z]{2}-[a-z]+-\d-[a-z0-9]+$` (Multi-region Services)
 
-Few considerations for the custom regexp:
+Few considerations for the custom ids:
 
 - The regexp must match the entire segment value, not just part of it.
 - Keep regexp precise and correct so they don't match unrelated values from other endpoints in the same cluster. The value will be evaluated against all un-templated http spans in the pipeline.

--- a/collector/processors/odigosurltemplateprocessor/README.md
+++ b/collector/processors/odigosurltemplateprocessor/README.md
@@ -84,7 +84,7 @@ processors:
     # for performance reasons, avoid using compute-intensive expressions or adding too many values here.
     custom_ids:
       - regexp: "^inc_\d+$"
-        name: "incidentId"
+        template_name: "incidentId"
 ```
 
 ## Include/Exclude Filters

--- a/collector/processors/odigosurltemplateprocessor/filtermatcher.go
+++ b/collector/processors/odigosurltemplateprocessor/filtermatcher.go
@@ -2,6 +2,7 @@ package odigosurltemplateprocessor
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -17,6 +18,13 @@ type workloadStringRepresentation string
 func k8sWorkloadToStringRepresentation(workload K8sWorkload) workloadStringRepresentation {
 	lowercaseKind := strings.ToLower(workload.Kind)
 	return workloadStringRepresentation(fmt.Sprintf("%s/%s/%s", workload.Namespace, lowercaseKind, workload.Name))
+}
+
+// internal representation of the custom id config.
+// in this representation, the regexp is already parsed from the input string.
+type internalCustomIdConfig struct {
+	Regexp regexp.Regexp
+	Name   string
 }
 
 func resourceToWorkloadStringRepresentation(resource pcommon.Resource) (workloadStringRepresentation, error) {

--- a/collector/processors/odigosurltemplateprocessor/processor_test.go
+++ b/collector/processors/odigosurltemplateprocessor/processor_test.go
@@ -750,24 +750,36 @@ func TestProcessor_TemplatizationRules(t *testing.T) {
 func TestProcessor_CustomIdsRegexp(t *testing.T) {
 	tt := []struct {
 		name              string
-		customIds         []string
+		customIds         []CustomIdConfig
 		path              string
 		expectedName      string
 		expectedHttpRoute string
 	}{
 		{
 			name:              "custom id",
-			customIds:         []string{"^in_[0-9]+$"},
+			customIds:         []CustomIdConfig{{Regexp: "^in_[0-9]+$"}},
 			path:              "/product/in_005",
 			expectedName:      "GET /product/{id}",
 			expectedHttpRoute: "/product/{id}",
 		},
 		{
 			name:              "multiple custom ids",
-			customIds:         []string{"^in_[0-9]+$", "^out_[0-9]+$"},
+			customIds:         []CustomIdConfig{{Regexp: "^in_[0-9]+$"}, {Regexp: "^out_[0-9]+$"}},
 			path:              "/foo/out_005/bar/in_123",
 			expectedName:      "GET /foo/{id}/bar/{id}",
 			expectedHttpRoute: "/foo/{id}/bar/{id}",
+		},
+		{
+			name: "custom id with template name",
+			customIds: []CustomIdConfig{
+				{
+					Regexp:       "^in_[0-9]+$",
+					TemplateName: "custom-id",
+				},
+			},
+			path:              "/product/in_005",
+			expectedName:      "GET /product/{custom-id}",
+			expectedHttpRoute: "/product/{custom-id}",
 		},
 	}
 
@@ -781,7 +793,7 @@ func TestProcessor_CustomIdsRegexp(t *testing.T) {
 			// Add the templated rule to the processor
 			processor, err := newUrlTemplateProcessor(processortest.NewNopSettings(processortest.NopType), &Config{
 				TemplatizationConfig: TemplatizationConfig{
-					CustomIdsRegexp: tc.customIds,
+					CustomIds: tc.customIds,
 				},
 			})
 			require.NoError(t, err)

--- a/collector/processors/odigosurltemplateprocessor/templatize.go
+++ b/collector/processors/odigosurltemplateprocessor/templatize.go
@@ -184,7 +184,7 @@ func attemptTemplateWithRule(pathSegments []string, ruleSegments TemplatizationR
 // return the name to use for templatization "id" / "date" etc which will be embedded in the template
 // as {id} / {date} etc
 // empty string as return value means that the segment is not a templated id
-func getSegmentTemplatizationString(segment string, customIdsRegexp []regexp.Regexp) string {
+func getSegmentTemplatizationString(segment string, customIds []internalCustomIdConfig) string {
 	// check if the segment is a number or uuid
 	if onlyDigitsRegex.MatchString(segment) ||
 		longNumberAnywhereRegex.MatchString(segment) ||
@@ -202,9 +202,9 @@ func getSegmentTemplatizationString(segment string, customIdsRegexp []regexp.Reg
 	}
 
 	// check if the segment matches any of the custom ids regexp
-	for _, customRegexp := range customIdsRegexp {
-		if customRegexp.MatchString(segment) {
-			return "id"
+	for _, customRegexp := range customIds {
+		if customRegexp.Regexp.MatchString(segment) {
+			return customRegexp.Name
 		}
 	}
 
@@ -212,7 +212,7 @@ func getSegmentTemplatizationString(segment string, customIdsRegexp []regexp.Reg
 }
 
 // This function will replace all segments that matches a number or uuid with "{id}"
-func defaultTemplatizeURLPath(pathSegments []string, customIdsRegexp []regexp.Regexp) (string, bool) {
+func defaultTemplatizeURLPath(pathSegments []string, customIdsRegexp []internalCustomIdConfig) (string, bool) {
 	templated := false
 	// avoid modifying the original segments slice
 	templatizedSegments := make([]string, len(pathSegments))


### PR DESCRIPTION
## Description

If user set their our custom ids for url templatization, they can now also give the template name (instead of it being fallback to "id")

## How Has This Been Tested?

- [x] Added Unit Tests

## Kubernetes Checklist

No

## User Facing Changes

More configuration options