### PR TITLE
feat: add default data-stream label & data-stream validation in sources webhook

### DIFF
--- a/common/consts/consts.go
+++ b/common/consts/consts.go
@@ -25,6 +25,9 @@ const (
 	// Deprecated: Sources are used to mark workloads for instrumentation.
 	InstrumentationDisabled = "disabled"
 
+	// DefaultDataStream is the default data stream name used for telemetry data.
+	DefaultDataStream = "default"
+
 	// Deprecated: reported name is set via the Source CR.
 	OdigosReportedNameAnnotation = "odigos.io/reported-name"
 	RolloutTriggerAnnotation     = "rollout-trigger"

--- a/frontend/webapp/package.json
+++ b/frontend/webapp/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@apollo/client": "^3.13.8",
     "@apollo/experimental-nextjs-app-support": "^0.12.2",
-    "@odigos/ui-kit": "^0.0.31",
+    "@odigos/ui-kit": "^0.0.32",
     "graphql": "^16.11.0",
     "next": "15.3.2",
     "react": "19.1.0",

--- a/frontend/webapp/yarn.lock
+++ b/frontend/webapp/yarn.lock
@@ -426,10 +426,10 @@
   resolved "https://registry.yarnpkg.com/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz#3dc35ba0f1e66b403c00b39344f870298ebb1c8e"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
-"@odigos/ui-kit@^0.0.31":
-  version "0.0.31"
-  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.31.tgz#484943ae48865b050b6023bb1d1510b6de348d2f"
-  integrity sha512-qLtrcxOC0sACrAZ+QZ6rBHjQZEPEr3qCSGoHwD24KoiHkmeGciIsfRUSFhRYh4pnSLz/BFjbiXDtMfUQ6q7kbQ==
+"@odigos/ui-kit@^0.0.32":
+  version "0.0.32"
+  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.32.tgz#ffbbb551f3ecc98e62d14e0f84266e1f9020198d"
+  integrity sha512-lEsTftKRYrthYL0lUrzIgegW97wEiHgyxxwlIWbKc0/f+svhnZnri+gBM7c/ycgGCUI8Ng1iiO1L7egZ0Ijlkg==
   dependencies:
     "@xyflow/react" "^12.6.3"
     javascript-time-ago "^2.5.11"

--- a/tests/e2e/webhooks/defaulting-01-assert-source-without-labels.yaml
+++ b/tests/e2e/webhooks/defaulting-01-assert-source-without-labels.yaml
@@ -7,6 +7,7 @@ metadata:
     odigos.io/workload-kind: Deployment
     odigos.io/workload-namespace: default
     odigos.io/workload-name: source-without-labels
+    odigos.io/group-default: 'true'
 spec:
   workload:
     name: source-without-labels


### PR DESCRIPTION
This PR adds a default data-stream label to Source CRDs, and validates the existence of a label.