### PR TITLE
Check if odigos-pro secret exists before installing helm chart

### DIFF
--- a/docs/setup/installation.mdx
+++ b/docs/setup/installation.mdx
@@ -14,7 +14,7 @@ There are 3 ways to install odigos in your kubernetes cluster:
 - [Helm Chart](#helm-chart)
 - [OpenShift Operator](#openshift-operator)
 
-All install methods will deploy and configure resources in the active Kubernetes cluster as per the current context. 
+All install methods will deploy and configure resources in the active Kubernetes cluster as per the current context.
 Before proceeding with the installation, ensure that you are targeting the correct cluster with `kubectl config current-context`.
 
 <Info>
@@ -53,10 +53,10 @@ Before proceeding with the installation, ensure that you are targeting the corre
 
 3. Move the Binary to a Folder in Your PATH: Windows has specific folders where it looks for programs to run, called the "PATH". To make Odigos work from anywhere on your system, you’ll need to move the program (binary) into one of these folders. Here’s how:
 
-   - **Option 1**:  
+   - **Option 1**:
      Move the file to a folder already in the PATH, such as `C:\Windows\System32`. Simply drag the extracted file (often named something like `odigos.exe`) into that folder.
-   
-   - **Option 2**:  
+
+   - **Option 2**:
      Add the folder containing the extracted binary to your PATH manually:
      1. Right-click the **Start** button and select **System**.
      2. Click **Advanced system settings** on the left.
@@ -79,7 +79,7 @@ Before proceeding with the installation, ensure that you are targeting the corre
     ```
   </Tab>
   <Tab title="Enterprise">
-  The enterprise version of Odigos requires a license token. Please contact the Odigos team to inquire about access to the Pro version.    
+  The enterprise version of Odigos requires a license token. Please contact the Odigos team to inquire about access to the Pro version.
   ```shell
     odigos install --onprem-token $ODIGOS_TOKEN
     ```
@@ -112,12 +112,25 @@ helm repo add odigos https://odigos-io.github.io/odigos/
     ```
   </Tab>
   <Tab title="Enterprise">
-  The enterprise version of Odigos requires a license token. Please contact the Odigos team to inquire about access to the Pro version.    
+  The enterprise version of Odigos requires a license token. Please contact the Odigos team to inquire about access to the Pro version.
   ```shell
     helm repo update
   helm upgrade --install odigos odigos/odigos --namespace odigos-system --create-namespace --set onPremToken=$ODIGOS_TOKEN
     ```
   </Tab>
+
+  The license token can also be provided by creating a secret in kubernetes before installing Odigos.
+  ```yaml
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: odigos-pro
+    namespace: odigos-system
+    labels:
+      odigos.io/system-object: "true"
+  stringData:
+    odigos-onprem-token: <TOKEN>
+  ```
 </Tabs>
 
 Once all the Odigos pods are online, you will need to port-forward the ui service to load the Odigos UI.

--- a/helm/odigos-central/templates/_helpers.tpl
+++ b/helm/odigos-central/templates/_helpers.tpl
@@ -18,3 +18,11 @@ odigos-
 :
 {{- .Tag -}}
 {{- end -}}
+
+{{- define "odigos.secretExists" -}}
+  {{- $sec   := lookup "v1" "Secret" .Release.Namespace "odigos-central" -}}
+  {{- $token := default "" .Values.ODIGOS_ONPREM_TOKEN -}}
+  {{- if or $sec (ne $token "") -}}
+true
+  {{- end -}}
+{{- end -}}

--- a/helm/odigos-central/templates/centralbackend/central-backend-service.yaml
+++ b/helm/odigos-central/templates/centralbackend/central-backend-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.onPremToken }}
+{{- if (include "odigos.secretExists" .) }}
 
 apiVersion: v1
 kind: Service

--- a/helm/odigos-central/templates/centralbackend/deployment.yaml
+++ b/helm/odigos-central/templates/centralbackend/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.onPremToken  }}
+{{- if (include "odigos.secretExists" .) }}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -21,7 +21,7 @@ spec:
       containers:
         - name: central-backend
           {{- $imageTag := .Values.image.tag | default .Chart.AppVersion }}
-          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "central-backend" "Tag" $imageTag) }}
+          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-central-backend" "Tag" $imageTag) }}
           env:
             - name: ODIGOS_ONPREM_TOKEN
               valueFrom:

--- a/helm/odigos-central/templates/centralui/deployment.yaml
+++ b/helm/odigos-central/templates/centralui/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.onPremToken }}
+{{- if (include "odigos.secretExists" .) }}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -21,7 +21,7 @@ spec:
       containers:
         - name: central-ui
           {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
-          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "central-ui" "Tag" $imageTag) }}
+          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-central-ui" "Tag" $imageTag) }}
           resources:
             requests:
               cpu: {{ .Values.centralUI.resources.requests.cpu }}

--- a/helm/odigos-central/templates/redis/redis-service.yaml
+++ b/helm/odigos-central/templates/redis/redis-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.onPremToken}}
+{{- if (include "odigos.secretExists" .) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/odigos-central/templates/redis/redis.yaml
+++ b/helm/odigos-central/templates/redis/redis.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.onPremToken }}
+{{- if (include "odigos.secretExists" .) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/odigos-central/values.yaml
+++ b/helm/odigos-central/values.yaml
@@ -3,8 +3,6 @@ image:
 imagePrefix: ''
 imagePullSecrets: []
 
-onPremToken: ''
-
 centralBackend:
   resources:
     requests:

--- a/helm/odigos/templates/_helpers.tpl
+++ b/helm/odigos/templates/_helpers.tpl
@@ -29,4 +29,10 @@ Returns "true" if any userInstrumentationEnvs.language is enabled or has env var
   {{- print $shouldRender }}
 {{- end }}
 
-
+{{- define "odigos.secretExists" -}}
+  {{- $sec   := lookup "v1" "Secret" .Release.Namespace "odigos-pro" -}}
+  {{- $token := default "" .Values.onPremToken -}}
+  {{- if or $sec (ne $token "") -}}
+true
+  {{- end -}}
+{{- end -}}

--- a/helm/odigos/templates/centralproxy/deployment.yaml
+++ b/helm/odigos/templates/centralproxy/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.centralProxy.enabled .Values.centralProxy.centralBackendURL .Values.clusterName .Values.onPremToken}}
+{{- if and .Values.centralProxy.enabled .Values.centralProxy.centralBackendURL .Values.clusterName (include "odigos.secretExists" .)}}
 
 apiVersion: apps/v1
 kind: Deployment

--- a/helm/odigos/templates/centralproxy/role.yaml
+++ b/helm/odigos/templates/centralproxy/role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.centralProxy.enabled .Values.centralProxy.centralBackendURL .Values.clusterName .Values.onPremToken}}
+{{- if and .Values.centralProxy.enabled .Values.centralProxy.centralBackendURL .Values.clusterName (include "odigos.secretExists" .)}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/helm/odigos/templates/centralproxy/rolebinding.yaml
+++ b/helm/odigos/templates/centralproxy/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.centralProxy.enabled .Values.centralProxy.centralBackendURL .Values.clusterName .Values.onPremToken}}
+{{- if and .Values.centralProxy.enabled .Values.centralProxy.centralBackendURL .Values.clusterName (include "odigos.secretExists" .)}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/helm/odigos/templates/centralproxy/serviceaccount.yaml
+++ b/helm/odigos/templates/centralproxy/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.centralProxy.enabled .Values.centralProxy.centralBackendURL .Values.clusterName .Values.onPremToken}}
+{{- if and .Values.centralProxy.enabled .Values.centralProxy.centralBackendURL .Values.clusterName (include "odigos.secretExists" .)}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/odigos/templates/instrumentor/deployment.yaml
+++ b/helm/odigos/templates/instrumentor/deployment.yaml
@@ -39,7 +39,7 @@ spec:
         command:
           - /app
         {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
-        {{- if .Values.onPremToken }}
+        {{- if include "odigos.secretExists" . }}
         image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-instrumentor" "Tag" $imageTag) }}
         {{- else }}
         image: {{ template "utils.imageName" (dict "Values" .Values "Component" "instrumentor" "Tag" $imageTag) }}
@@ -60,7 +60,7 @@ spec:
               configMapKeyRef:
                 key: ODIGOS_TIER
                 name: odigos-deployment
-          {{- if .Values.onPremToken }}
+          {{- if include "odigos.secretExists" . }}
           - name: ODIGOS_ONPREM_TOKEN
             valueFrom:
               secretKeyRef:

--- a/helm/odigos/templates/odiglet/daemonset.yaml
+++ b/helm/odigos/templates/odiglet/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
       initContainers:
         - name: init
           {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
-          {{- if .Values.onPremToken }}
+          {{- if include "odigos.secretExists" . }}
           image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-odiglet" "Tag" $imageTag) }}
           {{- else }}
           image: {{ template "utils.imageName" (dict "Values" .Values "Component" "odiglet" "Tag" $imageTag) }}
@@ -73,7 +73,7 @@ spec:
       containers:
         - name: odiglet
           {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
-          {{- if .Values.onPremToken }}
+          {{- if include "odigos.secretExists" . }}
           image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-odiglet" "Tag" $imageTag) }}
           {{- else }}
           image: {{ template "utils.imageName" (dict "Values" .Values "Component" "odiglet" "Tag" $imageTag) }}
@@ -97,7 +97,7 @@ spec:
                   fieldPath: metadata.namespace
             - name: OTEL_LOG_LEVEL
               value: info
-            {{- if .Values.onPremToken }}
+            {{- if include "odigos.secretExists" . }}
             - name: OTEL_GO_OFFSETS_FILE
               value: /offsets/go_offset_results.json
             - name: ODIGOS_ONPREM_TOKEN
@@ -149,7 +149,7 @@ spec:
               readOnly: true
             - name: kernel-debug
               mountPath: /sys/kernel/debug
-            {{- if .Values.onPremToken }}
+            {{- if include "odigos.secretExists" . }}
             - name: odigos-go-offsets
               mountPath: /offsets
             {{- end }}
@@ -186,7 +186,7 @@ spec:
         - name: kernel-debug
           hostPath:
             path: /sys/kernel/debug
-        {{- if .Values.onPremToken }}
+        {{- if include "odigos.secretExists" . }}
         - name: odigos-go-offsets
           configMap:
             name: odigos-go-offsets

--- a/helm/odigos/templates/odigos-deployment.yaml
+++ b/helm/odigos/templates/odigos-deployment.yaml
@@ -7,6 +7,6 @@ metadata:
     odigos.io/system-object: "true"
 data:
   ODIGOS_VERSION: '{{ .Values.image.tag | default .Chart.AppVersion }}'
-  ODIGOS_TIER: '{{- if .Values.onPremToken }}onprem{{- else }}community{{- end }}'
+  ODIGOS_TIER: '{{- if include "odigos.secretExists" . }}onprem{{- else }}community{{- end }}'
   installation-method: helm
   odigos-deployment-id: '{{ uuidv4 }}'

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -260,3 +260,4 @@ autoRollback:
   disabled: false
   graceTime: 5m
   stabilityWindowTime: 1h
+


### PR DESCRIPTION
## Description
Allow installing odigos pro using an existing secret
<!-- Short summary of the changes -->

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
