### PR TITLE
fix: remove use of JAVA_OPTS for instrumentation

### DIFF
--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -38,7 +38,6 @@ var configCmd = &cobra.Command{
 	- "mount-method": Determines how Odigos agent files are mounted into the pod's container filesystem. Options include k8s-host-path (direct hostPath mount) and k8s-virtual-device (virtual device-based injection).
 	- "container-runtime-socket-path": Path to the custom container runtime socket (e.g /var/lib/rancher/rke2/agent/containerd/containerd.sock).
 	- "k8s-node-logs-directory": Directory where Kubernetes logs are symlinked in a node (e.g /mnt/var/log).
-	- "avoid-java-opts-env-var": Avoid injecting the Odigos value in JAVA_OPTS environment variable into Java applications.
 	- "user-instrumentation-envs": JSON string defining per-language env vars to customize instrumentation, e.g., {"languages":{"java":{"enabled":true,"env":{"OTEL_INSTRUMENTATION_COMMON_EXPERIMENTAL_VIEW_TELEMETRY_ENABLED":"true"}}}}
 	- "agent-env-vars-injection-method": Method for injecting agent environment variables into the instrumented processes. Options include loader, pod-manifest and loader-fallback-to-pod-manifest.
 	- "node-selector": Apply a space-separated list of Kubernetes NodeSelectors to all Odigos components (ex: "kubernetes.io/os=linux mylabel=foo").
@@ -116,7 +115,7 @@ func setConfigProperty(config *common.OdigosConfiguration, property string, valu
 		config.CentralBackendURL = value[0]
 
 	case consts.TelemetryEnabledProperty, consts.OpenshiftEnabledProperty, consts.PspProperty,
-		consts.SkipWebhookIssuerCreationProperty, consts.AllowConcurrentAgentsProperty, consts.AvoidJavaOptsEnvVar,
+		consts.SkipWebhookIssuerCreationProperty, consts.AllowConcurrentAgentsProperty,
 		consts.KarpenterEnabledProperty:
 
 		if len(value) != 1 {
@@ -138,8 +137,6 @@ func setConfigProperty(config *common.OdigosConfiguration, property string, valu
 			config.SkipWebhookIssuerCreation = boolValue
 		case consts.AllowConcurrentAgentsProperty:
 			config.AllowConcurrentAgents = &boolValue
-		case consts.AvoidJavaOptsEnvVar:
-			config.AvoidInjectingJavaOptsEnvVar = &boolValue
 		case consts.KarpenterEnabledProperty:
 			config.KarpenterEnabled = &boolValue
 		}

--- a/common/consts/consts.go
+++ b/common/consts/consts.go
@@ -70,7 +70,6 @@ const (
 	CentralBackendURLProperty         = "central-backend-url"
 	CustomContainerRuntimeSocketPath  = "custom-container-runtime-socket-path"
 	K8sNodeLogsDirectory              = "k8s-node-logs-directory"
-	AvoidJavaOptsEnvVar               = "avoid-java-opts-env-var"
 	AgentEnvVarsInjectionMethod       = "agent-env-vars-injection-method"
 	ClusterNameProperty               = "cluster-name"
 	UserInstrumentationEnvsProperty   = "user-instrumentation-envs"

--- a/common/envOverwrite/overwriter.go
+++ b/common/envOverwrite/overwriter.go
@@ -36,16 +36,6 @@ var EnvValuesMap = map[string]envValues{
 			common.OtelSdkEbpfEnterprise:  "/var/odigos/python-ebpf:/var/odigos/python/opentelemetry/instrumentation/auto_instrumentation:/var/odigos/python",
 		},
 	},
-	"JAVA_OPTS": {
-		delim:               " ",
-		programmingLanguage: common.JavaProgrammingLanguage,
-		values: map[common.OtelSdk]string{
-			common.OtelSdkNativeCommunity: "-javaagent:/var/odigos/java/javaagent.jar",
-			common.OtelSdkEbpfEnterprise:  "-javaagent:/var/odigos/java-ebpf/dtrace-injector.jar",
-			common.OtelSdkNativeEnterprise: "-javaagent:/var/odigos/java-ext-ebpf/javaagent.jar " +
-				"-Dotel.javaagent.extensions=/var/odigos/java-ext-ebpf/otel_agent_extension.jar",
-		},
-	},
 	"JAVA_TOOL_OPTIONS": {
 		delim:               " ",
 		programmingLanguage: common.JavaProgrammingLanguage,
@@ -62,7 +52,7 @@ var EnvValuesMap = map[string]envValues{
 var EnvVarsForLanguage = map[common.ProgrammingLanguage][]string{
 	common.JavascriptProgrammingLanguage: {"NODE_OPTIONS"},
 	common.PythonProgrammingLanguage:     {"PYTHONPATH"},
-	common.JavaProgrammingLanguage:       {"JAVA_OPTS", "JAVA_TOOL_OPTIONS"},
+	common.JavaProgrammingLanguage:       {"JAVA_TOOL_OPTIONS"},
 }
 
 func GetRelevantEnvVarsKeys() []string {

--- a/common/odigos_config.go
+++ b/common/odigos_config.go
@@ -131,14 +131,8 @@ type OdigosConfiguration struct {
 	MountMethod                      *MountMethod                   `json:"mountMethod,omitempty"`
 	ClusterName                      string                         `json:"clusterName,omitempty"`
 	CustomContainerRuntimeSocketPath string                         `json:"customContainerRuntimeSocketPath,omitempty"`
-
-	// Used for migration - we are migrating away from using the JAVA_OPTS env var
-	// to only using the JAVA_TOOL_OPTIONS env var.
-	// When this is true, we will not inject the JAVA_OPTS env var into the container.
-	// when false or not set the original behavior will be used and the JAVA_OPTS env var will be injected.
-	AvoidInjectingJavaOptsEnvVar *bool                    `json:"avoidInjectingJavaOptsEnvVar,omitempty"`
-	AgentEnvVarsInjectionMethod  *EnvInjectionMethod      `json:"agentEnvVarsInjectionMethod,omitempty"`
-	UserInstrumentationEnvs      *UserInstrumentationEnvs `json:"UserInstrumentationEnvs,omitempty"`
-	NodeSelector                 map[string]string        `json:"nodeSelector,omitempty"`
-	KarpenterEnabled             *bool                    `json:"karpenterEnabled,omitempty"`
+	AgentEnvVarsInjectionMethod      *EnvInjectionMethod            `json:"agentEnvVarsInjectionMethod,omitempty"`
+	UserInstrumentationEnvs          *UserInstrumentationEnvs       `json:"UserInstrumentationEnvs,omitempty"`
+	NodeSelector                     map[string]string              `json:"nodeSelector,omitempty"`
+	KarpenterEnabled                 *bool                          `json:"karpenterEnabled,omitempty"`
 }

--- a/distros/yamls/java-community.yaml
+++ b/distros/yamls/java-community.yaml
@@ -19,9 +19,6 @@ spec:
     k8sAttrsViaEnvVars: true
     device: 'instrumentation.odigos.io/generic'
     environmentVariables:
-      - envName: JAVA_OPTS
-        envValue: '-javaagent:{{ODIGOS_AGENTS_DIR}}/java/javaagent.jar'
-        delimiter: ' '
       - envName: JAVA_TOOL_OPTIONS
         envValue: '-javaagent:{{ODIGOS_AGENTS_DIR}}/java/javaagent.jar'
         delimiter: ' '

--- a/docs/cli/odigos_config.mdx
+++ b/docs/cli/odigos_config.mdx
@@ -24,7 +24,6 @@ Manage Odigos configuration settings to customize system behavior.
 	- "mount-method": Determines how Odigos agent files are mounted into the pod's container filesystem. Options include k8s-host-path (direct hostPath mount) and k8s-virtual-device (virtual device-based injection).
 	- "container-runtime-socket-path": Path to the custom container runtime socket (e.g /var/lib/rancher/rke2/agent/containerd/containerd.sock).
 	- "k8s-node-logs-directory": Directory where Kubernetes logs are symlinked in a node (e.g /mnt/var/log).
-	- "avoid-java-opts-env-var": Avoid injecting the Odigos value in JAVA_OPTS environment variable into Java applications.
 	- "user-instrumentation-envs": JSON string defining per-language env vars to customize instrumentation, e.g., {"languages":{"java":{"enabled":true,"env":{"OTEL_INSTRUMENTATION_COMMON_EXPERIMENTAL_VIEW_TELEMETRY_ENABLED":"true"}}}}
 	- "agent-env-vars-injection-method": Method for injecting agent environment variables into the instrumented processes. Options include loader, pod-manifest and loader-fallback-to-pod-manifest.
 	- "node-selector": Apply a space-separated list of Kubernetes NodeSelectors to all Odigos components (ex: "kubernetes.io/os=linux mylabel=foo").

--- a/helm/odigos/templates/odigos-config-cm.yaml
+++ b/helm/odigos/templates/odigos-config-cm.yaml
@@ -125,9 +125,6 @@ data:
         {{- fail "Error: Invalid mountMethod. Supported values are 'k8s-host-path' and 'k8s-virtual-device'." }}
       {{- end }}
     {{- end }}
-    {{- if .Values.avoidInjectingJavaOptsEnvVar }}
-    avoidInjectingJavaOptsEnvVar: {{ .Values.avoidInjectingJavaOptsEnvVar }}
-    {{- end }}
     {{- $envMethod := .Values.instrumentor.agentEnvVarsInjectionMethod }}
     {{- if and $envMethod (not (has $envMethod (list "loader" "pod-manifest" "loader-fallback-to-pod-manifest"))) }}
     {{- fail "Error: Invalid agentEnvVarsInjectionMethod. Supported values are 'loader', 'pod-manifest', and 'loader-fallback-to-pod-manifest'." }}

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -241,11 +241,6 @@ gke:
 
 profiles: []
 
-# Used for migration - we are migrating away from using the JAVA_OPTS env var
-# to only using the JAVA_TOOL_OPTIONS env var.
-# When this is true, we will not inject the JAVA_OPTS env var into the container.
-# when false or not set the original behavior will be used and the JAVA_OPTS env var will be injected.
-avoidInjectingJavaOptsEnvVar: null
 # Optional NodeSelector to apply to all Odigos components
 # Note: Odigos will only be able to instrument workloads on the same nodes.
 nodeSelector: {}

--- a/profiles/aggregators/kratos.go
+++ b/profiles/aggregators/kratos.go
@@ -22,7 +22,6 @@ var KratosProfile = profile.Profile{
 		"size_m",
 		"allow_concurrent_agents",
 		"mount-method-k8s-host-path",
-		"avoid-java-opts-env-var",
 		"reduce-span-name-cardinality",
 	},
 }

--- a/profiles/allprofiles.go
+++ b/profiles/allprofiles.go
@@ -31,7 +31,6 @@ var AllProfiles = []profile.Profile{
 	instrumentation.LegacyDotNetProfile,
 	instrumentation.MountMethodK8sHostPathProfile,
 	instrumentation.MountMethodK8sVirtualDevice,
-	instrumentation.AvoidInjectingJavaOptsEnvVar,
 	instrumentation.LoaderFallbackToPodManifestEnvVarInjection,
 
 	pipeline.SmallBatchesProfile,

--- a/profiles/instrumentation/envvar_injection.go
+++ b/profiles/instrumentation/envvar_injection.go
@@ -5,21 +5,6 @@ import (
 	"github.com/odigos-io/odigos/profiles/profile"
 )
 
-// Used as a migration path - eventually this will be the default
-// and we will never add to the JAVA_OPTS env var
-// This profile is used to avoid injecting the Odigos value in JAVA_OPTS environment variable into Java applications
-var AvoidInjectingJavaOptsEnvVar = profile.Profile{
-	ProfileName:      common.ProfileName("avoid-java-opts-env-var"),
-	MinimumTier:      common.CommunityOdigosTier,
-	ShortDescription: "Avoid injecting the Odigos value in JAVA_OPTS environment variable into Java applications",
-	ModifyConfigFunc: func(config *common.OdigosConfiguration) {
-		b := true
-		if config.AvoidInjectingJavaOptsEnvVar == nil {
-			config.AvoidInjectingJavaOptsEnvVar = &b
-		}
-	},
-}
-
 var LoaderFallbackToPodManifestEnvVarInjection = profile.Profile{
 	ProfileName:      common.ProfileName("loader-fallback-to-pod-manifest-env-var-injection"),
 	MinimumTier:      common.CommunityOdigosTier,

--- a/tests/common/assert/simple-demo-instrumented-full.yaml
+++ b/tests/common/assert/simple-demo-instrumented-full.yaml
@@ -44,8 +44,6 @@ spec:
         - value: frontend
       (env[?name == 'OTEL_RESOURCE_ATTRIBUTES']):
         - value: 'k8s.pod.name=$(ODIGOS_POD_NAME),k8s.container.name=frontend,k8s.namespace.name=default,k8s.deployment.name=frontend'
-      (env[?name == 'JAVA_OPTS']):
-        - value: '-javaagent:/var/odigos/java/javaagent.jar'
       (env[?name == 'JAVA_TOOL_OPTIONS']):
         - value: '-javaagent:/var/odigos/java/javaagent.jar'
 status:

--- a/tests/e2e/env-injection/01-assert-apps-installed.yaml
+++ b/tests/e2e/env-injection/01-assert-apps-installed.yaml
@@ -30,20 +30,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    app: java-supported-empty-manifest-env
-  namespace: default
-status:
-  containerStatuses:
-    - name: java-supported-empty-manifest-env
-      ready: true
-      restartCount: 0
-      started: true
-  phase: Running
----
-apiVersion: v1
-kind: Pod
-metadata:
-  labels:
     app: java-latest-version
   namespace: default
 status:

--- a/tests/e2e/env-injection/01-assert-env-vars.yaml
+++ b/tests/e2e/env-injection/01-assert-env-vars.yaml
@@ -8,10 +8,6 @@ spec:
   containers:
     - image: public.ecr.aws/odigos/java-latest-version:v0.0.1
       name: java-latest-version
-      # nor JAVA_OPTS or JAVA_TOOL_OPTIONS are set in the manifest or Dockerfile of java-latest-version,
-      # In this case we need to ensure that they are both exists in the pod spec.
-      (env[?name=='JAVA_OPTS']):
-       - value: "-javaagent:/var/odigos/java/javaagent.jar"
       (env[?name=='JAVA_TOOL_OPTIONS']):
        - value: "-javaagent:/var/odigos/java/javaagent.jar"
       (env[?name=='LD_PRELOAD']): []
@@ -28,26 +24,6 @@ spec:
       name: java-supported-manifest-env
       (env[?name=='JAVA_TOOL_OPTIONS']):
       - value: "-Dnot.work=true -javaagent:/var/odigos/java/javaagent.jar"
-    # JAVA_OPTS is not set in the manifest of java-supported-manifest-env,
-    # so we need to ensure it is also not set in the pod spec.
-      (env[?name=='JAVA_OPTS']): []
-      (env[?name=='LD_PRELOAD']): []
----
-apiVersion: v1
-kind: Pod
-metadata:
-  labels:
-    app: java-supported-empty-manifest-env
-  namespace: default
-spec:
-  containers:
-    - image: public.ecr.aws/odigos/java-supported-manifest-env:v0.0.1
-      # JAVA_OPTS is defined in the manifest but it is empty,
-      # so we expect here to have our value in both env vars.
-      (env[?name=='JAVA_OPTS']):
-       - value: "-javaagent:/var/odigos/java/javaagent.jar"
-      (env[?name=='JAVA_TOOL_OPTIONS']):
-       - value: "-javaagent:/var/odigos/java/javaagent.jar"
       (env[?name=='LD_PRELOAD']): []
 ---
 apiVersion: v1
@@ -60,11 +36,12 @@ spec:
   containers:
     - image: public.ecr.aws/odigos/java-supported-docker-env:v0.0.1
       name: java-supported-docker-env
-      (env[?name=='JAVA_OPTS']):
-      - value: -Dthis.does.not.exist=true -javaagent:/var/odigos/java/javaagent.jar
+    # the container has a value defined for JAVA_OPTS, we should not touch it
+      (env[?name=='JAVA_OPTS']): []
     # JAVA_TOOL_OPTIONS is not set in the Dockerfile of java-supported-docker-env,
     # so we need to ensure it is also not set in the pod spec.
-      (env[?name=='JAVA_TOOL_OPTIONS']): []
+      (env[?name=='JAVA_TOOL_OPTIONS']):
+      - value: -javaagent:/var/odigos/java/javaagent.jar
       (env[?name=='LD_PRELOAD']): []
 ---
 apiVersion: v1

--- a/tests/e2e/env-injection/01-assert-runtime-detected.yaml
+++ b/tests/e2e/env-injection/01-assert-runtime-detected.yaml
@@ -6,13 +6,9 @@ metadata:
 status:
   runtimeDetailsByContainer:
   - containerName: java-supported-docker-env
-    (envFromContainerRuntime[?name=='JAVA_OPTS']):
-      - value:  -Dthis.does.not.exist=true
     (envFromContainerRuntime[?name=='LD_PRELOAD']):
       - value: ""
     (envFromContainerRuntime[?name=='JAVA_TOOL_OPTIONS']): []
-    (envVars[?name=='JAVA_OPTS']):
-      - value:  -Dthis.does.not.exist=true
     (envVars[?name=='LD_PRELOAD']):
       - value: ""
     (envVars[?name=='JAVA_TOOL_OPTIONS']): []           
@@ -31,21 +27,6 @@ status:
     - name: JAVA_TOOL_OPTIONS
       value: "-Dnot.work=true"
     (envVars[?name=='JAVA_OPTS']): []      
-    language: java
----
-apiVersion: odigos.io/v1alpha1
-kind: InstrumentationConfig
-metadata:
-  namespace: default
-  name: deployment-java-supported-empty-manifest-env
-status:
-  runtimeDetailsByContainer:
-  - containerName: java-supported-empty-manifest-env
-    (!envFromContainerRuntime): true
-    envVars:
-    - name: JAVA_OPTS
-      value: ""
-    (envVars[?name=='JAVA_TOOL_OPTIONS']): []
     language: java
 ---
 apiVersion: odigos.io/v1alpha1

--- a/tests/e2e/env-injection/01-install-test-apps.yaml
+++ b/tests/e2e/env-injection/01-install-test-apps.yaml
@@ -82,48 +82,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: java-supported-empty-manifest-env
-  namespace: default
-  labels:
-    app: java-supported-empty-manifest-env
-spec:
-  selector:
-    matchLabels:
-      app: java-supported-empty-manifest-env
-  template:
-    metadata:
-      labels:
-        app: java-supported-empty-manifest-env
-    spec:
-      containers:
-        - name: java-supported-empty-manifest-env
-          image: public.ecr.aws/odigos/java-supported-manifest-env:v0.0.1
-          imagePullPolicy: IfNotPresent
-          ports:
-            - containerPort: 3000
-          env:
-            - name: JAVA_OPTS
-              value: ""
-          readinessProbe:
-            tcpSocket:
-              port: 3000
-            initialDelaySeconds: 20
----
-kind: Service
-apiVersion: v1
-metadata:
-  name: java-supported-empty-manifest-env
-  namespace: default
-spec:
-  selector:
-    app: java-supported-empty-manifest-env
-  ports:
-    - protocol: TCP
-      port: 3000
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
   name: java-latest-version
   namespace: default
   labels:

--- a/tests/e2e/env-injection/02-assert-env-vars.yaml
+++ b/tests/e2e/env-injection/02-assert-env-vars.yaml
@@ -33,22 +33,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    app: java-supported-empty-manifest-env
-  namespace: default
-spec:
-  containers:
-    - image: public.ecr.aws/odigos/java-supported-manifest-env:v0.0.1
-      (env[?name=='JAVA_TOOL_OPTIONS']): []
-      # user defined JAVA_OPTS in the manifest but it is empty,
-      (env[?name=='JAVA_OPTS']):
-        - name: JAVA_OPTS
-      (env[?name=='LD_PRELOAD']):
-       - value: "/var/odigos/loader.so"
----
-apiVersion: v1
-kind: Pod
-metadata:
-  labels:
     app: java-supported-docker-env
   namespace: default
 spec:
@@ -56,9 +40,9 @@ spec:
     - image: public.ecr.aws/odigos/java-supported-docker-env:v0.0.1
       name: java-supported-docker-env
       # LD_PRELOAD is declared in the Dockerfile, hence we fallback to adding it to the user defined env vars.
-      (env[?name=='JAVA_OPTS']):
-      - value: -Dthis.does.not.exist=true -javaagent:/var/odigos/java/javaagent.jar
-      (env[?name=='JAVA_TOOL_OPTIONS']): []
+      (env[?name=='JAVA_OPTS']): []
+      (env[?name=='JAVA_TOOL_OPTIONS']):
+      - value: -javaagent:/var/odigos/java/javaagent.jar
       (env[?name=='LD_PRELOAD']): []
 ---
 apiVersion: v1

--- a/tests/e2e/env-injection/03-assert-env-vars.yaml
+++ b/tests/e2e/env-injection/03-assert-env-vars.yaml
@@ -33,22 +33,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    app: java-supported-empty-manifest-env
-  namespace: default
-spec:
-  containers:
-    - image: public.ecr.aws/odigos/java-supported-manifest-env:v0.0.1
-      (env[?name=='JAVA_TOOL_OPTIONS']): []
-      # user defined JAVA_OPTS in the manifest but it is empty,
-      (env[?name=='JAVA_OPTS']):
-        - name: JAVA_OPTS
-      (env[?name=='LD_PRELOAD']):
-       - value: "/var/odigos/loader.so"
----
-apiVersion: v1
-kind: Pod
-metadata:
-  labels:
     app: java-supported-docker-env
   namespace: default
 spec:
@@ -58,7 +42,6 @@ spec:
       # LD_PRELOAD is declared in the Dockerfile, hence we can't add the loader
       # in this test the user specified the env var injection to be loader only,
       # hence we assert here that nothing is added from our side.
-      (env[?name=='JAVA_OPTS']): []
       (env[?name=='JAVA_TOOL_OPTIONS']): []
       (env[?name=='LD_PRELOAD']): []
 ---

--- a/tests/e2e/workload-lifecycle/01-assert-runtime-detected.yaml
+++ b/tests/e2e/workload-lifecycle/01-assert-runtime-detected.yaml
@@ -179,8 +179,6 @@ status:
     - containerName: java-supported-docker-env
       language: java
       envFromContainerRuntime:
-        - name: JAVA_OPTS
-          value: "-Dthis.does.not.exist=true"
         - name: LD_PRELOAD
           value: ""
       runtimeVersion: 17.0.12+7


### PR DESCRIPTION
## Description

Complete the transition started at #2776 - and remove any modification to the JAVA_OPTS env var.
JAVA_OPTS is used by tools like catalina/tomact that are usually launched using a big bash script. This env var is usually used for configuring such tools, but it has not affect on the JVM itself.
Following https://github.com/odigos-io/odigos/pull/2667, when a user app is using JAVA_OPTS we'll end up adding our value there which will not add our agent.
After this PR only JAVA_TOOL_OPTIONS will be used.
Users that experience the described bug will need to upgrade the odigos version, and do a rollout to their workloads if they are in a Crashloop state, or re-instrument them.
Previous version of odigos can use the `avoid-java-opts` profile which is being removed here.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [x] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

