### PR TITLE
fix: otlp oauth required fields prevent adding non-auth dest

### DIFF
--- a/common/config/genericotlp.go
+++ b/common/config/genericotlp.go
@@ -41,7 +41,10 @@ func (g *GenericOTLP) ModifyConfig(dest ExporterConfigurer, currentConfig *Confi
 	userTlsEnabled := dest.GetConfig()[genericOtlpTlsKey] == "true"
 
 	// Check for OAuth2 authentication early to determine TLS requirements
-	oauth2ExtensionName, oauth2ExtensionConf := applyGrpcOAuth2Auth(dest)
+	oauth2ExtensionName, oauth2ExtensionConf, err := applyGrpcOAuth2Auth(dest)
+	if err != nil {
+		return nil, err
+	}
 	oauth2Enabled := oauth2ExtensionName != ""
 
 	// Determine final TLS setting: gRPC requires TLS when using authentication credentials like OAuth2
@@ -139,12 +142,12 @@ func (g *GenericOTLP) ModifyConfig(dest ExporterConfigurer, currentConfig *Confi
 	return pipelineNames, nil
 }
 
-func applyGrpcOAuth2Auth(dest ExporterConfigurer) (extensionName string, extensionConf *GenericMap) {
+func applyGrpcOAuth2Auth(dest ExporterConfigurer) (extensionName string, extensionConf *GenericMap, err error) {
 	config := dest.GetConfig()
 
 	oauth2Enabled := config[otlpGrpcOAuth2EnabledKey]
 	if oauth2Enabled != "true" {
-		return "", nil
+		return "", nil, nil
 	}
 
 	clientId := config[otlpGrpcOAuth2ClientIdKey]
@@ -153,7 +156,7 @@ func applyGrpcOAuth2Auth(dest ExporterConfigurer) (extensionName string, extensi
 	// Note: client secret is stored in the secret and injected as environment variable
 	// We don't validate it here since it's not in the regular config data
 	if clientId == "" || tokenUrl == "" {
-		return "", nil
+		return "", nil, errors.New("when OAuth2 is enabled, client ID and token URL must be provided")
 	}
 
 	extensionName = "oauth2client/otlpgrpc-" + dest.GetID()
@@ -186,5 +189,5 @@ func applyGrpcOAuth2Auth(dest ExporterConfigurer) (extensionName string, extensi
 		(*extensionConf)["scopes"] = scopesList
 	}
 
-	return extensionName, extensionConf
+	return extensionName, extensionConf, nil
 }

--- a/common/config/otlphttp.go
+++ b/common/config/otlphttp.go
@@ -32,6 +32,7 @@ func (g *OTLPHttp) DestType() common.DestinationType {
 	return common.OtlpHttpDestinationType
 }
 
+//nolint:funlen // TODO: make it shorter
 func (g *OTLPHttp) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) ([]string, error) {
 	config := dest.GetConfig()
 

--- a/common/config/otlphttp_test.go
+++ b/common/config/otlphttp_test.go
@@ -208,6 +208,7 @@ func TestOAuth2Configuration(t *testing.T) {
 	tests := []struct {
 		name            string
 		config          map[string]string
+		expectedError   bool
 		expectedAuth    bool
 		expectedExtName string
 		expectedScopes  []string
@@ -216,12 +217,12 @@ func TestOAuth2Configuration(t *testing.T) {
 		{
 			name: "OAuth2 enabled with all parameters",
 			config: map[string]string{
-				"OTLP_HTTP_ENDPOINT":               "https://example.com:4318",
-				"OTLP_HTTP_OAUTH2_ENABLED":         "true",
-				"OTLP_HTTP_OAUTH2_CLIENT_ID":       "test-client-id",
-				"OTLP_HTTP_OAUTH2_TOKEN_URL":       "https://auth.example.com/token",
-				"OTLP_HTTP_OAUTH2_SCOPES":          "api.metrics,api.traces",
-				"OTLP_HTTP_OAUTH2_AUDIENCE":        "api.example.com",
+				"OTLP_HTTP_ENDPOINT":         "https://example.com:4318",
+				"OTLP_HTTP_OAUTH2_ENABLED":   "true",
+				"OTLP_HTTP_OAUTH2_CLIENT_ID": "test-client-id",
+				"OTLP_HTTP_OAUTH2_TOKEN_URL": "https://auth.example.com/token",
+				"OTLP_HTTP_OAUTH2_SCOPES":    "api.metrics,api.traces",
+				"OTLP_HTTP_OAUTH2_AUDIENCE":  "api.example.com",
 				// Note: OTLP_HTTP_OAUTH2_CLIENT_SECRET is handled separately through secrets
 			},
 			expectedAuth:    true,
@@ -232,15 +233,15 @@ func TestOAuth2Configuration(t *testing.T) {
 		{
 			name: "Real user configuration",
 			config: map[string]string{
-				"OTLP_HTTP_ENDPOINT":               "http://eden.com",
-				"OTLP_HTTP_COMPRESSION":            "none",
-				"OTLP_HTTP_TLS_ENABLED":            "false",
-				"OTLP_HTTP_INSECURE_SKIP_VERIFY":   "false",
-				"OTLP_HTTP_OAUTH2_ENABLED":         "true",
-				"OTLP_HTTP_OAUTH2_CLIENT_ID":       "123123",
-				"OTLP_HTTP_OAUTH2_TOKEN_URL":       "https://gooogle.com",
-				"OTLP_HTTP_OAUTH2_SCOPES":          "asdasd",
-				"OTLP_HTTP_OAUTH2_AUDIENCE":        "ccccx",
+				"OTLP_HTTP_ENDPOINT":             "http://eden.com",
+				"OTLP_HTTP_COMPRESSION":          "none",
+				"OTLP_HTTP_TLS_ENABLED":          "false",
+				"OTLP_HTTP_INSECURE_SKIP_VERIFY": "false",
+				"OTLP_HTTP_OAUTH2_ENABLED":       "true",
+				"OTLP_HTTP_OAUTH2_CLIENT_ID":     "123123",
+				"OTLP_HTTP_OAUTH2_TOKEN_URL":     "https://gooogle.com",
+				"OTLP_HTTP_OAUTH2_SCOPES":        "asdasd",
+				"OTLP_HTTP_OAUTH2_AUDIENCE":      "ccccx",
 				// Client secret stored separately in secret
 			},
 			expectedAuth:    true,
@@ -295,16 +296,15 @@ func TestOAuth2Configuration(t *testing.T) {
 				"OTLP_HTTP_OAUTH2_CLIENT_ID": "test-client-id",
 				// Missing TOKEN_URL
 			},
-			expectedAuth:    false,
-			expectTLSConfig: false,
+			expectedError: true,
 		},
 		{
 			name: "Basic Auth takes precedence when OAuth2 disabled",
 			config: map[string]string{
-				"OTLP_HTTP_ENDPOINT":                 "https://example.com:4318",
-				"OTLP_HTTP_OAUTH2_ENABLED":           "false",
-				"OTLP_HTTP_BASIC_AUTH_USERNAME":      "user",
-				"OTLP_HTTP_BASIC_AUTH_PASSWORD":      "pass",
+				"OTLP_HTTP_ENDPOINT":            "https://example.com:4318",
+				"OTLP_HTTP_OAUTH2_ENABLED":      "false",
+				"OTLP_HTTP_BASIC_AUTH_USERNAME": "user",
+				"OTLP_HTTP_BASIC_AUTH_PASSWORD": "pass",
 			},
 			expectedAuth:    true,
 			expectedExtName: "basicauth/otlphttp-test-id",
@@ -313,12 +313,12 @@ func TestOAuth2Configuration(t *testing.T) {
 		{
 			name: "OAuth2 takes precedence over Basic Auth",
 			config: map[string]string{
-				"OTLP_HTTP_ENDPOINT":                 "https://example.com:4318",
-				"OTLP_HTTP_OAUTH2_ENABLED":           "true",
-				"OTLP_HTTP_OAUTH2_CLIENT_ID":         "test-client-id",
-				"OTLP_HTTP_OAUTH2_TOKEN_URL":         "https://auth.example.com/token",
-				"OTLP_HTTP_BASIC_AUTH_USERNAME":      "user",
-				"OTLP_HTTP_BASIC_AUTH_PASSWORD":      "pass",
+				"OTLP_HTTP_ENDPOINT":            "https://example.com:4318",
+				"OTLP_HTTP_OAUTH2_ENABLED":      "true",
+				"OTLP_HTTP_OAUTH2_CLIENT_ID":    "test-client-id",
+				"OTLP_HTTP_OAUTH2_TOKEN_URL":    "https://auth.example.com/token",
+				"OTLP_HTTP_BASIC_AUTH_USERNAME": "user",
+				"OTLP_HTTP_BASIC_AUTH_PASSWORD": "pass",
 			},
 			expectedAuth:    true,
 			expectedExtName: "oauth2client/otlphttp-test-id",
@@ -336,7 +336,7 @@ func TestOAuth2Configuration(t *testing.T) {
 
 			// Create OTLP HTTP configurator
 			otlpHttp := &OTLPHttp{}
-			
+
 			// Create initial config
 			config := &Config{
 				Extensions: make(map[string]interface{}),
@@ -349,6 +349,10 @@ func TestOAuth2Configuration(t *testing.T) {
 
 			// Apply the configuration
 			pipelineNames, err := otlpHttp.ModifyConfig(dest, config)
+			if tt.expectedError {
+				assert.Error(t, err)
+				return
+			}
 
 			if tt.config["OTLP_HTTP_ENDPOINT"] == "" {
 				// Should fail if no endpoint
@@ -381,24 +385,24 @@ func TestOAuth2Configuration(t *testing.T) {
 			if tt.expectedAuth {
 				assert.Contains(t, config.Service.Extensions, tt.expectedExtName)
 				assert.Contains(t, config.Extensions, tt.expectedExtName)
-				
+
 				// Verify the extension configuration
 				if tt.expectedExtName == "oauth2client/otlphttp-test-id" {
 					extConfig := config.Extensions[tt.expectedExtName].(GenericMap)
 					assert.Equal(t, tt.config["OTLP_HTTP_OAUTH2_CLIENT_ID"], extConfig["client_id"])
 					assert.Equal(t, "${OTLP_HTTP_OAUTH2_CLIENT_SECRET}", extConfig["client_secret"])
 					assert.Equal(t, tt.config["OTLP_HTTP_OAUTH2_TOKEN_URL"], extConfig["token_url"])
-					
+
 					if tt.expectedScopes != nil {
 						assert.Equal(t, tt.expectedScopes, extConfig["scopes"])
 					}
-					
+
 					if tt.config["OTLP_HTTP_OAUTH2_AUDIENCE"] != "" {
 						endpointParams := extConfig["endpoint_params"].(GenericMap)
 						assert.Equal(t, tt.config["OTLP_HTTP_OAUTH2_AUDIENCE"], endpointParams["audience"])
 					}
 				}
-				
+
 				// Verify exporter has auth configuration
 				authConfig := exporterConfig["auth"].(GenericMap)
 				assert.Equal(t, tt.expectedExtName, authConfig["authenticator"])

--- a/destinations/data/otlp.yaml
+++ b/destinations/data/otlp.yaml
@@ -62,7 +62,7 @@ spec:
       componentType: input
       componentProps:
         type: text
-        required: true
+        required: false # TODO: required only if 'Enable OAuth2' is true
         placeholder: 'your-client-id'
         tooltip: 'OAuth2 client identifier for client credentials flow'
       renderCondition: ['OTLP_GRPC_OAUTH2_ENABLED', '==', 'true']
@@ -71,7 +71,7 @@ spec:
       componentType: input
       componentProps:
         type: password
-        required: true
+        required: false # TODO: required only if 'Enable OAuth2' is true
         placeholder: 'your-client-secret'
         tooltip: 'OAuth2 client secret for client credentials flow'
       renderCondition: ['OTLP_GRPC_OAUTH2_ENABLED', '==', 'true']
@@ -81,7 +81,7 @@ spec:
       componentType: input
       componentProps:
         type: text
-        required: true
+        required: false # TODO: required only if 'Enable OAuth2' is true
         placeholder: 'https://example.com/oauth2/token'
         tooltip: 'OAuth2 token endpoint URL for obtaining access tokens'
       renderCondition: ['OTLP_GRPC_OAUTH2_ENABLED', '==', 'true']

--- a/destinations/data/otlphttp.yaml
+++ b/destinations/data/otlphttp.yaml
@@ -62,7 +62,7 @@ spec:
       componentType: input
       componentProps:
         type: text
-        required: true
+        required: false # TODO: required only if 'Enable OAuth2' is true
         placeholder: 'your-client-id'
         tooltip: 'OAuth2 client identifier for client credentials flow'
       renderCondition: ['OTLP_HTTP_OAUTH2_ENABLED', '==', 'true']
@@ -72,7 +72,7 @@ spec:
       componentType: input
       componentProps:
         type: password
-        required: true
+        required: false # TODO: required only if 'Enable OAuth2' is true
         placeholder: 'your-client-secret'
         tooltip: 'OAuth2 client secret for client credentials flow'
       renderCondition: ['OTLP_HTTP_OAUTH2_ENABLED', '==', 'true']
@@ -83,7 +83,7 @@ spec:
       componentType: input
       componentProps:
         type: text
-        required: true
+        required: false # TODO: required only if 'Enable OAuth2' is true
         placeholder: 'https://example.com/oauth2/token'
         tooltip: 'OAuth2 token endpoint URL for obtaining access tokens'
       renderCondition: ['OTLP_HTTP_OAUTH2_ENABLED', '==', 'true']

--- a/docs/backends/otlp.mdx
+++ b/docs/backends/otlp.mdx
@@ -57,13 +57,13 @@ For advanced users trying to implement complex observability pipelines, Odigos s
 - **OTLP_GRPC_OAUTH2_ENABLED** `boolean` : Enable OAuth2. Enable OAuth2 client credentials authentication
   - This field is optional and defaults to `False`
 - **OTLP_GRPC_OAUTH2_CLIENT_ID** `string` : OAuth2 Client ID. OAuth2 client identifier for client credentials flow
-  - This field is required
+  - This field is optional
   - Example: `your-client-id`
 - **OTLP_GRPC_OAUTH2_CLIENT_SECRET** `string` : OAuth2 Client Secret. OAuth2 client secret for client credentials flow
-  - This field is required
+  - This field is optional
   - Example: `your-client-secret`
 - **OTLP_GRPC_OAUTH2_TOKEN_URL** `string` : OAuth2 Token URL. OAuth2 token endpoint URL for obtaining access tokens
-  - This field is required
+  - This field is optional
   - Example: `https://example.com/oauth2/token`
 - **OTLP_GRPC_OAUTH2_SCOPES** `string` : OAuth2 Scopes. Comma-separated list of OAuth2 scopes to request (e.g., "api.metrics,api.traces")
   - This field is optional
@@ -111,20 +111,21 @@ There are two primary methods for configuring destinations in Odigos:
     spec:
       data:
         OTLP_GRPC_ENDPOINT: <OTLP gRPC Endpoint>
-        OTLP_GRPC_OAUTH2_CLIENT_ID: <OAuth2 Client ID>
-        OTLP_GRPC_OAUTH2_TOKEN_URL: <OAuth2 Token URL>
         # Note: The commented fields below are optional.
         # OTLP_GRPC_COMPRESSION: <Destination Compression Type (default: none) (options: [none, gzip, snappy, lz4, zlib, deflate, zstd])>
         # OTLP_GRPC_HEADERS: <Headers>
         # OTLP_GRPC_OAUTH2_ENABLED: <Enable OAuth2>
+        # OTLP_GRPC_OAUTH2_CLIENT_ID: <OAuth2 Client ID>
+        # OTLP_GRPC_OAUTH2_TOKEN_URL: <OAuth2 Token URL>
         # OTLP_GRPC_OAUTH2_SCOPES: <OAuth2 Scopes>
         # OTLP_GRPC_OAUTH2_AUDIENCE: <OAuth2 Audience>
         # OTLP_GRPC_TLS_ENABLED: <Enable TLS>
         # OTLP_GRPC_CA_PEM: <Certificate Authority>
         # OTLP_GRPC_INSECURE_SKIP_VERIFY: <Insecure Skip Verify>
       destinationName: otlp
-      secretRef:
-        name: otlp-secret
+      # Uncomment the 'secretRef' below if you are using the optional Secret.
+      # secretRef:
+      #   name: otlp-secret
       signals:
       - TRACES
       - METRICS
@@ -133,14 +134,15 @@ There are two primary methods for configuring destinations in Odigos:
 
     ---
 
-    apiVersion: v1
-    data:
-      OTLP_GRPC_OAUTH2_CLIENT_SECRET: <Base64 OAuth2 Client Secret>
-    kind: Secret
-    metadata:
-      name: otlp-secret
-      namespace: odigos-system
-    type: Opaque
+    # The following Secret is optional. Uncomment the entire block if you need to use it.
+    # apiVersion: v1
+    # data:
+    #   OTLP_GRPC_OAUTH2_CLIENT_SECRET: <Base64 OAuth2 Client Secret>
+    # kind: Secret
+    # metadata:
+    #   name: otlp-secret
+    #   namespace: odigos-system
+    # type: Opaque
     ```
   </Step>
   <Step>

--- a/docs/backends/otlphttp.mdx
+++ b/docs/backends/otlphttp.mdx
@@ -65,13 +65,13 @@ To configure basic authentication, use the optional config options `Basic Auth U
 - **OTLP_HTTP_OAUTH2_ENABLED** `boolean` : Enable OAuth2. Enable OAuth2 client credentials authentication
   - This field is optional and defaults to `False`
 - **OTLP_HTTP_OAUTH2_CLIENT_ID** `string` : OAuth2 Client ID. OAuth2 client identifier for client credentials flow
-  - This field is required
+  - This field is optional
   - Example: `your-client-id`
 - **OTLP_HTTP_OAUTH2_CLIENT_SECRET** `string` : OAuth2 Client Secret. OAuth2 client secret for client credentials flow
-  - This field is required
+  - This field is optional
   - Example: `your-client-secret`
 - **OTLP_HTTP_OAUTH2_TOKEN_URL** `string` : OAuth2 Token URL. OAuth2 token endpoint URL for obtaining access tokens
-  - This field is required
+  - This field is optional
   - Example: `https://example.com/oauth2/token`
 - **OTLP_HTTP_OAUTH2_SCOPES** `string` : OAuth2 Scopes. Comma-separated list of OAuth2 scopes to request (e.g., "api.metrics,api.traces")
   - This field is optional
@@ -123,11 +123,11 @@ There are two primary methods for configuring destinations in Odigos:
     spec:
       data:
         OTLP_HTTP_ENDPOINT: <OTLP http Endpoint>
-        OTLP_HTTP_OAUTH2_CLIENT_ID: <OAuth2 Client ID>
-        OTLP_HTTP_OAUTH2_TOKEN_URL: <OAuth2 Token URL>
         # Note: The commented fields below are optional.
         # OTLP_HTTP_BASIC_AUTH_USERNAME: <Basic Auth Username>
         # OTLP_HTTP_OAUTH2_ENABLED: <Enable OAuth2>
+        # OTLP_HTTP_OAUTH2_CLIENT_ID: <OAuth2 Client ID>
+        # OTLP_HTTP_OAUTH2_TOKEN_URL: <OAuth2 Token URL>
         # OTLP_HTTP_OAUTH2_SCOPES: <OAuth2 Scopes>
         # OTLP_HTTP_OAUTH2_AUDIENCE: <OAuth2 Audience>
         # OTLP_HTTP_COMPRESSION: <Destination Compression Type (default: none) (options: [none, gzip, snappy, lz4, zlib, deflate, zstd])>


### PR DESCRIPTION
## Description

The otlp and otlp-http destination requires few oauth2 fields.
If user want an otlp destination without these fields, the UI fails to add the new destination since those required fields are empty.

Fix: make the fields optional and check during reconcile

## How Has This Been Tested?

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [X] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

No

## User Facing Changes

user can add new otlp and otlphttp destinations after the fix
