### PR TITLE
chore: generalise GetSource func

### DIFF
--- a/api/odigos/v1alpha1/source_types.go
+++ b/api/odigos/v1alpha1/source_types.go
@@ -112,21 +112,21 @@ type SourceSelector struct {
 // GetSources returns a WorkloadSources listing the Workload and Namespace Source
 // that currently apply to the given object. In theory, this should only ever return at most
 // 1 Namespace and/or 1 Workload Source for an object. If more are found, an error is returned.
-func GetSources(ctx context.Context, kubeClient client.Client, obj client.Object) (*WorkloadSources, error) {
+func GetSources(ctx context.Context, kubeClient client.Client, workloadObj k8sconsts.PodWorkload) (*WorkloadSources, error) {
 	var err error
 	workloadSources := &WorkloadSources{}
 
-	namespace := obj.GetNamespace()
-	if len(namespace) == 0 && obj.GetObjectKind().GroupVersionKind().Kind == string(k8sconsts.WorkloadKindNamespace) {
-		namespace = obj.GetName()
+	namespace := workloadObj.Namespace
+	if len(namespace) == 0 && workloadObj.Kind == k8sconsts.WorkloadKindNamespace {
+		namespace = workloadObj.Name
 	}
 
-	if obj.GetObjectKind().GroupVersionKind().Kind != string(k8sconsts.WorkloadKindNamespace) {
+	if workloadObj.Kind != k8sconsts.WorkloadKindNamespace {
 		sourceList := SourceList{}
 		selector := labels.SelectorFromSet(labels.Set{
-			k8sconsts.WorkloadNameLabel:      obj.GetName(),
+			k8sconsts.WorkloadNameLabel:      workloadObj.Name,
 			k8sconsts.WorkloadNamespaceLabel: namespace,
-			k8sconsts.WorkloadKindLabel:      obj.GetObjectKind().GroupVersionKind().Kind,
+			k8sconsts.WorkloadKindLabel:      string(workloadObj.Kind),
 		})
 		err := kubeClient.List(ctx, &sourceList, &client.ListOptions{LabelSelector: selector}, client.InNamespace(namespace))
 		if err != nil {

--- a/api/odigos/v1alpha1/source_types.go
+++ b/api/odigos/v1alpha1/source_types.go
@@ -112,21 +112,21 @@ type SourceSelector struct {
 // GetSources returns a WorkloadSources listing the Workload and Namespace Source
 // that currently apply to the given object. In theory, this should only ever return at most
 // 1 Namespace and/or 1 Workload Source for an object. If more are found, an error is returned.
-func GetSources(ctx context.Context, kubeClient client.Client, workloadObj k8sconsts.PodWorkload) (*WorkloadSources, error) {
+func GetSources(ctx context.Context, kubeClient client.Client, pw k8sconsts.PodWorkload) (*WorkloadSources, error) {
 	var err error
 	workloadSources := &WorkloadSources{}
 
-	namespace := workloadObj.Namespace
-	if len(namespace) == 0 && workloadObj.Kind == k8sconsts.WorkloadKindNamespace {
-		namespace = workloadObj.Name
+	namespace := pw.Namespace
+	if len(namespace) == 0 && pw.Kind == k8sconsts.WorkloadKindNamespace {
+		namespace = pw.Name
 	}
 
-	if workloadObj.Kind != k8sconsts.WorkloadKindNamespace {
+	if pw.Kind != k8sconsts.WorkloadKindNamespace {
 		sourceList := SourceList{}
 		selector := labels.SelectorFromSet(labels.Set{
-			k8sconsts.WorkloadNameLabel:      workloadObj.Name,
+			k8sconsts.WorkloadNameLabel:      pw.Name,
 			k8sconsts.WorkloadNamespaceLabel: namespace,
-			k8sconsts.WorkloadKindLabel:      string(workloadObj.Kind),
+			k8sconsts.WorkloadKindLabel:      string(pw.Kind),
 		})
 		err := kubeClient.List(ctx, &sourceList, &client.ListOptions{LabelSelector: selector}, client.InNamespace(namespace))
 		if err != nil {

--- a/instrumentor/controllers/workloadmigrations/controllers.go
+++ b/instrumentor/controllers/workloadmigrations/controllers.go
@@ -122,7 +122,11 @@ func createOrUpdateSourceForObject(ctx context.Context,
 		namespace = obj.GetName()
 	}
 
-	sources, err := v1alpha1.GetSources(ctx, k8sClient, obj)
+	sources, err := v1alpha1.GetSources(ctx, k8sClient, k8sconsts.PodWorkload{
+		Name:      obj.GetName(),
+		Namespace: namespace,
+		Kind:      kind,
+	})
 	if err != nil {
 		return err
 	}

--- a/k8sutils/pkg/source/source.go
+++ b/k8sutils/pkg/source/source.go
@@ -6,6 +6,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/odigos-io/odigos/api/k8sconsts"
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	k8sutils "github.com/odigos-io/odigos/k8sutils/pkg/utils"
 	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
@@ -22,7 +23,12 @@ func IsObjectInstrumentedBySource(ctx context.Context,
 	k8sClient client.Client,
 	obj client.Object) (bool, metav1.Condition, error) {
 	// Check if a Source object exists for this object
-	sources, err := odigosv1.GetSources(ctx, k8sClient, obj)
+	workloadObj := k8sconsts.PodWorkload{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+		Kind:      k8sconsts.WorkloadKind(obj.GetObjectKind().GroupVersionKind().Kind),
+	}
+	sources, err := odigosv1.GetSources(ctx, k8sClient, workloadObj)
 	if err != nil {
 		condition := metav1.Condition{
 			Type:    odigosv1.MarkedForInstrumentationStatusConditionType,
@@ -84,7 +90,12 @@ func IsObjectInstrumentedBySource(ctx context.Context,
 // OTel service name is only valid for workload sources (not namespace sources).
 // If none is configured, it returns the default name which is the k8s workload resource name.
 func OtelServiceNameBySource(ctx context.Context, k8sClient client.Client, obj client.Object) (string, error) {
-	sources, err := odigosv1.GetSources(ctx, k8sClient, obj)
+	workloadObj := k8sconsts.PodWorkload{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+		Kind:      k8sconsts.WorkloadKind(obj.GetObjectKind().GroupVersionKind().Kind),
+	}
+	sources, err := odigosv1.GetSources(ctx, k8sClient, workloadObj)
 	if err != nil {
 		return "", err
 	}

--- a/k8sutils/pkg/source/source.go
+++ b/k8sutils/pkg/source/source.go
@@ -23,12 +23,12 @@ func IsObjectInstrumentedBySource(ctx context.Context,
 	k8sClient client.Client,
 	obj client.Object) (bool, metav1.Condition, error) {
 	// Check if a Source object exists for this object
-	workloadObj := k8sconsts.PodWorkload{
+	pw := k8sconsts.PodWorkload{
 		Name:      obj.GetName(),
 		Namespace: obj.GetNamespace(),
 		Kind:      k8sconsts.WorkloadKind(obj.GetObjectKind().GroupVersionKind().Kind),
 	}
-	sources, err := odigosv1.GetSources(ctx, k8sClient, workloadObj)
+	sources, err := odigosv1.GetSources(ctx, k8sClient, pw)
 	if err != nil {
 		condition := metav1.Condition{
 			Type:    odigosv1.MarkedForInstrumentationStatusConditionType,
@@ -90,12 +90,12 @@ func IsObjectInstrumentedBySource(ctx context.Context,
 // OTel service name is only valid for workload sources (not namespace sources).
 // If none is configured, it returns the default name which is the k8s workload resource name.
 func OtelServiceNameBySource(ctx context.Context, k8sClient client.Client, obj client.Object) (string, error) {
-	workloadObj := k8sconsts.PodWorkload{
+	pw := k8sconsts.PodWorkload{
 		Name:      obj.GetName(),
 		Namespace: obj.GetNamespace(),
 		Kind:      k8sconsts.WorkloadKind(obj.GetObjectKind().GroupVersionKind().Kind),
 	}
-	sources, err := odigosv1.GetSources(ctx, k8sClient, workloadObj)
+	sources, err := odigosv1.GetSources(ctx, k8sClient, pw)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Description
This function can be used for any PodWorkload and it is not really need to get a  generic `client.Object`.
We use all over Odigos the PodWorkload object.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
