### PR TITLE
docs: Update go workspace in CRD docgen

### DIFF
--- a/.github/workflows/generated-docs.yaml
+++ b/.github/workflows/generated-docs.yaml
@@ -13,12 +13,12 @@ jobs:
         uses: actions/checkout@v4
       - name: Generate CRD API docs
         run: |
-          go work init && go work use operator
+          go work init && go work use -r .
           cd api
           make docgen
       - name: Check for changes in CRD API docs
         run: |
-          if [[ $(git diff --exit-code) ]]; then
+          if [[ -n $(git status --porcelain) ]]; then
             git diff
             echo "CRD API docs need to be updated. Please run 'cd api && make docgen', then commit the changes."
             exit 1
@@ -34,7 +34,7 @@ jobs:
           make cli-docs
       - name: Check for changes in CLI docs
         run: |
-          if [[ $(git diff --exit-code) ]]; then
+          if [[ -n $(git status --porcelain) ]]; then
             git diff
             echo "CLI docs need to be updated. Please run 'make cli-docs', then commit the changes."
             exit 1
@@ -52,7 +52,7 @@ jobs:
           make rbac-docs
       - name: Check for changes in RBAC docs
         run: |
-          if [[ $(git diff --exit-code) ]]; then
+          if [[ -n $(git status --porcelain) ]]; then
             git diff
             echo "RBAC docs need to be updated. Please run 'make rbac-docs', then commit the changes."
             exit 1
@@ -77,7 +77,7 @@ jobs:
           python sync-dest-doc.py
       - name: Check for changes in Destinations docs
         run: |
-          if [[ $(git diff --exit-code) ]]; then
+          if [[ -n $(git status --porcelain) ]]; then
             git diff
             echo "Destinations docs need to be updated. Please run 'cd docs && python sync-dest-doc.py', then commit the changes."
             exit 1
@@ -104,7 +104,7 @@ jobs:
           python sync-instru-doc.py
       - name: Check for changes in Instrumentation docs
         run: |
-          if [[ $(git diff --exit-code) ]]; then
+          if [[ -n $(git status --porcelain) ]]; then
             git diff
             echo "Instrumentation docs need to be updated. Pleaserun 'cd docs && python sync-instru-doc.py', then commit the changes."
             exit 1

--- a/docs/api-reference/operator.odigos.io.v1alpha1.mdx
+++ b/docs/api-reference/operator.odigos.io.v1alpha1.mdx
@@ -1,0 +1,244 @@
+
+
+## Resource Types 
+
+
+  
+    
+    
+
+## `Odigos` <a id="Odigos"></a>
+    
+<p>Odigos is the Schema for the odigos API</p>
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Type</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr>
+<td>
+<code>metadata</code> <B>[Required]</B>
+</td>
+<td>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#objectmeta-v1-meta"><code>meta/v1.ObjectMeta</code></a>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   Refer to the Kubernetes API documentation for the fields of the <code>metadata</code> field.
+   </td>
+</tr>
+<tr>
+<td>
+<code>spec</code> <B>[Required]</B>
+</td>
+<td>
+<a href="#OdigosSpec"><code>OdigosSpec</code></a>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+<tr>
+<td>
+<code>status</code> <B>[Required]</B>
+</td>
+<td>
+<a href="#OdigosStatus"><code>OdigosStatus</code></a>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+</tbody>
+</table>
+
+## `OdigosSpec` <a id="OdigosSpec"></a>
+    
+
+**Appears in:**
+
+- [Odigos](#Odigos)
+
+<p>OdigosSpec defines the desired state of Odigos</p>
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Type</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr>
+<td>
+<code>onPremToken</code> <B>[Required]</B>
+</td>
+<td>
+<code>string</code>
+</td>
+<td>
+   <p>(Optional) OnPremToken is an enterprise token for Odigos Enterprise.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>uiMode</code> <B>[Required]</B>
+</td>
+<td>
+<a href="https://pkg.go.dev/github.com/odigos-io/odigos/common#UiMode"><code>common.UiMode</code></a>
+</td>
+<td>
+   <p>(Optional) UIMode sets the UI mode to either &quot;normal&quot; or &quot;readonly&quot;.
+In &quot;normal&quot; mode the UI is fully interactive, allowing users to view and edit
+Odigos configuration and settings. In &quot;readonly&quot; mode, the UI can only be
+used to view current Odigos configuration and is not interactive.
+Default=normal</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>telemetryEnabled</code> <B>[Required]</B>
+</td>
+<td>
+<code>bool</code>
+</td>
+<td>
+   <p>(Optional) TelemetryEnabled records general telemetry regarding Odigos usage.
+Default=false</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ignoredNamespaces</code> <B>[Required]</B>
+</td>
+<td>
+<code>[]string</code>
+</td>
+<td>
+   <p>(Optional) IgnoredNamespaces is a list of namespaces to not show in the Odigos UI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ignoredContainers</code> <B>[Required]</B>
+</td>
+<td>
+<code>[]string</code>
+</td>
+<td>
+   <p>(Optional) IgnoredContainers is a list of container names to exclude from instrumentation (useful for ignoring sidecars).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>profiles</code> <B>[Required]</B>
+</td>
+<td>
+<a href="https://pkg.go.dev/github.com/odigos-io/odigos/common#ProfileName"><code>[]common.ProfileName</code></a>
+</td>
+<td>
+   <p>(Optional) Profiles is a list of preset profiles with a specific configuration.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeSelector</code> <B>[Required]</B>
+</td>
+<td>
+<code>map[string]string</code>
+</td>
+<td>
+   <p>(Optional) NodeSelector is a map of key-value Kubernetes NodeSelector labels to apply to all Odigos components.
+Note that Odigos will only be able to instrument applications on the same node.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>skipWebhookIssuerCreation</code> <B>[Required]</B>
+</td>
+<td>
+<code>bool</code>
+</td>
+<td>
+   <p>(Optional) SkipWebhookIssuerCreation skips creating the Issuer and Certificate for the Instrumentor pod webhook if cert-manager is installed.
+Default=false</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>podSecurityPolicy</code> <B>[Required]</B>
+</td>
+<td>
+<code>bool</code>
+</td>
+<td>
+   <p>(Optional) PodSecurityPolicy allows Odigos pods to use a privileged pod security policy.
+Default=false</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imagePrefix</code> <B>[Required]</B>
+</td>
+<td>
+<code>string</code>
+</td>
+<td>
+   <p>(Optional) ImagePrefix is a prefix for all container images.
+This should only be used if you are pulling Odigos images from the non-default registry.
+Default: registry.odigos.io
+Default (OpenShift): registry.connect.redhat.com</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>mountMethod</code> <B>[Required]</B>
+</td>
+<td>
+<a href="https://pkg.go.dev/github.com/odigos-io/odigos/common#MountMethod"><code>common.MountMethod</code></a>
+</td>
+<td>
+   <p>(Optional) MountMethod optionally defines the mechanism for mounting Odigos files into instrumented pods.
+One of &quot;k8s-virtual-device&quot; (default) or &quot;k8s-host-path&quot;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>openshiftEnabled</code> <B>[Required]</B>
+</td>
+<td>
+<code>bool</code>
+</td>
+<td>
+   <p>(Optional) OpenShiftEnabled configures selinux on OpenShift nodes.
+DEPRECATED: OpenShift clusters are auto-detected and this API field will be removed in a future release.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+## `OdigosStatus` <a id="OdigosStatus"></a>
+    
+
+**Appears in:**
+
+- [Odigos](#Odigos)
+
+<p>OdigosStatus defines the observed state of Odigos</p>
+
+<table class="table">
+<thead><tr><th width="30%">Field</th><th>Type</th><th>Description</th></tr></thead>
+<tbody>
+    
+  
+<tr>
+<td>
+<code>conditions</code> <B>[Required]</B>
+</td>
+<td>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#condition-v1-meta"><code>[]meta/v1.Condition</code></a>
+</td>
+<td>
+   <p>Conditions store the status conditions of the Odigos instances</p>
+</td>
+</tr>
+</tbody>
+</table>


### PR DESCRIPTION
## Description

In several PRs, we are removing and re-adding the Operator CRD docs, see:

* https://github.com/odigos-io/odigos/pull/2731/files (added)
* https://github.com/odigos-io/odigos/pull/2707/files (deleted)
* https://github.com/odigos-io/odigos/pull/2783/files (added)
* https://github.com/odigos-io/odigos/pull/2783/files (deleted)

This tries to update the CRD docgen check to make sure the local go workspace in the action is actually verifying all docs are present

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
