### PR TITLE
odiglet/openshift: Re-add os.Exit when OpenShift setup fails

### DIFF
--- a/odiglet/odiglet.go
+++ b/odiglet/odiglet.go
@@ -202,9 +202,7 @@ func OdigletInitPhase(clientset *kubernetes.Clientset) {
 	// executing selinux commands to make agents readable by pods.
 	if err := fs.ApplyOpenShiftSELinuxSettings(); err != nil {
 		log.Logger.Error(err, "Failed to apply SELinux settings on RHEL host")
-		// TODO: semanage can sometimes return an error that's non-fatal, need to find a better way to handle all scenarios
-		// For now, allow it through (as the only errors we have seen in practice have been non-fatal so far)
-		//os.Exit(-1)
+		os.Exit(-1)
 	}
 
 	os.Exit(0)


### PR DESCRIPTION
## Description

This was removed as a breakglass effort to allow recoverable errors from SEManage to continue execution in https://github.com/odigos-io/odigos/pull/2805. Further testing showed that the changes from #2805 are sufficient to prevent these recoverable errors. Reverting the `os.Exit` call to prevent odiglet from starting in other error cases

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [x] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
