### PR TITLE
fix(frontend): retry create object with generated name on conflict

### DIFF
--- a/frontend/graph/schema.resolvers.go
+++ b/frontend/graph/schema.resolvers.go
@@ -652,7 +652,9 @@ func (r *mutationResolver) CreateNewDestination(ctx context.Context, destination
 		k8sDestination.Spec.SecretRef = secretRef
 	}
 
-	dest, err := kube.DefaultClient.OdigosClient.Destinations(ns).Create(ctx, &k8sDestination, metav1.CreateOptions{})
+	dest, err := services.CreateResourceWithGenerateName(ctx, func() (*v1alpha1.Destination, error) {
+		return kube.DefaultClient.OdigosClient.Destinations(ns).Create(ctx, &k8sDestination, metav1.CreateOptions{})
+	})
 	if err != nil {
 		if createSecret {
 			kube.DefaultClient.CoreV1().Secrets(ns).Delete(ctx, destName, metav1.DeleteOptions{})

--- a/frontend/services/destinations.go
+++ b/frontend/services/destinations.go
@@ -297,7 +297,9 @@ func CreateDestinationSecret(ctx context.Context, destType common.DestinationTyp
 		},
 		StringData: secretFields,
 	}
-	newSecret, err := kube.DefaultClient.CoreV1().Secrets(ns).Create(ctx, &secret, metav1.CreateOptions{})
+	newSecret, err := CreateResourceWithGenerateName(ctx, func() (*k8s.Secret, error) {
+		return kube.DefaultClient.CoreV1().Secrets(ns).Create(ctx, &secret, metav1.CreateOptions{})
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/frontend/services/instrumentationrule.go
+++ b/frontend/services/instrumentationrule.go
@@ -311,7 +311,9 @@ func CreateInstrumentationRule(ctx context.Context, input model.InstrumentationR
 	}
 
 	// Create the rule in Kubernetes
-	createdRule, err := kube.DefaultClient.OdigosClient.InstrumentationRules(ns).Create(ctx, newRule, metav1.CreateOptions{})
+	createdRule, err := CreateResourceWithGenerateName(ctx, func() (*v1alpha1.InstrumentationRule, error) {
+		return kube.DefaultClient.OdigosClient.InstrumentationRules(ns).Create(ctx, newRule, metav1.CreateOptions{})
+	})
 	if err != nil {
 		return nil, fmt.Errorf("error creating instrumentation rule: %w", err)
 	}

--- a/frontend/services/sources.go
+++ b/frontend/services/sources.go
@@ -310,7 +310,9 @@ func EnsureSourceCRD(ctx context.Context, nsName string, workloadName string, wo
 		}
 	}
 
-	source, err = kube.DefaultClient.OdigosClient.Sources(nsName).Create(ctx, newSource, metav1.CreateOptions{})
+	source, err = CreateResourceWithGenerateName(ctx, func() (*v1alpha1.Source, error) {
+		return kube.DefaultClient.OdigosClient.Sources(nsName).Create(ctx, newSource, metav1.CreateOptions{})
+	})
 	return source, err
 }
 

--- a/k8sutils/pkg/feature/feature.go
+++ b/k8sutils/pkg/feature/feature.go
@@ -93,6 +93,19 @@ var (
 	}
 )
 
+// https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/4420-retry-generate-name/README.md
+var (
+	retryGenerateName = &featureSupport{
+		alphaVersion: "1.30.0",
+		betaVersion:  "1.31.0",
+		gaVersion:    "1.32.0",
+	}
+
+	RetryGenerateName = func(ml maturityLevel) bool {
+		return retryGenerateName.isEnabled(ml)
+	}
+)
+
 // K8sVersion returns the Kubernetes version detected once Setup is called.
 // It returns nil if Setup has not been called or failed.
 //


### PR DESCRIPTION
## Description

see https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/4420-retry-generate-name/README.md

> But there is a problem with name conflicts. There is a 50% chance of hitting a conflict before generating even 5000 names, and a 0.1% chance at only 500 names!
> 
> Today a HTTP 409 respose returned to the client if a name conflict happens. It is possible for clients to detect the error and retry, but we've seen that most clients don't realize to do this and hit this problem in production.

It appears that pre k8s 1.32, every call to create a new resource in k8s with `GenerateName` can fail with this error reported from one of our users:

![image](https://github.com/user-attachments/assets/bd2933a3-04af-4f35-b275-d48feaad7ae2)

This PR fixes this bug by retrying the Create operation if we got back conflict and the k8s version is < 1.32.

With k8s >= 1.32, the api server will automatically retry the create if it gets a conflict.


## How Has This Been Tested?

Hard to reproduce this in a deterministic way. I run this locally and verified everything still works.

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [x] Changes how Odigos interacts with Kubernetes
- [x] Introduces additional calls to the API Server (potential performance impact)
         retry mechanism recommended by k8s team. should happen very rarely  
- [x] New Query/feature supported in all the k8s versions supported by Odigos
         added feature gate

## User Facing Changes

The above error should not happen anymore