### PR TITLE
fix: set k8s attributes as nodejs agent env to show when opamp is down

### DIFF
--- a/distros/yamls/nodejs-community.yaml
+++ b/distros/yamls/nodejs-community.yaml
@@ -23,3 +23,5 @@ spec:
       - envName: NODE_OPTIONS
         envValue: '--require {{ODIGOS_AGENTS_DIR}}/nodejs/autoinstrumentation.js'
         delimiter: ' '
+    k8sAttrsViaEnvVars: true
+


### PR DESCRIPTION
When instrumenting a nodejs application, if OpAMP is unable to connect, then we use default config. but this config lacks important attributes like `k8s.namespace.name`, `k8s.deployment.name` and `service.name`.

At the moment, the spans from nodejs when opamp cannot start looks like this:

![image](https://github.com/user-attachments/assets/f852ba73-cab3-4652-b715-df8944a716ac)

and missing k8s attributes. This PR adds these k8s attributes as environment variable which solves the issue