### PR TITLE
Update odigos-config-cm.yaml

### DIFF
--- a/helm/odigos/templates/odigos-config-cm.yaml
+++ b/helm/odigos/templates/odigos-config-cm.yaml
@@ -31,16 +31,16 @@ data:
     centralBackendURL: {{ .Values.ui.centralBackendURL }}
     {{- end }}
     {{- if or .Values.ui.oidcTenantUrl .Values.ui.oidcClientId .Values.ui.oidcClientSecret }}
-      oidc:
-        {{- if .Values.ui.oidcTenantUrl }}
-        tenantUrl: {{ .Values.ui.oidcTenantUrl }}
-        {{- end }}
-        {{- if .Values.ui.oidcClientId }}
-        clientId: {{ .Values.ui.oidcClientId }}
-        {{- end }}
-        {{- if .Values.ui.oidcClientSecret }}
-        clientSecret: secretRef:odigos-oidc
-        {{- end }}
+    oidc:
+      {{- if .Values.ui.oidcTenantUrl }}
+      tenantUrl: {{ .Values.ui.oidcTenantUrl }}
+      {{- end }}
+      {{- if .Values.ui.oidcClientId }}
+      clientId: {{ .Values.ui.oidcClientId }}
+      {{- end }}
+      {{- if .Values.ui.oidcClientSecret }}
+      clientSecret: secretRef:odigos-oidc
+      {{- end }}
     {{- end }}
     {{- if .Values.collectorGateway }}
     collectorGateway:


### PR DESCRIPTION
## Description

Fix indent of oidc config in configmap. This is due to a bug that cause odigos-ui cannot parse YAML properly when I upgrade Odigos to version 1.0.201 using Helm

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [x] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [x] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [x] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
