### PR TITLE
refactor(odiglet): use distros to read "append" env var names for detection

### DIFF
--- a/distros/distro/appendenvs.go
+++ b/distros/distro/appendenvs.go
@@ -1,11 +1,15 @@
 package distro
 
+import "github.com/odigos-io/odigos/common/consts"
+
 // Givin a set of distros, return a map of all the names of the environment variables
 // that participate in append mechanism (PYTHONPATH, JAVA_TOOL_OPTIONS, NODE_OPTIONS, etc.)
 // This is used at runtime detection and for enterprise loader to filter relevant env vars
 // for further patching downstream.
 func GetAppendEnvVarNames(distros []*OtelDistro) map[string]struct{} {
-	appendEnvVarNames := map[string]struct{}{}
+	appendEnvVarNames := map[string]struct{}{
+		consts.LdPreloadEnvVarName: {}, // LD_PRELOAD is special, and is always collected for any distro with special handling
+	}
 	for _, distro := range distros {
 		for _, envVar := range distro.EnvironmentVariables.AppendOdigosVariables {
 			envName := envVar.EnvName

--- a/distros/distro/appendenvs.go
+++ b/distros/distro/appendenvs.go
@@ -7,11 +7,9 @@ package distro
 func GetAppendEnvVarNames(distros []*OtelDistro) map[string]struct{} {
 	appendEnvVarNames := map[string]struct{}{}
 	for _, distro := range distros {
-		if distro.RuntimeAgent != nil {
-			for _, envVar := range distro.RuntimeAgent.EnvironmentVariables {
-				envName := envVar.EnvName
-				appendEnvVarNames[envName] = struct{}{}
-			}
+		for _, envVar := range distro.EnvironmentVariables.AppendOdigosVariables {
+			envName := envVar.EnvName
+			appendEnvVarNames[envName] = struct{}{}
 		}
 	}
 	return appendEnvVarNames

--- a/distros/distro/appendenvs.go
+++ b/distros/distro/appendenvs.go
@@ -1,0 +1,18 @@
+package distro
+
+// Givin a set of distros, return a map of all the names of the environment variables
+// that participate in append mechanism (PYTHONPATH, JAVA_TOOL_OPTIONS, NODE_OPTIONS, etc.)
+// This is used at runtime detection and for enterprise loader to filter relevant env vars
+// for further patching downstream.
+func GetAppendEnvVarNames(distros []*OtelDistro) map[string]struct{} {
+	appendEnvVarNames := map[string]struct{}{}
+	for _, distro := range distros {
+		if distro.RuntimeAgent != nil {
+			for _, envVar := range distro.RuntimeAgent.EnvironmentVariables {
+				envName := envVar.EnvName
+				appendEnvVarNames[envName] = struct{}{}
+			}
+		}
+	}
+	return appendEnvVarNames
+}

--- a/distros/distro/oteldistribution.go
+++ b/distros/distro/oteldistribution.go
@@ -43,26 +43,31 @@ type EnvironmentVariables struct {
 
 	// list of static environment variables that need to be set in the application runtime.
 	StaticVariables []StaticEnvironmentVariable `yaml:"staticVariables,omitempty"`
+
+	// list of environment variables that needs to be appended based on the existing value.
+	AppendOdigosVariables []AppendOdigosEnvironmentVariable `yaml:"appendOdigosVariables,omitempty"`
 }
 
 // this struct describes environment variables that needs to be set in the application runtime
 // to enable the distribution.
 // This environment variable should be patched with odigos value if it already exists in the manifest.
 // If this value is determined to arrive from Container Runtime during runtime inspection, this value should be set in manifest so not to break the application.
-type RuntimeAgentEnvironmentVariable struct {
+type AppendOdigosEnvironmentVariable struct {
 
 	// The name of the environment variable to set or patch.
 	EnvName string `yaml:"envName"`
 
-	// The value of the environment variable to set or patch.
-	// One special value can be used in this text which is substituted by the actual value at runtime.
-	// The special value is: `{{ODIGOS_AGENTS_DIR}}` which is replaced by `/var/odigos`, for k8s and with other values for other platforms.
-	EnvValue string `yaml:"envValue"`
-
-	// In case the environment variable needs to be appended to an existing value,
-	// this field specifies the delimiter to use.
-	// e.g. `:` for PYTHONPATH=/path/to/lib1:/path/to/lib2
-	Delimiter string `yaml:"delimiter"`
+	// A pattern to replace the existing value in case it exists.
+	// An example is `{{ORIGINAL_ENV_VALUE}} -javaagent:{{ODIGOS_AGENTS_DIR}}/java/javaagent.jar`
+	// while updating an env var value, the user can use pre-defined templates to interact with dynamic values:
+	// - `{{ORIGINAL_ENV_VALUE}}` - the original value of the environment variable
+	// - `{{ODIGOS_AGENTS_DIR}}` - where odigos directory is mounted in the container ('/var/odigos' for k8s, and other values for other platforms)
+	//
+	// This allows distros to update the value with control over:
+	// - the delimiter used for this language
+	// - if odigos value is prepended or appended (or both)
+	// - reference the agents directory in a platform-agnostic way
+	ReplacePattern string `yaml:"replacePattern"`
 }
 
 type RuntimeAgent struct {
@@ -86,10 +91,6 @@ type RuntimeAgent struct {
 	// This list contains the full path of the files that need to be opened for the agent to properly start.
 	// All these paths must be contained in one of the directoryNames.
 	FileOpenTriggers []string `yaml:"fileOpenTriggers,omitempty"`
-
-	// List of environment variables that need to be set in the application runtime to enable the distribution.
-	// those are patched if exist in the manifest, and supplemented from runtime inspection when relevant (value from docker runtime).
-	EnvironmentVariables []RuntimeAgentEnvironmentVariable `yaml:"environmentVariables,omitempty"`
 }
 
 // OtelDistro (Short for OpenTelemetry Distribution) is a collection of OpenTelemetry components,

--- a/distros/yamls/java-community.yaml
+++ b/distros/yamls/java-community.yaml
@@ -13,12 +13,11 @@ spec:
     This distribution is for JVM-based applications (Java, Scala, Kotlin, etc.) using OpenTelemetry Native SDK and instrumentation libraries from the OpenTelemetry community.
   environmentVariables:
     otlpHttpLocalNode: true
+    appendOdigosVariables:
+      - envName: JAVA_TOOL_OPTIONS
+        replacePattern: '{{ORIGINAL_ENV_VALUE}} -javaagent:{{ODIGOS_AGENTS_DIR}}/java/javaagent.jar'
   runtimeAgent:
     directoryNames:
       - "{{ODIGOS_AGENTS_DIR}}/java"
     k8sAttrsViaEnvVars: true
     device: 'instrumentation.odigos.io/generic'
-    environmentVariables:
-      - envName: JAVA_TOOL_OPTIONS
-        envValue: '-javaagent:{{ODIGOS_AGENTS_DIR}}/java/javaagent.jar'
-        delimiter: ' '

--- a/distros/yamls/nodejs-community.yaml
+++ b/distros/yamls/nodejs-community.yaml
@@ -14,14 +14,12 @@ spec:
   environmentVariables:
     opAmpClientEnvironments: true
     otlpHttpLocalNode: true
+    appendOdigosVariables:
+      - envName: NODE_OPTIONS
+        replacePattern: '{{ORIGINAL_ENV_VALUE}} --require {{ODIGOS_AGENTS_DIR}}/nodejs/autoinstrumentation.js'
   runtimeAgent:
     directoryNames:
       - "{{ODIGOS_AGENTS_DIR}}/nodejs-community"
       - "{{ODIGOS_AGENTS_DIR}}/opentelemetry-node"
     device: 'instrumentation.odigos.io/generic'
-    environmentVariables:
-      - envName: NODE_OPTIONS
-        envValue: '--require {{ODIGOS_AGENTS_DIR}}/nodejs/autoinstrumentation.js'
-        delimiter: ' '
     k8sAttrsViaEnvVars: true
-

--- a/distros/yamls/python-community.yaml
+++ b/distros/yamls/python-community.yaml
@@ -17,12 +17,11 @@ spec:
     staticVariables:
       - envName: OTEL_PYTHON_CONFIGURATOR
         envValue: 'odigos-python-configurator'
+    appendOdigosVariables:
+      - envName: PYTHONPATH
+        replacePattern: '{{ORIGINAL_ENV_VALUE}}:{{ODIGOS_AGENTS_DIR}}/python:{{ODIGOS_AGENTS_DIR}}/python/opentelemetry/instrumentation/auto_instrumentation'
   runtimeAgent:
     directoryNames:
       - "{{ODIGOS_AGENTS_DIR}}/python"
     device: 'instrumentation.odigos.io/generic'
-    environmentVariables:
-      - envName: PYTHONPATH
-        envValue: '{{ODIGOS_AGENTS_DIR}}/python:{{ODIGOS_AGENTS_DIR}}/python/opentelemetry/instrumentation/auto_instrumentation'
-        delimiter: ':'
     k8sAttrsViaEnvVars: true

--- a/odiglet/odiglet.go
+++ b/odiglet/odiglet.go
@@ -8,6 +8,7 @@ import (
 	"github.com/odigos-io/odigos-device-plugin/pkg/dpm"
 	"github.com/odigos-io/odigos/api/k8sconsts"
 	"github.com/odigos-io/odigos/common"
+	"github.com/odigos-io/odigos/distros/distro"
 	commonInstrumentation "github.com/odigos-io/odigos/instrumentation"
 	criwrapper "github.com/odigos-io/odigos/k8sutils/pkg/cri"
 	k8senv "github.com/odigos-io/odigos/k8sutils/pkg/env"
@@ -64,6 +65,8 @@ func New(clientset *kubernetes.Clientset, deviceInjectionCallbacks instrumentati
 	}
 	instrumentationMgrOpts.MeterProvider = provider
 
+	appendEnvVarNames := distro.GetAppendEnvVarNames(instrumentationMgrOpts.DistributionGetter.GetAllDistros())
+
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		return nil, fmt.Errorf("unable to set up health check: %w", err)
 	}
@@ -79,10 +82,11 @@ func New(clientset *kubernetes.Clientset, deviceInjectionCallbacks instrumentati
 	criWrapper := criwrapper.CriClient{Logger: log.Logger}
 
 	kubeManagerOptions := kube.KubeManagerOptions{
-		Mgr:           mgr,
-		Clientset:     clientset,
-		ConfigUpdates: configUpdates,
-		CriClient:     &criWrapper,
+		Mgr:               mgr,
+		Clientset:         clientset,
+		ConfigUpdates:     configUpdates,
+		CriClient:         &criWrapper,
+		AppendEnvVarNames: appendEnvVarNames,
 	}
 
 	err = kube.SetupWithManager(kubeManagerOptions)

--- a/odiglet/pkg/kube/manager.go
+++ b/odiglet/pkg/kube/manager.go
@@ -86,7 +86,7 @@ func CreateManager() (ctrl.Manager, error) {
 }
 
 func SetupWithManager(kubeManagerOptions KubeManagerOptions) error {
-	err := runtime_details.SetupWithManager(kubeManagerOptions.Mgr, kubeManagerOptions.Clientset, kubeManagerOptions.CriClient)
+	err := runtime_details.SetupWithManager(kubeManagerOptions.Mgr, kubeManagerOptions.Clientset, kubeManagerOptions.CriClient, kubeManagerOptions.AppendEnvVarNames)
 	if err != nil {
 		return err
 	}

--- a/odiglet/pkg/kube/manager.go
+++ b/odiglet/pkg/kube/manager.go
@@ -43,6 +43,9 @@ type KubeManagerOptions struct {
 	Clientset     *kubernetes.Clientset
 	ConfigUpdates chan<- instrumentation.ConfigUpdate[ebpf.K8sConfigGroup]
 	CriClient     *criwrapper.CriClient
+	// map where keys are the names of the environment variables that participate in append mechanism
+	// they need to be recorded by runtime detection into the runtime info, and this list instruct what to collect.
+	AppendEnvVarNames map[string]struct{}
 }
 
 func CreateManager() (ctrl.Manager, error) {

--- a/odiglet/pkg/kube/runtime_details/inspection.go
+++ b/odiglet/pkg/kube/runtime_details/inspection.go
@@ -25,12 +25,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func runtimeInspection(ctx context.Context, pods []corev1.Pod, criClient *criwrapper.CriClient) ([]odigosv1.RuntimeDetailsByContainer, error) {
+func runtimeInspection(ctx context.Context, pods []corev1.Pod, criClient *criwrapper.CriClient, appendEnvVarNames map[string]struct{}) ([]odigosv1.RuntimeDetailsByContainer, error) {
 	resultsMap := make(map[string]odigosv1.RuntimeDetailsByContainer)
 	for _, pod := range pods {
 		for _, container := range pod.Spec.Containers {
 
-			processes, err := process.FindAllInContainer(string(pod.UID), container.Name)
+			processes, err := process.FindAllInContainer(string(pod.UID), container.Name, appendEnvVarNames)
 			if err != nil {
 				log.Logger.Error(err, "failed to find processes in pod container", "pod", pod.Name, "container", container.Name, "namespace", pod.Namespace)
 				return nil, err

--- a/odiglet/pkg/kube/runtime_details/instrumentationconfigs_controller.go
+++ b/odiglet/pkg/kube/runtime_details/instrumentationconfigs_controller.go
@@ -54,6 +54,10 @@ type InstrumentationConfigReconciler struct {
 	// which can be expensive (memory and CPU)
 	Clientset *kubernetes.Clientset
 	CriClient *criwrapper.CriClient
+
+	// map where keys are the names of the environment variables that participate in append mechanism
+	// they need to be recorded by runtime detection into the runtime info, and this list instruct what to collect.
+	AppendEnvVarNames map[string]struct{}
 }
 
 func (r *InstrumentationConfigReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
@@ -105,7 +109,7 @@ func (r *InstrumentationConfigReconciler) Reconcile(ctx context.Context, request
 		return reconcile.Result{}, nil
 	}
 
-	runtimeResults, err := runtimeInspection(ctx, selectedPods, r.CriClient)
+	runtimeResults, err := runtimeInspection(ctx, selectedPods, r.CriClient, r.AppendEnvVarNames)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/odiglet/pkg/kube/runtime_details/manager.go
+++ b/odiglet/pkg/kube/runtime_details/manager.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 )
 
-func SetupWithManager(mgr ctrl.Manager, clientset *kubernetes.Clientset, criClient *criwrapper.CriClient) error {
+func SetupWithManager(mgr ctrl.Manager, clientset *kubernetes.Clientset, criClient *criwrapper.CriClient, appendEnvVarNames map[string]struct{}) error {
 	readyPred := &odigospredicate.AllContainersReadyPredicate{}
 	err := builder.
 		ControllerManagedBy(mgr).

--- a/odiglet/pkg/kube/runtime_details/pods_controller.go
+++ b/odiglet/pkg/kube/runtime_details/pods_controller.go
@@ -24,6 +24,10 @@ type PodsReconciler struct {
 	// which can be expensive (memory and CPU)
 	Clientset *kubernetes.Clientset
 	CriClient *criwrapper.CriClient
+
+	// map where keys are the names of the environment variables that participate in append mechanism
+	// they need to be recorded by runtime detection into the runtime info, and this list instruct what to collect.
+	AppendEnvVarNames map[string]struct{}
 }
 
 // We need to apply runtime details detection for a new running pod in the following cases:
@@ -56,7 +60,7 @@ func (p *PodsReconciler) Reconcile(ctx context.Context, request reconcile.Reques
 	}
 
 	// Perform runtime inspection once we know the pod is newer that the latest runtime inspection performed and saved.
-	runtimeResults, err := runtimeInspection(ctx, []corev1.Pod{pod}, p.CriClient)
+	runtimeResults, err := runtimeInspection(ctx, []corev1.Pod{pod}, p.CriClient, p.AppendEnvVarNames)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/odiglet/pkg/process/process_linux.go
+++ b/odiglet/pkg/process/process_linux.go
@@ -44,6 +44,6 @@ func isPodContainerPredicate(podUID string, containerName string) func(string) b
 	}
 }
 
-func FindAllInContainer(podUID string, containerName string) ([]procdiscovery.Details, error) {
-	return procdiscovery.FindAllProcesses(isPodContainerPredicate(podUID, containerName))
+func FindAllInContainer(podUID string, containerName string, appendEnvVarNames map[string]struct{}) ([]procdiscovery.Details, error) {
+	return procdiscovery.FindAllProcesses(isPodContainerPredicate(podUID, containerName), appendEnvVarNames)
 }

--- a/odiglet/pkg/process/process_other.go
+++ b/odiglet/pkg/process/process_other.go
@@ -12,6 +12,6 @@ func isPodContainerPredicate(_ string, _ string) func(string) bool {
 	}
 }
 
-func FindAllInContainer(podUID string, containerName string) ([]procdiscovery.Details, error) {
+func FindAllInContainer(podUID string, containerName string, appendEnvVarNames map[string]struct{}) ([]procdiscovery.Details, error) {
 	return nil, nil
 }

--- a/procdiscovery/pkg/process/process.go
+++ b/procdiscovery/pkg/process/process.go
@@ -8,9 +8,6 @@ import (
 	"io"
 	"os"
 	"strings"
-
-	"github.com/odigos-io/odigos/common/consts"
-	"github.com/odigos-io/odigos/common/envOverwrite"
 )
 
 const (
@@ -151,7 +148,7 @@ func (d *Details) GetOverwriteEnvsValue(key string) (string, bool) {
 
 // Find all processes in the system.
 // The function accepts a predicate function that can be used to filter the results.
-func FindAllProcesses(predicate func(string) bool) ([]Details, error) {
+func FindAllProcesses(predicate func(string) bool, appendEnvVarNames map[string]struct{}) ([]Details, error) {
 	dirs, err := os.ReadDir("/proc")
 	if err != nil {
 		return nil, err
@@ -176,17 +173,17 @@ func FindAllProcesses(predicate func(string) bool) ([]Details, error) {
 			continue
 		}
 
-		details := GetPidDetails(pid)
+		details := GetPidDetails(pid, appendEnvVarNames)
 		result = append(result, details)
 	}
 
 	return result, nil
 }
 
-func GetPidDetails(pid int) Details {
+func GetPidDetails(pid int, appendEnvVarNames map[string]struct{}) Details {
 	exePath := getExePath(pid)
 	cmdLine := getCommandLine(pid)
-	envVars := getRelevantEnvVars(pid)
+	envVars := getRelevantEnvVars(pid, appendEnvVarNames)
 	secureExecutionMode, err := isSecureExecutionMode(pid)
 	secureExecutionModePtr := &secureExecutionMode
 	if err != nil {
@@ -230,7 +227,7 @@ func getCommandLine(pid int) string {
 	}
 }
 
-func getRelevantEnvVars(pid int) ProcessEnvs {
+func getRelevantEnvVars(pid int, appendEnvVarNames map[string]struct{}) ProcessEnvs {
 	envFileName := fmt.Sprintf("/proc/%d/environ", pid)
 	fileContent, err := os.ReadFile(envFileName)
 	if err != nil {
@@ -240,15 +237,6 @@ func getRelevantEnvVars(pid int) ProcessEnvs {
 	}
 
 	r := bufio.NewReader(strings.NewReader(string(fileContent)))
-
-	// We only care about the environment variables that we might overwrite
-	relevantOverwriteEnvVars := make(map[string]interface{})
-	for k := range envOverwrite.EnvValuesMap {
-		relevantOverwriteEnvVars[k] = nil
-	}
-
-	// Add LD_PRELOAD to the list of relevant environment variables
-	relevantOverwriteEnvVars[consts.LdPreloadEnvVarName] = nil
 
 	overWriteEnvsResult := make(map[string]string)
 	detailedEnvsResult := make(map[string]string)
@@ -269,16 +257,19 @@ func getRelevantEnvVars(pid int) ProcessEnvs {
 			continue
 		}
 
-		if _, ok := relevantOverwriteEnvVars[envParts[0]]; ok {
-			overWriteEnvsResult[envParts[0]] = envParts[1]
+		envName := envParts[0]
+		envDetectionValue := envParts[1]
+
+		if _, ok := appendEnvVarNames[envName]; ok {
+			overWriteEnvsResult[envName] = envDetectionValue
 		}
 
-		if _, ok := LangsVersionEnvs[envParts[0]]; ok {
-			detailedEnvsResult[envParts[0]] = envParts[1]
+		if _, ok := LangsVersionEnvs[envName]; ok {
+			detailedEnvsResult[envName] = envDetectionValue
 		}
 
-		if _, ok := OtherAgentEnvs[envParts[0]]; ok {
-			detailedEnvsResult[envParts[0]] = envParts[1]
+		if _, ok := OtherAgentEnvs[envName]; ok {
+			detailedEnvsResult[envName] = envDetectionValue
 		}
 	}
 


### PR DESCRIPTION
## Description

There is an ongoing effort to consolidate all "distro" related properties into a single place which is the distro manifest.
At the moment, we maintain an `overwriter.go` file with specific env variables per language we use for appending odigos values, and for specifying the override per language.

This PR is another step towards retiring these old code "maps" and "ifs" that controls distro-based logic. once we migrate all uses of this overwrite file, we can delete it and maintain everything env related in the distro manifest.

- migrate odiglet runtime detection to use distro for append environment
- move this configuration to reside under the `environmentVaribales` under each distro - which makes more sense.
- change the configuration option for this property, to allow more flexible replace pattern

Notice: these setting should also be fixed as followup in:
- odiglet ebpf manager
- instrometor webhook
- enterprise loader

## How Has This Been Tested?

Run manually + existing tests that should cover many of these cases.

## Kubernetes Checklist

Not related to k8s in any way

## User Facing Changes

Internal refactor, no changes to user.