### PR TITLE
refactor: runtime-object extraction func to return pod workload

### DIFF
--- a/frontend/kube/watchers/instrumentation_config_watcher.go
+++ b/frontend/kube/watchers/instrumentation_config_watcher.go
@@ -89,28 +89,26 @@ func handleInstrumentationConfigWatchEvents(ctx context.Context, watcher watch.I
 }
 
 func handleAddedInstrumentationConfig(instruConfig *v1alpha1.InstrumentationConfig) {
-	namespace := instruConfig.Namespace
-	name, kind, err := commonutils.ExtractWorkloadInfoFromRuntimeObjectName(instruConfig.Name)
+	pw, err := commonutils.ExtractWorkloadInfoFromRuntimeObjectName(instruConfig.Name, instruConfig.Namespace)
 	if err != nil {
 		genericErrorMessage(sse.MessageEventAdded, consts.InstrumentationConfig, err.Error())
 		return
 	}
 
-	target := fmt.Sprintf("namespace=%s&name=%s&kind=%s", namespace, name, kind)
-	data := fmt.Sprintf(`Successfully created "%s" source`, name)
+	target := fmt.Sprintf("namespace=%s&name=%s&kind=%s", pw.Namespace, pw.Name, pw.Kind)
+	data := fmt.Sprintf(`Successfully created "%s" source`, pw.Name)
 	instrumentationConfigAddedEventBatcher.AddEvent(sse.MessageTypeSuccess, data, target)
 }
 
 func handleModifiedInstrumentationConfig(instruConfig *v1alpha1.InstrumentationConfig) {
-	namespace := instruConfig.Namespace
-	name, kind, err := commonutils.ExtractWorkloadInfoFromRuntimeObjectName(instruConfig.Name)
+	pw, err := commonutils.ExtractWorkloadInfoFromRuntimeObjectName(instruConfig.Name, instruConfig.Namespace)
 	if err != nil {
 		genericErrorMessage(sse.MessageEventModified, consts.InstrumentationConfig, err.Error())
 		return
 	}
 
-	target := fmt.Sprintf("namespace=%s&name=%s&kind=%s", namespace, name, kind)
-	data := fmt.Sprintf(`Successfully updated "%s" source`, name)
+	target := fmt.Sprintf("namespace=%s&name=%s&kind=%s", pw.Namespace, pw.Name, pw.Kind)
+	data := fmt.Sprintf(`Successfully updated "%s" source`, pw.Name)
 
 	// We have to ensure that the event is always an individual event - no batching.
 	// We need to do this because we have to get an event with the target ID, which is not possible with batching.
@@ -125,14 +123,13 @@ func handleModifiedInstrumentationConfig(instruConfig *v1alpha1.InstrumentationC
 }
 
 func handleDeletedInstrumentationConfig(instruConfig *v1alpha1.InstrumentationConfig) {
-	namespace := instruConfig.Namespace
-	name, kind, err := commonutils.ExtractWorkloadInfoFromRuntimeObjectName(instruConfig.Name)
+	pw, err := commonutils.ExtractWorkloadInfoFromRuntimeObjectName(instruConfig.Name, instruConfig.Namespace)
 	if err != nil {
 		genericErrorMessage(sse.MessageEventDeleted, consts.InstrumentationConfig, err.Error())
 		return
 	}
 
-	target := fmt.Sprintf("namespace=%s&name=%s&kind=%s", namespace, name, kind)
-	data := fmt.Sprintf(`Successfully deleted "%s" source`, name)
+	target := fmt.Sprintf("namespace=%s&name=%s&kind=%s", pw.Namespace, pw.Name, pw.Kind)
+	data := fmt.Sprintf(`Successfully deleted "%s" source`, pw.Name)
 	instrumentationConfigDeletedEventBatcher.AddEvent(sse.MessageTypeSuccess, data, target)
 }

--- a/frontend/services/collector_metrics/watchers.go
+++ b/frontend/services/collector_metrics/watchers.go
@@ -141,11 +141,11 @@ func runWatcherLoop(ctx context.Context, w watchers, notifyChan chan<- notificat
 			switch t {
 			case watch.Deleted, watch.Added:
 				app := event.Object.(*v1alpha1.InstrumentationConfig)
-				name, kind, err := commonutils.ExtractWorkloadInfoFromRuntimeObjectName(app.Name)
+				pw, err := commonutils.ExtractWorkloadInfoFromRuntimeObjectName(app.Name, app.Namespace)
 				if err != nil {
 					fmt.Printf("error getting workload info: %v\n", err)
 				}
-				notifyChan <- notification{notificationType: source, sourceID: common.SourceID{Kind: kind, Name: name, Namespace: app.Namespace}, eventType: t}
+				notifyChan <- notification{notificationType: source, sourceID: common.SourceID{Kind: pw.Kind, Name: pw.Name, Namespace: pw.Namespace}, eventType: t}
 			}
 		}
 	}

--- a/frontend/services/sources.go
+++ b/frontend/services/sources.go
@@ -539,18 +539,17 @@ func getInstrumentationInstancesConditions(ctx context.Context, namespace string
 		if !exists {
 			continue
 		}
-		thisNamespace := instance.Namespace
-		thisName, thisKind, err := workload.ExtractWorkloadInfoFromRuntimeObjectName(objectName)
+		pw, err := workload.ExtractWorkloadInfoFromRuntimeObjectName(objectName, instance.Namespace)
 		if err != nil {
 			continue
 		}
-		key := fmt.Sprintf("%s/%s/%s", thisNamespace, thisName, thisKind)
+		key := fmt.Sprintf("%s/%s/%s", pw.Namespace, pw.Name, pw.Kind)
 
 		if _, exists := conditionsMap[key]; !exists {
 			conditionsMap[key] = &model.SourceConditions{
-				Namespace:  thisNamespace,
-				Name:       thisName,
-				Kind:       model.K8sResourceKind(thisKind),
+				Namespace:  pw.Namespace,
+				Name:       pw.Name,
+				Kind:       model.K8sResourceKind(pw.Kind),
 				Conditions: []*model.Condition{},
 			}
 			instanceCountsMap[key] = &InstanceCounts{

--- a/instrumentor/controllers/agentenabled/sync.go
+++ b/instrumentor/controllers/agentenabled/sync.go
@@ -75,15 +75,10 @@ func reconcileAll(ctx context.Context, c client.Client, dp *distros.Provider) (c
 func reconcileWorkload(ctx context.Context, c client.Client, icName string, namespace string, distroProvider *distros.Provider, conf *common.OdigosConfiguration) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
-	workloadName, workloadKind, err := workload.ExtractWorkloadInfoFromRuntimeObjectName(icName)
+	pw, err := workload.ExtractWorkloadInfoFromRuntimeObjectName(icName, namespace)
 	if err != nil {
 		logger.Error(err, "error parsing workload info from runtime object name")
 		return ctrl.Result{}, nil // return nil so not to retry
-	}
-	pw := k8sconsts.PodWorkload{
-		Namespace: namespace,
-		Kind:      workloadKind,
-		Name:      workloadName,
 	}
 
 	ic := odigosv1.InstrumentationConfig{}

--- a/instrumentor/controllers/instrumentationconfig/common.go
+++ b/instrumentor/controllers/instrumentationconfig/common.go
@@ -1,7 +1,6 @@
 package instrumentationconfig
 
 import (
-	"github.com/odigos-io/odigos/api/k8sconsts"
 	odigosv1alpha1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/api/odigos/v1alpha1/instrumentationrules"
 	"github.com/odigos-io/odigos/common"
@@ -11,14 +10,9 @@ import (
 
 func updateInstrumentationConfigForWorkload(ic *odigosv1alpha1.InstrumentationConfig, rules *odigosv1alpha1.InstrumentationRuleList) error {
 
-	workloadName, workloadKind, err := workload.ExtractWorkloadInfoFromRuntimeObjectName(ic.Name)
+	workload, err := workload.ExtractWorkloadInfoFromRuntimeObjectName(ic.Name, ic.Namespace)
 	if err != nil {
 		return err
-	}
-	workload := k8sconsts.PodWorkload{
-		Name:      workloadName,
-		Namespace: ic.Namespace,
-		Kind:      workloadKind,
 	}
 
 	sdkConfigs := make([]odigosv1alpha1.SdkConfig, 0, len(ic.Status.RuntimeDetailsByContainer))

--- a/k8sutils/pkg/workload/runtimeobjects.go
+++ b/k8sutils/pkg/workload/runtimeobjects.go
@@ -18,7 +18,7 @@ func CalculateWorkloadRuntimeObjectName[T string | k8sconsts.WorkloadKind | k8sc
 	return strings.ToLower(string(workloadKind) + "-" + workloadName)
 }
 
-func ExtractWorkloadInfoFromRuntimeObjectName(runtimeObjectName string) (workloadName string, workloadKind k8sconsts.WorkloadKind, err error) {
+func ExtractWorkloadInfoFromRuntimeObjectName(runtimeObjectName string, ns string) (pw k8sconsts.PodWorkload, err error) {
 	parts := strings.SplitN(runtimeObjectName, "-", 2)
 	if len(parts) != 2 {
 		err = errors.New("invalid workload runtime object name, missing hyphen")
@@ -27,13 +27,17 @@ func ExtractWorkloadInfoFromRuntimeObjectName(runtimeObjectName string) (workloa
 
 	// convert the lowercase kind to pascal case and validate it
 	workloadKindLowerCase := k8sconsts.WorkloadKindLowerCase(parts[0])
-	workloadKind = WorkloadKindFromLowerCase(workloadKindLowerCase)
+	workloadKind := WorkloadKindFromLowerCase(workloadKindLowerCase)
 	if workloadKind == "" {
 		err = ErrKindNotSupported
 		return
 	}
 
-	workloadName = parts[1]
+	workloadName := parts[1]
 
-	return
+	return k8sconsts.PodWorkload{
+		Namespace: ns,
+		Kind:      workloadKind,
+		Name:      workloadName,
+	}, nil
 }

--- a/k8sutils/pkg/workload/runtimeobjects_test.go
+++ b/k8sutils/pkg/workload/runtimeobjects_test.go
@@ -15,34 +15,34 @@ func TestRuntimeObjectName(t *testing.T) {
 
 func TestExtractDeploymentWorkloadInfoFromRuntimeObjectName(t *testing.T) {
 	runtimeObjectName := workload.CalculateWorkloadRuntimeObjectName("my-app", "Deployment")
-	workloadName, workloadKind, err := workload.ExtractWorkloadInfoFromRuntimeObjectName(runtimeObjectName)
+	pw, err := workload.ExtractWorkloadInfoFromRuntimeObjectName(runtimeObjectName, "test")
 	assert.Nil(t, err)
-	assert.Equal(t, "my-app", workloadName)
-	assert.Equal(t, k8sconsts.WorkloadKindDeployment, workloadKind)
+	assert.Equal(t, "my-app", pw.Name)
+	assert.Equal(t, k8sconsts.WorkloadKindDeployment, pw.Kind)
 }
 
 func TestExtractDaemonSetWorkloadInfoFromRuntimeObjectName(t *testing.T) {
 	runtimeObjectName := workload.CalculateWorkloadRuntimeObjectName("my-app", "DaemonSet")
-	workloadName, workloadKind, err := workload.ExtractWorkloadInfoFromRuntimeObjectName(runtimeObjectName)
+	pw, err := workload.ExtractWorkloadInfoFromRuntimeObjectName(runtimeObjectName, "test")
 	assert.Nil(t, err)
-	assert.Equal(t, "my-app", workloadName)
-	assert.Equal(t, k8sconsts.WorkloadKindDaemonSet, workloadKind)
+	assert.Equal(t, "my-app", pw.Name)
+	assert.Equal(t, k8sconsts.WorkloadKindDaemonSet, pw.Kind)
 }
 
 func TestExtractStatefulSetWorkloadInfoFromRuntimeObjectName(t *testing.T) {
 	runtimeObjectName := workload.CalculateWorkloadRuntimeObjectName("my-app", "StatefulSet")
-	workloadName, workloadKind, err := workload.ExtractWorkloadInfoFromRuntimeObjectName(runtimeObjectName)
+	pw, err := workload.ExtractWorkloadInfoFromRuntimeObjectName(runtimeObjectName, "test")
 	assert.Nil(t, err)
-	assert.Equal(t, "my-app", workloadName)
-	assert.Equal(t, k8sconsts.WorkloadKindStatefulSet, workloadKind)
+	assert.Equal(t, "my-app", pw.Name)
+	assert.Equal(t, k8sconsts.WorkloadKindStatefulSet, pw.Kind)
 }
 
 func TestExtractInvalidWorkloadInfoFromRuntimeObjectName(t *testing.T) {
-	_, _, err := workload.ExtractWorkloadInfoFromRuntimeObjectName("nohyphen")
+	_, err := workload.ExtractWorkloadInfoFromRuntimeObjectName("nohyphen", "test")
 	assert.NotNil(t, err)
 }
 
 func TestExtractUnknownWorkloadInfoFromRuntimeObjectName(t *testing.T) {
-	_, _, err := workload.ExtractWorkloadInfoFromRuntimeObjectName("unknownkind-my-app")
+	_, err := workload.ExtractWorkloadInfoFromRuntimeObjectName("unknownkind-my-app", "test")
 	assert.NotNil(t, err)
 }

--- a/odiglet/pkg/kube/instrumentation_ebpf/instrumentationconfig.go
+++ b/odiglet/pkg/kube/instrumentation_ebpf/instrumentationconfig.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/odigos-io/odigos/api/k8sconsts"
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/instrumentation"
 	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
@@ -28,15 +27,9 @@ var (
 )
 
 func (i *InstrumentationConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	workloadName, workloadKind, err := workload.ExtractWorkloadInfoFromRuntimeObjectName(req.Name)
+	podWorkload, err := workload.ExtractWorkloadInfoFromRuntimeObjectName(req.Name, req.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err
-	}
-
-	podWorkload := k8sconsts.PodWorkload{
-		Namespace: req.Namespace,
-		Kind:      workloadKind,
-		Name:      workloadName,
 	}
 
 	// Fetch the InstrumentationConfig instrumentationConfig

--- a/opampserver/pkg/sdkconfig/instrumentationconfigs_controller.go
+++ b/opampserver/pkg/sdkconfig/instrumentationconfigs_controller.go
@@ -3,7 +3,6 @@ package sdkconfig
 import (
 	"context"
 
-	"github.com/odigos-io/odigos/api/k8sconsts"
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
 	"github.com/odigos-io/odigos/opampserver/pkg/connection"
@@ -26,15 +25,9 @@ func (i *InstrumentationConfigReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	workloadName, workloadKind, err := workload.ExtractWorkloadInfoFromRuntimeObjectName(req.Name)
+	podWorkload, err := workload.ExtractWorkloadInfoFromRuntimeObjectName(req.Name, req.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err
-	}
-
-	podWorkload := k8sconsts.PodWorkload{
-		Namespace: req.Namespace,
-		Kind:      k8sconsts.WorkloadKind(workloadKind),
-		Name:      workloadName,
 	}
 
 	for _, sdkConfig := range instrumentationConfig.Spec.SdkConfigs {


### PR DESCRIPTION
The `ExtractWorkloadInfoFromRuntimeObjectName` function in odigos is quite popular, and it sounds from the name like it will return `PodWorkload`, however, it returns `name + kind` which most of it's caller then need to convert to `PodWorkload`.

This PR makes it so that the function already returns the pod workload ready by callers to be integrated with other functionality in odigos