### PR TITLE
fix: inject agent only if signals are enabled

### DIFF
--- a/api/odigos/v1alpha1/instrumentationconfig_types.go
+++ b/api/odigos/v1alpha1/instrumentationconfig_types.go
@@ -94,6 +94,7 @@ const (
 	AgentEnabledReasonEnabledSuccessfully            AgentEnabledReason = "EnabledSuccessfully"
 	AgentEnabledReasonWaitingForRuntimeInspection    AgentEnabledReason = "WaitingForRuntimeInspection"
 	AgentEnabledReasonWaitingForNodeCollector        AgentEnabledReason = "WaitingForNodeCollector"
+	AgentEnabledReasonNoCollectedSignals             AgentEnabledReason = "NoCollectedSignals"
 	AgentEnabledReasonIgnoredContainer               AgentEnabledReason = "IgnoredContainer"
 	AgentEnabledReasonUnsupportedProgrammingLanguage AgentEnabledReason = "UnsupportedProgrammingLanguage"
 	AgentEnabledReasonNoAvailableAgent               AgentEnabledReason = "NoAvailableAgent"
@@ -136,6 +137,8 @@ func AgentInjectionReasonPriority(reason AgentEnabledReason) int {
 		return 20
 	case AgentEnabledReasonWaitingForNodeCollector:
 		return 30
+	case AgentEnabledReasonNoCollectedSignals:
+		return 31
 	case AgentEnabledReasonIgnoredContainer:
 		return 40
 	case AgentEnabledReasonUnsupportedProgrammingLanguage:
@@ -163,6 +166,7 @@ func IsReasonStatusDisabled(reason string) bool {
 	case string(AgentEnabledReasonUnsupportedProgrammingLanguage),
 		string(AgentEnabledReasonUnsupportedRuntimeVersion),
 		string(RuntimeDetectionReasonNoRunningPods),
+		string(AgentEnabledReasonNoCollectedSignals),
 		string(AgentEnabledReasonIgnoredContainer),
 		string(AgentEnabledReasonNoAvailableAgent),
 		string(AgentEnabledReasonOtherAgentDetected),

--- a/instrumentor/controllers/agentenabled/sync.go
+++ b/instrumentor/controllers/agentenabled/sync.go
@@ -490,6 +490,11 @@ func isReadyForInstrumentation(cg *odigosv1.CollectorsGroup, ic *odigosv1.Instru
 		return false, odigosv1.AgentEnabledReasonWaitingForNodeCollector, message
 	}
 
+	gotReadySignals, message := gotReadySignals(cg)
+	if !gotReadySignals {
+		return false, odigosv1.AgentEnabledReasonNoCollectedSignals, message
+	}
+
 	// if there are any overrides, we use them (and exist early)
 	for _, containerOverride := range ic.Spec.ContainersOverrides {
 		if containerOverride.RuntimeInfo != nil {
@@ -525,5 +530,17 @@ func isNodeCollectorReady(cg *odigosv1.CollectorsGroup) (bool, string) {
 	}
 
 	// node collector is ready to receive telemetry
+	return true, ""
+}
+
+func gotReadySignals(cg *odigosv1.CollectorsGroup) (bool, string) {
+	if cg == nil {
+		return false, "waiting for OpenTelemetry Collector to be created"
+	}
+
+	if len(cg.Status.ReceiverSignals) == 0 {
+		return false, "no signals are being collected"
+	}
+
 	return true, ""
 }


### PR DESCRIPTION
## Description

Since https://github.com/odigos-io/odigos/pull/2738 , the cluster collectors group is generated even if there are no destinations.
That means that once sources are added, the datacollection will become ready and we will inject agent and rollout.

This is problematic because:

- Some distributions consumes the enabled signals as env vars  at pod creation time, and currently we are rollouting too early, creating pods with all signals disabled which are not being updated later once a destination is added.
- We are creating noise in the cluster, doing rollouts before it's relevant.
- There is no indication to the user that the agent is injected but all signals are disabled, thus they should not expect any telemetry

Fix: add a new condition for that, and test it in agentenabled controller of instrumentor.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [x] Manual Testing

## Kubernetes Checklist

No

## User Facing Changes

Show up like this in the ui:

![image](https://github.com/user-attachments/assets/57435db7-3c72-43fd-9f71-762fe4b76c8a)
