### PR TITLE
chore: configurable liveness/readiness port on odiglet to avoid port conflicts for hostnetwork mood

### DIFF
--- a/api/k8sconsts/odiglet.go
+++ b/api/k8sconsts/odiglet.go
@@ -14,14 +14,15 @@ const (
 	OdigletEnterpriseImageUBI9    = "odigos-enterprise-odiglet-ubi9"
 	OdigletImageUBI9              = "odigos-odiglet-ubi9"
 	// Used to indicate that the odiglet is installed on a node.
-	OdigletOSSInstalledLabel        = "odigos.io/odiglet-oss-installed"
-	OdigletEnterpriseInstalledLabel = "odigos.io/odiglet-enterprise-installed"
-	OdigletInstalledLabelValue      = "true"
+	OdigletOSSInstalledLabel          = "odigos.io/odiglet-oss-installed"
+	OdigletEnterpriseInstalledLabel   = "odigos.io/odiglet-enterprise-installed"
+	OdigletInstalledLabelValue        = "true"
+	OdigletDefaultHealthProbeBindPort = 55683
 
 	// ConfigMap used to store custom/updated Go instrumentation offsets
-	GoOffsetsConfigMap = "odigos-go-offsets"
-	GoOffsetsFileName  = "go_offset_results.json"
-	GoOffsetsEnvVar    = "OTEL_GO_OFFSETS_FILE"
+	GoOffsetsConfigMap  = "odigos-go-offsets"
+	GoOffsetsFileName   = "go_offset_results.json"
+	GoOffsetsEnvVar     = "OTEL_GO_OFFSETS_FILE"
 	OffsetFileMountPath = "/offsets"
 
 	OdigletLocalTrafficServiceName = "odiglet-local"

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -85,6 +85,7 @@ var configCmd = &cobra.Command{
 		consts.AutomaticRolloutDisabledProperty,
 		consts.OidcTenantUrlProperty,
 		consts.OidcClientIdProperty,
+		consts.OidcClientSecretProperty,
 		consts.HealthProbeBindPortProperty,
 	),
 }

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -57,6 +57,7 @@ var configCmd = &cobra.Command{
 	- "%s": Sets the URL of the OIDC tenant.
 	- "%s": Sets the client ID of the OIDC application.
 	- "%s": Sets the client secret of the OIDC application.
+	- "%s": Sets the port for the health probe.
 	`,
 		consts.TelemetryEnabledProperty,
 		consts.OpenshiftEnabledProperty,
@@ -84,7 +85,7 @@ var configCmd = &cobra.Command{
 		consts.AutomaticRolloutDisabledProperty,
 		consts.OidcTenantUrlProperty,
 		consts.OidcClientIdProperty,
-		consts.OidcClientSecretProperty,
+		consts.HealthProbeBindPortProperty,
 	),
 }
 
@@ -186,7 +187,8 @@ func validatePropertyValue(property string, value []string) error {
 		consts.AutomaticRolloutDisabledProperty,
 		consts.OidcTenantUrlProperty,
 		consts.OidcClientIdProperty,
-		consts.OidcClientSecretProperty:
+		consts.OidcClientSecretProperty,
+		consts.HealthProbeBindPortProperty:
 
 		if len(value) != 1 {
 			return fmt.Errorf("%s expects exactly one value", property)
@@ -206,7 +208,8 @@ func validatePropertyValue(property string, value []string) error {
 				return fmt.Errorf("invalid boolean value for %s: %s", property, value[0])
 			}
 
-		case consts.UiPaginationLimitProperty:
+		case consts.UiPaginationLimitProperty,
+			consts.HealthProbeBindPortProperty:
 			_, err := strconv.Atoi(value[0])
 			if err != nil {
 				return fmt.Errorf("invalid integer value for %s: %s", property, value[0])
@@ -391,6 +394,10 @@ func setConfigProperty(ctx context.Context, client *kube.Client, config *common.
 			config.Oidc = &common.OidcConfiguration{}
 		}
 		config.Oidc.ClientSecret = fmt.Sprintf("secretRef:%s", consts.OidcSecretName)
+
+	case consts.HealthProbeBindPortProperty:
+		intValue, _ := strconv.Atoi(value[0])
+		config.HealthProbeBindPort = intValue
 
 	default:
 		return fmt.Errorf("invalid property: %s", property)

--- a/cli/cmd/resources/odiglet.go
+++ b/cli/cmd/resources/odiglet.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"path/filepath"
+	"strconv"
 
 	"github.com/odigos-io/odigos/api/k8sconsts"
 	"github.com/odigos-io/odigos/cli/pkg/autodetect"
@@ -267,7 +268,7 @@ func NewResourceQuota(ns string) *corev1.ResourceQuota {
 }
 
 func NewOdigletDaemonSet(ns string, version string, imagePrefix string, imageName string,
-	odigosTier common.OdigosTier, openshiftEnabled bool, clusterDetails *autodetect.ClusterDetails, customContainerRuntimeSocketPath string, nodeSelector map[string]string) *appsv1.DaemonSet {
+	odigosTier common.OdigosTier, openshiftEnabled bool, clusterDetails *autodetect.ClusterDetails, customContainerRuntimeSocketPath string, nodeSelector map[string]string, healthProbeBindPort int) *appsv1.DaemonSet {
 	if nodeSelector == nil {
 		nodeSelector = make(map[string]string)
 	}
@@ -475,7 +476,13 @@ func NewOdigletDaemonSet(ns string, version string, imagePrefix string, imageNam
 					},
 					Containers: []corev1.Container{
 						{
-							Name:  k8sconsts.OdigletContainerName,
+							Name: k8sconsts.OdigletContainerName,
+							Command: []string{
+								"/root/odiglet",
+							},
+							Args: []string{
+								"--health-probe-bind-port=" + strconv.Itoa(healthProbeBindPort),
+							},
 							Image: containers.GetImageName(imagePrefix, imageName, version),
 							Env: append([]corev1.EnvVar{
 								{
@@ -523,7 +530,7 @@ func NewOdigletDaemonSet(ns string, version string, imagePrefix string, imageNam
 										Path: "/healthz",
 										Port: intstr.IntOrString{
 											Type:   intstr.Type(0),
-											IntVal: 8081,
+											IntVal: int32(healthProbeBindPort),
 										},
 									},
 								},
@@ -539,7 +546,7 @@ func NewOdigletDaemonSet(ns string, version string, imagePrefix string, imageNam
 										Path: "/readyz",
 										Port: intstr.IntOrString{
 											Type:   intstr.Type(0),
-											IntVal: 8081,
+											IntVal: int32(healthProbeBindPort),
 										},
 									},
 								},
@@ -776,13 +783,18 @@ func (a *odigletResourceManager) InstallFromScratch(ctx context.Context) error {
 		resources = append(resources, NewResourceQuota(a.ns))
 	}
 
+	// if the health probe bind port is not set, use the default value
+	if a.config.HealthProbeBindPort == 0 {
+		a.config.HealthProbeBindPort = k8sconsts.OdigletDefaultHealthProbeBindPort
+	}
+
 	// before creating the daemonset, we need to create the service account, cluster role and cluster role binding
 	resources = append(resources,
 		NewOdigletDaemonSet(a.ns, a.odigosVersion, a.config.ImagePrefix, a.managerOpts.ImageReferences.OdigletImage, a.odigosTier, a.config.OpenshiftEnabled,
 			&autodetect.ClusterDetails{
 				Kind:       clusterKind,
 				K8SVersion: k8sVersion,
-			}, a.config.CustomContainerRuntimeSocketPath, a.config.NodeSelector))
+			}, a.config.CustomContainerRuntimeSocketPath, a.config.NodeSelector, a.config.HealthProbeBindPort))
 
 	return a.client.ApplyResources(ctx, a.config.ConfigVersion, resources, a.managerOpts)
 }

--- a/cli/cmd/resources/resourcemanager/resourcemanager.go
+++ b/cli/cmd/resources/resourcemanager/resourcemanager.go
@@ -17,6 +17,8 @@ type ManagerOpts struct {
 	// NodeSelector is a Kubernetes NodeSelector that will be applied to all Odigos components.
 	// Note that Odigos will only be able to instrument applications on the same node.
 	NodeSelector map[string]string
+	// HealthProbeBindAddress is the address the probe endpoint binds to.
+	HealthProbeBindPort int
 }
 
 type ImageReferences struct {

--- a/common/consts/consts.go
+++ b/common/consts/consts.go
@@ -90,6 +90,7 @@ const (
 	OidcTenantUrlProperty             = "oidc-tenant-url"
 	OidcClientIdProperty              = "oidc-client-id"
 	OidcClientSecretProperty          = "oidc-client-secret"
+	HealthProbeBindPortProperty       = "health-probe-bind-port"
 )
 
 var (

--- a/common/odigos_config.go
+++ b/common/odigos_config.go
@@ -164,4 +164,5 @@ type OdigosConfiguration struct {
 	RollbackGraceTime                string                         `json:"rollbackGraceTime,omitempty"`
 	RollbackStabilityWindow          string                         `json:"rollbackStabilityWindow,omitempty"`
 	Oidc                             *OidcConfiguration             `json:"oidc,omitempty"`
+	HealthProbeBindPort              int                            `json:"healthProbeBindPort,omitempty"`
 }

--- a/docs/cli/odigos_config.mdx
+++ b/docs/cli/odigos_config.mdx
@@ -38,6 +38,7 @@ Manage Odigos configuration settings to customize system behavior.
 	- "oidc-tenant-url": Sets the URL of the OIDC tenant.
 	- "oidc-client-id": Sets the client ID of the OIDC application.
 	- "oidc-client-secret": Sets the client secret of the OIDC application.
+	- "health-probe-bind-port": Sets the port for the health probe.
 	
 
 ### Options

--- a/helm/odigos/templates/odiglet/daemonset.yaml
+++ b/helm/odigos/templates/odiglet/daemonset.yaml
@@ -80,6 +80,10 @@ spec:
           {{- else }}
           image: {{ template "utils.imageName" (dict "Values" .Values "Component" "odiglet" "Tag" $imageTag) }}
           {{- end }}
+          args:
+            - --health-probe-bind-port={{ .Values.odiglet.readinessAndLivenessProbePort }}
+          command:
+            - /root/odiglet
           env:
             - name: NODE_NAME
               valueFrom:
@@ -125,13 +129,13 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 8081
+              port: {{ .Values.odiglet.readinessAndLivenessProbePort }}
             initialDelaySeconds: 15
             periodSeconds: 20
           readinessProbe:
             httpGet:
               path: /readyz
-              port: 8081
+              port: {{ .Values.odiglet.readinessAndLivenessProbePort }}
             periodSeconds: 10
           volumeMounts:
             - name: run-dir

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -263,6 +263,11 @@ odiglet:
   # into the Odiglet to ensure it can access the container runtime unix socket.
   customContainerRuntimeSocketPath: ''
 
+  # Prior to Kubernetes v1.26, Odigos uses host networking.
+  # In some environments, different ports may already be in use on the host (e.g., due to other daemons or networking constraints).
+  # Use the following values to configure the readiness and liveness probe ports to avoid conflicts.
+  readinessAndLivenessProbePort: 55683
+
 centralProxy:
   enabled: false
   # Central backend URL where this proxy will forward data

--- a/odiglet/cmd/main.go
+++ b/odiglet/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"os"
 
 	"github.com/odigos-io/odigos/distros"
@@ -22,6 +23,9 @@ import (
 )
 
 func main() {
+	var healthProbeBindPort int
+	flag.IntVar(&healthProbeBindPort, "health-probe-bind-port", 8081, "The port the probe endpoint binds to.")
+
 	// Init Kubernetes clientset
 	cfg, err := rest.InClusterConfig()
 	if err != nil {
@@ -62,8 +66,9 @@ func main() {
 	}
 
 	instrumentationManagerOptions := ebpf.InstrumentationManagerOptions{
-		Factories:          ebpfInstrumentationFactories(),
-		DistributionGetter: dg,
+		Factories:           ebpfInstrumentationFactories(),
+		DistributionGetter:  dg,
+		HealthProbeBindPort: healthProbeBindPort,
 	}
 
 	o, err := odiglet.New(clientset, deviceInjectionCallbacks(), instrumentationManagerOptions)

--- a/odiglet/odiglet.go
+++ b/odiglet/odiglet.go
@@ -51,7 +51,7 @@ func New(clientset *kubernetes.Clientset, deviceInjectionCallbacks instrumentati
 		return nil, err
 	}
 
-	mgr, err := kube.CreateManager()
+	mgr, err := kube.CreateManager(instrumentationMgrOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create controller-runtime manager %w", err)
 	}

--- a/odiglet/pkg/ebpf/common.go
+++ b/odiglet/pkg/ebpf/common.go
@@ -17,9 +17,10 @@ import (
 )
 
 type InstrumentationManagerOptions struct {
-	Factories          map[instrumentation.OtelDistribution]instrumentation.Factory
-	DistributionGetter *distros.Getter
-	MeterProvider      metric.MeterProvider
+	Factories           map[instrumentation.OtelDistribution]instrumentation.Factory
+	DistributionGetter  *distros.Getter
+	MeterProvider       metric.MeterProvider
+	HealthProbeBindPort int
 }
 
 // NewManager creates a new instrumentation manager for eBPF which is configured to work with Kubernetes.

--- a/odiglet/pkg/kube/manager.go
+++ b/odiglet/pkg/kube/manager.go
@@ -48,7 +48,7 @@ type KubeManagerOptions struct {
 	AppendEnvVarNames map[string]struct{}
 }
 
-func CreateManager() (ctrl.Manager, error) {
+func CreateManager(instrumentationMgrOpts ebpf.InstrumentationManagerOptions) (ctrl.Manager, error) {
 	log.Logger.V(0).Info("Starting reconcileres for runtime details")
 	ctrl.SetLogger(log.Logger)
 
@@ -81,7 +81,7 @@ func CreateManager() (ctrl.Manager, error) {
 		Metrics: metricsserver.Options{
 			BindAddress: metricsBindAddress,
 		},
-		HealthProbeBindAddress: ":8081",
+		HealthProbeBindAddress: fmt.Sprintf(":%d", instrumentationMgrOpts.HealthProbeBindPort),
 	})
 }
 


### PR DESCRIPTION
…conflicting

## Description

For Kubernetes versions below 1.26, Odigos installs the Odiglet with hostNetwork enabled. This can lead to port conflicts with other services running on the same node.

Previously, the Odiglet used port 8081 for its liveness and readiness probes. However, in some environments, this port was already in use, causing issues during deployment.

To address this, we need to make the probe port configurable—either through the Helm chart or via a dedicated configuration option—so users can avoid these conflicts by selecting a custom port.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
