### PR TITLE
Handle Dynatrace wrapped Go binaries in language detection

### DIFF
--- a/procdiscovery/pkg/inspectors/golang/golang.go
+++ b/procdiscovery/pkg/inspectors/golang/golang.go
@@ -17,7 +17,7 @@ const GolangVersionRegex = `go(\d+\.\d+\.\d+)`
 var re = regexp.MustCompile(GolangVersionRegex)
 
 func (g *GolangInspector) QuickScan(pcx *process.ProcessContext) (common.ProgrammingLanguage, bool) {
-	exeFile, err := pcx.GetExeFile()
+	exeFile, err := pcx.GetOriginalExeFile()
 	if err != nil {
 		return "", false
 	}
@@ -35,7 +35,7 @@ func (g *GolangInspector) DeepScan(pcx *process.ProcessContext) (common.Programm
 }
 
 func (g *GolangInspector) GetRuntimeVersion(pcx *process.ProcessContext, containerURL string) *version.Version {
-	exeFile, err := pcx.GetExeFile()
+	exeFile, err := pcx.GetOriginalExeFile()
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
## Summary
- detect Dynatrace OneAgent wrapper when the running binary is `oneagentdynamizer`
- open the original application binary for Go language detection
- mark Dynatrace OneAgent as another agent when inspecting processes

## Testing
- `go test ./procdiscovery/...`


------
https://chatgpt.com/codex/tasks/task_b_6848a5d30b0083248704959f79e5f640