### PR TITLE
refactor: pods webhook read signals from ic

### DIFF
--- a/instrumentor/controllers/agentenabled/pods_webhook.go
+++ b/instrumentor/controllers/agentenabled/pods_webhook.go
@@ -17,7 +17,6 @@ import (
 	podutils "github.com/odigos-io/odigos/instrumentor/internal/pod"
 	webhookenvinjector "github.com/odigos-io/odigos/instrumentor/internal/webhook_env_injector"
 	"github.com/odigos-io/odigos/instrumentor/sdks"
-	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	k8sutils "github.com/odigos-io/odigos/k8sutils/pkg/utils"
 	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
 	corev1 "k8s.io/api/core/v1"
@@ -71,17 +70,6 @@ func (p *PodsWebhook) Default(ctx context.Context, obj runtime.Object) error {
 		return nil
 	}
 
-	// get the node collector group for the enabled signals.
-	// this is temporary and should be refactored so that signals are written to the instrumentation config per container.
-	// it is better to do as little resource fetching as possible in webhook.
-	odigosNamespace := env.GetCurrentNamespace()
-	var nodeCollectorGroup odigosv1.CollectorsGroup
-	if err := p.Get(ctx, client.ObjectKey{Namespace: odigosNamespace, Name: k8sconsts.OdigosNodeCollectorCollectorGroupName}, &nodeCollectorGroup); err != nil {
-		logger.Error(err, "failed to get node collector group. Skipping Injection of ODIGOS agent")
-		return client.IgnoreNotFound(err)
-	}
-	enabledSignals := nodeCollectorGroup.Status.ReceiverSignals
-
 	odigosConfig, err := k8sutils.GetCurrentOdigosConfig(ctx, p.Client)
 	if err != nil {
 		logger.Error(err, "failed to get ODIGOS config. Skipping Injection of ODIGOS agent")
@@ -119,7 +107,7 @@ func (p *PodsWebhook) Default(ctx context.Context, obj runtime.Object) error {
 			continue
 		}
 
-		containerVolumeMounted, err := p.injectOdigosToContainer(containerConfig, runtimeDetails, podContainerSpec, *pw, serviceName, odigosConfig, enabledSignals)
+		containerVolumeMounted, err := p.injectOdigosToContainer(containerConfig, runtimeDetails, podContainerSpec, *pw, serviceName, odigosConfig)
 		if err != nil {
 			logger.Error(err, "failed to inject ODIGOS agent to container")
 			continue
@@ -213,7 +201,7 @@ func (p *PodsWebhook) injectOdigosInstrumentation(ctx context.Context, pod *core
 	return nil
 }
 
-func (p *PodsWebhook) injectOdigosToContainer(containerConfig *odigosv1.ContainerAgentConfig, runtimeDetails *odigosv1.RuntimeDetailsByContainer, podContainerSpec *corev1.Container, pw k8sconsts.PodWorkload, serviceName string, config common.OdigosConfiguration, enabledSignals []common.ObservabilitySignal) (bool, error) {
+func (p *PodsWebhook) injectOdigosToContainer(containerConfig *odigosv1.ContainerAgentConfig, runtimeDetails *odigosv1.RuntimeDetailsByContainer, podContainerSpec *corev1.Container, pw k8sconsts.PodWorkload, serviceName string, config common.OdigosConfiguration) (bool, error) {
 	distroName := containerConfig.OtelDistroName
 	distroMetadata := p.DistrosGetter.GetDistroByName(distroName)
 	if distroMetadata == nil {
@@ -232,7 +220,10 @@ func (p *PodsWebhook) injectOdigosToContainer(containerConfig *odigosv1.Containe
 		existingEnvNames = podswebhook.InjectOpampServerEnvVar(existingEnvNames, podContainerSpec)
 	}
 	if distroMetadata.EnvironmentVariables.SignalsAsStaticOtelEnvVars {
-		existingEnvNames = podswebhook.InjectSignalsAsStaticOtelEnvVars(existingEnvNames, podContainerSpec, enabledSignals)
+		tracesEnabled := containerConfig.Traces != nil
+		metricsEnabled := containerConfig.Metrics != nil
+		logsEnabled := containerConfig.Logs != nil
+		existingEnvNames = podswebhook.InjectSignalsAsStaticOtelEnvVars(existingEnvNames, podContainerSpec, tracesEnabled, metricsEnabled, logsEnabled)
 	}
 	if distroMetadata.EnvironmentVariables.OtlpHttpLocalNode {
 		existingEnvNames = podswebhook.InjectOtlpHttpEndpointEnvVar(existingEnvNames, podContainerSpec)

--- a/instrumentor/controllers/agentenabled/podswebhook/env.go
+++ b/instrumentor/controllers/agentenabled/podswebhook/env.go
@@ -1,7 +1,6 @@
 package podswebhook
 
 import (
-	"slices"
 	"strings"
 
 	"github.com/odigos-io/odigos/api/k8sconsts"
@@ -87,22 +86,22 @@ func InjectOtlpHttpEndpointEnvVar(existingEnvNames EnvVarNamesMap, container *co
 	return existingEnvNames
 }
 
-func signalOtlpExporterEnvValue(enabledSignals []common.ObservabilitySignal, signal common.ObservabilitySignal) string {
-	if slices.Contains(enabledSignals, signal) {
+func signalOtlpExporterEnvValue(enabled bool) string {
+	if enabled {
 		return "otlp"
 	}
 	return "none"
 }
 
-func InjectSignalsAsStaticOtelEnvVars(existingEnvNames EnvVarNamesMap, container *corev1.Container, enabledSignals []common.ObservabilitySignal) EnvVarNamesMap {
+func InjectSignalsAsStaticOtelEnvVars(existingEnvNames EnvVarNamesMap, container *corev1.Container, tracesEnabled bool, metricsEnabled bool, logsEnabled bool) EnvVarNamesMap {
 
-	logsExporter := signalOtlpExporterEnvValue(enabledSignals, common.LogsObservabilitySignal)
+	logsExporter := signalOtlpExporterEnvValue(logsEnabled)
 	existingEnvNames = InjectEnvVarToPodContainer(existingEnvNames, container, commonconsts.OtelLogsExporter, logsExporter, nil)
 
-	metricsExporter := signalOtlpExporterEnvValue(enabledSignals, common.MetricsObservabilitySignal)
+	metricsExporter := signalOtlpExporterEnvValue(metricsEnabled)
 	existingEnvNames = InjectEnvVarToPodContainer(existingEnvNames, container, commonconsts.OtelMetricsExporter, metricsExporter, nil)
 
-	tracesExporter := signalOtlpExporterEnvValue(enabledSignals, common.TracesObservabilitySignal)
+	tracesExporter := signalOtlpExporterEnvValue(tracesEnabled)
 	existingEnvNames = InjectEnvVarToPodContainer(existingEnvNames, container, commonconsts.OtelTracesExporter, tracesExporter, nil)
 
 	return existingEnvNames


### PR DESCRIPTION
A small refactor.

In the pods webhook, we are currentlyr reading the enabled signals from the collectors group.

Now that this info is found on the containers array of instrumentation config spec, we can use it from there, and avoid a cache call from webhook to get this.