### PR TITLE
feat: prevent reading secrets in UI readonly mode

### DIFF
--- a/cli/cmd/resources/ui.go
+++ b/cli/cmd/resources/ui.go
@@ -153,11 +153,6 @@ func NewUIRole(ns string, readonly bool) *rbacv1.Role {
 				Resources: []string{"configmaps"},
 				Verbs:     []string{"get", "list"},
 			},
-			{ // Needed for secret values in destinations
-				APIGroups: []string{""},
-				Resources: []string{"secrets"},
-				Verbs:     []string{"get", "list"},
-			},
 			{ // Needed for CRUD on instr. rule and destinations
 				APIGroups: []string{"odigos.io"},
 				Resources: []string{"instrumentationrules", "destinations"},

--- a/frontend/graph/schema.resolvers.go
+++ b/frontend/graph/schema.resolvers.go
@@ -228,9 +228,13 @@ func (r *computePlatformResolver) Destinations(ctx context.Context, obj *model.C
 
 	var destinations []*model.Destination
 	for _, dest := range dests.Items {
-		secretFields, err := services.GetDestinationSecretFields(ctx, ns, &dest)
-		if err != nil {
-			return nil, err
+		secretFields := make(map[string]string)
+
+		if !services.IsReadonlyMode(ctx) {
+			secretFields, err = services.GetDestinationSecretFields(ctx, ns, &dest)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		// Convert the k8s destination format to the expected endpoint format


### PR DESCRIPTION
## Description

This PR removes "reading secrets" for destinations, while the UI is in readonly mode.

## How Has This Been Tested?

- [x] Manual Testing
