### PR TITLE
Reorder destination creation

### DIFF
--- a/.github/actions/cross-cloud-tests/action.yml
+++ b/.github/actions/cross-cloud-tests/action.yml
@@ -157,16 +157,16 @@ runs:
       continue-on-error: true
 
     # 16) Destroy Resources (always attempts)
-    # - name: Destroy Resources
-    #   if: always()
-    #   shell: bash
-    #   run: |
-    #     export TF_DIR="./tests-infrastructure/terraform/${{ inputs.provider }}"
-    #     export TF_VAR_cluster_name="${{ inputs.test_scenario }}-${GITHUB_RUN_ID}"
-    #     export TF_VAR_run_id="${GITHUB_RUN_ID}"
-    #     export TF_VAR_resource_group_name="${{ inputs.test_scenario }}-${GITHUB_RUN_ID}"
-    #     tofu -chdir="$TF_DIR" destroy -auto-approve
-    #   continue-on-error: true
+    - name: Destroy Resources
+      if: always()
+      shell: bash
+      run: |
+        export TF_DIR="./tests-infrastructure/terraform/${{ inputs.provider }}"
+        export TF_VAR_cluster_name="${{ inputs.test_scenario }}-${GITHUB_RUN_ID}"
+        export TF_VAR_run_id="${GITHUB_RUN_ID}"
+        export TF_VAR_resource_group_name="${{ inputs.test_scenario }}-${GITHUB_RUN_ID}"
+        tofu -chdir="$TF_DIR" destroy -auto-approve
+      continue-on-error: true
 
     # 17) Extract Tag (optional)
     - name: Extract Tag

--- a/.github/actions/cross-cloud-tests/action.yml
+++ b/.github/actions/cross-cloud-tests/action.yml
@@ -157,16 +157,16 @@ runs:
       continue-on-error: true
 
     # 16) Destroy Resources (always attempts)
-    - name: Destroy Resources
-      if: always()
-      shell: bash
-      run: |
-        export TF_DIR="./tests-infrastructure/terraform/${{ inputs.provider }}"
-        export TF_VAR_cluster_name="${{ inputs.test_scenario }}-${GITHUB_RUN_ID}"
-        export TF_VAR_run_id="${GITHUB_RUN_ID}"
-        export TF_VAR_resource_group_name="${{ inputs.test_scenario }}-${GITHUB_RUN_ID}"
-        tofu -chdir="$TF_DIR" destroy -auto-approve
-      continue-on-error: true
+    # - name: Destroy Resources
+    #   if: always()
+    #   shell: bash
+    #   run: |
+    #     export TF_DIR="./tests-infrastructure/terraform/${{ inputs.provider }}"
+    #     export TF_VAR_cluster_name="${{ inputs.test_scenario }}-${GITHUB_RUN_ID}"
+    #     export TF_VAR_run_id="${GITHUB_RUN_ID}"
+    #     export TF_VAR_resource_group_name="${{ inputs.test_scenario }}-${GITHUB_RUN_ID}"
+    #     tofu -chdir="$TF_DIR" destroy -auto-approve
+    #   continue-on-error: true
 
     # 17) Extract Tag (optional)
     - name: Extract Tag

--- a/odiglet/pkg/kube/runtime_details/instrumentationconfigs_controller.go
+++ b/odiglet/pkg/kube/runtime_details/instrumentationconfigs_controller.go
@@ -115,6 +115,6 @@ func (r *InstrumentationConfigReconciler) Reconcile(ctx context.Context, request
 		return reconcile.Result{}, err
 	}
 
-	logger.Info("Completed runtime detection for new instrumentation config", "namespace", request.Namespace, "name", request.Name)
+	logger.Info("Completed runtime detection for new instrumentation config", "namespace", request.Namespace, "name", request.Name, "runtimeResults", runtimeResults)
 	return reconcile.Result{}, nil
 }

--- a/odiglet/pkg/kube/runtime_details/pods_controller.go
+++ b/odiglet/pkg/kube/runtime_details/pods_controller.go
@@ -66,7 +66,7 @@ func (p *PodsReconciler) Reconcile(ctx context.Context, request reconcile.Reques
 		return reconcile.Result{}, err
 	}
 
-	logger.V(0).Info("Completed runtime details detection for a new running pod", "name", request.Name, "namespace", request.Namespace)
+	logger.V(0).Info("Completed runtime details detection for a new running pod", "name", request.Name, "namespace", request.Namespace, "runtimeResults", runtimeResults)
 	return reconcile.Result{}, nil
 }
 

--- a/tests/e2e/helm-chart/chainsaw-test.yaml
+++ b/tests/e2e/helm-chart/chainsaw-test.yaml
@@ -72,6 +72,11 @@ spec:
             timeout: 1m
             file: ../../common/assert/simple-trace-db-running.yaml
 
+    - name: Add Destination
+      try:
+        - apply:
+            file: ../../common/apply/add-simple-trace-db-destination.yaml
+
     - name: Install - Simple Demo Apps
       try:
         - apply:
@@ -111,10 +116,6 @@ spec:
             timeout: 3m
             file: ../../common/assert/simple-demo-runtime-detected.yaml
 
-    - name: Add Destination
-      try:
-        - apply:
-            file: ../../common/apply/add-simple-trace-db-destination.yaml
 
     - name: Odigos pipeline ready
       try:

--- a/tests/e2e/source/chainsaw-test.yaml
+++ b/tests/e2e/source/chainsaw-test.yaml
@@ -37,6 +37,11 @@ spec:
             timeout: 1m
             file: ../../common/assert/simple-trace-db-running.yaml
 
+    - name: '[1 - Setup] Add Destination'
+      try:
+        - apply:
+            file: ../../common/apply/add-simple-trace-db-destination.yaml
+
     - name: '[1 - Setup] Install - Simple Demo Apps'
       try:
         - apply:
@@ -76,10 +81,6 @@ spec:
             timeout: 2m
             file: ../../common/assert/simple-demo-runtime-detected.yaml
 
-    - name: '[2 - Workload Instrumentation] Add Destination'
-      try:
-        - apply:
-            file: ../../common/apply/add-simple-trace-db-destination.yaml
 
     - name: '[2 - Workload Instrumentation] Odigos pipeline ready'
       try:

--- a/tests/e2e/source/chainsaw-test.yaml
+++ b/tests/e2e/source/chainsaw-test.yaml
@@ -87,6 +87,12 @@ spec:
             timeout: 1m
             file: ../../common/assert/pipeline-ready.yaml
 
+    - name: Simple-demo instrumented after destination added
+      try:
+        - assert:
+            timeout: 3m
+            file: ../../common/assert/simple-demo-instrumented-full.yaml
+
     - name: '[2 - Workload Instrumentation] Simple-demo instrumented after destination added'
       try:
         - assert:

--- a/tests/e2e/source/chainsaw-test.yaml
+++ b/tests/e2e/source/chainsaw-test.yaml
@@ -88,11 +88,6 @@ spec:
             timeout: 1m
             file: ../../common/assert/pipeline-ready.yaml
 
-    - name: Simple-demo instrumented after destination added
-      try:
-        - assert:
-            timeout: 3m
-            file: ../../common/assert/simple-demo-instrumented-full.yaml
 
     - name: '[2 - Workload Instrumentation] Simple-demo instrumented after destination added'
       try:


### PR DESCRIPTION
## Description

This PR reorders destination creation in the test suite to fix a bug where source creation prematurely triggers data collection deployment without a selected destination. This issue leads to incorrect environment variable settings for OTEL exporters in Java, Ruby, and .NET applications, as these variables are set based on supported signals that remain unconfigured due to the absence of a destination.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
