### PR TITLE
fix: double env injections

### DIFF
--- a/instrumentor/controllers/agentenabled/podswebhook/env.go
+++ b/instrumentor/controllers/agentenabled/podswebhook/env.go
@@ -32,7 +32,7 @@ func injectEnvVarObjectFieldRefToPodContainer(existingEnvNames EnvVarNamesMap, c
 	return existingEnvNames
 }
 
-func injectEnvVarToPodContainer(existingEnvNames EnvVarNamesMap, container *corev1.Container, envVarName, envVarValue string, runtimeDetails *odigosv1.RuntimeDetailsByContainer) EnvVarNamesMap {
+func InjectEnvVarToPodContainer(existingEnvNames EnvVarNamesMap, container *corev1.Container, envVarName, envVarValue string, runtimeDetails *odigosv1.RuntimeDetailsByContainer) EnvVarNamesMap {
 	if _, exists := existingEnvNames[envVarName]; exists {
 		return existingEnvNames
 	}
@@ -63,28 +63,28 @@ func injectNodeIpEnvVar(existingEnvNames EnvVarNamesMap, container *corev1.Conta
 }
 
 func InjectOdigosK8sEnvVars(existingEnvNames EnvVarNamesMap, container *corev1.Container, distroName string, ns string) EnvVarNamesMap {
-	existingEnvNames = injectEnvVarToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarContainerName, container.Name, nil)
-	existingEnvNames = injectEnvVarToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarDistroName, distroName, nil)
+	existingEnvNames = InjectEnvVarToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarContainerName, container.Name, nil)
+	existingEnvNames = InjectEnvVarToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarDistroName, distroName, nil)
 	existingEnvNames = injectEnvVarObjectFieldRefToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarPodName, "metadata.name")
-	existingEnvNames = injectEnvVarToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarNamespace, ns, nil)
+	existingEnvNames = InjectEnvVarToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarNamespace, ns, nil)
 	return existingEnvNames
 }
 
 func InjectStaticEnvVar(existingEnvNames EnvVarNamesMap, container *corev1.Container, envVarName string, envVarValue string, runtimeDetails *odigosv1.RuntimeDetailsByContainer) EnvVarNamesMap {
-	return injectEnvVarToPodContainer(existingEnvNames, container, envVarName, envVarValue, runtimeDetails)
+	return InjectEnvVarToPodContainer(existingEnvNames, container, envVarName, envVarValue, runtimeDetails)
 }
 
 func InjectOpampServerEnvVar(existingEnvNames EnvVarNamesMap, container *corev1.Container) EnvVarNamesMap {
 	existingEnvNames = injectNodeIpEnvVar(existingEnvNames, container)
 	opAmpServerHost := fmt.Sprintf("$(NODE_IP):%d", commonconsts.OpAMPPort)
-	existingEnvNames = injectEnvVarToPodContainer(existingEnvNames, container, commonconsts.OpampServerHostEnvName, opAmpServerHost, nil)
+	existingEnvNames = InjectEnvVarToPodContainer(existingEnvNames, container, commonconsts.OpampServerHostEnvName, opAmpServerHost, nil)
 	return existingEnvNames
 }
 
 func InjectOtlpHttpEndpointEnvVar(existingEnvNames EnvVarNamesMap, container *corev1.Container) EnvVarNamesMap {
 	existingEnvNames = injectNodeIpEnvVar(existingEnvNames, container)
 	otlpHttpEndpoint := service.LocalTrafficOTLPHttpDataCollectionEndpoint("$(NODE_IP)")
-	existingEnvNames = injectEnvVarToPodContainer(existingEnvNames, container, commonconsts.OtelExporterEndpointEnvName, otlpHttpEndpoint, nil)
+	existingEnvNames = InjectEnvVarToPodContainer(existingEnvNames, container, commonconsts.OtelExporterEndpointEnvName, otlpHttpEndpoint, nil)
 	return existingEnvNames
 }
 
@@ -105,7 +105,7 @@ func InjectUserEnvForLang(odigosConfig *common.OdigosConfiguration, pod *corev1.
 		existingEnvNames := GetEnvVarNamesSet(container)
 
 		for envName, envValue := range langConfig.EnvVars {
-			existingEnvNames = injectEnvVarToPodContainer(
+			existingEnvNames = InjectEnvVarToPodContainer(
 				existingEnvNames,
 				container,
 				envName,

--- a/instrumentor/controllers/agentenabled/podswebhook/otelresource.go
+++ b/instrumentor/controllers/agentenabled/podswebhook/otelresource.go
@@ -63,11 +63,11 @@ func getResourceAttributesEnvVarValue(ra []resourceAttribute) string {
 func InjectOtelResourceAndServiceNameEnvVars(existingEnvNames EnvVarNamesMap, container *corev1.Container, distroName string, pw k8sconsts.PodWorkload, serviceName string) EnvVarNamesMap {
 
 	// OTEL_SERVICE_NAME
-	existingEnvNames = injectEnvVarToPodContainer(existingEnvNames, container, otelServiceNameEnvVarName, serviceName, nil)
+	existingEnvNames = InjectEnvVarToPodContainer(existingEnvNames, container, otelServiceNameEnvVarName, serviceName, nil)
 
 	// OTEL_RESOURCE_ATTRIBUTES
 	resourceAttributes := getResourceAttributes(pw, container.Name)
 	resourceAttributesEnvValue := getResourceAttributesEnvVarValue(resourceAttributes)
-	existingEnvNames = injectEnvVarToPodContainer(existingEnvNames, container, otelResourceAttributesEnvVarName, resourceAttributesEnvValue, nil)
+	existingEnvNames = InjectEnvVarToPodContainer(existingEnvNames, container, otelResourceAttributesEnvVarName, resourceAttributesEnvValue, nil)
 	return existingEnvNames
 }


### PR DESCRIPTION
Bug caught by nightly tests;
The 3 `OTEL_<SIGNAL>_EXPORTER` envs were injected twice due to no checks on exiting envs.
This PR makes sure the envs are checked before being injected.

---

Output from nightly with double envs:
```
Error: some tests failed
    l.go:52: | 00:26:55 | multi-apps | Simple-demo instrumented after destination added | ASSERT    | ERROR | v1/Pod @ default/*
        === ERROR
        ----------------------------------------
        v1/Pod/default/currency-695979478b-t6xb9
        ----------------------------------------
        * spec.containers[0].(env[?name == 'OTEL_LOGS_EXPORTER']): Invalid value: []interface {}{map[string]interface {}{"name":"OTEL_LOGS_EXPORTER", "value":"none"}, map[string]interface {}{"name":"OTEL_LOGS_EXPORTER", "value":"none"}}: lengths of slices don't match
        * spec.containers[0].(env[?name == 'OTEL_METRICS_EXPORTER']): Invalid value: []interface {}{map[string]interface {}{"name":"OTEL_METRICS_EXPORTER", "value":"none"}, map[string]interface {}{"name":"OTEL_METRICS_EXPORTER", "value":"none"}}: lengths of slices don't match
        * spec.containers[0].(env[?name == 'OTEL_TRACES_EXPORTER']): Invalid value: []interface {}{map[string]interface {}{"name":"OTEL_TRACES_EXPORTER", "value":"otlp"}, map[string]interface {}{"name":"OTEL_TRACES_EXPORTER", "value":"otlp"}}: lengths of slices don't match
        
        --- expected
        +++ actual
        @@ -3,7 +3,15 @@
         metadata:
           labels:
             app: currency
        +  name: currency-695979478b-t6xb9
           namespace: default
        +  ownerReferences:
        +  - apiVersion: apps/v1
        +    blockOwnerDeletion: true
        +    controller: true
        +    kind: ReplicaSet
        +    name: currency-695979478b
        +    uid: d31a835a-556e-4bcb-a22f-c4311198cac2
         spec:
           affinity:
             nodeAffinity:
        @@ -15,44 +23,79 @@
                     values:
                     - "true"
           containers:
        -  - (env[?name == 'ODIGOS_CONTAINER_NAME']):
        -    - value: currency
        -    (env[?name == 'ODIGOS_DISTRO_NAME']):
        -    - value: php-community
        -    (env[?name == 'ODIGOS_POD_NAME']):
        -    - valueFrom:
        +  - env:
        +    - name: ODIGOS_CONTAINER_NAME
        +      value: currency
        +    - name: ODIGOS_DISTRO_NAME
        +      value: php-community
        +    - name: ODIGOS_POD_NAME
        +      valueFrom:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
        -    (env[?name == 'ODIGOS_WORKLOAD_NAMESPACE']):
        -    - value: default
        -    (env[?name == 'OTEL_EXPORTER_OTLP_ENDPOINT']):
        -    - ? (($values.k8sMinorVersion < `26` && value == 'http://$(NODE_IP):4318') ||
        -        value == 'http://odigos-data-collection-local-traffic.odigos-test:4318/')
        -      : true
        -    (env[?name == 'OTEL_LOGS_EXPORTER']):
        -    - value: none
        -    (env[?name == 'OTEL_METRICS_EXPORTER']):
        -    - value: none
        -    (env[?name == 'OTEL_RESOURCE_ATTRIBUTES']):
        -    - value: k8s.pod.name=$(ODIGOS_POD_NAME),k8s.container.name=currency,k8s.namespace.name=default,k8s.deployment.name=currency
        -    (env[?name == 'OTEL_SERVICE_NAME']):
        -    - value: currency
        -    (env[?name == 'OTEL_TRACES_EXPORTER']):
        -    - value: otlp
        -    (env[?name == 'PHP_INI_SCAN_DIR']):
        -    - value: :/var/odigos/php/8.2
        +    - name: ODIGOS_WORKLOAD_NAMESPACE
        +      value: default
        +    - name: PHP_INI_SCAN_DIR
        +      value: :/var/odigos/php/8.2
        +    - name: OTEL_PHP_AUTOLOAD_ENABLED
        +      value: "true"
        +    - name: NODE_IP
        +      valueFrom:
        +        fieldRef:
        +          apiVersion: v1
        +          fieldPath: status.hostIP
        +    - name: OTEL_EXPORTER_OTLP_ENDPOINT
        +      value: http://odigos-data-collection-local-traffic.odigos-test:4318/
        +    - name: OTEL_SERVICE_NAME
        +      value: currency
        +    - name: OTEL_RESOURCE_ATTRIBUTES
        +      value: k8s.pod.name=$(ODIGOS_POD_NAME),k8s.container.name=currency,k8s.namespace.name=default,k8s.deployment.name=currency
        +    - name: OTEL_LOGS_EXPORTER
        +      value: none
        +    - name: OTEL_METRICS_EXPORTER
        +      value: none
        +    - name: OTEL_TRACES_EXPORTER
        +      value: otlp
        +    - name: OTEL_LOGS_EXPORTER
        +      value: none
        +    - name: OTEL_METRICS_EXPORTER
        +      value: none
        +    - name: OTEL_TRACES_EXPORTER
        +      value: otlp
        +    image: registry.odigos.io/odigos-demo-currency:v0.1.15
        +    imagePullPolicy: IfNotPresent
             name: currency
        +    ports:
        +    - containerPort: 8080
        +      protocol: TCP
             resources:
               limits:
                 instrumentation.odigos.io/generic: "1"
               requests:
                 instrumentation.odigos.io/generic: "1"
        +    terminationMessagePath: /dev/termination-log
        +    terminationMessagePolicy: File
        +    volumeMounts:
        +    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
        +      name: kube-api-access-jpdzh
        +      readOnly: true
         status:
           containerStatuses:
        -  - name: currency
        +  - containerID: containerd://189c974bd6aefb080f2558dc834d4dd0ee9cdcb1c9994d8fedebabd53c8a1f39
        +    image: registry.odigos.io/odigos-demo-currency:v0.1.15
        +    imageID: registry.odigos.io/odigos-demo-currency@sha256:52f6f7ced4d0e874dd3bc3d0cdc08d904e4b3412783b5ca85627ba5d0cd3772b
        +    lastState: {}
        +    name: currency
             ready: true
             restartCount: 0
             started: true
        +    state:
        +      running:
        +        startedAt: "2025-04-29T00:26:16Z"
        +    volumeMounts:
        +    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
        +      name: kube-api-access-jpdzh
        +      readOnly: true
        +      recursiveReadOnly: Disabled
           phase: Running
```