### PR TITLE
Migrate to docker bake

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -56,7 +56,6 @@ jobs:
           name: odigos-images
           path: |
             odigos-images.tar
-            cli-image.tar
 
   kubernetes-test:
     needs:
@@ -120,7 +119,6 @@ jobs:
           name: odigos-images
       - run: |
           docker load -i odigos-images.tar
-          docker load -i cli-image.tar
           TAG=e2e-test make load-to-kind
 
       - name: Download CLI binary

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -50,13 +50,6 @@ jobs:
           TAG=e2e-test make build-images
           docker save -o odigos-images.tar $(docker images --format "{{.Repository}}:{{.Tag}}" | grep "odigos")
 
-      - uses: ko-build/setup-ko@v0.9
-
-      - name: Build CLI Image
-        run: |
-          TAG=e2e-test make build-cli-image
-          docker save registry.odigos.io/odigos-cli:e2e-test -o cli-image.tar
-
       - name: Upload Odigos Images
         uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -350,7 +350,6 @@ helm-install-central:
 		--namespace odigos-central \
 		--set image.tag=$(ODIGOS_CLI_VERSION) \
 		--set onPremToken=$(ONPREM_TOKEN) \
-	kubectl label namespace odigos-central odigos.io/central-system-object="true" --overwrite
 
 helm-uninstall:
 	@echo "Uninstalling odigos using helm"

--- a/Makefile
+++ b/Makefile
@@ -33,26 +33,26 @@ BUILD_DIR  ?= .
 # ──────────────────────────────────────────────
 # Build / push helpers
 # ──────────────────────────────────────────────
-.PHONY: print-tag
-print-tag:
-	@echo $(TAG)
 define bake-load
-	@TAG=$(TAG) ORG=$(ORG) IMG_SUFFIX=$(IMG_SUFFIX) \
-	docker buildx bake $(1) --load \
-	$(if $(PLATFORMS),--set '*.platform=$(PLATFORMS)',)
+	TAG=$(TAG) ORG=$(ORG) IMG_SUFFIX=$(IMG_SUFFIX) \
+	docker buildx bake $(1) --load --no-cache \
+	$(if $(PLATFORMS),--set '*.platform=$(PLATFORMS)',) \
+	$(if $(LD_FLAGS),--set '*.args.LD_FLAGS=$(LD_FLAGS)',)
 endef
 
 define bake-push
 	@TAG=$(TAG) ORG=$(ORG) IMG_SUFFIX=$(IMG_SUFFIX) \
 	docker buildx bake $(1) --push \
-	$(if $(PLATFORMS),--set '*.platform=$(PLATFORMS)',)
+	$(if $(PLATFORMS),--set '*.platform=$(PLATFORMS)',) \
+	$(if $(LD_FLAGS),--set '*.args.LD_FLAGS=$(LD_FLAGS)',)
 endef
 
 # Pattern rules for every service image
 build-%: FORCE ; $(call bake-load,$*)
 push-%: FORCE ; $(call bake-push,$*)
 
-FORCE:
+.PHONY: FORCE
+FORCE:;
 
 # Convenience groups matching the HCL
 .PHONY: build-images push-images build-images-rhel push-images-rhel build-cli build-cli-rhel

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 # Core variables
 # ──────────────────────────────────────────────
 # TODO: Use installed version, if not applicatble, use latest git tag
-# LATEST_GIT_TAG = $(shell git tag --list 'v*' --sort=-v:refname | head -n1 2>/dev/null)
-TAG ?= $(shell odigos version --cluster 2>/dev/null)
+LATEST_GIT_TAG = $(shell git tag --list 'v*' --sort=-v:refname | head -n1 2>/dev/null)
+TAG ?= $(shell odigos version --cluster 2>/dev/null || echo $LATEST_GIT_TAG)
 ODIGOS_CLI_VERSION ?= $(shell odigos version --cli)
 CLUSTER_NAME ?= local-dev-cluster
 CENTRAL_BACKEND_URL ?=

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ BUILD_DIR  ?= .
 # ──────────────────────────────────────────────
 define bake-load
 	TAG=$(TAG) ORG=$(ORG) IMG_SUFFIX=$(IMG_SUFFIX) \
-	docker buildx bake $(1) --load --no-cache \
+	docker buildx bake $(1) --load \
 	$(if $(PLATFORMS),--set '*.platform=$(PLATFORMS)',) \
 	$(if $(LD_FLAGS),--set '*.args.LD_FLAGS=$(LD_FLAGS)',)
 endef
@@ -180,86 +180,6 @@ debug-odiglet:
 .PHONY: build-operator-index
 build-operator-index:
 	opm index add --bundles $(ORG)/odigos-bundle:$(TAG) --tag $(ORG)/odigos-index:$(TAG) --container-tool=docker
-
-<<<<<<< HEAD
-push-image/%:
-	docker buildx build --platform linux/amd64,linux/arm64/v8 -t $(ORG)/odigos-$*$(IMG_SUFFIX):$(TAG) $(BUILD_DIR) -f $(DOCKERFILE) \
-	--build-arg SERVICE_NAME="$*" \
-	--build-arg VERSION=$(TAG) \
-	--build-arg RELEASE=$(TAG) \
-	--build-arg SUMMARY="$(SUMMARY)" \
-	--build-arg DESCRIPTION="$(DESCRIPTION)"
-
-.PHONY: push-operator
-push-operator:
-	$(MAKE) push-image/operator DOCKERFILE=operator/$(DOCKERFILE) SUMMARY="Odigos Operator" DESCRIPTION="Kubernetes Operator for Odigos installs Odigos" TAG=$(TAG) ORG=$(ORG) IMG_SUFFIX=$(IMG_SUFFIX)
-
-.PHONY: push-odiglet
-push-odiglet:
-	$(MAKE) push-image/odiglet DOCKERFILE=odiglet/$(DOCKERFILE) SUMMARY="Odiglet for Odigos" DESCRIPTION="Odiglet is the core component of Odigos managing auto-instrumentation." TAG=$(TAG) ORG=$(ORG) IMG_SUFFIX=$(IMG_SUFFIX)
-
-.PHONY: push-autoscaler
-push-autoscaler:
-	$(MAKE) push-image/autoscaler SUMMARY="Autoscaler for Odigos" DESCRIPTION="Autoscaler manages the installation of Odigos components." TAG=$(TAG) ORG=$(ORG) IMG_SUFFIX=$(IMG_SUFFIX)
-
-.PHONY: push-instrumentor
-push-instrumentor:
-	$(MAKE) push-image/instrumentor SUMMARY="Instrumentor for Odigos" DESCRIPTION="Instrumentor manages auto-instrumentation for workloads with Odigos." TAG=$(TAG) ORG=$(ORG) IMG_SUFFIX=$(IMG_SUFFIX)
-
-.PHONY: push-scheduler
-push-scheduler:
-	$(MAKE) push-image/scheduler SUMMARY="Scheduler for Odigos" DESCRIPTION="Scheduler manages the installation of OpenTelemetry Collectors with Odigos." TAG=$(TAG) ORG=$(ORG) IMG_SUFFIX=$(IMG_SUFFIX)
-
-.PHONY: push-collector
-push-collector:
-	$(MAKE) push-image/collector DOCKERFILE=collector/$(DOCKERFILE) BUILD_DIR=collector SUMMARY="Odigos Collector" DESCRIPTION="The Odigos build of the OpenTelemetry Collector." TAG=$(TAG) ORG=$(ORG) IMG_SUFFIX=$(IMG_SUFFIX)
-
-.PHONY: push-ui
-push-ui:
-	$(MAKE) push-image/ui DOCKERFILE=frontend/$(DOCKERFILE) SUMMARY="UI for Odigos" DESCRIPTION="UI provides the frontend webapp for managing an Odigos installation." TAG=$(TAG) ORG=$(ORG) IMG_SUFFIX=$(IMG_SUFFIX)
-
-.PHONY: push-images
-push-images:
-	make push-autoscaler push-scheduler push-odiglet push-instrumentor push-collector push-ui TAG=$(TAG) ORG=$(ORG) IMG_SUFFIX=$(IMG_SUFFIX) DOCKERFILE=$(DOCKERFILE)
-
-.PHONY: push-images-rhel
-push-images-rhel:
-	$(MAKE) push-images IMG_SUFFIX=-ubi9 DOCKERFILE=Dockerfile.rhel TAG=$(TAG) ORG=$(ORG)
-
-load-to-kind-%:
-	kind load docker-image $(ORG)/odigos-$*$(IMG_SUFFIX):$(TAG)
-
-.PHONY: load-to-kind
-load-to-kind:
-	make -j 6 load-to-kind-instrumentor load-to-kind-autoscaler load-to-kind-scheduler load-to-kind-odiglet load-to-kind-collector load-to-kind-ui load-to-kind-cli ORG=$(ORG) TAG=$(TAG) IMG_SUFFIX=$(IMG_SUFFIX) DOCKERFILE=$(DOCKERFILE)
-
-.PHONY: restart-ui
-restart-ui:
-	-kubectl rollout restart deployment odigos-ui -n odigos-system
-
-.PHONY: restart-odiglet
-restart-odiglet:
-	-kubectl rollout restart daemonset odiglet -n odigos-system
-
-.PHONY: restart-autoscaler
-restart-autoscaler:
-	-kubectl rollout restart deployment odigos-autoscaler -n odigos-system
-
-.PHONY: restart-instrumentor
-restart-instrumentor:
-	-kubectl rollout restart deployment odigos-instrumentor -n odigos-system
-
-.PHONY: restart-scheduler
-restart-scheduler:
-	-kubectl rollout restart deployment odigos-scheduler -n odigos-system
-
-.PHONY: restart-collector
-restart-collector:
-	-kubectl rollout restart deployment odigos-gateway -n odigos-system
-	# DaemonSets don't directly support the rollout restart command in the same way Deployments do. However, you can achieve the same result by updating an environment variable or any other field in the DaemonSet's pod template, triggering a rolling update of the pods managed by the DaemonSet
-	-kubectl -n odigos-system patch daemonset odigos-data-collection -p "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"kubectl.kubernetes.io/restartedAt\":\"$(date +%Y-%m-%dT%H:%M:%S%z)\"}}}}}"
-=======
->>>>>>> 1908cb4f (Makefile cleanup and refactor)
 
 # ──────────────────────────────────────────────
 # Deploy helpers

--- a/Makefile
+++ b/Makefile
@@ -348,6 +348,25 @@ update-otel:
 
 
 # ──────────────────────────────────────────────
+# Kind helpers
+# ──────────────────────────────────────────────
+.PHONY: dev-tests-kind-cluster
+dev-tests-kind-cluster:
+	@echo "Creating a kind cluster for development"
+	kind delete cluster
+	kind create cluster --config=tests/common/apply/kind-config.yaml
+
+.PHONY: dev-tests-setup
+dev-tests-setup: TAG := e2e-test
+dev-tests-setup: dev-tests-kind-cluster cli-build build-cli-image build-images load-to-kind
+
+# Use this target to avoid rebuilding the images if all that changed is the e2e test code
+.PHONY: dev-tests-setup-no-build
+dev-tests-setup-no-build: TAG := e2e-test
+dev-tests-setup-no-build: dev-tests-kind-cluster load-to-kind
+
+
+# ──────────────────────────────────────────────
 # Debug & test destinations
 # ──────────────────────────────────────────────
 .PHONY: dev-debug-destination dev-nop-destination dev-dynamic-destination dev-backpressue-destination

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,0 +1,36 @@
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS builder
+
+ARG VERSION
+ARG SHORT_COMMIT
+ARG DATE
+
+WORKDIR /src
+
+# -------- 1) Copy ONLY go.mod/sum files for cache-friendly deps --------
+COPY api/go.mod            api/go.sum            ./api/
+COPY autoscaler/go.mod     autoscaler/go.sum     ./autoscaler/
+COPY common/go.mod         common/go.sum         ./common/
+COPY k8sutils/go.mod       k8sutils/go.sum       ./k8sutils/
+COPY profiles/go.mod       profiles/go.sum       ./profiles/
+COPY cli/go.mod            cli/go.sum            ./cli/
+
+WORKDIR /src/cli
+RUN go mod download
+
+# -------- 2) Now copy the full source trees ----------------------------
+WORKDIR /src/
+COPY api/        ./api/
+COPY autoscaler/ ./autoscaler/
+COPY common/     ./common/
+COPY k8sutils/   ./k8sutils/
+COPY profiles/   ./profiles/
+COPY cli/        ./cli/
+
+WORKDIR /src/cli
+RUN CGO_ENABLED=0 GOOS=linux \
+    go build -tags=embed_manifests -o odigos .
+
+# -------- 3) Minimal final image --------------------------------------
+FROM scratch
+COPY --from=builder /src/cli/odigos /usr/local/bin/odigos
+ENTRYPOINT ["/usr/local/bin/odigos"]

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,161 @@
+# ──────────────────────────────────────────────
+# docker-bake.hcl  (compatible with Buildx <0.11)
+# ──────────────────────────────────────────────
+
+variable "TAG"        { default = "latest" }
+variable "ORG"        { default = "registry.odigos.io" }
+variable "IMG_SUFFIX" { default = "" }
+variable "SHORT_COMMIT" { default = "" }
+variable "DATE"         { default = "" }
+
+# ── Shared metadata (was “template common”) ───
+target "common" {
+  args = {
+    ODIGOS_VERSION = "${TAG}"
+    VERSION        = "${TAG}"
+    RELEASE        = "${TAG}"
+  }
+}
+
+# ── RHEL / UBI-9 metadata (was “template rhel”) ──
+target "rhel" {
+  inherits = ["common"]
+  args = { IMG_SUFFIX = "-ubi9" }
+}
+
+# ── Main images ───────────────────────────────
+target "operator" {
+  inherits   = ["common"]
+  context    = "."
+  dockerfile = "operator/Dockerfile"
+  args = {
+    SERVICE_NAME = "operator"
+    SUMMARY      = "Odigos Operator"
+    DESCRIPTION  = "Kubernetes Operator for Odigos installs Odigos"
+  }
+  tags = ["${ORG}/odigos-operator${IMG_SUFFIX}:${TAG}"]
+}
+
+target "odiglet" {
+  inherits   = ["common"]
+  context    = "."
+  dockerfile = "odiglet/Dockerfile"
+  args = {
+    SERVICE_NAME = "odiglet"
+    SUMMARY      = "Odiglet for Odigos"
+    DESCRIPTION  = "Odiglet is the core component of Odigos managing auto-instrumentation."
+  }
+  tags = ["${ORG}/odigos-odiglet${IMG_SUFFIX}:${TAG}"]
+}
+
+target "autoscaler" {
+  inherits = ["common"]
+  context  = "."
+  args = {
+    SERVICE_NAME = "autoscaler"
+    SUMMARY      = "Autoscaler for Odigos"
+    DESCRIPTION  = "Autoscaler manages the installation of Odigos components."
+  }
+  tags = ["${ORG}/odigos-autoscaler${IMG_SUFFIX}:${TAG}"]
+}
+
+target "instrumentor" {
+  inherits = ["common"]
+  context  = "."
+  args = {
+    SERVICE_NAME = "instrumentor"
+    SUMMARY      = "Instrumentor for Odigos"
+    DESCRIPTION  = "Instrumentor manages auto-instrumentation for workloads with Odigos."
+  }
+  tags = ["${ORG}/odigos-instrumentor${IMG_SUFFIX}:${TAG}"]
+}
+
+target "scheduler" {
+  inherits = ["common"]
+  context  = "."
+  args = {
+    SERVICE_NAME = "scheduler"
+    SUMMARY      = "Scheduler for Odigos"
+    DESCRIPTION  = "Scheduler manages the installation of OpenTelemetry Collectors with Odigos."
+  }
+  tags = ["${ORG}/odigos-scheduler${IMG_SUFFIX}:${TAG}"]
+}
+
+target "collector" {
+  inherits   = ["common"]
+  context    = "collector"
+  dockerfile = "Dockerfile"
+  args = {
+    SERVICE_NAME = "collector"
+    SUMMARY      = "Odigos Collector"
+    DESCRIPTION  = "The Odigos build of the OpenTelemetry Collector."
+  }
+  tags = ["${ORG}/odigos-collector${IMG_SUFFIX}:${TAG}"]
+}
+
+target "ui" {
+  inherits   = ["common"]
+  context    = "."
+  dockerfile = "frontend/Dockerfile"
+  args = {
+    SERVICE_NAME = "ui"
+    SUMMARY      = "UI for Odigos"
+    DESCRIPTION  = "UI provides the frontend webapp for managing an Odigos installation."
+  }
+  tags = ["${ORG}/odigos-ui${IMG_SUFFIX}:${TAG}"]
+}
+
+target "cli" {
+  inherits = ["common"]
+  context  = "."
+  dockerfile = "cli/Dockerfile"
+  tags = ["${ORG}/odigos-cli${IMG_SUFFIX}:${TAG}"]
+}
+
+# ── UBI-9 / RHEL image variants ───────────────
+target "operator-rhel" {
+  inherits   = ["operator", "rhel"]
+  dockerfile = "operator/Dockerfile.rhel"
+}
+
+target "odiglet-rhel" {
+  inherits   = ["odiglet", "rhel"]
+  dockerfile = "odiglet/Dockerfile.rhel"
+}
+
+target "autoscaler-rhel"    { inherits = ["autoscaler",   "rhel"] }
+target "instrumentor-rhel"  { inherits = ["instrumentor", "rhel"] }
+target "scheduler-rhel"     { inherits = ["scheduler",    "rhel"] }
+
+target "collector-rhel" {
+  inherits   = ["collector", "rhel"]
+  dockerfile = "Dockerfile.rhel"
+}
+
+target "ui-rhel" {
+  inherits   = ["ui", "rhel"]
+  dockerfile = "frontend/Dockerfile.rhel"
+}
+
+target "cli-rhel" {
+  inherits   = ["cli", "rhel"]
+}
+
+
+# ── Convenience groups ───────────────────────
+group "images" {
+  targets = [
+    "operator","odiglet","autoscaler",
+    "instrumentor","scheduler","collector","ui",
+    "cli"
+  ]
+}
+
+group "images-rhel" {
+  targets = [
+    "operator-rhel","odiglet-rhel","autoscaler-rhel",
+    "instrumentor-rhel","scheduler-rhel",
+    "collector-rhel","ui-rhel",
+    "cli-rhel"
+  ]
+}


### PR DESCRIPTION
## Description
Migrate our build system to use docker bake
Cleanup and optimize Makefile

<!-- Short summary of the changes -->

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
