### PR TITLE
add loader dir to be used by host path mount when needed

### DIFF
--- a/common/consts/consts.go
+++ b/common/consts/consts.go
@@ -51,6 +51,7 @@ const (
 	GoOffsetsPublicURL = "https://storage.googleapis.com/odigos-cloud/offset_results_min.json"
 
 	LdPreloadEnvVarName = "LD_PRELOAD"
+	OdigosLoaderDirName = "loader"
 	OdigosLoaderName    = "loader.so"
 )
 

--- a/instrumentor/controllers/agentenabled/podswebhook/mount.go
+++ b/instrumentor/controllers/agentenabled/podswebhook/mount.go
@@ -1,6 +1,7 @@
 package podswebhook
 
 import (
+	"path/filepath"
 	"strings"
 
 	"github.com/odigos-io/odigos/api/k8sconsts"
@@ -11,8 +12,8 @@ import (
 func MountDirectory(containerSpec *corev1.Container, dir string) {
 	// TODO: assuming the directory always starts with {{ODIGOS_AGENTS_DIR}}. This should be validated.
 	// Should we return errors here to validate static values?
-	relativePath := strings.TrimPrefix(dir, distro.AgentPlaceholderDirectory+"/")
 	absolutePath := strings.ReplaceAll(dir, distro.AgentPlaceholderDirectory, k8sconsts.OdigosAgentsDirectory)
+	relativePath := filepath.Base(absolutePath)
 
 	// make sure we are idempotent, not adding ourselves multiple times
 	for _, volumeMount := range containerSpec.VolumeMounts {

--- a/instrumentor/internal/webhook_env_injector/webhook_env_injector.go
+++ b/instrumentor/internal/webhook_env_injector/webhook_env_injector.go
@@ -49,7 +49,7 @@ func InjectOdigosAgentEnvVars(ctx context.Context, logger logr.Logger, podWorklo
 
 	// check if odigos loader should be used
 	if *injectionMethod == common.LoaderEnvInjectionMethod || *injectionMethod == common.LoaderFallbackToPodManifestInjectionMethod {
-		odigosLoaderPath := filepath.Join(k8sconsts.OdigosAgentsDirectory, commonconsts.OdigosLoaderName)
+		odigosLoaderPath := filepath.Join(k8sconsts.OdigosAgentsDirectory, commonconsts.OdigosLoaderDirName, commonconsts.OdigosLoaderName)
 
 		manifestValExits := getContainerEnvVarPointer(&container.Env, commonconsts.LdPreloadEnvVarName) != nil
 		runtimeDetailsVal, foundInInspection := getEnvVarFromRuntimeDetails(runtimeDetails, commonconsts.LdPreloadEnvVarName)

--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -146,7 +146,7 @@ COPY --from=php-agents /php-agents/opentelemetry-php/8.4 /instrumentations/php/8
 
 # loader
 ARG ODIGOS_LOADER_VERSION=v0.0.3
-RUN wget https://storage.googleapis.com/odigos-loader/$ODIGOS_LOADER_VERSION/$TARGETARCH/loader.so
+RUN wget --directory-prefix=loader https://storage.googleapis.com/odigos-loader/$ODIGOS_LOADER_VERSION/$TARGETARCH/loader.so
 
 FROM gcr.io/distroless/base:latest
 COPY --from=builder /go/src/github.com/odigos-io/odigos/odiglet/odiglet /root/odiglet

--- a/odiglet/Dockerfile.rhel
+++ b/odiglet/Dockerfile.rhel
@@ -150,7 +150,7 @@ COPY --from=php-agents /php-agents/opentelemetry-php/8.4 /instrumentations/php/8
 
 # loader
 ARG ODIGOS_LOADER_VERSION=v0.0.3
-RUN wget https://storage.googleapis.com/odigos-loader/$ODIGOS_LOADER_VERSION/$TARGETARCH/loader.so
+RUN wget --directory-prefix=loader https://storage.googleapis.com/odigos-loader/$ODIGOS_LOADER_VERSION/$TARGETARCH/loader.so
 
 FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 ARG VERSION

--- a/odiglet/debug.Dockerfile
+++ b/odiglet/debug.Dockerfile
@@ -148,7 +148,7 @@ COPY --from=php-agents /php-agents/opentelemetry-php/8.4 /instrumentations/php/8
 
 # loader
 ARG ODIGOS_LOADER_VERSION=v0.0.3
-RUN wget https://storage.googleapis.com/odigos-loader/$ODIGOS_LOADER_VERSION/$TARGETARCH/loader.so
+RUN wget --directory-prefix=loader https://storage.googleapis.com/odigos-loader/$ODIGOS_LOADER_VERSION/$TARGETARCH/loader.so
 
 FROM registry.fedoraproject.org/fedora-minimal:38
 COPY --from=builder /go/src/github.com/odigos-io/odigos/odiglet/odiglet /root/odiglet

--- a/profiles/aggregators/kratos.go
+++ b/profiles/aggregators/kratos.go
@@ -23,5 +23,6 @@ var KratosProfile = profile.Profile{
 		"allow_concurrent_agents",
 		"mount-method-k8s-host-path",
 		"reduce-span-name-cardinality",
+		"loader-fallback-to-pod-manifest-env-var-injection",
 	},
 }

--- a/tests/e2e/env-injection/02-assert-env-vars.yaml
+++ b/tests/e2e/env-injection/02-assert-env-vars.yaml
@@ -11,7 +11,7 @@ spec:
       (env[?name=='JAVA_OPTS']): []
       (env[?name=='JAVA_TOOL_OPTIONS']): []
       (env[?name=='LD_PRELOAD']):
-       - value: "/var/odigos/loader.so"
+      - value: "/var/odigos/loader/loader.so"
 ---
 apiVersion: v1
 kind: Pod
@@ -27,7 +27,7 @@ spec:
       - value: "-Dnot.work=true"
       (env[?name=='JAVA_OPTS']): []
       (env[?name=='LD_PRELOAD']):
-       - value: "/var/odigos/loader.so"
+      - value: "/var/odigos/loader/loader.so"
 ---
 apiVersion: v1
 kind: Pod
@@ -64,7 +64,7 @@ spec:
             name: env-configmap
       (env[?name=='ORIGINAL_PYTHONPATH']): []
       (env[?name=='LD_PRELOAD']):
-       - value: "/var/odigos/loader.so"
+      - value: "/var/odigos/loader/loader.so"
 ---
 apiVersion: v1
 kind: Pod
@@ -101,4 +101,4 @@ spec:
             name: env-configmap
       (env[?name=='ORIGINAL_JAVA_TOOL_OPTIONS']): []
       (env[?name=='LD_PRELOAD']):
-       - value: "/var/odigos/loader.so"
+      - value: "/var/odigos/loader/loader.so"

--- a/tests/e2e/env-injection/03-assert-env-vars.yaml
+++ b/tests/e2e/env-injection/03-assert-env-vars.yaml
@@ -11,7 +11,7 @@ spec:
       (env[?name=='JAVA_OPTS']): []
       (env[?name=='JAVA_TOOL_OPTIONS']): []
       (env[?name=='LD_PRELOAD']):
-       - value: "/var/odigos/loader.so"
+        - value: "/var/odigos/loader/loader.so"
 ---
 apiVersion: v1
 kind: Pod
@@ -27,7 +27,7 @@ spec:
       - value: "-Dnot.work=true"
       (env[?name=='JAVA_OPTS']): []
       (env[?name=='LD_PRELOAD']):
-       - value: "/var/odigos/loader.so"
+      - value: "/var/odigos/loader/loader.so"
 ---
 apiVersion: v1
 kind: Pod
@@ -64,7 +64,7 @@ spec:
             name: env-configmap
       (env[?name=='ORIGINAL_PYTHONPATH']): []
       (env[?name=='LD_PRELOAD']):
-       - value: "/var/odigos/loader.so"
+      - value: "/var/odigos/loader/loader.so"
 ---
 apiVersion: v1
 kind: Pod
@@ -102,4 +102,4 @@ spec:
             name: env-configmap
       (env[?name=='ORIGINAL_JAVA_TOOL_OPTIONS']): []
       (env[?name=='LD_PRELOAD']):
-       - value: "/var/odigos/loader.so"
+      - value: "/var/odigos/loader/loader.so"


### PR DESCRIPTION
* Change the location of the loader from `/var/odigos/loader.so` to `/var/odigos/loader/loader.so` - this will allow us to make more precise mounts when using the host path method for mounting.
* Add `loader-fallback-to-pod-manifest` to kratos profils.