### PR TITLE
cli: add  `download-file` and `from-file` flags to update-offsets

### DIFF
--- a/docs/cli/odigos_pro_update-offsets.mdx
+++ b/docs/cli/odigos_pro_update-offsets.mdx
@@ -33,13 +33,21 @@ odigos pro update-offsets
 # Revert to using the default offsets data shipped with Odigos
 odigos pro update-offsets --default
 
+# Download the offsets file to a specific location without updating the cluster
+odigos pro update-offsets --download-file /path/to/save/offsets.json
+
+# Use a local offsets file instead of downloading it
+odigos pro update-offsets --from-file /path/to/local/offsets.json
+
 ```
 
 ### Options
 
 ```
-      --default   revert to using the default offsets data shipped with the current version of Odigos
-  -h, --help      help for update-offsets
+      --default                revert to using the default offsets data shipped with the current version of Odigos
+      --download-file string   download the offsets file to the specified location without updating the cluster
+      --from-file string       use the offsets file from the specified location instead of downloading it
+  -h, --help                   help for update-offsets
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
## Description

This allows downloading a Go offsets file locally and using the local file (ideally for users where the cluster itself may not have direct internet access)

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
