### PR TITLE
feat: update PHP agent version to v0.1.21

### DIFF
--- a/distros/yamls/php-community.yaml
+++ b/distros/yamls/php-community.yaml
@@ -19,11 +19,11 @@ spec:
       - envName: PHP_INI_SCAN_DIR
         envValue: ':/var/odigos/php/{{RUNTIME_VERSION_MAJOR_MINOR}}'
       - envName: OTEL_PHP_AUTOLOAD_ENABLED
-        envValue: true
+        envValue: 'true'
       - envName: OTEL_EXPORTER_OTLP_PROTOCOL
-        envValue: http/protobuf
+        envValue: 'http/protobuf'
       - envName: OTEL_PROPAGATORS
-        envValue: tracecontext,baggage
+        envValue: 'tracecontext,baggage'
   runtimeAgent:
     directoryNames:
       - '{{ODIGOS_AGENTS_DIR}}/php'

--- a/distros/yamls/php-community.yaml
+++ b/distros/yamls/php-community.yaml
@@ -20,6 +20,10 @@ spec:
         envValue: ':/var/odigos/php/{{RUNTIME_VERSION_MAJOR_MINOR}}'
       - envName: OTEL_PHP_AUTOLOAD_ENABLED
         envValue: true
+      - envName: OTEL_EXPORTER_OTLP_PROTOCOL
+        envValue: http/protobuf
+      - envName: OTEL_PROPAGATORS
+        envValue: tracecontext,baggage
   runtimeAgent:
     directoryNames:
       - '{{ODIGOS_AGENTS_DIR}}/php'

--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -87,10 +87,10 @@ RUN ARCH_SUFFIX=$(cat /tmp/arch_suffix) && \
 FROM --platform=$BUILDPLATFORM maniator/gh AS php-agents
 WORKDIR /php-agents
 ARG TARGETARCH
-ARG PHP_AGENT_VERSION="v0.1.18"
+ARG PHP_AGENT_VERSION="v0.1.21"
 ARG PHP_VERSIONS="8.0 8.1 8.2 8.3 8.4"
 ENV PHP_VERSIONS=${PHP_VERSIONS}
-# Clone agents repo (contains pre-compiled binaries and libraries for each PHP version)
+# Clone agents repo (contains pre-compiled binaries, and pre-installed dependencies for each PHP version)
 RUN git clone https://github.com/odigos-io/opentelemetry-php \
     && cd opentelemetry-php \
     && git checkout tags/${PHP_AGENT_VERSION}

--- a/odiglet/Dockerfile.rhel
+++ b/odiglet/Dockerfile.rhel
@@ -90,10 +90,10 @@ RUN ARCH_SUFFIX=$(cat /tmp/arch_suffix) && \
 FROM --platform=$BUILDPLATFORM maniator/gh AS php-agents
 WORKDIR /php-agents
 ARG TARGETARCH
-ARG PHP_AGENT_VERSION="v0.1.18"
+ARG PHP_AGENT_VERSION="v0.1.21"
 ARG PHP_VERSIONS="8.0 8.1 8.2 8.3 8.4"
 ENV PHP_VERSIONS=${PHP_VERSIONS}
-# Clone agents repo (contains pre-compiled binaries and libraries for each PHP version)
+# Clone agents repo (contains pre-compiled binaries, and pre-installed dependencies for each PHP version)
 RUN git clone https://github.com/odigos-io/opentelemetry-php \
     && cd opentelemetry-php \
     && git checkout tags/${PHP_AGENT_VERSION}

--- a/odiglet/debug.Dockerfile
+++ b/odiglet/debug.Dockerfile
@@ -87,10 +87,10 @@ RUN ARCH_SUFFIX=$(cat /tmp/arch_suffix) && \
 FROM --platform=$BUILDPLATFORM maniator/gh AS php-agents
 WORKDIR /php-agents
 ARG TARGETARCH
-ARG PHP_AGENT_VERSION="v0.1.18"
+ARG PHP_AGENT_VERSION="v0.1.21"
 ARG PHP_VERSIONS="8.0 8.1 8.2 8.3 8.4"
 ENV PHP_VERSIONS=${PHP_VERSIONS}
-# Clone agents repo (contains pre-compiled binaries and libraries for each PHP version)
+# Clone agents repo (contains pre-compiled binaries, and pre-installed dependencies for each PHP version)
 RUN git clone https://github.com/odigos-io/opentelemetry-php \
     && cd opentelemetry-php \
     && git checkout tags/${PHP_AGENT_VERSION}

--- a/odiglet/pkg/instrumentation/fs/agents.go
+++ b/odiglet/pkg/instrumentation/fs/agents.go
@@ -38,16 +38,6 @@ func CopyAgentsDirectoryToHost() error {
 		"/var/odigos/java-ebpf/tracing_probes.so":                                                      {},
 		"/var/odigos/java-ext-ebpf/end_span_usdt.so":                                                   {},
 		"/var/odigos/python-ebpf/pythonUSDT.abi3.so":                                                   {},
-
-		// the following paths are temporary...
-		// we removed the index files from all PHP agents (after PHP agents v0.1.21),
-		// but we need to keep them during CLI upgrades, prior to Odigos v1.0.188 (not including),
-		// once the CLI is upgraded, and the PHP pods were restarted, we no longer need to keep them.
-		"/var/odigos/php/8.0/index.php": {},
-		"/var/odigos/php/8.1/index.php": {},
-		"/var/odigos/php/8.2/index.php": {},
-		"/var/odigos/php/8.3/index.php": {},
-		"/var/odigos/php/8.4/index.php": {},
 	}
 
 	updatedFilesToKeepMap, err := removeChangedFilesFromKeepMap(filesToKeep, containerDir, k8sconsts.OdigosAgentsDirectory)

--- a/odiglet/pkg/instrumentation/fs/agents.go
+++ b/odiglet/pkg/instrumentation/fs/agents.go
@@ -38,6 +38,16 @@ func CopyAgentsDirectoryToHost() error {
 		"/var/odigos/java-ebpf/tracing_probes.so":                                                      {},
 		"/var/odigos/java-ext-ebpf/end_span_usdt.so":                                                   {},
 		"/var/odigos/python-ebpf/pythonUSDT.abi3.so":                                                   {},
+
+		// the following paths are temporary...
+		// we removed the index files from all PHP agents (after PHP agents v0.1.21),
+		// but we need to keep them during CLI upgrades, prior to Odigos v1.0.188 (not including),
+		// once the CLI is upgraded, and the PHP pods were restarted, we no longer need to keep them.
+		"/var/odigos/php/8.0/index.php": {},
+		"/var/odigos/php/8.1/index.php": {},
+		"/var/odigos/php/8.2/index.php": {},
+		"/var/odigos/php/8.3/index.php": {},
+		"/var/odigos/php/8.4/index.php": {},
 	}
 
 	updatedFilesToKeepMap, err := removeChangedFilesFromKeepMap(filesToKeep, containerDir, k8sconsts.OdigosAgentsDirectory)

--- a/tests/common/assert/simple-demo-instrumented-full.yaml
+++ b/tests/common/assert/simple-demo-instrumented-full.yaml
@@ -294,7 +294,7 @@ spec:
       (env[?name == 'PHP_INI_SCAN_DIR']):
         - value: ':/var/odigos/php/8.2'
       (env[?name == 'OTEL_PHP_AUTOLOAD_ENABLED']):
-        - value: true
+        - value: 'true'
       (env[?name == 'OTEL_EXPORTER_OTLP_PROTOCOL']):
         - value: 'http/protobuf'
       (env[?name == 'OTEL_PROPAGATORS']):

--- a/tests/common/assert/simple-demo-instrumented-full.yaml
+++ b/tests/common/assert/simple-demo-instrumented-full.yaml
@@ -293,6 +293,12 @@ spec:
         - (($values.k8sMinorVersion < `26` && value == 'http://$(NODE_IP):4318') || value == 'http://odigos-data-collection-local-traffic.odigos-test:4318'): true
       (env[?name == 'PHP_INI_SCAN_DIR']):
         - value: ':/var/odigos/php/8.2'
+      (env[?name == 'OTEL_PHP_AUTOLOAD_ENABLED']):
+        - value: true
+      (env[?name == 'OTEL_EXPORTER_OTLP_PROTOCOL']):
+        - value: 'http/protobuf'
+      (env[?name == 'OTEL_PROPAGATORS']):
+        - value: 'tracecontext,baggage'
     - name: nginx
 status:
   containerStatuses:

--- a/tests/e2e/cli-upgrade/chainsaw-test.yaml
+++ b/tests/e2e/cli-upgrade/chainsaw-test.yaml
@@ -119,6 +119,15 @@ spec:
             apiVersion: v1
             kind: Pod
 
+    # TODO: remove this after release of v1.0.188
+    - name: Restart PHP pod
+      try:
+        - script:
+            timeout: 1m
+            content: |
+              kubectl delete pod -l app=currency
+              kubectl wait --for=condition=ready pod -l app=currency --timeout=60s
+
     - name: Odigos pipeline ready after upgrade
       try:
         - assert:


### PR DESCRIPTION
## Description

The PHP agents had the OTel SDK built & registered twice, which caused issues such as recording spans from the OTel exporter itself.

This version kills the custom built SDK in favor of the auto-built SDK.