### PR TITLE
use internalTrafficPolicy for opAmp to allow removing hostNetwork from odiglet

### DIFF
--- a/api/k8sconsts/odiglet.go
+++ b/api/k8sconsts/odiglet.go
@@ -23,6 +23,8 @@ const (
 	GoOffsetsFileName  = "go_offset_results.json"
 	GoOffsetsEnvVar    = "OTEL_GO_OFFSETS_FILE"
 	OffsetFileMountPath = "/offsets"
+
+	OdigletLocalTrafficServiceName = "odiglet-local"
 )
 
 var OdigletOSSInstalled = map[string]string{

--- a/cli/cmd/resources/odiglet.go
+++ b/cli/cmd/resources/odiglet.go
@@ -551,12 +551,16 @@ func NewOdigletDaemonSet(ns string, version string, imagePrefix string, imageNam
 					},
 					DNSPolicy:          "ClusterFirstWithHostNet",
 					ServiceAccountName: k8sconsts.OdigletServiceAccountName,
-					HostNetwork:        true,
 					HostPID:            true,
 					PriorityClassName:  "system-node-critical",
 				},
 			},
 		},
+	}
+
+	// if inetrnal trffic policy is not yet supported in the cluster, fall back to host network
+	if k8sversionInCluster == nil || k8sversionInCluster.LessThan(k8sversion.MustParse("v1.26")) {
+		ds.Spec.Template.Spec.HostNetwork = true
 	}
 
 	return ds
@@ -593,6 +597,33 @@ func NewOdigletGoOffsetsConfigMap(ctx context.Context, client *kube.Client, ns s
 			k8sconsts.GoOffsetsFileName: goOffsetContent,
 		},
 	}, nil
+}
+
+func NewOdigletLocalTrafficService(ns string) *corev1.Service {
+	localTrafficPolicy := v1.ServiceInternalTrafficPolicyLocal
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      k8sconsts.OdigletLocalTrafficServiceName,
+			Namespace: ns,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"app.kubernetes.io/name": k8sconsts.OdigletAppLabelValue,
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "op-amp",
+					Port:       int32(consts.OpAMPPort),
+					TargetPort: intstr.FromInt(consts.OpAMPPort),
+				},
+			},
+			InternalTrafficPolicy: &localTrafficPolicy,
+		},
+	}
 }
 
 // used to inject the host volumes into odigos components for selinux update
@@ -689,6 +720,11 @@ func (a *odigletResourceManager) InstallFromScratch(ctx context.Context) error {
 		goOffsetConfigMap,
 	}
 
+	k8sVersion := cmdcontext.K8SVersionFromContext(ctx)
+	if k8sVersion != nil && k8sVersion.AtLeast(k8sversion.MustParse("v1.26")) {
+		resources = append(resources, NewOdigletLocalTrafficService(a.ns))
+	}
+
 	clusterKind := cmdcontext.ClusterKindFromContext(ctx)
 
 	// if openshift is enabled, we need to create additional SCC cluster role binding first
@@ -707,7 +743,7 @@ func (a *odigletResourceManager) InstallFromScratch(ctx context.Context) error {
 		NewOdigletDaemonSet(a.ns, a.odigosVersion, a.config.ImagePrefix, a.managerOpts.ImageReferences.OdigletImage, a.odigosTier, a.config.OpenshiftEnabled,
 			&autodetect.ClusterDetails{
 				Kind:       clusterKind,
-				K8SVersion: cmdcontext.K8SVersionFromContext(ctx),
+				K8SVersion: k8sVersion,
 			}, a.config.CustomContainerRuntimeSocketPath, a.config.NodeSelector))
 
 	return a.client.ApplyResources(ctx, a.config.ConfigVersion, resources, a.managerOpts)

--- a/helm/odigos/templates/odiglet/daemonset.yaml
+++ b/helm/odigos/templates/odiglet/daemonset.yaml
@@ -141,7 +141,9 @@ spec:
             - name: odigos-go-offsets
               mountPath: /offsets
             {{- end }}
+      {{- if semverCompare "<1.26.0" .Capabilities.KubeVersion.Version }}
       hostNetwork: true
+      {{- end}}
       hostPID: true
       dnsPolicy: ClusterFirstWithHostNet
       priorityClassName: system-node-critical

--- a/helm/odigos/templates/odiglet/local-service.yaml
+++ b/helm/odigos/templates/odiglet/local-service.yaml
@@ -1,0 +1,16 @@
+{{- if semverCompare ">=1.26.0" .Capabilities.KubeVersion.Version }}
+kind: Service
+metadata:
+  name: odiglet-local
+  namespace: {{ .Release.Namespace }}
+  labels:
+    odigos.io/system-object: "true"
+spec:
+  ports:
+    - name: op-amp
+      port: 4320
+      targetPort: 4320
+  selector:
+    app.kubernetes.io/name: odiglet
+  internalTrafficPolicy: Local
+{{- end}}

--- a/helm/odigos/templates/odiglet/local-service.yaml
+++ b/helm/odigos/templates/odiglet/local-service.yaml
@@ -1,4 +1,5 @@
 {{- if semverCompare ">=1.26.0" .Capabilities.KubeVersion.Version }}
+apiVersion: v1
 kind: Service
 metadata:
   name: odiglet-local

--- a/instrumentor/controllers/agentenabled/podswebhook/env.go
+++ b/instrumentor/controllers/agentenabled/podswebhook/env.go
@@ -1,7 +1,6 @@
 package podswebhook
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/odigos-io/odigos/api/k8sconsts"
@@ -75,7 +74,7 @@ func InjectStaticEnvVar(existingEnvNames EnvVarNamesMap, container *corev1.Conta
 
 func InjectOpampServerEnvVar(existingEnvNames EnvVarNamesMap, container *corev1.Container) EnvVarNamesMap {
 	existingEnvNames = injectNodeIpEnvVar(existingEnvNames, container)
-	opAmpServerHost := fmt.Sprintf("$(NODE_IP):%d", commonconsts.OpAMPPort)
+	opAmpServerHost := service.LocalTrafficOpAmpOdigletEndpoint("$(NODE_IP)")
 	existingEnvNames = InjectEnvVarToPodContainer(existingEnvNames, container, commonconsts.OpampServerHostEnvName, opAmpServerHost, nil)
 	return existingEnvNames
 }

--- a/k8sutils/pkg/service/service.go
+++ b/k8sutils/pkg/service/service.go
@@ -28,3 +28,16 @@ func LocalTrafficOTLPHttpDataCollectionEndpoint(nodeIP string) string {
 	}
 	return fmt.Sprintf("http://%s:%d", nodeIP, consts.OTLPHttpPort)
 }
+
+// LocalTrafficOTLPHttpDataCollectionEndpoint returns the endpoint for OpAmp server on the same node (odiglet).
+// If the internal traffic policy is enabled, the endpoint will use the service name.
+// Otherwise, it will use the node IP.
+// The node IP might be passed as explicit IP or as a pattern like "$(NODE_IP)"
+// which also requires having the `NODE_IP` environment variable set in the manifest.
+// Using a pattern is useful when the target node is not known once calling this function.
+func LocalTrafficOpAmpOdigletEndpoint(nodeIP string) string {
+	if feature.ServiceInternalTrafficPolicy(feature.GA) {
+		return fmt.Sprintf("%s.%s:%d", k8sconsts.OdigletLocalTrafficServiceName, env.GetCurrentNamespace(), consts.OpAMPPort)
+	}
+	return fmt.Sprintf("%s:%d", nodeIP, consts.OpAMPPort)
+}

--- a/odiglet/pkg/instrumentation/instrumentlang/nodejs.go
+++ b/odiglet/pkg/instrumentation/instrumentlang/nodejs.go
@@ -1,10 +1,7 @@
 package instrumentlang
 
 import (
-	"fmt"
-
 	"github.com/odigos-io/odigos/common"
-	commonconsts "github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/k8sutils/pkg/service"
 	"github.com/odigos-io/odigos/odiglet/pkg/env"
 	"k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
@@ -19,7 +16,7 @@ const (
 )
 
 func NodeJS(deviceId string, uniqueDestinationSignals map[common.ObservabilitySignal]struct{}) *v1beta1.ContainerAllocateResponse {
-	opampServerHost := fmt.Sprintf("%s:%d", env.Current.NodeIP, commonconsts.OpAMPPort)
+	opampServerHost := service.LocalTrafficOpAmpOdigletEndpoint(env.Current.NodeIP)
 
 	return &v1beta1.ContainerAllocateResponse{
 		Envs: map[string]string{

--- a/odiglet/pkg/instrumentation/instrumentlang/python.go
+++ b/odiglet/pkg/instrumentation/instrumentlang/python.go
@@ -1,10 +1,7 @@
 package instrumentlang
 
 import (
-	"fmt"
-
 	"github.com/odigos-io/odigos/common"
-	"github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/k8sutils/pkg/service"
 	"github.com/odigos-io/odigos/odiglet/pkg/env"
 	"k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
@@ -25,7 +22,7 @@ const (
 )
 
 func Python(deviceId string, uniqueDestinationSignals map[common.ObservabilitySignal]struct{}) *v1beta1.ContainerAllocateResponse {
-	opampServerHost := fmt.Sprintf("%s:%d", env.Current.NodeIP, consts.OpAMPPort)
+	opampServerHost := service.LocalTrafficOpAmpOdigletEndpoint(env.Current.NodeIP)
 
 	logsExporter := "none"
 	metricsExporter := "none"

--- a/tests/common/assert/odigos-installed.yaml
+++ b/tests/common/assert/odigos-installed.yaml
@@ -82,7 +82,7 @@ spec:
           add:
             - SYS_PTRACE
         privileged: true
-  hostNetwork: true
+  (($values.k8sMinorVersion < `26` && hostNetwork != null) || (hostNetwork == null)): true
   hostPID: true
   nodeSelector:
     kubernetes.io/os: linux

--- a/tests/common/assert/odigos-upgraded.yaml
+++ b/tests/common/assert/odigos-upgraded.yaml
@@ -81,7 +81,7 @@ spec:
             - SYS_PTRACE
         privileged: true
       image: registry.odigos.io/odigos-odiglet:e2e-test
-  hostNetwork: true
+  (($values.k8sMinorVersion < `26` && hostNetwork != null) || (hostNetwork == null)): true
   hostPID: true
   nodeName: kind-control-plane
   nodeSelector:
@@ -117,7 +117,7 @@ spec:
             - SYS_PTRACE
         privileged: true
       image: registry.odigos.io/odigos-odiglet:e2e-test
-  hostNetwork: true
+  (($values.k8sMinorVersion < `26` && hostNetwork != null) || (hostNetwork == null)): true
   hostPID: true
   nodeName: kind-worker
   nodeSelector:

--- a/tests/common/assert/simple-demo-instrumented-full.yaml
+++ b/tests/common/assert/simple-demo-instrumented-full.yaml
@@ -94,7 +94,7 @@ spec:
               apiVersion: v1
               fieldPath: status.hostIP
       (env[?name == 'ODIGOS_OPAMP_SERVER_HOST']):
-        - value: '$(NODE_IP):4320'
+        - (($values.k8sMinorVersion < `26` && value == '$(NODE_IP):4320') || value == 'odiglet-local.odigos-test:4320'): true
       (env[?name == 'OTEL_EXPORTER_OTLP_ENDPOINT']):
         - (($values.k8sMinorVersion < `26` && value == 'http://$(NODE_IP):4318') || value == 'http://odigos-data-collection-local-traffic.odigos-test:4318'): true
       (env[?name == 'NODE_OPTIONS']):
@@ -147,7 +147,7 @@ spec:
               apiVersion: v1
               fieldPath: status.hostIP
       (env[?name == 'ODIGOS_OPAMP_SERVER_HOST']):
-        - value: '$(NODE_IP):4320'
+        - (($values.k8sMinorVersion < `26` && value == '$(NODE_IP):4320') || value == 'odiglet-local.odigos-test:4320'): true
       (env[?name == 'OTEL_EXPORTER_OTLP_ENDPOINT']):
         - (($values.k8sMinorVersion < `26` && value == 'http://$(NODE_IP):4318') || value == 'http://odigos-data-collection-local-traffic.odigos-test:4318'): true
       (env[?name == 'PYTHONPATH']):


### PR DESCRIPTION
Followup to #2458 - adding similar service to `Odiglet` - this allows us to run without `hostNetwork` for k8s versions >= 1.26.
For version < 1.26 the same behavior is kept.
