### PR TITLE
fix(instrumentor): apply trace config rules to agent enabled signals

### DIFF
--- a/api/config/crd/bases/odigos.io_instrumentationconfigs.yaml
+++ b/api/config/crd/bases/odigos.io_instrumentationconfigs.yaml
@@ -82,12 +82,14 @@ spec:
                       - EnabledSuccessfully
                       - WaitingForRuntimeInspection
                       - WaitingForNodeCollector
+                      - NoCollectedSignals
                       - UnsupportedProgrammingLanguage
                       - IgnoredContainer
                       - NoAvailableAgent
                       - UnsupportedRuntimeVersion
                       - MissingDistroParameter
                       - OtherAgentDetected
+                      - RuntimeDetailsUnavailable
                       - CrashLoopBackOff
                       type: string
                     containerName:

--- a/api/odigos/v1alpha1/instrumentationconfig_types.go
+++ b/api/odigos/v1alpha1/instrumentationconfig_types.go
@@ -87,7 +87,7 @@ const (
 	RuntimeDetectionReasonError RuntimeDetectionReason = "Error"
 )
 
-// +kubebuilder:validation:Enum=EnabledSuccessfully;WaitingForRuntimeInspection;WaitingForNodeCollector;UnsupportedProgrammingLanguage;IgnoredContainer;NoAvailableAgent;UnsupportedRuntimeVersion;MissingDistroParameter;OtherAgentDetected;CrashLoopBackOff
+// +kubebuilder:validation:Enum=EnabledSuccessfully;WaitingForRuntimeInspection;WaitingForNodeCollector;NoCollectedSignals;UnsupportedProgrammingLanguage;IgnoredContainer;NoAvailableAgent;UnsupportedRuntimeVersion;MissingDistroParameter;OtherAgentDetected;RuntimeDetailsUnavailable;CrashLoopBackOff
 type AgentEnabledReason string
 
 const (
@@ -137,10 +137,10 @@ func AgentInjectionReasonPriority(reason AgentEnabledReason) int {
 		return 20
 	case AgentEnabledReasonWaitingForNodeCollector:
 		return 30
-	case AgentEnabledReasonNoCollectedSignals:
-		return 31
 	case AgentEnabledReasonIgnoredContainer:
 		return 40
+	case AgentEnabledReasonNoCollectedSignals:
+		return 45
 	case AgentEnabledReasonUnsupportedProgrammingLanguage:
 		return 50
 	case AgentEnabledReasonUnsupportedRuntimeVersion:

--- a/helm/odigos/templates/crds/odigos.io_instrumentationconfigs.yaml
+++ b/helm/odigos/templates/crds/odigos.io_instrumentationconfigs.yaml
@@ -82,12 +82,14 @@ spec:
                       - EnabledSuccessfully
                       - WaitingForRuntimeInspection
                       - WaitingForNodeCollector
+                      - NoCollectedSignals
                       - UnsupportedProgrammingLanguage
                       - IgnoredContainer
                       - NoAvailableAgent
                       - UnsupportedRuntimeVersion
                       - MissingDistroParameter
                       - OtherAgentDetected
+                      - RuntimeDetailsUnavailable
                       - CrashLoopBackOff
                       type: string
                     containerName:

--- a/instrumentor/controllers/agentenabled/resources.go
+++ b/instrumentor/controllers/agentenabled/resources.go
@@ -62,17 +62,21 @@ func getRelevantInstrumentationRules(ctx context.Context, c client.Client, pw k8
 	for i := range irList.Items {
 		ir := &irList.Items[i]
 
+		// ignore disabled rules
+		if ir.Spec.Disabled {
+			continue
+		}
+
 		if !utils.IsWorkloadParticipatingInRule(pw, ir) {
 			continue
 		}
 
-		if ir.Spec.OtelSdks == nil {
-			// we only care about otel sdks rules at the moment.
-			// no need to process other rules.
-			continue
-		}
+		// filter only rules that are relevant to the agent enabled logic
+		if (ir.Spec.OtelSdks != nil || ir.Spec.OtelDistros != nil) ||
+			(ir.Spec.TraceConfig != nil && ir.Spec.TraceConfig.Disabled != nil) {
 
-		relevantIr = append(relevantIr, *ir)
+			relevantIr = append(relevantIr, *ir)
+		}
 	}
 
 	return &relevantIr, nil

--- a/instrumentor/controllers/utils/predicates/instrumentation_rule.go
+++ b/instrumentor/controllers/utils/predicates/instrumentation_rule.go
@@ -14,20 +14,23 @@ func (o AgentInjectionRelevantRulesPredicate) Create(e event.CreateEvent) bool {
 		return false
 	}
 
-	return instrumentationRule.Spec.OtelSdks != nil || instrumentationRule.Spec.OtelDistros != nil
+	return instrumentationRule.Spec.OtelSdks != nil ||
+		instrumentationRule.Spec.OtelDistros != nil ||
+		instrumentationRule.Spec.TraceConfig != nil
 }
 
 func (i AgentInjectionRelevantRulesPredicate) Update(e event.UpdateEvent) bool {
-	oldInstrumentationRule, oldOk := e.ObjectOld.(*odigosv1alpha1.InstrumentationRule)
-	newInstrumentationRule, newOk := e.ObjectNew.(*odigosv1alpha1.InstrumentationRule)
+	old, oldOk := e.ObjectOld.(*odigosv1alpha1.InstrumentationRule)
+	new, newOk := e.ObjectNew.(*odigosv1alpha1.InstrumentationRule)
 
 	if !oldOk || !newOk {
 		return false
 	}
 
 	// only handle rules for otel sdks or distros configuration
-	return oldInstrumentationRule.Spec.OtelSdks != nil || newInstrumentationRule.Spec.OtelSdks != nil ||
-		oldInstrumentationRule.Spec.OtelDistros != nil || newInstrumentationRule.Spec.OtelDistros != nil
+	return old.Spec.OtelSdks != nil || new.Spec.OtelSdks != nil ||
+		old.Spec.OtelDistros != nil || new.Spec.OtelDistros != nil ||
+		old.Spec.TraceConfig != nil || new.Spec.TraceConfig != nil
 }
 
 func (i AgentInjectionRelevantRulesPredicate) Delete(e event.DeleteEvent) bool {
@@ -37,7 +40,9 @@ func (i AgentInjectionRelevantRulesPredicate) Delete(e event.DeleteEvent) bool {
 		return false
 	}
 
-	return instrumentationRule.Spec.OtelSdks != nil || instrumentationRule.Spec.OtelDistros != nil
+	return instrumentationRule.Spec.OtelSdks != nil ||
+		instrumentationRule.Spec.OtelDistros != nil ||
+		instrumentationRule.Spec.TraceConfig != nil
 }
 
 func (i AgentInjectionRelevantRulesPredicate) Generic(e event.GenericEvent) bool {


### PR DESCRIPTION
## Description

The instrumentation config containers array in the spec contains enabled signals, which are currently used for injecting env vars for collectors in java ruby and php.
However, this list only takes into effect the signals enabled in collector, but any instrumentation rule that disables traces is not calculated here.

This PR fixes that, so if someone configures an instrumentation rule for disabling traces, the fields in the container agent config will reflect this correctly.

It also make it so if a rule disables traces so that no more signals are left, we will avoid enabling the agent and show a good message indicating what is going on:

![image](https://github.com/user-attachments/assets/6d147948-3522-4cf0-aee6-a13216e6af50)

![image](https://github.com/user-attachments/assets/3cc675aa-e34d-4cc7-9886-8678aa193fc5)


## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [x] Manual Testing

## Kubernetes Checklist

No

## User Facing Changes

One more option to see as to why agent is not enabled in a specific source
