### PR TITLE
feat: add container and process resource attributes to eBPF instrumentations

### DIFF
--- a/odiglet/pkg/ebpf/settings_getter.go
+++ b/odiglet/pkg/ebpf/settings_getter.go
@@ -3,11 +3,15 @@ package ebpf
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/odigos-io/odigos/api/k8sconsts"
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/instrumentation"
+	"github.com/odigos-io/odigos/instrumentation/detector"
 	workload "github.com/odigos-io/odigos/k8sutils/pkg/workload"
-	"github.com/odigos-io/odigos/odiglet/pkg/kube/utils"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -30,7 +34,7 @@ func (ksg *k8sSettingsGetter) Settings(ctx context.Context, kd K8sProcessDetails
 
 	return instrumentation.Settings{
 		ServiceName:        OtelServiceName,
-		ResourceAttributes: utils.GetResourceAttributes(kd.pw, kd.pod.Name),
+		ResourceAttributes: getResourceAttributes(kd.pw, kd.pod.Name, kd.procEvent),
 		InitialConfig:      sdkConfig,
 	}, nil
 }
@@ -51,4 +55,55 @@ func (ksg *k8sSettingsGetter) instrumentationSDKConfig(ctx context.Context, kd K
 		}
 	}
 	return nil, "", fmt.Errorf("no sdk config found for language %s", dist.Language)
+}
+
+func getResourceAttributes(podWorkload *k8sconsts.PodWorkload, podName string, pe detector.ProcessEvent) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		semconv.K8SNamespaceName(podWorkload.Namespace),
+		semconv.K8SPodName(podName),
+	}
+
+	switch podWorkload.Kind {
+	case k8sconsts.WorkloadKindDeployment:
+		attrs = append(attrs, semconv.K8SDeploymentName(podWorkload.Name))
+	case k8sconsts.WorkloadKindStatefulSet:
+		attrs = append(attrs, semconv.K8SStatefulSetName(podWorkload.Name))
+	case k8sconsts.WorkloadKindDaemonSet:
+		attrs = append(attrs, semconv.K8SDaemonSetName(podWorkload.Name))
+	}
+
+	if pe.ExecDetails != nil {
+		envs := pe.ExecDetails.Environments
+
+		containerName, ok := envs[k8sconsts.OdigosEnvVarContainerName]
+		if ok && containerName != "" {
+			attrs = append(attrs, semconv.K8SContainerName(containerName))
+		}
+
+		if pe.ExecDetails.ExePath != "" {
+			attrs = append(attrs, semconv.ProcessExecutablePath(pe.ExecDetails.ExePath))
+		}
+
+		if pe.ExecDetails.CmdLine != "" {
+			cmdLine := pe.ExecDetails.CmdLine
+			// we're getting the command line with space as a separator,
+			// original from the /proc filesystem it has a null byte as a separator
+			// TODO: we should probably change the runtime detector to return the cmdline as a string slice
+			// once we do that, we can add the command args resource as well
+			parts := strings.Split(cmdLine, " ")
+			if len(parts) > 0 {
+				attrs = append(attrs, semconv.ProcessCommand(parts[0]))
+			}
+		}
+	}
+
+	if pe.PID != 0 {
+		attrs = append(attrs, semconv.ProcessPID(pe.PID))
+	}
+
+	if pe.ExecDetails.ContainerProcessID != 0 {
+		attrs = append(attrs, semconv.ProcessVpid(pe.ExecDetails.ContainerProcessID))
+	}
+
+	return attrs
 }

--- a/odiglet/pkg/kube/utils/utils.go
+++ b/odiglet/pkg/kube/utils/utils.go
@@ -3,33 +3,12 @@ package utils
 import (
 	"fmt"
 
-	"github.com/odigos-io/odigos/api/k8sconsts"
 	"github.com/odigos-io/odigos/odiglet/pkg/env"
-	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	corev1 "k8s.io/api/core/v1"
 )
 
 func IsPodInCurrentNode(pod *corev1.Pod) bool {
 	return pod.Spec.NodeName == env.Current.NodeName
-}
-
-func GetResourceAttributes(podWorkload *k8sconsts.PodWorkload, podName string) []attribute.KeyValue {
-	attrs := []attribute.KeyValue{
-		semconv.K8SNamespaceName(podWorkload.Namespace),
-		semconv.K8SPodName(podName),
-	}
-
-	switch podWorkload.Kind {
-	case k8sconsts.WorkloadKindDeployment:
-		attrs = append(attrs, semconv.K8SDeploymentName(podWorkload.Name))
-	case k8sconsts.WorkloadKindStatefulSet:
-		attrs = append(attrs, semconv.K8SStatefulSetName(podWorkload.Name))
-	case k8sconsts.WorkloadKindDaemonSet:
-		attrs = append(attrs, semconv.K8SDaemonSetName(podWorkload.Name))
-	}
-
-	return attrs
 }
 
 func GetPodExternalURL(ip string, ports []corev1.ContainerPort) string {

--- a/tests/common/queries/resource-attributes.yaml
+++ b/tests/common/queries/resource-attributes.yaml
@@ -9,6 +9,8 @@ query: |
     !span.resourceAttributes."odigos.version" ||
     !span.resourceAttributes."k8s.deployment.name" ||
     !span.resourceAttributes."k8s.pod.name" ||
+    !span.resourceAttributes."k8s.namespace.name" ||
+    !span.resourceAttributes."k8s.container.name" ||
     !(
       starts_with(span.resourceAttributes."k8s.node.name", 'kind-') ||
       starts_with(span.resourceAttributes."k8s.node.name", 'aks-') ||


### PR DESCRIPTION
Adding the following resource attributes to the eBPF instrumentations:
* `k8s.container.name`
* `process.command`
* `process.executable.path`
* `process.pid`
* `process.vpid`

Adding the container name allows the `k8sAttributesResolver` to add more container attributes about the container image and tag.

Updated e2e query to assert that the container name is present in all the spans.