### PR TITLE
instrumentor: Set ignorePolicy: Fail on Source ValidatingWebhook

### DIFF
--- a/cli/cmd/resources/instrumentor.go
+++ b/cli/cmd/resources/instrumentor.go
@@ -302,7 +302,7 @@ func NewSourceValidatingWebhookConfiguration(ns string, caBundle []byte) *admiss
 						},
 					},
 				},
-				FailurePolicy:  ptrGeneric(admissionregistrationv1.Ignore),
+				FailurePolicy:  ptrGeneric(admissionregistrationv1.Fail),
 				SideEffects:    ptrGeneric(admissionregistrationv1.SideEffectClassNone),
 				TimeoutSeconds: intPtr(10),
 				AdmissionReviewVersions: []string{

--- a/helm/odigos/templates/instrumentor/webhooks.yaml
+++ b/helm/odigos/templates/instrumentor/webhooks.yaml
@@ -94,7 +94,7 @@ webhooks:
         apiVersions: ["v1alpha1"]
         resources: ["sources"]
         scope: Namespaced
-    failurePolicy: Ignore
+    failurePolicy: Fail
     sideEffects: None
     timeoutSeconds: 10
     admissionReviewVersions: ["v1"]


### PR DESCRIPTION
## Description

We should really be rejecting Sources that fail the Validating webhook, since we rely on a lot of assumptions from it (like the format of labels etc)

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
