### PR TITLE
ui: Show bad Workload conditions as disabled instead of error

### DIFF
--- a/api/odigos/v1alpha1/instrumentationconfig_types.go
+++ b/api/odigos/v1alpha1/instrumentationconfig_types.go
@@ -114,6 +114,11 @@ const (
 	WorkloadRolloutReasonPreviousRolloutOngoing WorkloadRolloutReason = "PreviousRolloutOngoing"
 )
 
+const (
+	// K8s workload status conditions, not set in the InstrumentationConfigStatus but used in the frontend to display the status.
+	K8sWorkloadRolloutReasonFailedCreate = "FailedCreate"
+)
+
 // givin multiple reasons for not injecting an agent, this function returns the priority of the reason.
 // which is - it allows choosing the most important reason to be displayed to the user in the aggregate status.
 func AgentInjectionReasonPriority(reason AgentEnabledReason) int {
@@ -147,14 +152,16 @@ func AgentInjectionReasonPriority(reason AgentEnabledReason) int {
 // this function returns true if the reason is considered as "disabled" status.
 func IsReasonStatusDisabled(reason string) bool {
 	switch reason {
+	// Agent-related reasons
 	case string(AgentEnabledReasonUnsupportedProgrammingLanguage),
 		string(AgentEnabledReasonUnsupportedRuntimeVersion),
 		string(RuntimeDetectionReasonNoRunningPods),
 		string(AgentEnabledReasonIgnoredContainer),
 		string(AgentEnabledReasonNoAvailableAgent),
 		string(AgentEnabledReasonOtherAgentDetected),
-		string(AgentEnabledReasonRuntimeDetailsUnavailable):
-
+		string(AgentEnabledReasonRuntimeDetailsUnavailable),
+		// K8s workload-related reasons
+		string(K8sWorkloadRolloutReasonFailedCreate):
 		return true
 	default:
 		return false
@@ -181,15 +188,15 @@ const (
 
 // +kubebuilder:object:generate=true
 type RuntimeDetailsByContainer struct {
-	ContainerName       string                     `json:"containerName"`
-	Language            common.ProgrammingLanguage `json:"language"`
-	RuntimeVersion      string                     `json:"runtimeVersion,omitempty"`
-	EnvVars             []EnvVar                   `json:"envVars,omitempty"`
-	OtherAgent          *OtherAgent                `json:"otherAgent,omitempty"`
-	LibCType            *common.LibCType           `json:"libCType,omitempty"`
+	ContainerName  string                     `json:"containerName"`
+	Language       common.ProgrammingLanguage `json:"language"`
+	RuntimeVersion string                     `json:"runtimeVersion,omitempty"`
+	EnvVars        []EnvVar                   `json:"envVars,omitempty"`
+	OtherAgent     *OtherAgent                `json:"otherAgent,omitempty"`
+	LibCType       *common.LibCType           `json:"libCType,omitempty"`
 	// Indicates whether the target process is running is secure-execution mode.
 	// nil means we were unable to determine the secure-execution mode.
-	SecureExecutionMode *bool                      `json:"secureExecutionMode,omitempty"`
+	SecureExecutionMode *bool `json:"secureExecutionMode,omitempty"`
 
 	// Stores the error message from the CRI runtime if returned to prevent instrumenting the container if an error exists.
 	CriErrorMessage *string `json:"criErrorMessage,omitempty"`

--- a/frontend/services/utils.go
+++ b/frontend/services/utils.go
@@ -16,7 +16,6 @@ import (
 	"github.com/odigos-io/odigos/frontend/kube"
 	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 
-	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/yaml"
@@ -118,12 +117,7 @@ func TransformConditionStatus(condStatus metav1.ConditionStatus, condType string
 	case metav1.ConditionUnknown:
 		status = model.ConditionStatusLoading
 	case metav1.ConditionTrue:
-		if condType == string(appsv1.DeploymentReplicaFailure) {
-			status = model.ConditionStatusError
-		} else {
-			status = model.ConditionStatusSuccess
-		}
-
+		status = model.ConditionStatusSuccess
 	case metav1.ConditionFalse:
 		status = model.ConditionStatusError
 	}


### PR DESCRIPTION
## Description

This adds the k8s workload condition reason for `FailedCreate` to the disabled status conditions list in the UI

The PR https://github.com/odigos-io/odigos/pull/2871 originally added this and other failed workload conditions so it would appear as a failure, which can be confusing for users (thinking that Odigos itself has failed when in reality it is the workload rollout). This softens that appearance

Note that before we were making this condition show as an error by looking at its _type_ (`ReplicaFailure`), but now we are using its _reason_ (`FailedCreate`) which aligns with the disabled conditions we are already checking.

In the future we may want to expand this, as well as check for _types_ instead of just _reason_s, but this is a start

For reference, see the following failing deployment yaml:

```
  status:
    availableReplicas: 1
    conditions:
    - lastTransitionTime: "2025-06-03T19:01:44Z"
      lastUpdateTime: "2025-06-03T19:01:44Z"
      message: Deployment has minimum availability.
      reason: MinimumReplicasAvailable
      status: "True"
      type: Available
    - lastTransitionTime: "2025-06-03T19:01:42Z"
      lastUpdateTime: "2025-06-03T19:04:25Z"
      message: Created new replica set "pricing-79d4745b9f"
      reason: NewReplicaSetCreated
      status: "True"
      type: Progressing
    - lastTransitionTime: "2025-06-03T19:04:25Z"
      lastUpdateTime: "2025-06-03T19:04:25Z"
      message: 'pods "pricing-79d4745b9f-jpvmr" is forbidden: exceeded quota: compute-resources,
        requested: limits.cpu=1,limits.memory=300Mi,requests.cpu=1,requests.memory=300Mi,
        used: limits.cpu=7,limits.memory=2100Mi,requests.cpu=7,requests.memory=2100Mi,
        limited: limits.cpu=7,limits.memory=2150Mi,requests.cpu=7,requests.memory=2150Mi'
      reason: FailedCreate
      status: "True"
      type: ReplicaFailure
    observedGeneration: 2
    readyReplicas: 1
    replicas: 1
    unavailableReplicas: 1
```

currently in the ui, this will look like:

![Screenshot 2025-06-03 at 2 32 07 PM](https://github.com/user-attachments/assets/f08ef504-889e-48f7-a97d-a4d2e0a0572d)
![Screenshot 2025-06-03 at 2 32 13 PM](https://github.com/user-attachments/assets/64ac294a-15da-43a2-94cc-ad974ee6c046)

After this change, it looks like this:

![Screenshot 2025-06-03 at 3 04 40 PM](https://github.com/user-attachments/assets/bbac6d5a-178b-4a93-b336-e19fc62d87b3)
![Screenshot 2025-06-03 at 3 04 55 PM](https://github.com/user-attachments/assets/3b294502-7db5-47f6-8ffe-3b41dbc16f79)


## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [x] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
