### PR TITLE
fix: goreleaser deprecations

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,11 +19,11 @@ builds:
       - -X github.com/odigos-io/odigos/cli/cmd.OdigosCommit={{ .ShortCommit }}
       - -X github.com/odigos-io/odigos/cli/cmd.OdigosDate={{ .Date }}
     tags:
-     - embed_manifests
+      - embed_manifests
 archives:
   - id: odigos
     name_template: "cli_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    builds:
+    ids:
       - odigos
     files:
       - none*
@@ -37,7 +37,7 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
-brews:
+homebrew_casks:
   - repository:
       owner: keyval-dev
       name: homebrew-odigos-cli


### PR DESCRIPTION
## Description

This PR tries to fix deprecations in `goreleaser`:
- https://goreleaser.com/deprecations/#brews
- https://goreleaser.com/deprecations/#snapsbuilds

<img width="1299" alt="Screenshot 2025-07-01 at 16 48 14" src="https://github.com/user-attachments/assets/4e685eb3-52bc-477e-8619-e87a0bbf05ee" />
