### PR TITLE
openshift: Check if SEManage rule already exists

### DIFF
--- a/odiglet/odiglet.go
+++ b/odiglet/odiglet.go
@@ -202,7 +202,6 @@ func OdigletInitPhase(clientset *kubernetes.Clientset) {
 	// executing selinux commands to make agents readable by pods.
 	if err := fs.ApplyOpenShiftSELinuxSettings(); err != nil {
 		log.Logger.Error(err, "Failed to apply SELinux settings on RHEL host")
-		os.Exit(-1)
 	}
 
 	os.Exit(0)

--- a/odiglet/odiglet.go
+++ b/odiglet/odiglet.go
@@ -202,6 +202,9 @@ func OdigletInitPhase(clientset *kubernetes.Clientset) {
 	// executing selinux commands to make agents readable by pods.
 	if err := fs.ApplyOpenShiftSELinuxSettings(); err != nil {
 		log.Logger.Error(err, "Failed to apply SELinux settings on RHEL host")
+		// TODO: semanage can sometimes return an error that's non-fatal, need to find a better way to handle all scenarios
+		// For now, allow it through (as the only errors we have seen in practice have been non-fatal so far)
+		//os.Exit(-1)
 	}
 
 	os.Exit(0)

--- a/operator/DEVELOPMENT.md
+++ b/operator/DEVELOPMENT.md
@@ -61,14 +61,24 @@ make bundle-build IMAGE_TAG_BASE=mikeodigos/odigos-operator VERSION=dev
 
 This will build a new docker image for the bundle containing all the generated manifests.
 
+### Building with custom component images
+
+If you are testing custom components (eg, Odiglet, Instrumentor, etc), do the following:
+
+1. Build and push your custom images to your Docker registry
+2. Update each `RELATED_IMAGE_*` environment variable in `config/manager/manager.yaml`
+3. Run `make generate manifests bundle`
+4. Run `make bundle-build IMAGE_TAG_BASE=<your-registry>/odigos-operator VERSION=dev` to build a new bundle image
+5. Push the bundle image to your registry and run it with `operator-sdk run bundle` (see below)
+
 ### Running in OpenShift
 
 To test in an OpenShift cluster, push the operator image and bundle image to your registry.
 
-Connect to the cluster with `oc login` and run:
+Connect to the cluster with `oc login` (copy login command from OpenShift console) and run:
 
 ```
-operator-sdk run bundle <path to bundle image:tag>
+operator-sdk run bundle <path to bundle image:tag> -n odigos-operator-system
 ```
 
 Clean up with:
@@ -76,6 +86,10 @@ Clean up with:
 ```
 operator-sdk cleanup odigos-operator  --delete-all
 ```
+
+### ImagePull error on OpenShift
+
+To authenticate with your DockerHub account on OpenShift, follow [this OpenShift support page](https://access.redhat.com/solutions/6159832).
 
 ## Preparing a new release
 


### PR DESCRIPTION
## Description

SELinux doesn't seem to consistently handle re-applying existing rules with `semanage`. It can sometimes result in an error that currently prevents the Odiglet from starting up. This PR does 2 things for RHEL hosts:

1. First check if an selinux rule exists for Odigos. If it does, don't both trying to re-apply
2. If we do hit some (unknown) error anyway, log the error and don't crash the Odiglet. This means we can still start up as a best effort in error cases, with the tradeoff that Odigos may not work if there was a different issue.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [x] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
