### PR TITLE
operator: Add central backend support

### DIFF
--- a/operator/api/v1alpha1/odigos_types.go
+++ b/operator/api/v1alpha1/odigos_types.go
@@ -58,6 +58,14 @@ type OdigosSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=3
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
+	// (Optional) ClusterName is the name of this cluster for the Odigos Central Backend, if configured.
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=3
+	ClusterName string `json:"clusterName,omitempty"`
+
+	// (Optional) CentralBackendURL is the URL for the Odigos Central Backend, if configured.
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=3
+	CentralBackendURL string `json:"centralBackendURL,omitempty"`
+
 	// (Optional) SkipWebhookIssuerCreation skips creating the Issuer and Certificate for the Instrumentor pod webhook if cert-manager is installed.
 	// Default=false
 	// +operator-sdk:csv:customresourcedefinitions:type=spec

--- a/operator/config/crd/bases/operator.odigos.io_odigos.yaml
+++ b/operator/config/crd/bases/operator.odigos.io_odigos.yaml
@@ -39,6 +39,14 @@ spec:
           spec:
             description: OdigosSpec defines the desired state of Odigos
             properties:
+              centralBackendURL:
+                description: (Optional) CentralBackendURL is the URL for the Odigos
+                  Central Backend, if configured.
+                type: string
+              clusterName:
+                description: (Optional) ClusterName is the name of this cluster for
+                  the Odigos Central Backend, if configured.
+                type: string
               ignoredContainers:
                 description: (Optional) IgnoredContainers is a list of container names
                   to exclude from instrumentation (useful for ignoring sidecars).

--- a/operator/internal/controller/odigos_controller.go
+++ b/operator/internal/controller/odigos_controller.go
@@ -335,6 +335,8 @@ func (r *OdigosReconciler) install(ctx context.Context, kubeClient *kube.Client,
 	odigosConfig.Profiles = odigos.Spec.Profiles
 	odigosConfig.UiMode = common.UiMode(odigos.Spec.UIMode)
 	odigosConfig.NodeSelector = nodeSelector
+	odigosConfig.CentralBackendURL = odigos.Spec.CentralBackendURL
+	odigosConfig.ClusterName = odigos.Spec.ClusterName
 
 	ownerReference := metav1.OwnerReference{
 		APIVersion: odigos.APIVersion,


### PR DESCRIPTION
## Description

This adds the `centralBackendURL` and `clusterName` options to the operator CRD, allowing setup for the central proxy

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
