### PR TITLE
ui: Add Workload Conditions to Source view

### DIFF
--- a/frontend/graph/conversions.go
+++ b/frontend/graph/conversions.go
@@ -1,10 +1,14 @@
 package graph
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/frontend/graph/model"
+	"github.com/odigos-io/odigos/frontend/kube"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -29,7 +33,7 @@ func k8sLastTransitionTimeToGql(t v1.Time) *string {
 	return &str
 }
 
-func instrumentationConfigToActualSource(instruConfig v1alpha1.InstrumentationConfig) *model.K8sActualSource {
+func instrumentationConfigToActualSource(ctx context.Context, instruConfig v1alpha1.InstrumentationConfig) (*model.K8sActualSource, error) {
 	var containers []*model.SourceContainer
 
 	// Map the containers runtime details
@@ -59,6 +63,13 @@ func instrumentationConfigToActualSource(instruConfig v1alpha1.InstrumentationCo
 		})
 	}
 
+	workloadConditions, err := instrumentationConfigWorkloadConditions(ctx, instruConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	conditions := append(instruConfig.Status.Conditions, workloadConditions...)
+
 	// Return the converted K8sActualSource object
 	return &model.K8sActualSource{
 		Namespace:         instruConfig.Namespace,
@@ -67,8 +78,62 @@ func instrumentationConfigToActualSource(instruConfig v1alpha1.InstrumentationCo
 		NumberOfInstances: nil,
 		OtelServiceName:   &instruConfig.Spec.ServiceName,
 		Containers:        containers,
-		Conditions:        convertConditions(instruConfig.Status.Conditions),
+		Conditions:        convertConditions(conditions),
+	}, nil
+}
+
+func instrumentationConfigWorkloadConditions(ctx context.Context, ic v1alpha1.InstrumentationConfig) ([]v1.Condition, error) {
+	conditions := make([]v1.Condition, 0)
+	kind := k8sKindToGql(ic.OwnerReferences[0].Kind)
+	ns := ic.Namespace
+	name := ic.OwnerReferences[0].Name
+	switch kind {
+	case model.K8sResourceKindDeployment:
+		dep, err := kube.DefaultClient.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get Deployment: %w", err)
+		}
+		for _, c := range dep.Status.Conditions {
+			conditions = append(conditions, v1.Condition{
+				Type:               string(c.Type),
+				Status:             v1.ConditionStatus(c.Status),
+				Reason:             c.Reason,
+				Message:            c.Message,
+				LastTransitionTime: c.LastTransitionTime,
+			})
+		}
+	case model.K8sResourceKindDaemonSet:
+		ds, err := kube.DefaultClient.AppsV1().DaemonSets(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get DaemonSet: %w", err)
+		}
+		for _, c := range ds.Status.Conditions {
+			conditions = append(conditions, v1.Condition{
+				Type:               string(c.Type),
+				Status:             v1.ConditionStatus(c.Status),
+				Reason:             c.Reason,
+				Message:            c.Message,
+				LastTransitionTime: c.LastTransitionTime,
+			})
+		}
+	case model.K8sResourceKindStatefulSet:
+		ss, err := kube.DefaultClient.AppsV1().StatefulSets(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get StatefulSet: %w", err)
+		}
+		for _, c := range ss.Status.Conditions {
+			conditions = append(conditions, v1.Condition{
+				Type:               string(c.Type),
+				Status:             v1.ConditionStatus(c.Status),
+				Reason:             c.Reason,
+				Message:            c.Message,
+				LastTransitionTime: c.LastTransitionTime,
+			})
+		}
+	default:
+		return nil, fmt.Errorf("unknown workload kind: %+v", kind)
 	}
+	return conditions, nil
 }
 
 func convertConditions(conditions []v1.Condition) []*model.Condition {


### PR DESCRIPTION
## Description

Our UI currently only tracks InstrumentationConfig conditions, stopping at `rollout triggered successfully` and showing `Everything Successful` if we reach that point

But in reality, the rollout could have failed on the Workload's end (due to resource quotas, scheduling issues, etc). This is confusing to the user because Odigos says everything should be instrumented and working.

This tries to grab the Workload's conditions and shows them alongside the instrumentation. This will be much more convenient than trying to manually debug the workload with kubectl.

The alternative would be adding Workload conditions to Sources/InstrumentationConfigs in the backend. This would require a controller to watch for updates to every workload in the cluster, which would be very expensive and unnecessary, since the user only cares about these conditions when they're looking at the Source in particular.

For comparison, this is what a currently (failing) instrumentation looks like:

<img width="689" alt="Screenshot 2025-05-15 at 10 11 12 AM" src="https://github.com/user-attachments/assets/d6730109-f910-47c7-8597-30094918799f" />

That same app with these changes shows why instrumentation failed (resource quota):

<img width="689" alt="Screenshot 2025-05-15 at 10 01 44 AM" src="https://github.com/user-attachments/assets/2c593749-3d0b-49db-b021-a41b1d7a50f9" />


## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
