### PR TITLE
feat: url template unicode replacement character

### DIFF
--- a/collector/processors/odigosurltemplateprocessor/README.md
+++ b/collector/processors/odigosurltemplateprocessor/README.md
@@ -129,6 +129,7 @@ By default, the processor will split the path to segment (e.g. "/user/1234" -> [
 - long numbers anywhere - `\d{7,}` -> `{id}` (`1234567`, `INC328962358623904`, `sb_12345678901234567890_us`)
 - common [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) date-time formats - `^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}(?::\d{2})?)?(?:Z|[+-]\d{4})?$` -> `{date}` (`2023-10-01T12:00:00+0000`)
 - emails - `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$` like `foo@bar.io` -> `{email}`
+- unicode replacement character - `�` -> `{id}` (assume this is dynamic value and not static path segment)
 
 These default rules will not templatize paths like `/user/john`, `/user/s111222`, `/users/123456_789` which will be copied as is into the span name and attribute with potentially high cardinality.
 

--- a/collector/processors/odigosurltemplateprocessor/processor_test.go
+++ b/collector/processors/odigosurltemplateprocessor/processor_test.go
@@ -334,6 +334,18 @@ func TestProcessor_Traces(t *testing.T) {
 			expectedAttrKey:   "http.route",
 			expectedAttrValue: "/user/inc_654321",
 		},
+		{
+			name:          "invalid utf-8 char",
+			spanKind:      ptrace.SpanKindServer,
+			inputSpanName: "GET",
+			inputSpanAttrs: map[string]any{
+				"http.request.method": "GET",
+				"url.path":            "/foo/this_text_includes_invalid_char�",
+			},
+			expectedSpanName:  "GET /foo/{id}",
+			expectedAttrKey:   "http.route",
+			expectedAttrValue: "/foo/{id}",
+		},
 	}
 
 	runProcessorTests(t, tt, processor)

--- a/collector/processors/odigosurltemplateprocessor/templatize.go
+++ b/collector/processors/odigosurltemplateprocessor/templatize.go
@@ -68,6 +68,9 @@ var (
 
 	// matches email addresses
 	emailRegex = regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
+
+	// assume any invalid unicode character is not a static path segment
+	replacementChar = regexp.MustCompile(`�`)
 )
 
 type RulePathSegment struct {
@@ -208,7 +211,8 @@ func getSegmentTemplatizationString(segment string, customIds []internalCustomId
 	if noLettersRegex.MatchString(segment) ||
 		longNumberAnywhereRegex.MatchString(segment) ||
 		uuidRegex.MatchString(segment) ||
-		hexEncodedRegex.MatchString(segment) {
+		hexEncodedRegex.MatchString(segment) ||
+		replacementChar.MatchString(segment) {
 		return "id"
 	}
 


### PR DESCRIPTION
## Description

If a url path contains unicode replacement character, assume it's not static path segment and templtaize it with urltemplatization processor. following request from user

## How Has This Been Tested?

- [x] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

No

## User Facing Changes

Fix user issue for auto templatization behavior