### PR TITLE
Add dependencies-syncer-bot PR check to release workflow

### DIFF
--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -65,8 +65,63 @@ jobs:
             \"tag\": \"verify-offsets-failure\"
           }" $SLACK_WEBHOOK_URL      
 
-  print-tag:
+  verify-dependencies-sync:
     needs: verify-offsets
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: ['odigos-enterprise']
+    steps:
+      - name: Verify no open dependencies-syncer-bot PRs
+        id: verify
+        run: |
+          # Fetch open PRs and filter by "dependencies-syncer-bot" label
+          result=$(curl -s -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.RELEASE_BOT_TOKEN }}" \
+            "https://api.github.com/repos/odigos-io/${{ matrix.repo }}/pulls?state=open&per_page=100")
+
+          pr_links=$(echo "$result" \
+            | jq -r '[.[] | select(.labels | any(.name == "dependencies-syncer-bot")) | .html_url] | join(" ")')
+
+          count=$(echo "$pr_links" | wc -w)
+          if [ "$count" -gt 0 ]; then
+            # Write outputs to GITHUB_OUTPUT instead of using ::set-output
+            echo "status=failed" >> $GITHUB_OUTPUT
+            echo "links=$pr_links" >> $GITHUB_OUTPUT
+            echo "❌ Error: Open PRs with label \"dependencies-syncer-bot\" found!" >&2
+            exit 1
+          else
+            echo "status=success" >> $GITHUB_OUTPUT
+            echo "✅ No open PRs with label \"dependencies-syncer-bot\"."
+          fi
+          
+      - name: Notify Slack on Success
+        if: ${{ steps.verify.outputs.status == 'success' }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' --data '{
+            "description": "✅ No open dependencies-syncer-bot PRs in `${{ matrix.repo }}`",
+            "tag": "verify-dependencies-sync-success"
+          }' $SLACK_WEBHOOK_URL
+  
+      - name: Notify Slack on Failure
+        if: ${{ failure() }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        run: |
+          pr_links=${{ steps.verify.outputs.links }}
+          pr_links_formatted=$(echo "$pr_links" | jq -r '.[]' | awk '{print "- " $0}' | tr '\n' '\n')
+          curl -X POST -H 'Content-type: application/json' --data "{
+            \"description\": \"❌ ERROR: Open depenencies-syncer-bot PRs found in \`${{ matrix.repo }}\`\n\n$pr_links_formatted\",
+            \"link\": \"https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}\",
+            \"tag\": \"verify-dependencies-sync-failure\"
+          }" $SLACK_WEBHOOK_URL  
+
+  print-tag:
+    needs: verify-dependencies-sync
     runs-on: ubuntu-latest
     steps:
       - name: Extract Tag
@@ -80,7 +135,7 @@ jobs:
           curl -X POST -H 'Content-type: application/json' --data '{"description":"Detected new git tag. initializing a release", "tag":"${{ steps.extract_tag.outputs.tag }}"}' ${{ env.SLACK_WEBHOOK_URL }}
 
   tag-modules:
-    needs: verify-offsets
+    needs: verify-dependencies-sync
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -136,7 +191,7 @@ jobs:
           curl -X POST -H 'Content-type: application/json' --data '{"link":"https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}", "description":"ERROR: Odigos go modules release failed", "tag":"${{ steps.extract_tag.outputs.tag }}"}' ${{ env.SLACK_WEBHOOK_URL }}
 
   publish-images:
-    needs: verify-offsets
+    needs: verify-dependencies-sync
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -263,7 +318,7 @@ jobs:
           curl -X POST -H 'Content-type: application/json' --data '{"link":"https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}", "description":"ERROR: odigos component ${{ matrix.service }} release failed", "tag":"${{ steps.extract_tag.outputs.tag }}"}' ${{ env.SLACK_WEBHOOK_URL }}
 
   publish-collector-linux-packages:
-    needs: verify-offsets
+    needs: verify-dependencies-sync
     runs-on: ubuntu-latest
     steps:
       - name: Extract Tag


### PR DESCRIPTION
## Description

Similar to https://github.com/odigos-io/odigos/pull/2680, this adds a pre-release check for open enterprise dependency sync PRs.

Currently, the release flow will create a release PR in the enterprise repo that is effectively a dependency sync. However, if there are currently failing tests with the current dependency sync, it would be good to catch these before we start a release flow instead of having to debug it mid release.

Making this a separate job so it can depend on the verify-offsets check, which itself will trigger a dependency bump if there are offsets changes to be merged

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
