### PR TITLE
refactor(opamp): add ic predicates to reduce events

### DIFF
--- a/opampserver/pkg/sdkconfig/instrumentationconfigs_controller.go
+++ b/opampserver/pkg/sdkconfig/instrumentationconfigs_controller.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-// Only handle events where the agent is enabled.
+// Only handle events where the agent injection is enabled
 type agentEnabledPredicate struct{}
 
 func (i *agentEnabledPredicate) Create(e event.CreateEvent) bool {
@@ -81,6 +81,10 @@ func (i *InstrumentationConfigReconciler) SetupWithManager(mgr ctrl.Manager) err
 		Named("opampserver-instrumentationconfig").
 		For(&odigosv1.InstrumentationConfig{}).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		// if agent is disabled, we don't need to reconcile as all config is disabled.
+		// TODO: in the future, notify the agent to stop collection until a rollout is triggered?
+		// TODO2: do it also when object is deleted
+		// TODO3: refine the condition so it will be triggered even less
 		WithEventFilter(&agentEnabledPredicate{}).
 		Complete(i)
 }


### PR DESCRIPTION
## Description

Opamp server had no predicate on the instrumentation configs it was processing.
This caused us to reconcile too much, where we can limit the number of events like we do in other places.

This PR adds trivial filter which should already reduce quite a lot of events:
- generation change - filter condition updates and runtime details detections

The filter can be refined further, but I want to start with these and improve the filtering as I refactor the mechanism later on.

## How Has This Been Tested?

- [x] Manual Testing

## Kubernetes Checklist

Odiglet will reconcile less - less CPU. no effect on API server.

## User Facing Changes

Internal refactor