### PR TITLE
chore: semvercompare function fix

### DIFF
--- a/helm/odigos/templates/_helpers.tpl
+++ b/helm/odigos/templates/_helpers.tpl
@@ -37,3 +37,10 @@ true
   {{- end -}}
 {{- end -}}
 
+
+{{/*
+  Return the cleaned Kubernetes version (e.g., "1.30.13" from "v1.30.13-eks-5d4a308")
+  */}}
+  {{- define "utils.cleanKubeVersion" -}}
+  {{- regexReplaceAll "-.*" .Capabilities.KubeVersion.Version "" | trimPrefix "v" -}}
+  {{- end }}

--- a/helm/odigos/templates/_helpers.tpl
+++ b/helm/odigos/templates/_helpers.tpl
@@ -39,8 +39,8 @@ true
 
 
 {{/*
-  Return the cleaned Kubernetes version (e.g., "1.30.13" from "v1.30.13-eks-5d4a308")
+  Return cleaned Kubernetes version, keeping leading 'v', removing vendor suffix like -eks-...
   */}}
   {{- define "utils.cleanKubeVersion" -}}
-  {{- regexReplaceAll "-.*" .Capabilities.KubeVersion.Version "" | trimPrefix "v" -}}
+  {{- regexReplaceAll "-.*" .Capabilities.KubeVersion.Version "" -}}
   {{- end }}

--- a/helm/odigos/templates/odiglet/daemonset.yaml
+++ b/helm/odigos/templates/odiglet/daemonset.yaml
@@ -12,7 +12,8 @@ spec:
       app.kubernetes.io/name: odiglet
   updateStrategy:
     rollingUpdate:
-      {{- if semverCompare ">=1.22.0" .Capabilities.KubeVersion.Version }}
+      {{- $version := include "utils.cleanKubeVersion" . }}
+      {{- if semverCompare ">=1.22.0" $version }}
       maxSurge: 0
       {{- end }}
       maxUnavailable: 50%
@@ -156,7 +157,8 @@ spec:
               mountPath: /sys/kernel/debug
             - name: odigos-go-offsets
               mountPath: /offsets
-      {{- if semverCompare "<1.26.0" .Capabilities.KubeVersion.Version }}
+      {{- $version := include "utils.cleanKubeVersion" . }}
+      {{- if semverCompare "<1.26.0" $version }}
       hostNetwork: true
       {{- end}}
       hostPID: true

--- a/helm/odigos/templates/odiglet/local-service.yaml
+++ b/helm/odigos/templates/odiglet/local-service.yaml
@@ -1,4 +1,5 @@
-{{- if semverCompare ">=1.26.0" .Capabilities.KubeVersion.Version }}
+{{- $version := include "utils.cleanKubeVersion" . }}
+{{- if semverCompare ">=1.26.0" $version }}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
## Description

In some environments (e.g., EKS), the Kubernetes version string can appear in a format like v1.30.13-eks-5d4a308.
This non-standard format causes semverCompare to fail when attempting to compare versions.
To address this, I’ve implemented a helper function that sanitizes the version string, ensuring the comparison logic operates correctly.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
