### PR TITLE
Docs: Fix typo in group name and PR guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ When reporting an issue:
 
 ## Pull Request Guidelines
 
-When submitt
+When submitting a pull request:
 
 1. Include a clear description of the change and its purpose.
 2. Link to any related issues or documentation.

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -308,7 +308,7 @@
       ]
     },
     {
-      "group": "Contibution Guidelines",
+      "group": "Contribution Guidelines",
       "pages": [
         "adding-new-dest",
         "debugging"


### PR DESCRIPTION
## Description

Fixed typos:
•  "Contibution" -> "Contribution" in mint.json
•  "When submitt" -> "When submitting a pull request" in CONTRIBUTING.md
