### PR TITLE
feat: send container agent config over opamp

### DIFF
--- a/opampserver/pkg/sdkconfig/configsections/instrumentationconfig.go
+++ b/opampserver/pkg/sdkconfig/configsections/instrumentationconfig.go
@@ -44,3 +44,26 @@ func FilterRelevantSdk(instrumentationConfig *v1alpha1.InstrumentationConfig, pr
 	return &instrumentationConfigContent, nil
 
 }
+
+func FilterRelevantContainerConfig(instrumentationConfig *v1alpha1.InstrumentationConfig, containerName string) (*protobufs.AgentConfigFile, error) {
+	containerConfig := v1alpha1.ContainerAgentConfig{}
+
+	for _, container := range instrumentationConfig.Spec.Containers {
+		if container.ContainerName == containerName {
+			containerConfig = container
+		}
+	}
+
+	remoteConfigContainerConfigBytes, err := json.Marshal(containerConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	containerConfigContent := protobufs.AgentConfigFile{
+		Body:        remoteConfigContainerConfigBytes,
+		ContentType: "application/json",
+	}
+
+	return &containerConfigContent, nil
+
+}

--- a/opampserver/pkg/sdkconfig/instrumentationconfigs_controller.go
+++ b/opampserver/pkg/sdkconfig/instrumentationconfigs_controller.go
@@ -29,10 +29,7 @@ func (i *InstrumentationConfigReconciler) Reconcile(ctx context.Context, req ctr
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-
-	for _, sdkConfig := range instrumentationConfig.Spec.SdkConfigs {
-		i.ConnectionCache.UpdateWorkloadRemoteConfig(podWorkload, &sdkConfig)
-	}
+	i.ConnectionCache.UpdateWorkloadRemoteConfig(podWorkload, instrumentationConfig.Spec.SdkConfigs, instrumentationConfig.Spec.Containers)
 
 	return ctrl.Result{}, nil
 }

--- a/opampserver/pkg/server/handlers.go
+++ b/opampserver/pkg/server/handlers.go
@@ -96,7 +96,7 @@ func (c *ConnectionHandlers) OnNewConnection(ctx context.Context, firstMessage *
 		return nil, nil, err
 	}
 
-	fullRemoteConfig, err := c.sdkConfig.GetFullConfig(ctx, remoteResourceAttributes, &podWorkload, instrumentedAppName, attrs.ProgrammingLanguage, instrumentationConfig)
+	fullRemoteConfig, err := c.sdkConfig.GetFullConfig(ctx, remoteResourceAttributes, &podWorkload, instrumentedAppName, attrs.ProgrammingLanguage, instrumentationConfig, k8sAttributes.ContainerName)
 	if err != nil {
 		c.logger.Error(err, "failed to get full config", "k8sAttributes", k8sAttributes)
 		return nil, nil, err


### PR DESCRIPTION
## Description

This adds the content of the relevant "container" entry in the instrumentation config spec as a config map key in the opamp response.

## How Has This Been Tested?

Manual

## Kubernetes Checklist

No change in user k8s interactions

## User Facing Changes

Currently internal refactor only