### PR TITLE
fix(instrumentor): predicate for agent injection on rules check distros

### DIFF
--- a/instrumentor/controllers/agentenabled/manager.go
+++ b/instrumentor/controllers/agentenabled/manager.go
@@ -53,7 +53,7 @@ func SetupWithManager(mgr ctrl.Manager, dp *distros.Provider) error {
 		ControllerManagedBy(mgr).
 		Named("agentenabled-instrumentationrules").
 		For(&odigosv1.InstrumentationRule{}).
-		WithEventFilter(&instrumentorpredicate.OtelSdkInstrumentationRulePredicate{}).
+		WithEventFilter(&instrumentorpredicate.OtelDistroInstrumentationRulePredicate{}).
 		Complete(&InstrumentationRuleReconciler{
 			Client:          mgr.GetClient(),
 			DistrosProvider: dp,

--- a/instrumentor/controllers/agentenabled/manager.go
+++ b/instrumentor/controllers/agentenabled/manager.go
@@ -53,7 +53,7 @@ func SetupWithManager(mgr ctrl.Manager, dp *distros.Provider) error {
 		ControllerManagedBy(mgr).
 		Named("agentenabled-instrumentationrules").
 		For(&odigosv1.InstrumentationRule{}).
-		WithEventFilter(&instrumentorpredicate.OtelDistroInstrumentationRulePredicate{}).
+		WithEventFilter(&instrumentorpredicate.AgentInjectionRelevantRulesPredicate{}).
 		Complete(&InstrumentationRuleReconciler{
 			Client:          mgr.GetClient(),
 			DistrosProvider: dp,

--- a/instrumentor/controllers/utils/predicates/instrumentation_rule.go
+++ b/instrumentor/controllers/utils/predicates/instrumentation_rule.go
@@ -5,10 +5,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
-type OtelDistroInstrumentationRulePredicate struct{}
+type AgentInjectionRelevantRulesPredicate struct{}
 
-func (o OtelDistroInstrumentationRulePredicate) Create(e event.CreateEvent) bool {
-	// check if delete rule is for otel sdk
+func (o AgentInjectionRelevantRulesPredicate) Create(e event.CreateEvent) bool {
+	// check if delete rule is relevant for agent enabling controllers
 	instrumentationRule, ok := e.Object.(*odigosv1alpha1.InstrumentationRule)
 	if !ok {
 		return false
@@ -17,7 +17,7 @@ func (o OtelDistroInstrumentationRulePredicate) Create(e event.CreateEvent) bool
 	return instrumentationRule.Spec.OtelSdks != nil || instrumentationRule.Spec.OtelDistros != nil
 }
 
-func (i OtelDistroInstrumentationRulePredicate) Update(e event.UpdateEvent) bool {
+func (i AgentInjectionRelevantRulesPredicate) Update(e event.UpdateEvent) bool {
 	oldInstrumentationRule, oldOk := e.ObjectOld.(*odigosv1alpha1.InstrumentationRule)
 	newInstrumentationRule, newOk := e.ObjectNew.(*odigosv1alpha1.InstrumentationRule)
 
@@ -25,12 +25,12 @@ func (i OtelDistroInstrumentationRulePredicate) Update(e event.UpdateEvent) bool
 		return false
 	}
 
-	// only handle rules for otel sdks
+	// only handle rules for otel sdks or distros configuration
 	return oldInstrumentationRule.Spec.OtelSdks != nil || newInstrumentationRule.Spec.OtelSdks != nil ||
 		oldInstrumentationRule.Spec.OtelDistros != nil || newInstrumentationRule.Spec.OtelDistros != nil
 }
 
-func (i OtelDistroInstrumentationRulePredicate) Delete(e event.DeleteEvent) bool {
+func (i AgentInjectionRelevantRulesPredicate) Delete(e event.DeleteEvent) bool {
 	// check if delete rule is for otel sdk
 	instrumentationRule, ok := e.Object.(*odigosv1alpha1.InstrumentationRule)
 	if !ok {
@@ -40,6 +40,6 @@ func (i OtelDistroInstrumentationRulePredicate) Delete(e event.DeleteEvent) bool
 	return instrumentationRule.Spec.OtelSdks != nil || instrumentationRule.Spec.OtelDistros != nil
 }
 
-func (i OtelDistroInstrumentationRulePredicate) Generic(e event.GenericEvent) bool {
+func (i AgentInjectionRelevantRulesPredicate) Generic(e event.GenericEvent) bool {
 	return false
 }

--- a/instrumentor/controllers/utils/predicates/instrumentation_rule.go
+++ b/instrumentor/controllers/utils/predicates/instrumentation_rule.go
@@ -5,19 +5,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
-type OtelSdkInstrumentationRulePredicate struct{}
+type OtelDistroInstrumentationRulePredicate struct{}
 
-func (o OtelSdkInstrumentationRulePredicate) Create(e event.CreateEvent) bool {
+func (o OtelDistroInstrumentationRulePredicate) Create(e event.CreateEvent) bool {
 	// check if delete rule is for otel sdk
 	instrumentationRule, ok := e.Object.(*odigosv1alpha1.InstrumentationRule)
 	if !ok {
 		return false
 	}
 
-	return instrumentationRule.Spec.OtelSdks != nil
+	return instrumentationRule.Spec.OtelSdks != nil || instrumentationRule.Spec.OtelDistros != nil
 }
 
-func (i OtelSdkInstrumentationRulePredicate) Update(e event.UpdateEvent) bool {
+func (i OtelDistroInstrumentationRulePredicate) Update(e event.UpdateEvent) bool {
 	oldInstrumentationRule, oldOk := e.ObjectOld.(*odigosv1alpha1.InstrumentationRule)
 	newInstrumentationRule, newOk := e.ObjectNew.(*odigosv1alpha1.InstrumentationRule)
 
@@ -26,19 +26,20 @@ func (i OtelSdkInstrumentationRulePredicate) Update(e event.UpdateEvent) bool {
 	}
 
 	// only handle rules for otel sdks
-	return oldInstrumentationRule.Spec.OtelSdks != nil || newInstrumentationRule.Spec.OtelSdks != nil
+	return oldInstrumentationRule.Spec.OtelSdks != nil || newInstrumentationRule.Spec.OtelSdks != nil ||
+		oldInstrumentationRule.Spec.OtelDistros != nil || newInstrumentationRule.Spec.OtelDistros != nil
 }
 
-func (i OtelSdkInstrumentationRulePredicate) Delete(e event.DeleteEvent) bool {
+func (i OtelDistroInstrumentationRulePredicate) Delete(e event.DeleteEvent) bool {
 	// check if delete rule is for otel sdk
 	instrumentationRule, ok := e.Object.(*odigosv1alpha1.InstrumentationRule)
 	if !ok {
 		return false
 	}
 
-	return instrumentationRule.Spec.OtelSdks != nil
+	return instrumentationRule.Spec.OtelSdks != nil || instrumentationRule.Spec.OtelDistros != nil
 }
 
-func (i OtelSdkInstrumentationRulePredicate) Generic(e event.GenericEvent) bool {
+func (i OtelDistroInstrumentationRulePredicate) Generic(e event.GenericEvent) bool {
 	return false
 }


### PR DESCRIPTION
## Description

Fix 2 bugs in the triggering of agent injection from instrumentation rules changes:

1. the predicate only checks for the deprecated "OtelSdk" rule, and not checking for the new "OtelDistros" rule. this is fixed to check both
2. the reconciler only trigger recalculate if the rule is not `nil`, but it need to cleanup any possible modification even if the rule is nil if before the update it was not nil.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [x] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

More reconciles invocation to catch events that we should have handled and missed before.

## User Facing Changes

If any user is using the otelDistro rule (which is not yet in the UI) then his changes will take effect where before they did not immediately did.
