### PR TITLE
fix: override of runtime details

### DIFF
--- a/odiglet/pkg/kube/runtime_details/inspection.go
+++ b/odiglet/pkg/kube/runtime_details/inspection.go
@@ -251,7 +251,8 @@ func persistRuntimeDetailsToInstrumentationConfig(ctx context.Context, kubeclien
 			for j := range currentConfig.Status.RuntimeDetailsByContainer {
 				existingDetail := &currentConfig.Status.RuntimeDetailsByContainer[j]
 				if newDetail.ContainerName == existingDetail.ContainerName {
-					if mergeRuntimeDetails(existingDetail, newDetail) {
+					podKey := strings.Join([]string{currentConfig.Namespace, currentConfig.Name}, "/")
+					if mergeRuntimeDetails(existingDetail, newDetail, podKey) {
 						updated = true
 					}
 				}
@@ -296,15 +297,20 @@ func GetRuntimeDetails(ctx context.Context, kubeClient client.Client, podWorkloa
 	return &runtimeDetails, nil
 }
 
-func mergeRuntimeDetails(existing *odigosv1.RuntimeDetailsByContainer, new odigosv1.RuntimeDetailsByContainer) bool {
-	updated := false
+func mergeRuntimeDetails(existing *odigosv1.RuntimeDetailsByContainer, new odigosv1.RuntimeDetailsByContainer, podIdentintifier string) bool {
+	if new.Language != existing.Language && existing.Language != common.UnknownProgrammingLanguage {
+		log.Logger.V(0).Info("detected different language, skiping merge runtime details", "pod_identintifier", podIdentintifier, "container_name", new.ContainerName, "new.Language", new.Language, "existing.Language", existing.Language)
+		return false
+	}
 
 	// 1. Merge LD_PRELOAD from EnvVars [/proc/pid/environ]
 	odigosStr := "odigos"
-	updated = mergeLdPreloadEnvVars(new.EnvVars, &existing.EnvVars, &odigosStr)
+	updatedEnviron := mergeLdPreloadEnvVars(new.EnvVars, &existing.EnvVars, &odigosStr)
 
 	// 2. Merge LD_PRELOAD from EnvFromContainerRuntime [DockerFile]
-	updated = mergeLdPreloadEnvVars(new.EnvFromContainerRuntime, &existing.EnvFromContainerRuntime, nil)
+	updatedDocker := mergeLdPreloadEnvVars(new.EnvFromContainerRuntime, &existing.EnvFromContainerRuntime, nil)
+
+	updated := updatedEnviron || updatedDocker
 
 	// 3. Update SecureExecutionMode if needed
 	if existing.SecureExecutionMode == nil && new.SecureExecutionMode != nil {


### PR DESCRIPTION
## Description

An app was initially detected as Go, then shortly after as Ruby.
The runtime details were initially correct for Go, then overridden with those of Ruby (runtime only, no language).
This PR adds a check, so we don't override the runtime details if the language has changed.

## How Has This Been Tested?

- [x] Manual Testing
