### PR TITLE
Allow user workload instrumentation in system namespace + exclude Odigos components

### DIFF
--- a/autoscaler/controllers/clustercollector/sync.go
+++ b/autoscaler/controllers/clustercollector/sync.go
@@ -18,6 +18,7 @@ import (
 var (
 	ClusterCollectorGateway = map[string]string{
 		k8sconsts.OdigosCollectorRoleLabel: string(k8sconsts.CollectorsRoleClusterGateway),
+		k8sconsts.OdigosSystemLabelKey:     k8sconsts.OdigosSystemLabelValue,
 	}
 )
 

--- a/autoscaler/controllers/nodecollector/daemonset.go
+++ b/autoscaler/controllers/nodecollector/daemonset.go
@@ -35,6 +35,7 @@ const (
 var (
 	NodeCollectorsLabels = map[string]string{
 		k8sconsts.OdigosCollectorRoleLabel: string(k8sconsts.CollectorsRoleNodeCollector),
+		k8sconsts.OdigosSystemLabelKey:     k8sconsts.OdigosSystemLabelValue,
 	}
 )
 

--- a/frontend/services/sources.go
+++ b/frontend/services/sources.go
@@ -35,6 +35,8 @@ const (
 	WorkloadKindDaemonSet   WorkloadKind = "DaemonSet"
 )
 
+var NonSystemObjectLabelSelector = "!" + k8sconsts.OdigosSystemLabelKey
+
 func GetWorkload(c context.Context, ns string, kind string, name string) (metav1.Object, int) {
 	switch kind {
 	case "Deployment":
@@ -105,7 +107,7 @@ func GetWorkloadsInNamespace(ctx context.Context, nsName string) ([]model.K8sAct
 
 func getDeployments(ctx context.Context, namespace corev1.Namespace) ([]model.K8sActualSource, error) {
 	var response []model.K8sActualSource
-	err := client.ListWithPages(client.DefaultPageSize, kube.DefaultClient.AppsV1().Deployments(namespace.Name).List, ctx, &metav1.ListOptions{}, func(deps *appsv1.DeploymentList) error {
+	err := client.ListWithPages(client.DefaultPageSize, kube.DefaultClient.AppsV1().Deployments(namespace.Name).List, ctx, &metav1.ListOptions{LabelSelector: NonSystemObjectLabelSelector}, func(deps *appsv1.DeploymentList) error {
 		for _, dep := range deps.Items {
 			numberOfInstances := int(dep.Status.ReadyReplicas)
 			response = append(response, model.K8sActualSource{
@@ -127,7 +129,7 @@ func getDeployments(ctx context.Context, namespace corev1.Namespace) ([]model.K8
 
 func getDaemonSets(ctx context.Context, namespace corev1.Namespace) ([]model.K8sActualSource, error) {
 	var response []model.K8sActualSource
-	err := client.ListWithPages(client.DefaultPageSize, kube.DefaultClient.AppsV1().DaemonSets(namespace.Name).List, ctx, &metav1.ListOptions{}, func(dss *appsv1.DaemonSetList) error {
+	err := client.ListWithPages(client.DefaultPageSize, kube.DefaultClient.AppsV1().DaemonSets(namespace.Name).List, ctx, &metav1.ListOptions{LabelSelector: NonSystemObjectLabelSelector}, func(dss *appsv1.DaemonSetList) error {
 		for _, ds := range dss.Items {
 			numberOfInstances := int(ds.Status.NumberReady)
 			response = append(response, model.K8sActualSource{
@@ -149,7 +151,7 @@ func getDaemonSets(ctx context.Context, namespace corev1.Namespace) ([]model.K8s
 
 func getStatefulSets(ctx context.Context, namespace corev1.Namespace) ([]model.K8sActualSource, error) {
 	var response []model.K8sActualSource
-	err := client.ListWithPages(client.DefaultPageSize, kube.DefaultClient.AppsV1().StatefulSets(namespace.Name).List, ctx, &metav1.ListOptions{}, func(sss *appsv1.StatefulSetList) error {
+	err := client.ListWithPages(client.DefaultPageSize, kube.DefaultClient.AppsV1().StatefulSets(namespace.Name).List, ctx, &metav1.ListOptions{LabelSelector: NonSystemObjectLabelSelector}, func(sss *appsv1.StatefulSetList) error {
 		for _, ss := range sss.Items {
 			numberOfInstances := int(ss.Status.ReadyReplicas)
 			response = append(response, model.K8sActualSource{

--- a/scheduler/controllers/odigosconfig/odigosconfig_controller.go
+++ b/scheduler/controllers/odigosconfig/odigosconfig_controller.go
@@ -77,7 +77,6 @@ func (r *odigosConfigController) Reconcile(ctx context.Context, _ ctrl.Request) 
 
 	// make sure the default ignored namespaces are always present
 	odigosConfig.IgnoredNamespaces = mergeIgnoredItemLists(odigosConfig.IgnoredNamespaces, k8sconsts.DefaultIgnoredNamespaces)
-	odigosConfig.IgnoredNamespaces = append(odigosConfig.IgnoredNamespaces, env.GetCurrentNamespace())
 
 	// make sure the default ignored containers are always present
 	odigosConfig.IgnoredContainers = mergeIgnoredItemLists(odigosConfig.IgnoredContainers, k8sconsts.DefaultIgnoredContainers)


### PR DESCRIPTION
## Description

This change is meant to allow users to instrument their own workloads in the same namespace that Odigos is installed. 

Some users, especially in small test environments, may not be able to create a separate namespace for Odigos. Currently, it is possible (but not easy) to do so because we exclude the system namespace by default in the `effective-config`. 

Users can manually edit this configmap to remove the system namespace, and from manual testing everything seems to work from that point. But this is not ideal for those users.

Importantly, we do not want to allow users to instrument Odigos components (to prevent event hotloops). This change updates the UI and Source instrumentation helpers to exclude any workloads with the `odigos-system` label instead of the entire namespace.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
