### PR TITLE
feat: adjust owner reference observation to cronjobs

### DIFF
--- a/autoscaler/controllers/actions/k8sattributesresolver_controller.go
+++ b/autoscaler/controllers/actions/k8sattributesresolver_controller.go
@@ -58,12 +58,16 @@ var (
 		string(semconv.K8SDeploymentUIDKey),
 		string(semconv.K8SDaemonSetUIDKey),
 		string(semconv.K8SStatefulSetUIDKey),
+		string(semconv.K8SCronJobUIDKey),
+		string(semconv.K8SJobUIDKey),
 	}
 
 	workloadNameAttributes = []string{
 		string(semconv.K8SDeploymentNameKey),
 		string(semconv.K8SDaemonSetNameKey),
 		string(semconv.K8SStatefulSetNameKey),
+		string(semconv.K8SCronJobNameKey),
+		string(semconv.K8SJobNameKey),
 	}
 
 	containerAttributes = []string{

--- a/frontend/services/collector_metrics/collector_metrics.go
+++ b/frontend/services/collector_metrics/collector_metrics.go
@@ -76,6 +76,8 @@ var (
 	K8SDeploymentNameKey  = string(semconv.K8SDeploymentNameKey)
 	K8SStatefulSetNameKey = string(semconv.K8SStatefulSetNameKey)
 	K8SDaemonSetNameKey   = string(semconv.K8SDaemonSetNameKey)
+	K8SCronJobNameKey     = string(semconv.K8SCronJobNameKey)
+	K8SJobNameKey         = string(semconv.K8SJobNameKey)
 )
 
 func (c *OdigosMetricsConsumer) Capabilities() consumer.Capabilities {

--- a/frontend/services/collector_metrics/node_collector.go
+++ b/frontend/services/collector_metrics/node_collector.go
@@ -193,6 +193,12 @@ func metricAttributesToSourceID(attrs pcommon.Map) (common.SourceID, error) {
 	} else if dsName, ok := attrs.Get(K8SDaemonSetNameKey); ok {
 		kind = k8sconsts.WorkloadKindDaemonSet
 		name = dsName
+	} else if cjName, ok := attrs.Get(K8SCronJobNameKey); ok {
+		kind = k8sconsts.WorkloadKindCronJob
+		name = cjName
+	} else if jobName, ok := attrs.Get(K8SJobNameKey); ok {
+		kind = k8sconsts.WorkloadKindJob
+		name = jobName
 	} else {
 		return common.SourceID{}, errors.New("kind not found")
 	}

--- a/frontend/services/sources.go
+++ b/frontend/services/sources.go
@@ -259,7 +259,7 @@ func RolloutRestartWorkload(ctx context.Context, namespace string, name string, 
 		return nil
 
 	default:
-		return fmt.Errorf("unsupported kind: %s (must be Deployment, StatefulSet, or DaemonSet)", kind)
+		return fmt.Errorf("unsupported kind: %s (must be Deployment, StatefulSet, DaemonSet or CronJob)", kind)
 	}
 
 	return nil

--- a/instrumentor/controllers/agentenabled/podswebhook/otelresource.go
+++ b/instrumentor/controllers/agentenabled/podswebhook/otelresource.go
@@ -48,6 +48,10 @@ func getWorkloadKindAttributeKey(workloadKind k8sconsts.WorkloadKind) attribute.
 		return semconv.K8SStatefulSetNameKey
 	case k8sconsts.WorkloadKindDaemonSet:
 		return semconv.K8SDaemonSetNameKey
+	case k8sconsts.WorkloadKindCronJob:
+		return semconv.K8SCronJobNameKey
+	case k8sconsts.WorkloadKindJob:
+		return semconv.K8SJobNameKey
 	}
 	return attribute.Key("")
 }

--- a/instrumentor/controllers/agentenabled/rollout/rollout.go
+++ b/instrumentor/controllers/agentenabled/rollout/rollout.go
@@ -45,6 +45,9 @@ func Do(ctx context.Context, c client.Client, ic *odigosv1alpha1.Instrumentation
 	}
 
 	if pw.Kind == k8sconsts.WorkloadKindCronJob || pw.Kind == k8sconsts.WorkloadKindJob {
+		if ic == nil {
+			return false, ctrl.Result{}, nil
+		}
 		statusChanged := meta.SetStatusCondition(&ic.Status.Conditions, metav1.Condition{
 			Type:    odigosv1alpha1.WorkloadRolloutStatusConditionType,
 			Status:  metav1.ConditionTrue,

--- a/instrumentor/controllers/sourceinstrumentation/common.go
+++ b/instrumentor/controllers/sourceinstrumentation/common.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 
 	v1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,6 +40,7 @@ func syncNamespaceWorkloads(
 		k8sconsts.WorkloadKindDaemonSet,
 		k8sconsts.WorkloadKindDeployment,
 		k8sconsts.WorkloadKindStatefulSet,
+		k8sconsts.WorkloadKindCronJob,
 	} {
 		workloadObjects := workload.ClientListObjectFromWorkloadKind(kind)
 		err := k8sClient.List(ctx, workloadObjects, client.InNamespace(namespace))
@@ -70,6 +72,14 @@ func syncNamespaceWorkloads(
 					Name:      ss.GetName(),
 					Namespace: ss.GetNamespace(),
 					Kind:      k8sconsts.WorkloadKindStatefulSet,
+				})
+			}
+		case *batchv1.JobList:
+			for _, job := range obj.Items {
+				workloadsToSync = append(workloadsToSync, k8sconsts.PodWorkload{
+					Name:      job.GetName(),
+					Namespace: job.GetNamespace(),
+					Kind:      k8sconsts.WorkloadKindJob,
 				})
 			}
 		}

--- a/k8sutils/pkg/workload/ownerreference.go
+++ b/k8sutils/pkg/workload/ownerreference.go
@@ -60,14 +60,14 @@ func GetWorkloadNameAndKind(ownerName, ownerKind string) (string, k8sconsts.Work
 		return extractDeploymentInfo(ownerName)
 	}
 	// A CronJobs owner is a Job kind, but since we're not supporting instrumenting (at a source level) regular Jobs, this will suffice
-	if ownerKind == "CronJob" || ownerKind == "Job" {
+	if ownerKind == "Job" {
 		return extractJobInfo(ownerName)
 	}
 	return handleNonReplicaSet(ownerName, ownerKind)
 }
 
 func extractJobInfo(jobName string) (string, k8sconsts.WorkloadKind, error) {
-	hyphenIndex := strings.Index(jobName, "-")
+	hyphenIndex := strings.LastIndex(jobName, "-")
 	if hyphenIndex == -1 {
 		return "", "", fmt.Errorf("job name '%s' does not contain a hyphen", jobName)
 	}

--- a/k8sutils/pkg/workload/workloadkinds.go
+++ b/k8sutils/pkg/workload/workloadkinds.go
@@ -82,7 +82,7 @@ func WorkloadKindFromString(kind string) k8sconsts.WorkloadKind {
 		return k8sconsts.WorkloadKindDaemonSet
 	case string(k8sconsts.WorkloadKindLowerCaseStatefulSet):
 		return k8sconsts.WorkloadKindStatefulSet
-	case string(k8sconsts.WorkloadKindCronJob):
+	case string(k8sconsts.WorkloadKindLowerCaseCronJob):
 		return k8sconsts.WorkloadKindCronJob
 	case string(k8sconsts.WorkloadKindLowerCaseJob):
 		return k8sconsts.WorkloadKindJob

--- a/odiglet/pkg/ebpf/settings_getter.go
+++ b/odiglet/pkg/ebpf/settings_getter.go
@@ -70,6 +70,10 @@ func getResourceAttributes(podWorkload *k8sconsts.PodWorkload, podName string, p
 		attrs = append(attrs, semconv.K8SStatefulSetName(podWorkload.Name))
 	case k8sconsts.WorkloadKindDaemonSet:
 		attrs = append(attrs, semconv.K8SDaemonSetName(podWorkload.Name))
+	case k8sconsts.WorkloadKindCronJob:
+		attrs = append(attrs, semconv.K8SCronJobName(podWorkload.Name))
+	case k8sconsts.WorkloadKindJob:
+		attrs = append(attrs, semconv.K8SJobName(podWorkload.Name))
 	}
 
 	if pe.ExecDetails != nil {


### PR DESCRIPTION
## Description

This PR introduces several improvements for CronJobs:

1. Refines OwnerReference handling by removing appended Job UID fragments.
2. Adds support for displaying CronJob-related metrics in the UI.
3. Fix future selection and the handling of CronJobs there.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
