### PR TITLE
otlp destinations: Set tls insecure:true if TLS is not enabled

### DIFF
--- a/common/config/genericotlp.go
+++ b/common/config/genericotlp.go
@@ -60,10 +60,10 @@ func (g *GenericOTLP) ModifyConfig(dest ExporterConfigurer, currentConfig *Confi
 	}
 
 	// Only add TLS config if TLS is needed (user-enabled or OAuth2-required)
-	if userTlsEnabled || oauth2Enabled {
-		tlsConfig := GenericMap{
-			"insecure": !finalTlsEnabled,
-		}
+	tlsConfig := GenericMap{
+		"insecure": !finalTlsEnabled,
+	}
+	if finalTlsEnabled {
 		caPem, caExists := config[genericOtlpCaPemKey]
 		if caExists && caPem != "" {
 			tlsConfig["ca_pem"] = caPem
@@ -72,8 +72,8 @@ func (g *GenericOTLP) ModifyConfig(dest ExporterConfigurer, currentConfig *Confi
 		if skipExists && insecureSkipVerify != "" {
 			tlsConfig["insecure_skip_verify"] = parseBool(insecureSkipVerify)
 		}
-		exporterConf["tls"] = tlsConfig
 	}
+	exporterConf["tls"] = tlsConfig
 
 	// add OAuth2 authenticator extension if configured
 	if oauth2ExtensionName != "" && oauth2ExtensionConf != nil {

--- a/common/config/genericotlp_test.go
+++ b/common/config/genericotlp_test.go
@@ -62,7 +62,7 @@ func TestGrpcOAuth2AutoTLS(t *testing.T) {
 			},
 			expectedTLS:     false,
 			expectedAuth:    false,
-			expectTLSConfig: false, // NO TLS config should be present
+			expectTLSConfig: true, // TLS config should be present with insecure=true
 		},
 		{
 			name: "OAuth2 disabled, TLS setting respected",
@@ -73,7 +73,7 @@ func TestGrpcOAuth2AutoTLS(t *testing.T) {
 			},
 			expectedTLS:     false,
 			expectedAuth:    false,
-			expectTLSConfig: false, // NO TLS config should be present
+			expectTLSConfig: true, // TLS config should be present with insecure=true
 		},
 	}
 

--- a/common/config/otlphttp.go
+++ b/common/config/otlphttp.go
@@ -81,10 +81,10 @@ func (g *OTLPHttp) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) 
 	}
 
 	// Only add TLS config if TLS is explicitly enabled or authentication is being used
+	tlsConfig := GenericMap{
+		"insecure": !userTlsEnabled,
+	}
 	if userTlsEnabled || hasAuthentication {
-		tlsConfig := GenericMap{
-			"insecure": !userTlsEnabled,
-		}
 		caPem, caExists := config[otlpHttpCaPemKey]
 		if caExists && caPem != "" {
 			tlsConfig["ca_pem"] = caPem
@@ -93,8 +93,8 @@ func (g *OTLPHttp) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) 
 		if skipExists && insecureSkipVerify != "" {
 			tlsConfig["insecure_skip_verify"] = parseBool(insecureSkipVerify)
 		}
-		exporterConf["tls"] = tlsConfig
 	}
+	exporterConf["tls"] = tlsConfig
 
 	if authExtensionName != "" {
 		exporterConf["auth"] = GenericMap{

--- a/common/config/otlphttp_test.go
+++ b/common/config/otlphttp_test.go
@@ -277,7 +277,7 @@ func TestOAuth2Configuration(t *testing.T) {
 				// No TLS, no OAuth2, no Basic Auth
 			},
 			expectedAuth:    false,
-			expectTLSConfig: false,
+			expectTLSConfig: true,
 		},
 		{
 			name: "OAuth2 disabled",
@@ -286,7 +286,7 @@ func TestOAuth2Configuration(t *testing.T) {
 				"OTLP_HTTP_OAUTH2_ENABLED": "false",
 			},
 			expectedAuth:    false,
-			expectTLSConfig: false,
+			expectTLSConfig: true,
 		},
 		{
 			name: "OAuth2 enabled but missing required fields",


### PR DESCRIPTION
## Description

In https://github.com/odigos-io/odigos/pull/3069, the tls config was moved to only be set if configured by a user explicitly or through oauth

However, this means that disabling TLS in these destinations does not set `tls.insecure: true`. This updates both destinations to fix the regression

This can cause errors like:

```
rpc error: code = Unavailable desc = connection error: desc = \"transport: authentication handshake failed: tls: first record does not look like a TLS handshake
```

or

```
connection error: desc = "transport: Error while dialing: dial tcp 10.96.133.107:4317: connect: connection refused"
```

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [x] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
