### PR TITLE
Service graph

### DIFF
--- a/autoscaler/controllers/clustercollector/configmap.go
+++ b/autoscaler/controllers/clustercollector/configmap.go
@@ -365,15 +365,15 @@ func getSourcesForDataStream(
 
 	sourcesFilters := make([]pipelinegen.SourceFilter, 0, len(instrumentationConfigsList.Items))
 	for _, instrumentationConfig := range instrumentationConfigsList.Items {
-		workloadName, workloadKind, err := workload.ExtractWorkloadInfoFromRuntimeObjectName(instrumentationConfig.Name)
+		pw, err := workload.ExtractWorkloadInfoFromRuntimeObjectName(instrumentationConfig.Name, instrumentationConfig.Namespace)
 		if err != nil {
 			logger.Error(err, "Failed to extract workload info from instrumentation config name", "instrumentationConfig", instrumentationConfig.Name)
 			continue
 		}
 		sourcesFilters = append(sourcesFilters, pipelinegen.SourceFilter{
 			Namespace: instrumentationConfig.Namespace,
-			Kind:      string(workloadKind),
-			Name:      workloadName,
+			Kind:      string(pw.Kind),
+			Name:      pw.Name,
 		})
 	}
 

--- a/common/pipelinegen/config_builder.go
+++ b/common/pipelinegen/config_builder.go
@@ -10,6 +10,7 @@ import (
 	"github.com/odigos-io/odigos/common"
 	"github.com/odigos-io/odigos/common/config"
 	"github.com/odigos-io/odigos/common/consts"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
 func GetGatewayConfig(
@@ -213,7 +214,7 @@ func insertServiceGraphPipeline(currentConfig *config.Config) {
 		"store": config.GenericMap{
 			"ttl": "5m",
 		},
-		"dimensions": []string{"service.name"},
+		"dimensions": []string{string(semconv.ServiceNameKey)},
 	}
 
 	// Add the service graph pipeline to receive the service graph metrics from the root traces pipeline

--- a/common/pipelinegen/config_builder.go
+++ b/common/pipelinegen/config_builder.go
@@ -5,12 +5,12 @@ import (
 	"slices"
 	"strings"
 
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"gopkg.in/yaml.v2"
 
 	"github.com/odigos-io/odigos/common"
 	"github.com/odigos-io/odigos/common/config"
 	"github.com/odigos-io/odigos/common/consts"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
 func GetGatewayConfig(
@@ -228,8 +228,8 @@ func insertServiceGraphPipeline(currentConfig *config.Config) {
 	pipeline := currentConfig.Service.Pipelines[rootPipelineName]
 	pipeline.Exporters = append(pipeline.Exporters, "servicegraph")
 	currentConfig.Service.Pipelines[rootPipelineName] = pipeline
-
 }
+
 func GetBasicConfig(memoryLimiterConfig config.GenericMap) *config.Config {
 	return &config.Config{
 		Connectors: config.GenericMap{},

--- a/frontend/services/collector_metrics/cluster_collector.go
+++ b/frontend/services/collector_metrics/cluster_collector.go
@@ -365,6 +365,35 @@ func (sdm *singleDestinationMetrics) metrics() trafficMetrics {
 	return resultMetrics
 }
 
+// ServiceGraphEdges returns a snapshot of the service graph edges
+// It is used to build the service graph in the UI
+// example of the structure of the result:
+// map[
+//   coupon: map[
+//     membership:        {0 2025-06-24 16:16:39.384 +0000 UTC}
+//   ]
+
+//   frontend: map[
+//     coupon:            {0 2025-06-24 16:16:39.384 +0000 UTC}
+//     currency:          {0 2025-06-24 16:16:39.384 +0000 UTC}
+//     geolocation:       {0 2025-06-24 16:16:39.384 +0000 UTC}
+//     inventory:         {0 2025-06-24 16:16:39.384 +0000 UTC}
+//     pricing:           {0 2025-06-24 16:16:39.384 +0000 UTC}
+//   ]
+
+//   prometheus-server: map[
+//     prometheus-kube-state-metrics:      {181 2025-06-25 06:01:07.771 +0000 UTC}
+//     prometheus-prometheus-node-exporter:{181 2025-06-25 06:01:07.771 +0000 UTC}
+//     prometheus-prometheus-pushgateway:  {181 2025-06-25 06:01:07.771 +0000 UTC}
+//     prometheus-server:                  {181 2025-06-25 06:01:07.771 +0000 UTC}
+//   ]
+
+//   user: map[
+//     frontend:                          {0 2025-06-24 16:16:39.384 +0000 UTC}
+//     prometheus-server:                {2814 2025-06-25 06:01:07.771 +0000 UTC}
+//   ]
+// ]
+
 func (ccm *clusterCollectorMetrics) serviceGraphEdges() map[string]map[string]ServiceGraphEdge {
 	ccm.serviceGraph.mu.Lock()
 	defer ccm.serviceGraph.mu.Unlock()

--- a/frontend/services/collector_metrics/cluster_collector.go
+++ b/frontend/services/collector_metrics/cluster_collector.go
@@ -1,7 +1,6 @@
 package collectormetrics
 
 import (
-	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -474,23 +473,5 @@ func (sg *ServiceGraph) UpdateFromDataPoint(dp pmetric.NumberDataPoint) {
 		// always overwrite because it's a cumulative counter
 		edge.RequestCount = val
 		edge.LastUpdated = timestamp
-	}
-}
-
-func (sg *ServiceGraph) DebugPrintEdges() {
-	sg.mu.Lock()
-	defer sg.mu.Unlock()
-
-	if len(sg.edges) == 0 {
-		fmt.Println("🔍 Service graph is currently empty.")
-		return
-	}
-
-	fmt.Println("📊 Current Service Graph Edges:")
-	for client, servers := range sg.edges {
-		for server, edge := range servers {
-			fmt.Printf("  %s → %s : %d requests (last updated: %s)\n",
-				client, server, edge.RequestCount, edge.LastUpdated.Format(time.RFC3339))
-		}
 	}
 }

--- a/frontend/services/collector_metrics/collector_metrics.go
+++ b/frontend/services/collector_metrics/collector_metrics.go
@@ -66,9 +66,9 @@ func (tm *trafficMetrics) String() string {
 }
 
 type OdigosMetricsConsumer struct {
-	sources      sourcesMetrics
-	destinations destinationsMetrics
-	deletedChan  chan notification
+	sources                 sourcesMetrics
+	clusterCollectorMetrics clusterCollectorMetrics
+	deletedChan             chan notification
 }
 
 var (
@@ -110,9 +110,9 @@ func (c *OdigosMetricsConsumer) runNotificationsLoop(ctx context.Context) {
 			case nodeCollector:
 				c.sources.removeNodeCollector(n.object)
 			case clusterCollector:
-				c.destinations.removeClusterCollector(n.object)
+				c.clusterCollectorMetrics.removeClusterCollector(n.object)
 			case destination:
-				c.destinations.removeDestination(n.object)
+				c.clusterCollectorMetrics.removeDestination(n.object)
 			case source:
 				switch n.eventType {
 				case watch.Deleted:
@@ -151,7 +151,7 @@ func (c *OdigosMetricsConsumer) ConsumeMetrics(ctx context.Context, md pmetric.M
 	}
 
 	if strings.HasPrefix(senderPod, k8sconsts.OdigosClusterCollectorDeploymentName) {
-		c.destinations.handleClusterCollectorMetrics(senderPod, md)
+		c.clusterCollectorMetrics.handleClusterCollectorMetrics(senderPod, md)
 		return nil
 	}
 
@@ -160,9 +160,9 @@ func (c *OdigosMetricsConsumer) ConsumeMetrics(ctx context.Context, md pmetric.M
 
 func NewOdigosMetrics() *OdigosMetricsConsumer {
 	return &OdigosMetricsConsumer{
-		sources:      newSourcesMetrics(),
-		destinations: newDestinationsMetrics(),
-		deletedChan:  make(chan notification),
+		sources:                 newSourcesMetrics(),
+		clusterCollectorMetrics: newClusterCollectorMetrics(),
+		deletedChan:             make(chan notification),
 	}
 }
 
@@ -216,7 +216,7 @@ func (c *OdigosMetricsConsumer) GetSingleSourceMetrics(sID common.SourceID) (tra
 }
 
 func (c *OdigosMetricsConsumer) GetSingleDestinationMetrics(dID string) (trafficMetrics, bool) {
-	return c.destinations.metricsByID(dID)
+	return c.clusterCollectorMetrics.metricsByID(dID)
 }
 
 func (c *OdigosMetricsConsumer) GetSourcesMetrics() map[common.SourceID]trafficMetrics {
@@ -224,5 +224,9 @@ func (c *OdigosMetricsConsumer) GetSourcesMetrics() map[common.SourceID]trafficM
 }
 
 func (c *OdigosMetricsConsumer) GetDestinationsMetrics() map[string]trafficMetrics {
-	return c.destinations.metrics()
+	return c.clusterCollectorMetrics.destinationsMetrics()
+}
+
+func (c *OdigosMetricsConsumer) GetServiceGraphEdges() map[string]map[string]ServiceGraphEdge {
+	return c.clusterCollectorMetrics.serviceGraphEdges()
 }


### PR DESCRIPTION
## Description
Service-to-service interactions is not only a powerful observability feature, but also a valuable debugging tool.
This service graph view helps verify that traces are flowing correctly, since the graph is built directly from trace-based metrics.
It also provides real-time visibility into service connectivity patterns and traffic volume.

This PR adds support for exposing Service Graph metrics in the Odigos Gateway to enable UI visualization of service-to-service interactions.

1. Parses servicegraph_traces_service_graph_request_total metrics received from cluster collectors.
2. Maintains an in-memory structure (ServiceGraph) to store cumulative request counts between services.
3. Exposes the service graph via a new GetServiceGraphEdges() method.
4.Extends the gateway to forward these metrics to the UI layer.
5. The graph is represented as a `map[client][server]ServiceGraphEdge`, capturing both request count and last update time.

This functionality lays the groundwork for visualizing live service dependency maps.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
