### PR TITLE
chore: fixing issue where multiple container within the same pod shar…

### DIFF
--- a/odiglet/pkg/process/process_linux.go
+++ b/odiglet/pkg/process/process_linux.go
@@ -11,7 +11,11 @@ import (
 )
 
 func isPodContainerPredicate(podUID string, containerName string) func(string) bool {
-	expectedMountRoot := fmt.Sprintf("%s/containers/%s", podUID, containerName)
+
+	// Added trailing slash to avoid substring collisions like "membership" matching "membership1".
+	// Real m.Root ends with runtime ID (e.g., .../containers/membership/<runtime-id>), so exact match fails.
+	// Using slash ensures we only match full "containers/<name>/" segments in mount paths.
+	expectedMountRoot := fmt.Sprintf("%s/containers/%s/", podUID, containerName)
 
 	return func(procDirName string) bool {
 		mountInfoFile := path.Join("/proc", procDirName, "mountinfo")


### PR DESCRIPTION


In certain cases, when a pod contains multiple containers with similar names—for example:
```bash
podX
  container1: membership
  container2: membership2
```
Runtime detection incorrectly identifies processes from membership2 as belonging to membership. This misclassification confuses the runtime detection logic and leads to false positives.

<!-- Short summary of the changes -->

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
