### PR TITLE
Support for cronJobs in k8s version 1.20

### DIFF
--- a/cli/cmd/sources.go
+++ b/cli/cmd/sources.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/version"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -435,7 +436,12 @@ func updateOrCreateSourceForObject(ctx context.Context, client *kube.Client, wor
 		objNamespace = obj.GetName()
 		sourceNamespace = obj.GetName()
 	case k8sconsts.WorkloadKindCronJob:
-		obj, err = client.Clientset.BatchV1().CronJobs(sourceNamespaceFlag).Get(ctx, argName, metav1.GetOptions{})
+		ver := cmdcontext.K8SVersionFromContext(ctx)
+		if ver.LessThan(version.MustParseSemantic("1.21.0")) {
+			obj, err = client.Clientset.BatchV1beta1().CronJobs(sourceNamespaceFlag).Get(ctx, argName, metav1.GetOptions{})
+		} else {
+			obj, err = client.Clientset.BatchV1().CronJobs(sourceNamespaceFlag).Get(ctx, argName, metav1.GetOptions{})
+		}
 		objName = obj.GetName()
 		objNamespace = obj.GetNamespace()
 		sourceNamespace = sourceNamespaceFlag

--- a/instrumentor/controllers/sourceinstrumentation/instrumentationconfig_controller.go
+++ b/instrumentor/controllers/sourceinstrumentation/instrumentationconfig_controller.go
@@ -27,8 +27,12 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+
+	"github.com/odigos-io/odigos/k8sutils/pkg/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/version"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -57,9 +61,20 @@ func getObjectByOwnerReference(ctx context.Context, k8sClient client.Client, own
 	}
 
 	if ownerRef.Kind == "CronJob" {
-		cj := &batchv1.CronJob{}
-		err := k8sClient.Get(ctx, key, cj)
-		return cj, err
+
+		ver, err := utils.ClusterVersion()
+		if err != nil {
+			return nil, err
+		}
+		if ver != nil && ver.LessThan(version.MustParseSemantic("1.21.0")) {
+			cj := &batchv1beta1.CronJob{}
+			err := k8sClient.Get(ctx, key, cj)
+			return cj, err
+		} else {
+			cj := &batchv1.CronJob{}
+			err := k8sClient.Get(ctx, key, cj)
+			return cj, err
+		}
 	}
 
 	return nil, fmt.Errorf("unsupported owner kind %s", ownerRef.Kind)

--- a/k8sutils/pkg/utils/version.go
+++ b/k8sutils/pkg/utils/version.go
@@ -1,0 +1,34 @@
+package utils
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+// ClusterVersion returns the Kubernetes control-plane version as a *version.Version.
+func ClusterVersion() (*version.Version, error) {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("build in-cluster config: %w", err)
+	}
+
+	disco, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("create discovery client: %w", err)
+	}
+
+	info, err := disco.ServerVersion() // simple helper; no ctx support
+	if err != nil {
+		return nil, fmt.Errorf("query /version: %w", err)
+	}
+
+	// Parse the **GitVersion** field, e.g. "v1.29.3+k3s2".
+	v, err := version.ParseGeneric(info.GitVersion)
+	if err != nil {
+		return nil, fmt.Errorf("parse %q: %w", info.GitVersion, err)
+	}
+	return v, nil
+}


### PR DESCRIPTION
## Description

<!-- Short summary of the changes -->

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
