### PR TITLE
chore: adding the operation name fo the span name if missing

### DIFF
--- a/collector/processors/odigossqldboperationprocessor/processor.go
+++ b/collector/processors/odigossqldboperationprocessor/processor.go
@@ -2,6 +2,7 @@ package odigossqldboperationprocessor
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -56,6 +57,10 @@ func (sp *DBOperationProcessor) processTraces(ctx context.Context, td ptrace.Tra
 				// Only set the `db.operation.name` if the detected operation name is not "UNKNOWN"
 				if operationName != OperationUnknown {
 					span.Attributes().PutStr(string(semconv.DBOperationNameKey), operationName)
+
+					// Append operation name to the span name
+					originalName := span.Name()
+					span.SetName(fmt.Sprintf("%s %s", originalName, operationName))
 				}
 			}
 		}


### PR DESCRIPTION
## Description

We have a processor that heuristically determines the SQL operation name by extracting the first word from the db.query.text. Once identified, we append this operation name to the span names to avoid scenarios where users see spans labeled only as "DB", which can be ambiguous.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
