### PR TITLE
chore: remove check for version

### DIFF
--- a/tests/common/queries/span-attributes.yaml
+++ b/tests/common/queries/span-attributes.yaml
@@ -5,7 +5,6 @@ description: |
   TODO - JS, Python and DotNet SDK are not generating data in latest semconv. add additional checks when they are updated.
 query: |
   length([?(
-    span.resourceAttributes."odigos.version" == 'e2e-test' &&
     span.resourceAttributes."telemetry.sdk.language" == 'java' &&
     span.serviceName == 'frontend' &&
     span.kind == 'server' &&
@@ -18,7 +17,6 @@ query: |
   &&
 
   length([?(
-    span.resourceAttributes."odigos.version" == 'e2e-test' &&
     span.resourceAttributes."telemetry.sdk.language" == 'dotnet' &&
     span.serviceName == 'pricing' &&
     span.kind == 'server'
@@ -27,7 +25,6 @@ query: |
   &&
 
   length([?(
-    span.resourceAttributes."odigos.version" == 'e2e-test' &&
     span.resourceAttributes."telemetry.sdk.language" == 'python' &&
     span.serviceName == 'inventory' &&
     span.kind == 'server'
@@ -36,7 +33,6 @@ query: |
   &&
 
   length([?(
-    span.resourceAttributes."odigos.version" == 'e2e-test' &&
     span.resourceAttributes."telemetry.sdk.language" == 'nodejs' &&
     span.serviceName == 'coupon' &&
     span.kind == 'server'
@@ -45,7 +41,6 @@ query: |
   &&
 
   length([?(
-    span.resourceAttributes."odigos.version" == 'e2e-test' &&
     span.resourceAttributes."telemetry.sdk.language" == 'go' &&
     span.serviceName == 'membership' &&
     span.kind == 'server' &&
@@ -57,7 +52,6 @@ query: |
   &&
 
   length([?(
-    span.resourceAttributes."odigos.version" == 'e2e-test' &&
     span.resourceAttributes."telemetry.sdk.language" == 'php' &&
     span.serviceName == 'currency' &&
     span.kind == 'server' &&


### PR DESCRIPTION
## Description

Nightly build images with the latest commit hash as the version.
in the span-attributes.yaml we were checking explicitly version is e2e-test.
I think better to keep tagging the nightly images with hash so we will know what is the latest commit tested.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
