### PR TITLE
chore: fix datadog special senario

### DIFF
--- a/common/pipelinegen/config_builder.go
+++ b/common/pipelinegen/config_builder.go
@@ -92,7 +92,7 @@ func CalculateGatewayConfig(
 			currentConfig.Connectors[connectorName] = config.GenericMap{}
 			pipeline := currentConfig.Service.Pipelines[pipelineName]
 			// add the forward connector as a receiver to the pipeline
-			pipeline.Receivers = []string{connectorName}
+			pipeline.Receivers = append(pipeline.Receivers, connectorName)
 			// every destination pipeline should have a generic batch processor
 			pipeline.Processors = []string{consts.GenericBatchProcessorConfigKey}
 


### PR DESCRIPTION
## Description

Once creating a Datadog with combination of traces + metrics, we're creating connector to send metrics based on the traces to the metrics destination.
in the Datastream implementation we lack support for this and this PR fixes it.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
