### PR TITLE
fix: use the correct cli image for helm cleanup hook

### DIFF
--- a/helm/odigos/templates/cleanup/cleanup-job.yaml
+++ b/helm/odigos/templates/cleanup/cleanup-job.yaml
@@ -1,3 +1,4 @@
+{{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -15,10 +16,6 @@ spec:
       serviceAccountName: cleanup-sa
       containers:
       - name: cleanup
-        {{- if .Values.imagePrefix }}
-        image: "{{ .Values.imagePrefix }}/{{ .Values.cli.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-        {{- else }}
-        image: "{{ .Values.cli.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-        {{- end }}
+        image: {{ template "utils.imageName" (dict "Values" .Values "Component" "cli" "Tag" $imageTag) }}
         args: ["uninstall", "--yes"]
       restartPolicy: Never

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -217,10 +217,6 @@ centralProxy:
   tolerations: []
   affinity: {}
 
-cli:
-  image:
-    repository: registry.odigos.io/odigos-cli
-
 # Pod Security Policy
 psp:
   enabled: false


### PR DESCRIPTION
Fix bug, in which the image used for the cleanup hook could have the wrong name if the user has set `values.imagePrefix`.
Use the same helm template function we use for all other images in the templates.