### PR TITLE
Always mount Go offsets configmap in Odiglet

### DIFF
--- a/cli/cmd/resources/odiglet.go
+++ b/cli/cmd/resources/odiglet.go
@@ -307,25 +307,23 @@ func NewOdigletDaemonSet(ns string, version string, imagePrefix string, imageNam
 	additionalVolumes = append(additionalVolumes, customContainerRuntimeSocketVolumes...)
 	additionalVolumeMounts = append(additionalVolumeMounts, customContainerRunetimeSocketVolumeMounts...)
 
-	if odigosTier == common.OnPremOdigosTier {
-		goOffsetsVolume := corev1.Volume{
-			Name: k8sconsts.GoOffsetsConfigMap,
-			VolumeSource: v1.VolumeSource{
-				ConfigMap: &v1.ConfigMapVolumeSource{
-					LocalObjectReference: v1.LocalObjectReference{
-						Name: k8sconsts.GoOffsetsConfigMap,
-					},
+	goOffsetsVolume := corev1.Volume{
+		Name: k8sconsts.GoOffsetsConfigMap,
+		VolumeSource: v1.VolumeSource{
+			ConfigMap: &v1.ConfigMapVolumeSource{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: k8sconsts.GoOffsetsConfigMap,
 				},
 			},
-		}
-		goOffsetsVolumeMount := corev1.VolumeMount{
-			Name:      k8sconsts.GoOffsetsConfigMap,
-			MountPath: k8sconsts.OffsetFileMountPath,
-		}
-		additionalVolumes = append(additionalVolumes, goOffsetsVolume)
-		additionalVolumeMounts = append(additionalVolumeMounts, goOffsetsVolumeMount)
-		dynamicEnv = append(dynamicEnv, v1.EnvVar{Name: k8sconsts.GoOffsetsEnvVar, Value: k8sconsts.OffsetFileMountPath + "/" + k8sconsts.GoOffsetsFileName})
+		},
 	}
+	goOffsetsVolumeMount := corev1.VolumeMount{
+		Name:      k8sconsts.GoOffsetsConfigMap,
+		MountPath: k8sconsts.OffsetFileMountPath,
+	}
+	additionalVolumes = append(additionalVolumes, goOffsetsVolume)
+	additionalVolumeMounts = append(additionalVolumeMounts, goOffsetsVolumeMount)
+	dynamicEnv = append(dynamicEnv, v1.EnvVar{Name: k8sconsts.GoOffsetsEnvVar, Value: k8sconsts.OffsetFileMountPath + "/" + k8sconsts.GoOffsetsFileName})
 
 	// 50% of the nodes can be unavailable during the update.
 	// if we do not set it, the default value is 1.

--- a/helm/odigos/templates/odiglet/daemonset.yaml
+++ b/helm/odigos/templates/odiglet/daemonset.yaml
@@ -149,10 +149,8 @@ spec:
               readOnly: true
             - name: kernel-debug
               mountPath: /sys/kernel/debug
-            {{- if .Values.onPremToken }}
             - name: odigos-go-offsets
               mountPath: /offsets
-            {{- end }}
       {{- if semverCompare "<1.26.0" .Capabilities.KubeVersion.Version }}
       hostNetwork: true
       {{- end}}
@@ -186,11 +184,9 @@ spec:
         - name: kernel-debug
           hostPath:
             path: /sys/kernel/debug
-        {{- if .Values.onPremToken }}
         - name: odigos-go-offsets
           configMap:
             name: odigos-go-offsets
-        {{- end }}
 {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 6 }}


### PR DESCRIPTION
## Description

Currently, the custom Go offsets configmap is only mounted if using an onprem token. This can cause issues, particularly with the Helm chart if an onPremToken is not provided via values.yaml at install.

This updates it to always mount the offsets configmap. We already always create the offsets configmap anyway (for reasons like this), and it won't be consumed unless using the enterprise odiglet.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
