### PR TITLE
Reconcile sources to instrumentationconfig

### DIFF
--- a/api/k8sconsts/source.go
+++ b/api/k8sconsts/source.go
@@ -19,5 +19,7 @@ const (
 	WorkloadNamespaceLabel = "odigos.io/workload-namespace"
 	WorkloadKindLabel      = "odigos.io/workload-kind"
 
-	SourceGroupLabelPrefix = "odigos.io/group-"
+	// sourcegrouplabelprefix will be removed once merging the connectors approach
+	SourceGroupLabelPrefix      = "odigos.io/group-"
+	SourceDataStreamLabelPrefix = "odigos.io/data-stream-"
 )

--- a/instrumentor/controllers/sourceinstrumentation/instrumentationconfig_controller.go
+++ b/instrumentor/controllers/sourceinstrumentation/instrumentationconfig_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/odigos-io/odigos/api/k8sconsts"
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	sourceutils "github.com/odigos-io/odigos/k8sutils/pkg/source"
 	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
@@ -83,7 +84,14 @@ func (r *InstrumentationConfigReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, err
 	}
 
-	enabled, _, err := sourceutils.IsObjectInstrumentedBySource(ctx, r.Client, workloadObject)
+	pw := k8sconsts.PodWorkload{
+		Name:      workloadObject.GetName(),
+		Namespace: workloadObject.GetNamespace(),
+		Kind:      k8sconsts.WorkloadKind(workloadObject.GetObjectKind().GroupVersionKind().Kind),
+	}
+	sources, err := odigosv1.GetSources(ctx, r.Client, pw)
+
+	enabled, _, err := sourceutils.IsObjectInstrumentedBySource(ctx, sources, err)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/k8sutils/pkg/source/source.go
+++ b/k8sutils/pkg/source/source.go
@@ -120,7 +120,6 @@ func GetClientObjectFromSource(ctx context.Context, kubeClient client.Client, so
 
 func HandleInstrumentationConfigDataStreamsLabels(ctx context.Context,
 	workloadSources *odigosv1.WorkloadSources, ic *odigosv1.InstrumentationConfig) bool {
-
 	logger := log.FromContext(ctx)
 
 	workloadSource := workloadSources.Workload

--- a/k8sutils/pkg/source/source.go
+++ b/k8sutils/pkg/source/source.go
@@ -19,16 +19,8 @@ import (
 // 2) Is the object instrumentation disabled on the workload Source (overrides namespace instrumentation): false
 // 3) Is the object actively included by a namespace Source: true
 // 4) False
-func IsObjectInstrumentedBySource(ctx context.Context,
-	k8sClient client.Client,
-	obj client.Object) (bool, metav1.Condition, error) {
+func IsObjectInstrumentedBySource(ctx context.Context, sources *odigosv1.WorkloadSources, err error) (bool, metav1.Condition, error) {
 	// Check if a Source object exists for this object
-	pw := k8sconsts.PodWorkload{
-		Name:      obj.GetName(),
-		Namespace: obj.GetNamespace(),
-		Kind:      k8sconsts.WorkloadKind(obj.GetObjectKind().GroupVersionKind().Kind),
-	}
-	sources, err := odigosv1.GetSources(ctx, k8sClient, pw)
 	if err != nil {
 		condition := metav1.Condition{
 			Type:    odigosv1.MarkedForInstrumentationStatusConditionType,

--- a/k8sutils/pkg/source/source.go
+++ b/k8sutils/pkg/source/source.go
@@ -119,7 +119,6 @@ func GetClientObjectFromSource(ctx context.Context, kubeClient client.Client, so
 
 func HandleInstrumentationConfigDataStreamsLabels(ctx context.Context,
 	workloadSources *odigosv1.WorkloadSources, ic *odigosv1.InstrumentationConfig) bool {
-
 	// Extract labels from both sources (may be nil)
 	workloadLabels := getSourceDataStreamsLabels(workloadSources.Workload)
 	namespaceLabels := getSourceDataStreamsLabels(workloadSources.Namespace)


### PR DESCRIPTION
## Description

In the Datastreams world we agreed to use the instrumenationConfig as the single point of truth for building the configuration and also for the UI to consume.
This PR ensure that this data will reconcile into the  instrumenationConfig for each workload with the workload source and also the namespace source.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
