### PR TITLE
feat: configure Odigos gateway pods to run as non-root user

### DIFF
--- a/autoscaler/controllers/clustercollector/deployment.go
+++ b/autoscaler/controllers/clustercollector/deployment.go
@@ -141,6 +141,12 @@ func getDesiredDeployment(dests *odigosv1.DestinationList, configDataHash string
 				Spec: corev1.PodSpec{
 					NodeSelector:       nodeSelector,
 					ServiceAccountName: k8sconsts.OdigosClusterCollectorDeploymentName,
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: boolPtr(true),
+						RunAsUser:    int64Ptr(65534), // nobody user
+						RunAsGroup:   int64Ptr(65534), // nobody group
+						FSGroup:      int64Ptr(65534),
+					},
 					Containers: []corev1.Container{
 						{
 							Name:  containerName,


### PR DESCRIPTION
## Summary
This PR modifies the Odigos gateway pods to run as non-root users by adding pod-level security context configuration.

## Changes
- Added `SecurityContext` to the cluster collector deployment pod specification
- Configured pods to run as user ID 65534 (nobody user)
- Set `RunAsNonRoot: true` to enforce non-root execution
- Added `FSGroup` for proper volume permissions

## Security Benefits
- ✅ Follows principle of least privilege
- ✅ Reduces attack surface by preventing root container execution
- ✅ Complies with security policies that prohibit root containers
- ✅ Aligns with Kubernetes security best practices

## Testing
- [ ] Verify gateway pods start successfully with non-root user
- [ ] Confirm telemetry collection continues to work properly
- [ ] Test volume mount permissions are handled correctly

## Files Modified
- `autoscaler/controllers/clustercollector/deployment.go` - Added pod security context

## Breaking Changes
None - this is a security hardening change that maintains existing functionality.