### PR TITLE
fix(helm): do not default mountMethod to allow profile override

### DIFF
--- a/helm/odigos/templates/odigos-config-cm.yaml
+++ b/helm/odigos/templates/odigos-config-cm.yaml
@@ -116,10 +116,12 @@ data:
     ignoredContainers:
       {{- toYaml .Values.ignoredContainers | nindent 6 }}
     {{- end }}
-    {{- if and .Values.instrumentor.mountMethod (has .Values.instrumentor.mountMethod (list "k8s-host-path" "k8s-virtual-device")) }}
+    {{- if .Values.instrumentor.mountMethod }}
+      {{- if has .Values.instrumentor.mountMethod (list "k8s-host-path" "k8s-virtual-device") }}
     mountMethod: {{ .Values.instrumentor.mountMethod }}
-    {{- else }}
-    {{- fail "Error: Invalid mountMethod. Supported values are 'k8s-host-path' and 'k8s-virtual-device'." }}
+      {{- else }}
+        {{- fail "Error: Invalid mountMethod. Supported values are 'k8s-host-path' and 'k8s-virtual-device'." }}
+      {{- end }}
     {{- end }}
     {{- if .Values.avoidInjectingJavaOptsEnvVar }}
     avoidInjectingJavaOptsEnvVar: {{ .Values.avoidInjectingJavaOptsEnvVar }}

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -173,7 +173,7 @@ instrumentor:
   # which mount method to use for odigos agent directory
   # k8s-virtual-device: default method using a virtual device
   # k8s-host-path: alternative which uses hostPath volume (recommended if supported, requires hostPath volume to be enabled in the cluster)
-  mountMethod: 'k8s-virtual-device'
+  mountMethod: ''
   nodeSelector:
     kubernetes.io/os: linux
   tolerations: []


### PR DESCRIPTION
If user did not set `mountMethod` in helm values, do not default it in helm.

This is to accurately differentiate between user did not set any value, and user set a value to be the `k8s-virtual-device` (default).

odigos profile will only override the value if it's empty (assuming that if a user specified a value it will be used and not the profile), so this change allows us use profiles for mount method in helm correctly