### PR TITLE
otlphttp: Support TLS settings

### DIFF
--- a/common/config/otlphttp.go
+++ b/common/config/otlphttp.go
@@ -10,6 +10,9 @@ import (
 
 const (
 	otlpHttpEndpointKey          = "OTLP_HTTP_ENDPOINT"
+	otlpHttpTlsKey               = "OTLP_HTTP_TLS_ENABLED"
+	otlpHttpCaPemKey             = "OTLP_HTTP_CA_PEM"
+	otlpHttpInsecureSkipVerify   = "OTLP_HTTP_INSECURE_SKIP_VERIFY"
 	otlpHttpBasicAuthUsernameKey = "OTLP_HTTP_BASIC_AUTH_USERNAME"
 	otlpHttpBasicAuthPasswordKey = "OTLP_HTTP_BASIC_AUTH_PASSWORD"
 	otlpHttpCompression          = "OTLP_HTTP_COMPRESSION"
@@ -30,9 +33,24 @@ func (g *OTLPHttp) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) 
 		return nil, errors.New("OTLP http endpoint not specified, gateway will not be configured for otlp http")
 	}
 
+	tls := dest.GetConfig()[otlpHttpTlsKey]
+	tlsEnabled := tls == "true"
+
 	parsedUrl, err := parseOtlpHttpEndpoint(url, "", "")
 	if err != nil {
 		return nil, errors.Join(err, errors.New("otlp http endpoint invalid, gateway will not be configured for otlp http"))
+	}
+
+	tlsConfig := GenericMap{
+		"insecure": !tlsEnabled,
+	}
+	caPem, caExists := config[otlpHttpCaPemKey]
+	if caExists && caPem != "" {
+		tlsConfig["ca_pem"] = caPem
+	}
+	insecureSkipVerify, skipExists := config[otlpHttpInsecureSkipVerify]
+	if skipExists && insecureSkipVerify != "" {
+		tlsConfig["insecure_skip_verify"] = parseBool(insecureSkipVerify)
 	}
 
 	basicAuthExtensionName, basicAuthExtensionConf := applyBasicAuth(dest)
@@ -46,6 +64,7 @@ func (g *OTLPHttp) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) 
 	otlpHttpExporterName := "otlphttp/generic-" + dest.GetID()
 	exporterConf := GenericMap{
 		"endpoint": parsedUrl,
+		"tls":      tlsConfig,
 	}
 	if basicAuthExtensionName != "" {
 		exporterConf["auth"] = GenericMap{

--- a/destinations/data/otlp.yaml
+++ b/destinations/data/otlp.yaml
@@ -73,5 +73,5 @@ spec:
       componentProps:
         required: false
         tooltip: 'Skip TLS certificate verification'
-      renderCondition: ['OTLP_GRPC_TLS_ENABLED', '==', 'true']    
+      renderCondition: ['OTLP_GRPC_TLS_ENABLED', '==', 'true']
   testConnectionSupported: true

--- a/destinations/data/otlphttp.yaml
+++ b/destinations/data/otlphttp.yaml
@@ -63,4 +63,36 @@ spec:
       componentProps:
         required: false
         tooltip: 'Headers is the option to set custom HTTP headers for OTLP HTTP destination. If specified, please provide each header in the format: key:value. Multiple headers can be added. Keys must be non-empty strings and follow standard HTTP header conventions. Values must be non-empty strings and may include alphanumerics, whitespace, and standard punctuation.'
+
+    - name: OTLP_HTTP_TLS_ENABLED
+      displayName: Enable TLS
+      componentType: checkbox
+      initialValue: false
+      componentProps:
+        required: false
+        tooltip: 'Secure connection'
+      customReadDataLabels:
+        - condition: 'true'
+          title: 'TLS'
+          value: 'Encrypted'
+        - condition: 'false'
+          title: 'TLS'
+          value: 'Unencrypted'
+    - name: OTLP_HTTP_CA_PEM
+      displayName: Certificate Authority
+      componentType: textarea
+      componentProps:
+        required: false
+        placeholder: '-----BEGIN CERTIFICATE-----'
+        tooltip: 'When using TLS, provide the CA certificate in PEM format to verify the server. If empty uses system root CA'
+      renderCondition: ['OTLP_HTTP_TLS_ENABLED', '==', 'true']
+      hideFromReadData: ['true']
+    - name: OTLP_HTTP_INSECURE_SKIP_VERIFY
+      displayName: Insecure Skip Verify
+      componentType: checkbox
+      initialValue: false
+      componentProps:
+        required: false
+        tooltip: 'Skip TLS certificate verification'
+      renderCondition: ['OTLP_HTTP_TLS_ENABLED', '==', 'true']
   testConnectionSupported: true

--- a/docs/backends/otlphttp.mdx
+++ b/docs/backends/otlphttp.mdx
@@ -66,6 +66,13 @@ To configure basic authentication, use the optional config options `Basic Auth U
   - This field is optional and defaults to `none`
 - **OTLP_HTTP_HEADERS** `{ key: string; value: string; }[]` : Headers. Headers is the option to set custom HTTP headers for OTLP HTTP destination. If specified, please provide each header in the format: key:value. Multiple headers can be added. Keys must be non-empty strings and follow standard HTTP header conventions. Values must be non-empty strings and may include alphanumerics, whitespace, and standard punctuation.
   - This field is optional
+- **OTLP_HTTP_TLS_ENABLED** `boolean` : Enable TLS. Secure connection
+  - This field is optional and defaults to `False`
+- **OTLP_HTTP_CA_PEM** `string` : Certificate Authority. When using TLS, provide the CA certificate in PEM format to verify the server. If empty uses system root CA
+  - This field is optional
+  - Example: `-----BEGIN CERTIFICATE-----`
+- **OTLP_HTTP_INSECURE_SKIP_VERIFY** `boolean` : Insecure Skip Verify. Skip TLS certificate verification
+  - This field is optional and defaults to `False`
 
 ### Adding Destination to Odigos
 
@@ -103,6 +110,9 @@ There are two primary methods for configuring destinations in Odigos:
         # OTLP_HTTP_BASIC_AUTH_USERNAME: <Basic Auth Username>
         # OTLP_HTTP_COMPRESSION: <Destination Compression Type (default: none) (options: [none, gzip, snappy, lz4, zlib, deflate, zstd])>
         # OTLP_HTTP_HEADERS: <Headers>
+        # OTLP_HTTP_TLS_ENABLED: <Enable TLS>
+        # OTLP_HTTP_CA_PEM: <Certificate Authority>
+        # OTLP_HTTP_INSECURE_SKIP_VERIFY: <Insecure Skip Verify>
       destinationName: otlphttp
       # Uncomment the 'secretRef' below if you are using the optional Secret.
       # secretRef:


### PR DESCRIPTION
## Description

This adds the same TLS settings for otlpgrpc (https://github.com/odigos-io/odigos/pull/2763) to the otlphttp exporter

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [x] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
