### PR TITLE
chore: set agent enabled as container ignored over unknown language if both happens

### DIFF
--- a/instrumentor/controllers/agentenabled/sync.go
+++ b/instrumentor/controllers/agentenabled/sync.go
@@ -234,16 +234,8 @@ func containerInstrumentationConfig(containerName string,
 	distroGetter *distros.Getter,
 	crashDetected bool) odigosv1.ContainerAgentConfig {
 
-	// check unknown language first. if language is not supported, we can skip the rest of the checks.
-	if runtimeDetails.Language == common.UnknownProgrammingLanguage {
-		return odigosv1.ContainerAgentConfig{
-			ContainerName:      containerName,
-			AgentEnabled:       false,
-			AgentEnabledReason: odigosv1.AgentEnabledReasonUnsupportedProgrammingLanguage,
-		}
-	}
-
 	// check if container is ignored by name, assuming IgnoredContainers is a short list.
+	// This should be done first, because user should see workload not instrumented if container is ignored over unknown language in case both exist.
 	for _, ignoredContainer := range effectiveConfig.IgnoredContainers {
 		if ignoredContainer == containerName {
 			return odigosv1.ContainerAgentConfig{
@@ -251,6 +243,15 @@ func containerInstrumentationConfig(containerName string,
 				AgentEnabled:       false,
 				AgentEnabledReason: odigosv1.AgentEnabledReasonIgnoredContainer,
 			}
+		}
+	}
+
+	// check unknown language first. if language is not supported, we can skip the rest of the checks.
+	if runtimeDetails.Language == common.UnknownProgrammingLanguage {
+		return odigosv1.ContainerAgentConfig{
+			ContainerName:      containerName,
+			AgentEnabled:       false,
+			AgentEnabledReason: odigosv1.AgentEnabledReasonUnsupportedProgrammingLanguage,
 		}
 	}
 


### PR DESCRIPTION

## Description

If a user configures a container as an ignored container, and the language of this container is not supported, we should set its status to "Ignored Container" to avoid confusing users in the UI.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
