### PR TITLE
operator: update to v1.0.198

### DIFF
--- a/.github/workflows/check-rbac-changes.yml
+++ b/.github/workflows/check-rbac-changes.yml
@@ -1,0 +1,42 @@
+name: Check RBAC Changes
+
+on:
+  pull_request:
+    paths:
+      - 'helm/**/*role.yaml'
+      - 'helm/**/*clusterrole.yaml'
+      - 'operator/config/rbac/role.yaml'
+
+jobs:
+  check-rbac:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for RBAC changes
+        run: |
+          # Get list of changed files
+          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
+          
+          # Check if any helm RBAC files changed
+          HELM_RBAC_CHANGED=false
+          for file in $CHANGED_FILES; do
+            if [[ $file == helm/*role.yaml ]] || [[ $file == helm/*clusterrole.yaml ]]; then
+              HELM_RBAC_CHANGED=true
+              break
+            fi
+          done
+          
+          # Check if operator RBAC file changed
+          OPERATOR_RBAC_CHANGED=false
+          if echo "$CHANGED_FILES" | grep -q "operator/config/rbac/role.yaml"; then
+            OPERATOR_RBAC_CHANGED=true
+          fi
+          
+          # If helm RBAC changed but operator RBAC didn't, fail
+          if [ "$HELM_RBAC_CHANGED" = true ] && [ "$OPERATOR_RBAC_CHANGED" = false ]; then
+            echo "::error::Component RBAC updated without corresponding permissions changed in Operator, please update the kubebuilder tags in operator/internal/controller/odigos_controller.go and regenerate with 'cd operator && USE_IMAGE_DIGESTS=true make generate manifests bundle'"
+            exit 1
+          fi 

--- a/docs/permissions.mdx
+++ b/docs/permissions.mdx
@@ -197,12 +197,12 @@ This section lists the RBAC policies used by the Odigos Operator. Many of these 
 | APIGroups | Resources | Resource Names | Verbs |
 |---|---|---|---|
 | \* | configmaps<br />endpoints<br />secrets | \* | create<br />delete<br />get<br />list<br />patch<br />update<br />watch |
+| \* | configmaps/finalizers<br />pods/finalizers | \* | update |
 | \* | events | \* | create<br />patch |
 | \* | namespaces | \* | get<br />list<br />patch<br />watch |
 | \* | nodes | \* | get<br />list<br />patch<br />update<br />watch |
 | \* | nodes/proxy<br />nodes/stats | \* | get<br />list |
 | \* | pods | \* | get<br />list<br />watch |
-| \* | pods/finalizers | \* | update |
 | \* | pods/status | \* | get |
 | \* | serviceaccounts | \* | create<br />delete<br />get<br />list<br />patch<br />watch |
 | \* | services | \* | create<br />delete<br />deletecollection<br />get<br />list<br />patch<br />update<br />watch |

--- a/docs/permissions.mdx
+++ b/docs/permissions.mdx
@@ -214,6 +214,7 @@ This section lists the RBAC policies used by the Odigos Operator. Many of these 
 | apps | daemonsets/finalizers<br />deployments/finalizers<br />replicasets/finalizers<br />statefulsets/finalizers | \* | update |
 | apps | daemonsets/status<br />deployments/status<br />statefulsets/status | \* | get |
 | autoscaling | horizontalpodautoscalers | \* | create<br />delete<br />patch<br />update |
+| batch | cronjobs | \* | get<br />list<br />patch<br />update |
 | coordination.k8s.io | leases | \* | create<br />delete<br />get<br />list<br />patch<br />update<br />watch |
 | odigos.io | \* | \* | \* |
 | odigos.io | collectorsgroups/finalizers<br />sources/finalizers | \* | update |

--- a/docs/permissions.mdx
+++ b/docs/permissions.mdx
@@ -214,7 +214,7 @@ This section lists the RBAC policies used by the Odigos Operator. Many of these 
 | apps | daemonsets/finalizers<br />deployments/finalizers<br />replicasets/finalizers<br />statefulsets/finalizers | \* | update |
 | apps | daemonsets/status<br />deployments/status<br />statefulsets/status | \* | get |
 | autoscaling | horizontalpodautoscalers | \* | create<br />delete<br />patch<br />update |
-| batch | cronjobs | \* | get<br />list<br />patch<br />update |
+| batch | cronjobs | \* | get<br />list<br />patch<br />update<br />watch |
 | coordination.k8s.io | leases | \* | create<br />delete<br />get<br />list<br />patch<br />update<br />watch |
 | odigos.io | \* | \* | \* |
 | odigos.io | collectorsgroups/finalizers<br />sources/finalizers | \* | update |

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.0.196
+VERSION ?= 1.0.198
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/operator/bundle/manifests/odigos-operator-odigos-version-kfkk8hb6bf_v1_configmap.yaml
+++ b/operator/bundle/manifests/odigos-operator-odigos-version-kfkk8hb6bf_v1_configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+data:
+  ODIGOS_VERSION: 1.0.198
+kind: ConfigMap
+metadata:
+  name: odigos-operator-odigos-version-kfkk8hb6bf

--- a/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
@@ -19,8 +19,8 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Logging & Tracing
-    containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:57b483a46f9e46fb2df9f98cba995c1beb3e329c251c994d20a2b7cc121154d9
-    createdAt: "2025-06-12T15:38:07Z"
+    containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:18fe631d8d79ffb6f78350e514ce58087416a207e616270ed5034cf5a02d4cbc
+    createdAt: "2025-06-16T16:17:50Z"
     description: Odigos enables automatic distributed tracing with OpenTelemetry and eBPF.
     features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "true"
@@ -33,7 +33,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.40.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     support: Odigos
-  name: odigos-operator.v1.0.196
+  name: odigos-operator.v1.0.198
   namespace: odigos-operator-system
 spec:
   apiservicedefinitions: {}
@@ -452,24 +452,24 @@ spec:
                         valueFrom:
                           configMapKeyRef:
                             key: ODIGOS_VERSION
-                            name: odigos-operator-odigos-version-hdg2tc9chd
+                            name: odigos-operator-odigos-version-kfkk8hb6bf
                       - name: RELATED_IMAGE_AUTOSCALER
-                        value: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:596bfa2d32cb30be53ee61e800adb2709759424c3467c003da3aa006c6cea5fc
+                        value: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:68997fccdd5448cfbd64057bf72866c970183980fedc145fcf92bc6dd9d68a30
                       - name: RELATED_IMAGE_COLLECTOR
-                        value: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:239d0ae93232883709f53ea16e022a97be04a50daf2375353134b6073b87f3e4
+                        value: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:603af2d091b354d5b574667b48ab12f091173b22381f1ae0042cc4324af23120
                       - name: RELATED_IMAGE_FRONTEND
-                        value: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:cb2cff13ea96b7bf952d41a5ee43f0eb242b70da96eb4948fd081a951f63c760
+                        value: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:f53181c61b833b4f3f731f61bb404a3c2f9ce603c961caf431e613b4c7f39303
                       - name: RELATED_IMAGE_INSTRUMENTOR
-                        value: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:b3e2a17d926862f54a2526703b31c3ae60cd8160d961fc17ef631efc6e757db0
+                        value: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:48b15ec1ae2eae9c85303c9ea6cd46bdd0829a34deafbe66102343e6e48864c0
                       - name: RELATED_IMAGE_ENTERPRISE_INSTRUMENTOR
-                        value: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:e8821b68d024e285e9261711d9883b46395ded0adf2b6e354997e909e09e8a44
+                        value: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:5b13c53996d72c3940c9a10f835ae446697e2669a7fadb69255853ba0d3e298a
                       - name: RELATED_IMAGE_ODIGLET
-                        value: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:38fb7e2b7fb897ff031175cc13e08e16d25b86b989ded80cb290f1dc73ae7659
+                        value: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:e970daa5cf9b88768030f55c0be8dd2b8d9c979f90aa080b3d74ebf8cb7c6153
                       - name: RELATED_IMAGE_ENTERPRISE_ODIGLET
-                        value: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:b4a371913f927b0bfa9635965ae541971460523ca984e026527407c7f2491e6c
+                        value: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:64f900bebd1548b6229237a73afe248963599aa582eac014f6b1857baeac7c50
                       - name: RELATED_IMAGE_SCHEDULER
-                        value: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:75165a0c1d275735a5a888729c252d3d54e64e0f54050aac57c7e8d7d3bd5bd6
-                    image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:57b483a46f9e46fb2df9f98cba995c1beb3e329c251c994d20a2b7cc121154d9
+                        value: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:ea16dbb7124f3d3dc16e31a20e3451c256d7bd27d1fa113ed43a6ed40cd4a82d
+                    image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:18fe631d8d79ffb6f78350e514ce58087416a207e616270ed5034cf5a02d4cbc
                     livenessProbe:
                       httpGet:
                         path: /healthz
@@ -567,28 +567,28 @@ spec:
     name: Odigos
     url: https://odigos.io
   relatedImages:
-    - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:b3e2a17d926862f54a2526703b31c3ae60cd8160d961fc17ef631efc6e757db0
-      name: instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:38fb7e2b7fb897ff031175cc13e08e16d25b86b989ded80cb290f1dc73ae7659
-      name: odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:b4a371913f927b0bfa9635965ae541971460523ca984e026527407c7f2491e6c
-      name: enterprise-odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:75165a0c1d275735a5a888729c252d3d54e64e0f54050aac57c7e8d7d3bd5bd6
+    - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:ea16dbb7124f3d3dc16e31a20e3451c256d7bd27d1fa113ed43a6ed40cd4a82d
       name: scheduler
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:e8821b68d024e285e9261711d9883b46395ded0adf2b6e354997e909e09e8a44
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:5b13c53996d72c3940c9a10f835ae446697e2669a7fadb69255853ba0d3e298a
       name: enterprise_instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:596bfa2d32cb30be53ee61e800adb2709759424c3467c003da3aa006c6cea5fc
-      name: autoscaler
-    - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:239d0ae93232883709f53ea16e022a97be04a50daf2375353134b6073b87f3e4
-      name: collector
-    - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:cb2cff13ea96b7bf952d41a5ee43f0eb242b70da96eb4948fd081a951f63c760
-      name: frontend
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:e8821b68d024e285e9261711d9883b46395ded0adf2b6e354997e909e09e8a44
-      name: enterprise-instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:57b483a46f9e46fb2df9f98cba995c1beb3e329c251c994d20a2b7cc121154d9
-      name: manager
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:b4a371913f927b0bfa9635965ae541971460523ca984e026527407c7f2491e6c
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:64f900bebd1548b6229237a73afe248963599aa582eac014f6b1857baeac7c50
       name: enterprise_odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:57b483a46f9e46fb2df9f98cba995c1beb3e329c251c994d20a2b7cc121154d9
-      name: odigos-certified-operator-ubi9-57b483a46f9e46fb2df9f98cba995c1beb3e329c251c994d20a2b7cc121154d9-annotation
-  version: 1.0.196
+    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:18fe631d8d79ffb6f78350e514ce58087416a207e616270ed5034cf5a02d4cbc
+      name: odigos-certified-operator-ubi9-18fe631d8d79ffb6f78350e514ce58087416a207e616270ed5034cf5a02d4cbc-annotation
+    - image: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:68997fccdd5448cfbd64057bf72866c970183980fedc145fcf92bc6dd9d68a30
+      name: autoscaler
+    - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:48b15ec1ae2eae9c85303c9ea6cd46bdd0829a34deafbe66102343e6e48864c0
+      name: instrumentor
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:5b13c53996d72c3940c9a10f835ae446697e2669a7fadb69255853ba0d3e298a
+      name: enterprise-instrumentor
+    - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:e970daa5cf9b88768030f55c0be8dd2b8d9c979f90aa080b3d74ebf8cb7c6153
+      name: odiglet
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:64f900bebd1548b6229237a73afe248963599aa582eac014f6b1857baeac7c50
+      name: enterprise-odiglet
+    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:18fe631d8d79ffb6f78350e514ce58087416a207e616270ed5034cf5a02d4cbc
+      name: manager
+    - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:603af2d091b354d5b574667b48ab12f091173b22381f1ae0042cc4324af23120
+      name: collector
+    - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:f53181c61b833b4f3f731f61bb404a3c2f9ce603c961caf431e613b4c7f39303
+      name: frontend
+  version: 1.0.198

--- a/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
     capabilities: Basic Install
     categories: Logging & Tracing
     containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:18fe631d8d79ffb6f78350e514ce58087416a207e616270ed5034cf5a02d4cbc
-    createdAt: "2025-06-16T16:33:19Z"
+    createdAt: "2025-06-16T16:37:47Z"
     description: Odigos enables automatic distributed tracing with OpenTelemetry and eBPF.
     features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "true"
@@ -148,6 +148,13 @@ spec:
             - apiGroups:
                 - ""
               resources:
+                - configmaps/finalizers
+                - pods/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - ""
+              resources:
                 - events
               verbs:
                 - create
@@ -187,12 +194,6 @@ spec:
                 - get
                 - list
                 - watch
-            - apiGroups:
-                - ""
-              resources:
-                - pods/finalizers
-              verbs:
-                - update
             - apiGroups:
                 - ""
               resources:
@@ -577,12 +578,20 @@ spec:
     name: Odigos
     url: https://odigos.io
   relatedImages:
+    - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:ea16dbb7124f3d3dc16e31a20e3451c256d7bd27d1fa113ed43a6ed40cd4a82d
+      name: scheduler
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:5b13c53996d72c3940c9a10f835ae446697e2669a7fadb69255853ba0d3e298a
+      name: enterprise_instrumentor
+    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:18fe631d8d79ffb6f78350e514ce58087416a207e616270ed5034cf5a02d4cbc
+      name: odigos-certified-operator-ubi9-18fe631d8d79ffb6f78350e514ce58087416a207e616270ed5034cf5a02d4cbc-annotation
     - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:603af2d091b354d5b574667b48ab12f091173b22381f1ae0042cc4324af23120
       name: collector
     - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:48b15ec1ae2eae9c85303c9ea6cd46bdd0829a34deafbe66102343e6e48864c0
       name: instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:5b13c53996d72c3940c9a10f835ae446697e2669a7fadb69255853ba0d3e298a
-      name: enterprise-instrumentor
+    - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:e970daa5cf9b88768030f55c0be8dd2b8d9c979f90aa080b3d74ebf8cb7c6153
+      name: odiglet
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:64f900bebd1548b6229237a73afe248963599aa582eac014f6b1857baeac7c50
+      name: enterprise-odiglet
     - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:18fe631d8d79ffb6f78350e514ce58087416a207e616270ed5034cf5a02d4cbc
       name: manager
     - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:64f900bebd1548b6229237a73afe248963599aa582eac014f6b1857baeac7c50
@@ -591,14 +600,6 @@ spec:
       name: autoscaler
     - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:f53181c61b833b4f3f731f61bb404a3c2f9ce603c961caf431e613b4c7f39303
       name: frontend
-    - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:e970daa5cf9b88768030f55c0be8dd2b8d9c979f90aa080b3d74ebf8cb7c6153
-      name: odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:64f900bebd1548b6229237a73afe248963599aa582eac014f6b1857baeac7c50
-      name: enterprise-odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:ea16dbb7124f3d3dc16e31a20e3451c256d7bd27d1fa113ed43a6ed40cd4a82d
-      name: scheduler
     - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:5b13c53996d72c3940c9a10f835ae446697e2669a7fadb69255853ba0d3e298a
-      name: enterprise_instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:18fe631d8d79ffb6f78350e514ce58087416a207e616270ed5034cf5a02d4cbc
-      name: odigos-certified-operator-ubi9-18fe631d8d79ffb6f78350e514ce58087416a207e616270ed5034cf5a02d4cbc-annotation
+      name: enterprise-instrumentor
   version: 1.0.198

--- a/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
     capabilities: Basic Install
     categories: Logging & Tracing
     containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:18fe631d8d79ffb6f78350e514ce58087416a207e616270ed5034cf5a02d4cbc
-    createdAt: "2025-06-16T16:26:11Z"
+    createdAt: "2025-06-16T16:33:19Z"
     description: Odigos enables automatic distributed tracing with OpenTelemetry and eBPF.
     features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "true"
@@ -319,6 +319,7 @@ spec:
                 - list
                 - patch
                 - update
+                - watch
             - apiGroups:
                 - coordination.k8s.io
               resources:
@@ -576,28 +577,28 @@ spec:
     name: Odigos
     url: https://odigos.io
   relatedImages:
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:64f900bebd1548b6229237a73afe248963599aa582eac014f6b1857baeac7c50
-      name: enterprise-odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:ea16dbb7124f3d3dc16e31a20e3451c256d7bd27d1fa113ed43a6ed40cd4a82d
-      name: scheduler
-    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:18fe631d8d79ffb6f78350e514ce58087416a207e616270ed5034cf5a02d4cbc
-      name: manager
     - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:603af2d091b354d5b574667b48ab12f091173b22381f1ae0042cc4324af23120
       name: collector
-    - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:f53181c61b833b4f3f731f61bb404a3c2f9ce603c961caf431e613b4c7f39303
-      name: frontend
     - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:48b15ec1ae2eae9c85303c9ea6cd46bdd0829a34deafbe66102343e6e48864c0
       name: instrumentor
     - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:5b13c53996d72c3940c9a10f835ae446697e2669a7fadb69255853ba0d3e298a
       name: enterprise-instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:e970daa5cf9b88768030f55c0be8dd2b8d9c979f90aa080b3d74ebf8cb7c6153
-      name: odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:5b13c53996d72c3940c9a10f835ae446697e2669a7fadb69255853ba0d3e298a
-      name: enterprise_instrumentor
+    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:18fe631d8d79ffb6f78350e514ce58087416a207e616270ed5034cf5a02d4cbc
+      name: manager
     - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:64f900bebd1548b6229237a73afe248963599aa582eac014f6b1857baeac7c50
       name: enterprise_odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:18fe631d8d79ffb6f78350e514ce58087416a207e616270ed5034cf5a02d4cbc
-      name: odigos-certified-operator-ubi9-18fe631d8d79ffb6f78350e514ce58087416a207e616270ed5034cf5a02d4cbc-annotation
     - image: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:68997fccdd5448cfbd64057bf72866c970183980fedc145fcf92bc6dd9d68a30
       name: autoscaler
+    - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:f53181c61b833b4f3f731f61bb404a3c2f9ce603c961caf431e613b4c7f39303
+      name: frontend
+    - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:e970daa5cf9b88768030f55c0be8dd2b8d9c979f90aa080b3d74ebf8cb7c6153
+      name: odiglet
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:64f900bebd1548b6229237a73afe248963599aa582eac014f6b1857baeac7c50
+      name: enterprise-odiglet
+    - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:ea16dbb7124f3d3dc16e31a20e3451c256d7bd27d1fa113ed43a6ed40cd4a82d
+      name: scheduler
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:5b13c53996d72c3940c9a10f835ae446697e2669a7fadb69255853ba0d3e298a
+      name: enterprise_instrumentor
+    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:18fe631d8d79ffb6f78350e514ce58087416a207e616270ed5034cf5a02d4cbc
+      name: odigos-certified-operator-ubi9-18fe631d8d79ffb6f78350e514ce58087416a207e616270ed5034cf5a02d4cbc-annotation
   version: 1.0.198

--- a/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
     capabilities: Basic Install
     categories: Logging & Tracing
     containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:18fe631d8d79ffb6f78350e514ce58087416a207e616270ed5034cf5a02d4cbc
-    createdAt: "2025-06-16T16:17:50Z"
+    createdAt: "2025-06-16T16:26:11Z"
     description: Odigos enables automatic distributed tracing with OpenTelemetry and eBPF.
     features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "true"
@@ -311,6 +311,15 @@ spec:
                 - patch
                 - update
             - apiGroups:
+                - batch
+              resources:
+                - cronjobs
+              verbs:
+                - get
+                - list
+                - patch
+                - update
+            - apiGroups:
                 - coordination.k8s.io
               resources:
                 - leases
@@ -567,8 +576,22 @@ spec:
     name: Odigos
     url: https://odigos.io
   relatedImages:
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:64f900bebd1548b6229237a73afe248963599aa582eac014f6b1857baeac7c50
+      name: enterprise-odiglet
     - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:ea16dbb7124f3d3dc16e31a20e3451c256d7bd27d1fa113ed43a6ed40cd4a82d
       name: scheduler
+    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:18fe631d8d79ffb6f78350e514ce58087416a207e616270ed5034cf5a02d4cbc
+      name: manager
+    - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:603af2d091b354d5b574667b48ab12f091173b22381f1ae0042cc4324af23120
+      name: collector
+    - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:f53181c61b833b4f3f731f61bb404a3c2f9ce603c961caf431e613b4c7f39303
+      name: frontend
+    - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:48b15ec1ae2eae9c85303c9ea6cd46bdd0829a34deafbe66102343e6e48864c0
+      name: instrumentor
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:5b13c53996d72c3940c9a10f835ae446697e2669a7fadb69255853ba0d3e298a
+      name: enterprise-instrumentor
+    - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:e970daa5cf9b88768030f55c0be8dd2b8d9c979f90aa080b3d74ebf8cb7c6153
+      name: odiglet
     - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:5b13c53996d72c3940c9a10f835ae446697e2669a7fadb69255853ba0d3e298a
       name: enterprise_instrumentor
     - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:64f900bebd1548b6229237a73afe248963599aa582eac014f6b1857baeac7c50
@@ -577,18 +600,4 @@ spec:
       name: odigos-certified-operator-ubi9-18fe631d8d79ffb6f78350e514ce58087416a207e616270ed5034cf5a02d4cbc-annotation
     - image: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:68997fccdd5448cfbd64057bf72866c970183980fedc145fcf92bc6dd9d68a30
       name: autoscaler
-    - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:48b15ec1ae2eae9c85303c9ea6cd46bdd0829a34deafbe66102343e6e48864c0
-      name: instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:5b13c53996d72c3940c9a10f835ae446697e2669a7fadb69255853ba0d3e298a
-      name: enterprise-instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:e970daa5cf9b88768030f55c0be8dd2b8d9c979f90aa080b3d74ebf8cb7c6153
-      name: odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:64f900bebd1548b6229237a73afe248963599aa582eac014f6b1857baeac7c50
-      name: enterprise-odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:18fe631d8d79ffb6f78350e514ce58087416a207e616270ed5034cf5a02d4cbc
-      name: manager
-    - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:603af2d091b354d5b574667b48ab12f091173b22381f1ae0042cc4324af23120
-      name: collector
-    - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:f53181c61b833b4f3f731f61bb404a3c2f9ce603c961caf431e613b4c7f39303
-      name: frontend
   version: 1.0.198

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -5,32 +5,32 @@ kind: Kustomization
 images:
 - name: autoscaler
   newName: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9
-  newTag: v1.0.196
+  newTag: v1.0.198
 - name: collector
   newName: registry.connect.redhat.com/odigos/odigos-collector-ubi9
-  newTag: v1.0.196
+  newTag: v1.0.198
 - name: controller
   newName: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9
-  newTag: v1.0.196
+  newTag: v1.0.198
 - name: enterprise-instrumentor
   newName: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9
-  newTag: v1.0.196
+  newTag: v1.0.198
 - name: enterprise-odiglet
   newName: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9
-  newTag: v1.0.196
+  newTag: v1.0.198
 - name: frontend
   newName: registry.connect.redhat.com/odigos/odigos-ui-ubi9
-  newTag: v1.0.196
+  newTag: v1.0.198
 - name: instrumentor
   newName: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9
-  newTag: v1.0.196
+  newTag: v1.0.198
 - name: odiglet
   newName: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9
-  newTag: v1.0.196
+  newTag: v1.0.198
 - name: scheduler
   newName: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9
-  newTag: v1.0.196
+  newTag: v1.0.198
 configMapGenerator:
 - literals:
-  - ODIGOS_VERSION=1.0.196
+  - ODIGOS_VERSION=1.0.198
   name: odigos-version

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -78,21 +78,21 @@ spec:
               name: odigos-version
               key: ODIGOS_VERSION
         - name: RELATED_IMAGE_AUTOSCALER
-          value: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9:v1.0.196
+          value: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9:v1.0.198
         - name: RELATED_IMAGE_COLLECTOR
-          value: registry.connect.redhat.com/odigos/odigos-collector-ubi9:v1.0.196
+          value: registry.connect.redhat.com/odigos/odigos-collector-ubi9:v1.0.198
         - name: RELATED_IMAGE_FRONTEND
-          value: registry.connect.redhat.com/odigos/odigos-ui-ubi9:v1.0.196
+          value: registry.connect.redhat.com/odigos/odigos-ui-ubi9:v1.0.198
         - name: RELATED_IMAGE_INSTRUMENTOR
-          value: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9:v1.0.196
+          value: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9:v1.0.198
         - name: RELATED_IMAGE_ENTERPRISE_INSTRUMENTOR
-          value: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9:v1.0.196
+          value: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9:v1.0.198
         - name: RELATED_IMAGE_ODIGLET
-          value: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9:v1.0.196
+          value: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9:v1.0.198
         - name: RELATED_IMAGE_ENTERPRISE_ODIGLET
-          value: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9:v1.0.196
+          value: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9:v1.0.198
         - name: RELATED_IMAGE_SCHEDULER
-          value: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9:v1.0.196
+          value: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9:v1.0.198
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/operator/config/manifests/bases/odigos-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/odigos-operator.clusterserviceversion.yaml
@@ -3,10 +3,10 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     alm-examples: '[{"apiVersion":"operator.odigos.io/v1alpha1", "kind":"Odigos",
-      "metadata":{"name":"odigos","namespace":"odigos-operator-system"}, "spec":{"version":"v1.0.196"}}]'
+      "metadata":{"name":"odigos","namespace":"odigos-operator-system"}, "spec":{"version":"v1.0.198"}}]'
     capabilities: Basic Install
     categories: Logging & Tracing
-    containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9:v1.0.196
+    containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9:v1.0.198
     description: Odigos enables automatic distributed tracing with OpenTelemetry and
       eBPF.
     features.operators.openshift.io/disconnected: "false"
@@ -19,7 +19,7 @@ metadata:
     operators.openshift.io/valid-subscription: Odigos Enterprise subscription (for
       enterprise features)
     support: Odigos
-  name: odigos-operator.v1.0.196
+  name: odigos-operator.v1.0.198
   namespace: odigos-operator-system
 spec:
   apiservicedefinitions: {}
@@ -152,4 +152,4 @@ spec:
   provider:
     name: Odigos
     url: https://odigos.io
-  version: 1.0.196
+  version: 1.0.198

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -184,6 +184,15 @@ rules:
   - patch
   - update
 - apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -192,6 +192,7 @@ rules:
   - list
   - patch
   - update
+  - watch
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -21,6 +21,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps/finalizers
+  - pods/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create
@@ -60,12 +67,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods/finalizers
-  verbs:
-  - update
 - apiGroups:
   - ""
   resources:

--- a/operator/internal/controller/odigos_controller.go
+++ b/operator/internal/controller/odigos_controller.go
@@ -112,7 +112,7 @@ var relatedImageEnvVars = map[string]string{
 // +kubebuilder:rbac:groups=apps,resources=deployments;replicasets;daemonsets;statefulsets,verbs=get;list;watch;create;update;patch;delete;deletecollection
 // +kubebuilder:rbac:groups=apps,resources=deployments/finalizers;replicasets/finalizers;daemonsets/finalizers;statefulsets/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=deployments/status;daemonsets/status;statefulsets/status,verbs=get
-// +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;update;patch
+// +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;update;patch;watch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings;roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete

--- a/operator/internal/controller/odigos_controller.go
+++ b/operator/internal/controller/odigos_controller.go
@@ -112,6 +112,7 @@ var relatedImageEnvVars = map[string]string{
 // +kubebuilder:rbac:groups=apps,resources=deployments;replicasets;daemonsets;statefulsets,verbs=get;list;watch;create;update;patch;delete;deletecollection
 // +kubebuilder:rbac:groups=apps,resources=deployments/finalizers;replicasets/finalizers;daemonsets/finalizers;statefulsets/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=deployments/status;daemonsets/status;statefulsets/status,verbs=get
+// +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;update;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings;roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete

--- a/operator/internal/controller/odigos_controller.go
+++ b/operator/internal/controller/odigos_controller.go
@@ -100,6 +100,7 @@ var relatedImageEnvVars = map[string]string{
 // +kubebuilder:rbac:groups=odigos.io,resources=collectorsgroups/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete;deletecollection
 // +kubebuilder:rbac:groups="",resources=configmaps;endpoints;secrets,verbs=get;list;watch;create;update;delete;patch
+// +kubebuilder:rbac:groups="",resources=configmaps/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=create;get;list;watch;patch;delete
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch;patch;update


### PR DESCRIPTION
## Description

This updates the operator to 1.0.198 along with changes to permissions that are necessary for it to grant those permissions to components.

This also adds a workflow to make sure that when components are granted new permissions, the operator's RBAC is updated as well.

Openshift release PR: https://github.com/redhat-openshift-ecosystem/certified-operators/pull/5944

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [x] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
