### PR TITLE
refactor: runtime version as distro parameter

### DIFF
--- a/common/lang_detection.go
+++ b/common/lang_detection.go
@@ -59,11 +59,11 @@ func GetVersion(versionString string) *version.Version {
 	return runtimeVersion
 }
 
-func MajorMinorStringOnly(v *version.Version) string {
+func MajorMinorStringOnly(v *version.Version) (string, error) {
 	segments := v.Segments()
 	if len(segments) < 2 {
 		// fallback for malformed versions
-		return v.String()
+		return "", fmt.Errorf("version %s has less than 2 segments", v.String())
 	}
-	return fmt.Sprintf("%d.%d", segments[0], segments[1])
+	return fmt.Sprintf("%d.%d", segments[0], segments[1]), nil
 }

--- a/distros/distro/oteldistribution.go
+++ b/distros/distro/oteldistribution.go
@@ -1,9 +1,15 @@
 package distro
 
-import "github.com/odigos-io/odigos/common"
+import (
+	"text/template"
+
+	"github.com/odigos-io/odigos/common"
+)
 
 const AgentPlaceholderDirectory = "{{ODIGOS_AGENTS_DIR}}"
 const RuntimeVersionPlaceholderMajorMinor = "{{RUNTIME_VERSION_MAJOR_MINOR}}"
+
+const RuntimeVersionMajorMinorDistroParameterName = "RUNTIME_VERSION_MAJOR_MINOR"
 
 type RuntimeEnvironment struct {
 	// the runtime environment this distribution targets.
@@ -30,6 +36,12 @@ type StaticEnvironmentVariable struct {
 
 	// The value of the environment variable to set.
 	EnvValue string `yaml:"envValue"`
+
+	// pre-parsed template that is ready to be executed with the relevant parameters.
+	// if the EnvValue field is templated (e.g. contains {{.PARAM_NAME}}), this field is set.
+	// it indicates that the the value should be templated with the relevant parameters.
+	// this field is calculated and is not pulled from the manifest.
+	Template *template.Template
 }
 
 type EnvironmentVariables struct {

--- a/distros/distro/oteldistribution.go
+++ b/distros/distro/oteldistribution.go
@@ -38,8 +38,8 @@ type StaticEnvironmentVariable struct {
 
 	// pre-parsed template that is ready to be executed with the relevant parameters.
 	// if the EnvValue field is templated (e.g. contains {{.PARAM_NAME}}), this field is set.
-	// it indicates that the the value should be templated with the relevant parameters.
-	// this field is calculated and is not pulled from the manifest.
+	// it indicates that the value should be templated with the relevant parameters.
+	// this field is calculated based on the EnvValue field, and is not pulled from the yaml.
 	Template *template.Template
 }
 

--- a/distros/distro/oteldistribution.go
+++ b/distros/distro/oteldistribution.go
@@ -7,7 +7,6 @@ import (
 )
 
 const AgentPlaceholderDirectory = "{{ODIGOS_AGENTS_DIR}}"
-const RuntimeVersionPlaceholderMajorMinor = "{{RUNTIME_VERSION_MAJOR_MINOR}}"
 
 const RuntimeVersionMajorMinorDistroParameterName = "RUNTIME_VERSION_MAJOR_MINOR"
 

--- a/distros/yamls/php-community.yaml
+++ b/distros/yamls/php-community.yaml
@@ -11,6 +11,8 @@ spec:
   displayName: 'PHP Community Native Instrumentation'
   description: |
     This distribution is for PHP applications using OpenTelemetry Native SDK and instrumentation libraries from the OpenTelemetry community.
+  requireParameters:
+    - RUNTIME_VERSION_MAJOR_MINOR
   environmentVariables:
     otlpHttpLocalNode: true
     signalsAsStaticOtelEnvVars: true
@@ -18,7 +20,7 @@ spec:
       # How to use PHP_INI_SCAN_DIR env with colon (:) separator...
       # See https://github.com/odigos-io/opentelemetry-php?tab=readme-ov-file#deploying-an-agent
       - envName: PHP_INI_SCAN_DIR
-        envValue: ':/var/odigos/php/{{RUNTIME_VERSION_MAJOR_MINOR}}'
+        envValue: ':/var/odigos/php/{{.RUNTIME_VERSION_MAJOR_MINOR}}'
       - envName: OTEL_PHP_AUTOLOAD_ENABLED
         envValue: 'true'
       - envName: OTEL_EXPORTER_OTLP_PROTOCOL

--- a/distros/yamls/ruby-community.yaml
+++ b/distros/yamls/ruby-community.yaml
@@ -11,14 +11,16 @@ spec:
   displayName: 'Ruby Community Native Instrumentation'
   description: |
     This distribution is for Ruby applications using OpenTelemetry Native SDK and instrumentation libraries from the OpenTelemetry community.
+  requireParameters:
+    - RUNTIME_VERSION_MAJOR_MINOR
   environmentVariables:
     otlpHttpLocalNode: true
     signalsAsStaticOtelEnvVars: true
     staticVariables:
       - envName: RUBYOPT
-        envValue: '-r /var/odigos/ruby/{{RUNTIME_VERSION_MAJOR_MINOR}}/index'
+        envValue: '-r /var/odigos/ruby/{{.RUNTIME_VERSION_MAJOR_MINOR}}/index'
       - envName: ADDITIONAL_GEM_PATH
-        envValue: '/var/odigos/ruby/{{RUNTIME_VERSION_MAJOR_MINOR}}/bundle'
+        envValue: '/var/odigos/ruby/{{.RUNTIME_VERSION_MAJOR_MINOR}}/bundle'
       - envName: OTEL_EXPORTER_OTLP_PROTOCOL
         envValue: 'http/protobuf'
       - envName: OTEL_PROPAGATORS

--- a/instrumentor/controllers/agentenabled/podswebhook/env.go
+++ b/instrumentor/controllers/agentenabled/podswebhook/env.go
@@ -1,7 +1,9 @@
 package podswebhook
 
 import (
-	"strings"
+	"bytes"
+	"fmt"
+	"text/template"
 
 	"github.com/odigos-io/odigos/api/k8sconsts"
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
@@ -31,29 +33,38 @@ func injectEnvVarObjectFieldRefToPodContainer(existingEnvNames EnvVarNamesMap, c
 	return existingEnvNames
 }
 
-func InjectEnvVarToPodContainer(existingEnvNames EnvVarNamesMap, container *corev1.Container, envVarName, envVarValue string, runtimeDetails *odigosv1.RuntimeDetailsByContainer) EnvVarNamesMap {
+func InjectConstEnvVarToPodContainer(existingEnvNames EnvVarNamesMap, container *corev1.Container, envVarName, envVarValue string) EnvVarNamesMap {
 	if _, exists := existingEnvNames[envVarName]; exists {
 		return existingEnvNames
 	}
-
-	if strings.Contains(envVarValue, distro.RuntimeVersionPlaceholderMajorMinor) {
-		// This is a placeholder for the runtime version, we need to replace it with the actual runtime version
-		if runtimeDetails != nil {
-			majorMinor := common.MajorMinorStringOnly(common.GetVersion(runtimeDetails.RuntimeVersion))
-			envVarValue = strings.ReplaceAll(envVarValue, distro.RuntimeVersionPlaceholderMajorMinor, majorMinor)
-		} else {
-			// If we don't have runtime details, we can't replace the placeholder
-			return existingEnvNames
-		}
-	}
-
 	container.Env = append(container.Env, corev1.EnvVar{
 		Name:  envVarName,
 		Value: envVarValue,
 	})
-
 	existingEnvNames[envVarName] = struct{}{}
 	return existingEnvNames
+}
+
+func InjectTemplatedEnvVarToPodContainer(existingEnvNames EnvVarNamesMap, container *corev1.Container, envVarName string, envVarValueTemplate *template.Template, distroParams map[string]string) (EnvVarNamesMap, error) {
+	if _, exists := existingEnvNames[envVarName]; exists {
+		return existingEnvNames, nil
+	}
+
+	var buf bytes.Buffer
+	err := envVarValueTemplate.Execute(&buf, distroParams)
+	if err != nil {
+		// Should not happen. values are statically used from distro manifest which should be tested.
+		return existingEnvNames, err
+	}
+	templatedEnvVarValue := buf.String()
+
+	container.Env = append(container.Env, corev1.EnvVar{
+		Name:  envVarName,
+		Value: templatedEnvVarValue,
+	})
+
+	existingEnvNames[envVarName] = struct{}{}
+	return existingEnvNames, nil
 }
 
 func injectNodeIpEnvVar(existingEnvNames EnvVarNamesMap, container *corev1.Container) EnvVarNamesMap {
@@ -61,29 +72,40 @@ func injectNodeIpEnvVar(existingEnvNames EnvVarNamesMap, container *corev1.Conta
 }
 
 func InjectOdigosK8sEnvVars(existingEnvNames EnvVarNamesMap, container *corev1.Container, distroName string, ns string) EnvVarNamesMap {
-	existingEnvNames = InjectEnvVarToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarContainerName, container.Name, nil)
-	existingEnvNames = InjectEnvVarToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarDistroName, distroName, nil)
+	existingEnvNames = InjectConstEnvVarToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarContainerName, container.Name)
+	existingEnvNames = InjectConstEnvVarToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarDistroName, distroName)
 	existingEnvNames = injectEnvVarObjectFieldRefToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarPodName, "metadata.name")
-	existingEnvNames = InjectEnvVarToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarNamespace, ns, nil)
+	existingEnvNames = InjectConstEnvVarToPodContainer(existingEnvNames, container, k8sconsts.OdigosEnvVarNamespace, ns)
 	return existingEnvNames
-}
-
-func InjectStaticEnvVar(existingEnvNames EnvVarNamesMap, container *corev1.Container, envVarName string, envVarValue string, runtimeDetails *odigosv1.RuntimeDetailsByContainer) EnvVarNamesMap {
-	return InjectEnvVarToPodContainer(existingEnvNames, container, envVarName, envVarValue, runtimeDetails)
 }
 
 func InjectOpampServerEnvVar(existingEnvNames EnvVarNamesMap, container *corev1.Container) EnvVarNamesMap {
 	existingEnvNames = injectNodeIpEnvVar(existingEnvNames, container)
 	opAmpServerHost := service.LocalTrafficOpAmpOdigletEndpoint("$(NODE_IP)")
-	existingEnvNames = InjectEnvVarToPodContainer(existingEnvNames, container, commonconsts.OpampServerHostEnvName, opAmpServerHost, nil)
+	existingEnvNames = InjectConstEnvVarToPodContainer(existingEnvNames, container, commonconsts.OpampServerHostEnvName, opAmpServerHost)
 	return existingEnvNames
 }
 
 func InjectOtlpHttpEndpointEnvVar(existingEnvNames EnvVarNamesMap, container *corev1.Container) EnvVarNamesMap {
 	existingEnvNames = injectNodeIpEnvVar(existingEnvNames, container)
 	otlpHttpEndpoint := service.LocalTrafficOTLPHttpDataCollectionEndpoint("$(NODE_IP)")
-	existingEnvNames = InjectEnvVarToPodContainer(existingEnvNames, container, commonconsts.OtelExporterEndpointEnvName, otlpHttpEndpoint, nil)
+	existingEnvNames = InjectConstEnvVarToPodContainer(existingEnvNames, container, commonconsts.OtelExporterEndpointEnvName, otlpHttpEndpoint)
 	return existingEnvNames
+}
+
+func InjectStaticEnvVarsToPodContainer(existingEnvNames EnvVarNamesMap, container *corev1.Container, envVars []distro.StaticEnvironmentVariable, distroParams map[string]string) (EnvVarNamesMap, error) {
+	for _, envVar := range envVars {
+		if envVar.Template == nil {
+			existingEnvNames = InjectConstEnvVarToPodContainer(existingEnvNames, container, envVar.EnvName, envVar.EnvValue)
+		} else {
+			var err error // make sure we don't shadow the error or the existingEnvNames
+			existingEnvNames, err = InjectTemplatedEnvVarToPodContainer(existingEnvNames, container, envVar.EnvName, envVar.Template, distroParams)
+			if err != nil {
+				return existingEnvNames, fmt.Errorf("failed to inject static environment variable %s: %w", envVar.EnvName, err)
+			}
+		}
+	}
+	return existingEnvNames, nil
 }
 
 func signalOtlpExporterEnvValue(enabled bool) string {
@@ -96,13 +118,13 @@ func signalOtlpExporterEnvValue(enabled bool) string {
 func InjectSignalsAsStaticOtelEnvVars(existingEnvNames EnvVarNamesMap, container *corev1.Container, tracesEnabled bool, metricsEnabled bool, logsEnabled bool) EnvVarNamesMap {
 
 	logsExporter := signalOtlpExporterEnvValue(logsEnabled)
-	existingEnvNames = InjectEnvVarToPodContainer(existingEnvNames, container, commonconsts.OtelLogsExporter, logsExporter, nil)
+	existingEnvNames = InjectConstEnvVarToPodContainer(existingEnvNames, container, commonconsts.OtelLogsExporter, logsExporter)
 
 	metricsExporter := signalOtlpExporterEnvValue(metricsEnabled)
-	existingEnvNames = InjectEnvVarToPodContainer(existingEnvNames, container, commonconsts.OtelMetricsExporter, metricsExporter, nil)
+	existingEnvNames = InjectConstEnvVarToPodContainer(existingEnvNames, container, commonconsts.OtelMetricsExporter, metricsExporter)
 
 	tracesExporter := signalOtlpExporterEnvValue(tracesEnabled)
-	existingEnvNames = InjectEnvVarToPodContainer(existingEnvNames, container, commonconsts.OtelTracesExporter, tracesExporter, nil)
+	existingEnvNames = InjectConstEnvVarToPodContainer(existingEnvNames, container, commonconsts.OtelTracesExporter, tracesExporter)
 
 	return existingEnvNames
 }
@@ -124,12 +146,11 @@ func InjectUserEnvForLang(odigosConfig *common.OdigosConfiguration, pod *corev1.
 		existingEnvNames := GetEnvVarNamesSet(container)
 
 		for envName, envValue := range langConfig.EnvVars {
-			existingEnvNames = InjectEnvVarToPodContainer(
+			existingEnvNames = InjectConstEnvVarToPodContainer(
 				existingEnvNames,
 				container,
 				envName,
 				envValue,
-				nil,
 			)
 		}
 	}

--- a/instrumentor/controllers/agentenabled/podswebhook/otelresource.go
+++ b/instrumentor/controllers/agentenabled/podswebhook/otelresource.go
@@ -63,11 +63,11 @@ func getResourceAttributesEnvVarValue(ra []resourceAttribute) string {
 func InjectOtelResourceAndServiceNameEnvVars(existingEnvNames EnvVarNamesMap, container *corev1.Container, distroName string, pw k8sconsts.PodWorkload, serviceName string) EnvVarNamesMap {
 
 	// OTEL_SERVICE_NAME
-	existingEnvNames = InjectEnvVarToPodContainer(existingEnvNames, container, otelServiceNameEnvVarName, serviceName, nil)
+	existingEnvNames = InjectConstEnvVarToPodContainer(existingEnvNames, container, otelServiceNameEnvVarName, serviceName)
 
 	// OTEL_RESOURCE_ATTRIBUTES
 	resourceAttributes := getResourceAttributes(pw, container.Name)
 	resourceAttributesEnvValue := getResourceAttributesEnvVarValue(resourceAttributes)
-	existingEnvNames = InjectEnvVarToPodContainer(existingEnvNames, container, otelResourceAttributesEnvVarName, resourceAttributesEnvValue, nil)
+	existingEnvNames = InjectConstEnvVarToPodContainer(existingEnvNames, container, otelResourceAttributesEnvVarName, resourceAttributesEnvValue)
 	return existingEnvNames
 }

--- a/instrumentor/controllers/agentenabled/sync.go
+++ b/instrumentor/controllers/agentenabled/sync.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/hashicorp/go-version"
 	"github.com/odigos-io/odigos/api/k8sconsts"
@@ -351,19 +350,6 @@ func containerInstrumentationConfig(containerName string,
 				AgentEnabledMessage: fmt.Sprintf("%s runtime not supported by OpenTelemetry. supported versions: '%s', found: %s", distro.RuntimeEnvironments[0].Name, constraint, detectedVersion),
 			}
 		}
-	} else if runtimeDetails.RuntimeVersion == "" {
-		// If the runtime does not have a version, we can't replace placeholders
-		for _, staticVariable := range distro.EnvironmentVariables.StaticVariables {
-			// This is a placeholder for the runtime version, disable the agent
-			if strings.Contains(staticVariable.EnvValue, distroTypes.RuntimeVersionPlaceholderMajorMinor) {
-				return odigosv1.ContainerAgentConfig{
-					ContainerName:       containerName,
-					AgentEnabled:        false,
-					AgentEnabledReason:  odigosv1.AgentEnabledReasonUnsupportedRuntimeVersion,
-					AgentEnabledMessage: "runtime version is not available, but the distribution requires it to be set",
-				}
-			}
-		}
 	}
 
 	distroParameters := map[string]string{}
@@ -379,6 +365,35 @@ func containerInstrumentationConfig(containerName string,
 				}
 			}
 			distroParameters[common.LibcTypeDistroParameterName] = string(*runtimeDetails.LibCType)
+
+		case distroTypes.RuntimeVersionMajorMinorDistroParameterName:
+			if runtimeDetails.RuntimeVersion == "" {
+				return odigosv1.ContainerAgentConfig{
+					ContainerName:       containerName,
+					AgentEnabled:        false,
+					AgentEnabledReason:  odigosv1.AgentEnabledReasonMissingDistroParameter,
+					AgentEnabledMessage: fmt.Sprintf("missing required parameter '%s' for distro '%s'", distroTypes.RuntimeVersionMajorMinorDistroParameterName, distroName),
+				}
+			}
+			version, err := version.NewVersion(runtimeDetails.RuntimeVersion)
+			if err != nil {
+				return odigosv1.ContainerAgentConfig{
+					ContainerName:       containerName,
+					AgentEnabled:        false,
+					AgentEnabledReason:  odigosv1.AgentEnabledReasonMissingDistroParameter,
+					AgentEnabledMessage: fmt.Sprintf("failed to parse runtime version: %s", runtimeDetails.RuntimeVersion),
+				}
+			}
+			versionAsMajorMinor, err := common.MajorMinorStringOnly(version)
+			if err != nil {
+				return odigosv1.ContainerAgentConfig{
+					ContainerName:       containerName,
+					AgentEnabled:        false,
+					AgentEnabledReason:  odigosv1.AgentEnabledReasonMissingDistroParameter,
+					AgentEnabledMessage: fmt.Sprintf("failed to parse runtime version as major.minor: %s", runtimeDetails.RuntimeVersion),
+				}
+			}
+			distroParameters[distroTypes.RuntimeVersionMajorMinorDistroParameterName] = versionAsMajorMinor
 
 		default:
 			return odigosv1.ContainerAgentConfig{


### PR DESCRIPTION
## Description

Php and Ruby requires the runtime version as "Major.Minor" (`8.3`) to inject into environment variables.

At the moment, we read and parse the value in pods webhook, but this is not ideal for the following reasons:

- More work in webhook, vs pre-calculate at reconcile time and having the value ready at webhook time.
- No error checking - in webhook, we need to parse versions but do not check for errors (like if the version is updated at runtime detection and no longer valid)
- Race conditions - we read plain values from runtime detection in webhook, before they are being reconciled and potentially modify the agent config.

This PR migrate the php and ruby to pass distro parameter in the containers array for `RUNTIME_VERSION_MAJOR_MINOR`:

- process and parse the runtime detection version in the reconciler.
- any errors in the runtime detection is checked and makes the agent disabled with proper message to user
- use `text/template` module to do the environment runtime substitution instead of string.Replace - for better readability and options for formating

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

Tested manually + tested in e2e.

## Kubernetes Checklist

No change in CRDs and manifest. Ruby and PHP will now write one additional value into instrumentation config spec containers agent config

## User Facing Changes

Internal refactor