### PR TITLE
Bump odigos py agent

### DIFF
--- a/agents/python/setup.py
+++ b/agents/python/setup.py
@@ -3,10 +3,10 @@ from setuptools import setup, find_packages
 index_url = None
 
 # DEV - Local Uncomment to develop locally \/
-# index_url = 'http://host.docker.internal:8080/packages/odigos_opentelemetry_python-1.0.44-py3-none-any.whl'
+# index_url = 'http://host.docker.internal:8080/packages/odigos_opentelemetry_python-1.0.45-py3-none-any.whl'
 
 install_requires = [
-    f"odigos-opentelemetry-python @ {index_url}" if index_url else "odigos-opentelemetry-python==1.0.44"
+    f"odigos-opentelemetry-python @ {index_url}" if index_url else "odigos-opentelemetry-python==1.0.45"
 ]
 
 setup(

--- a/docs/instrumentations/python/native.mdx
+++ b/docs/instrumentations/python/native.mdx
@@ -35,6 +35,7 @@ The following Python modules will be auto instrumented by Odigos:
 - [`psycopg`](https://pypi.org/project/psycopg/) versions `psycopg >= 3.1.0`
 - [`psycopg2`](https://pypi.org/project/psycopg2/) versions `psycopg2 >= 2.7.3.1`
 - [`pymemcache`](https://pypi.org/project/pymemcache/) versions `pymemcache >= 1.3.5, < 5.0.0`
+- [`pymssql`](https://pypi.org/project/pymssql/) versions `pymssql >= 2.1.5, < 3`
 - [`pymongo`](https://pypi.org/project/pymongo/) versions `pymongo >= 3.1, < 5.0.0`
 - [`pymysql`](https://pypi.org/project/PyMySQL/) versions `pymysql < 2.0.0`
 - [`redis`](https://pypi.org/project/redis/) versions `redis >= 2.6`
@@ -100,6 +101,7 @@ The following Python modules will be auto instrumented by Odigos:
 ### Other
 
 - [`asyncio`](https://pypi.org/project/asyncio/)
+- [`click`](https://pypi.org/project/click/) versions `click >= 8.1.3, < 9.0.0`
 
 ### Gen AI
 


### PR DESCRIPTION
## Description

Bumping Odigos python agent version to v1.0.45 which include two additional instrumentations.
Also, adjusted the documentation and mention that these two libraries are now supported

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
