### PR TITLE
fix(instrumentor): fetch the object once in sync function instead of each caller

### DIFF
--- a/instrumentor/controllers/sourceinstrumentation/source_controller.go
+++ b/instrumentor/controllers/sourceinstrumentation/source_controller.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/odigos-io/odigos/api/k8sconsts"
 	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
-	sourceutils "github.com/odigos-io/odigos/k8sutils/pkg/source"
 	k8sutils "github.com/odigos-io/odigos/k8sutils/pkg/utils"
 )
 
@@ -38,16 +37,7 @@ func (r *SourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		// Get the object referenced by the Source to check whether the workload is being actively instrumented.
 		// The Source itself doesn't have enough information about the global state of this workload:
 		// For example, a deleted Workload Source might still be covered by a Namespace Source.
-		var obj client.Object
-		obj, err = sourceutils.GetClientObjectFromSource(ctx, r.Client, source)
-		if client.IgnoreNotFound(err) != nil {
-			// re-queue on any error besides NotFound
-			return ctrl.Result{}, err
-		}
-		if obj != nil {
-			// NotFound will return a nil object, nothing to sync without a workload obj
-			result, err = syncWorkload(ctx, r.Client, r.Scheme, obj)
-		}
+		result, err = syncWorkload(ctx, r.Client, r.Scheme, source.Spec.Workload)
 	}
 	// We could get a non-error Requeue signal from the reconcile functions,
 	// such as a conflict updating the instrumentationconfig status

--- a/instrumentor/controllers/sourceinstrumentation/workload_controllers.go
+++ b/instrumentor/controllers/sourceinstrumentation/workload_controllers.go
@@ -9,7 +9,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/odigos-io/odigos/api/k8sconsts"
-	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
 )
 
 type DeploymentReconciler struct {
@@ -18,7 +17,12 @@ type DeploymentReconciler struct {
 }
 
 func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	return reconcileWorkload(ctx, r.Client, k8sconsts.WorkloadKindDeployment, req.NamespacedName, r.Scheme)
+	pw := k8sconsts.PodWorkload{
+		Namespace: req.Namespace,
+		Kind:      k8sconsts.WorkloadKindDeployment,
+		Name:      req.Name,
+	}
+	return syncWorkload(ctx, r.Client, r.Scheme, pw)
 }
 
 type DaemonSetReconciler struct {
@@ -27,7 +31,12 @@ type DaemonSetReconciler struct {
 }
 
 func (r *DaemonSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	return reconcileWorkload(ctx, r.Client, k8sconsts.WorkloadKindDaemonSet, req.NamespacedName, r.Scheme)
+	pw := k8sconsts.PodWorkload{
+		Namespace: req.Namespace,
+		Kind:      k8sconsts.WorkloadKindDaemonSet,
+		Name:      req.Name,
+	}
+	return syncWorkload(ctx, r.Client, r.Scheme, pw)
 }
 
 type StatefulSetReconciler struct {
@@ -36,21 +45,10 @@ type StatefulSetReconciler struct {
 }
 
 func (r *StatefulSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	return reconcileWorkload(ctx, r.Client, k8sconsts.WorkloadKindStatefulSet, req.NamespacedName, r.Scheme)
-}
-
-func reconcileWorkload(
-	ctx context.Context,
-	k8sClient client.Client,
-	objKind k8sconsts.WorkloadKind,
-	key client.ObjectKey,
-	scheme *runtime.Scheme) (ctrl.Result, error) {
-
-	obj := workload.ClientObjectFromWorkloadKind(objKind)
-	err := k8sClient.Get(ctx, key, obj)
-	if err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+	pw := k8sconsts.PodWorkload{
+		Namespace: req.Namespace,
+		Kind:      k8sconsts.WorkloadKindStatefulSet,
+		Name:      req.Name,
 	}
-
-	return syncWorkload(ctx, k8sClient, scheme, obj)
+	return syncWorkload(ctx, r.Client, r.Scheme, pw)
 }


### PR DESCRIPTION

## Description

This PR addresses 2 things:
- fix bug, where we first list a group of objects and then reconcile them with possibly non-up-to-date state, thus leading to in-consistent state for an object. we already fixed a bunch of those in the past, but this one still looks like it needs addressing.
- the `syncWorkload` function in the `source instrumentation` controllers is called 4 times, and every caller needs to run the exact same lines: 

```
	obj := workload.ClientObjectFromWorkloadKind(objKind)
	err := k8sClient.Get(ctx, key, obj)
	if err != nil {
		return ctrl.Result{}, client.IgnoreNotFound(err)
	}
```

We already have the ctx and k8s client in the function, so better to do it there just once.

This one also guarantee that we are always working with a fresh copy from cache, and not something we `List`ed maybe some time ago and during the iteration became invalid.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [x] Manual Testing

## Kubernetes Checklist

No K8s changes. We are still making the same calls but now in one central place. All calls are to the cache and not api server

## User Facing Changes

Not noticeable, beside for the bug fix which should be quite rare 
