### PR TITLE
fix: add sources premission for helm cleanup job

### DIFF
--- a/docs/permissions.mdx
+++ b/docs/permissions.mdx
@@ -32,6 +32,7 @@ Below are the ClusterRoles used by Odigos components.
 | rbac.authorization.k8s.io | clusterroles<br />clusterrolebindings | \* | get<br />list<br />patch |
 | apiextensions.k8s.io | customresourcedefinitions | \* | list<br />get<br />patch<br />delete |
 | admissionregistration.k8s.io | mutatingwebhookconfigurations<br />validatingwebhookconfigurations | \* | get<br />list<br />delete |
+| odigos.io | sources | \* | get<br />list<br />delete |
 
 ### odigos-data-collection
 

--- a/helm/odigos/templates/cleanup/cleanup-clusterrole.yaml
+++ b/helm/odigos/templates/cleanup/cleanup-clusterrole.yaml
@@ -18,4 +18,7 @@ rules:
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
   verbs: ["get", "list", "delete"]
-  
+- apiGroups: ["odigos.io"]
+  resources: ["sources"]
+  verbs: ["get", "list", "delete"]
+


### PR DESCRIPTION
## Description

Following #2784, adding the required permissions for sources to the cleanup job in helm
