### PR TITLE
Add release-blockers option to label PRs for targeted release

### DIFF
--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -58,7 +58,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           PR_LINKS: ${{ steps.verify.outputs.links }}
         run: |
-          pr_links_formatted=$(echo "$PR_LINKS" | jq -r '.[]' | awk '{print "- " $0}' | tr '\n' '\n')
+          pr_links_formatted=$(echo "$PR_LINKS" | tr ' ' '\n' | awk '{print "- " $0}' | tr '\n' '\n')
           curl -X POST -H 'Content-type: application/json' --data "{
             \"description\": \"❌ ERROR: Open offset PRs found in \`${{ matrix.repo }}\`\n\n$pr_links_formatted\",
             \"link\": \"https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}\",
@@ -113,7 +113,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           PR_LINKS: ${{ steps.verify.outputs.links }}
         run: |
-          pr_links_formatted=$(echo "$PR_LINKS" | jq -r '.[]' | awk '{print "- " $0}' | tr '\n' '\n')
+          pr_links_formatted=$(echo "$PR_LINKS" | tr ' ' '\n' | awk '{print "- " $0}' | tr '\n' '\n')
           curl -X POST -H 'Content-type: application/json' --data "{
             \"description\": \"❌ ERROR: Open depenencies-syncer-bot PRs found in \`${{ matrix.repo }}\`\n\n$pr_links_formatted\",
             \"link\": \"https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}\",
@@ -168,7 +168,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           PR_LINKS: ${{ steps.verify.outputs.links }}
         run: |
-          pr_links_formatted=$(echo "$PR_LINKS" | jq -r '.[]' | awk '{print "- " $0}' | tr '\n' '\n')
+          pr_links_formatted=$(echo "$PR_LINKS" | tr ' ' '\n' | awk '{print "- " $0}' | tr '\n' '\n')
           curl -X POST -H 'Content-type: application/json' --data "{
             \"description\": \"❌ ERROR: Open release-blocker PRs found in \`${{ matrix.repo }}\`\n\n$pr_links_formatted\",
             \"link\": \"https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}\",

--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -176,7 +176,7 @@ jobs:
           }" $SLACK_WEBHOOK_URL
 
   print-tag:
-    needs: verify-dependencies-sync
+    needs: verify-release-blockers
     runs-on: ubuntu-latest
     steps:
       - name: Extract Tag
@@ -190,7 +190,7 @@ jobs:
           curl -X POST -H 'Content-type: application/json' --data '{"description":"Detected new git tag. initializing a release", "tag":"${{ steps.extract_tag.outputs.tag }}"}' ${{ env.SLACK_WEBHOOK_URL }}
 
   tag-modules:
-    needs: verify-dependencies-sync
+    needs: verify-release-blockers
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -246,7 +246,7 @@ jobs:
           curl -X POST -H 'Content-type: application/json' --data '{"link":"https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}", "description":"ERROR: Odigos go modules release failed", "tag":"${{ steps.extract_tag.outputs.tag }}"}' ${{ env.SLACK_WEBHOOK_URL }}
 
   publish-images:
-    needs: verify-dependencies-sync
+    needs: verify-release-blockers
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -368,7 +368,7 @@ jobs:
           curl -X POST -H 'Content-type: application/json' --data '{"link":"https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}", "description":"ERROR: odigos component ${{ matrix.service }} release failed", "tag":"${{ steps.extract_tag.outputs.tag }}"}' ${{ env.SLACK_WEBHOOK_URL }}
 
   publish-collector-linux-packages:
-    needs: verify-dependencies-sync
+    needs: verify-release-blockers
     runs-on: ubuntu-latest
     steps:
       - name: Extract Tag

--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -120,6 +120,61 @@ jobs:
             \"tag\": \"verify-dependencies-sync-failure\"
           }" $SLACK_WEBHOOK_URL
 
+  verify-release-blockers:
+    needs: verify-dependencies-sync
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: ['odigos', 'odigos-enterprise']
+    steps:
+      - name: Verify no open release-blocker PRs
+        id: verify
+        run: |
+          # Fetch open PRs and filter by "release-blocker" label
+          result=$(curl -s -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.RELEASE_BOT_TOKEN }}" \
+            "https://api.github.com/repos/odigos-io/${{ matrix.repo }}/pulls?state=open&per_page=100")
+
+          pr_links=$(echo "$result" \
+            | jq -r '[.[] | select(.labels | any(.name == "release-blocker")) | .html_url] | join(" ")')
+
+          count=$(echo "$pr_links" | wc -w)
+          if [ "$count" -gt 0 ]; then
+            # Write outputs to GITHUB_OUTPUT instead of using ::set-output
+            echo "status=failed" >> $GITHUB_OUTPUT
+            echo "links=$pr_links" >> $GITHUB_OUTPUT
+            echo "❌ Error: Open PRs with label \"release-blocker\" found!" >&2
+            exit 1
+          else
+            echo "status=success" >> $GITHUB_OUTPUT
+            echo "✅ No open PRs with label \"release-blocker\"."
+          fi
+
+      - name: Notify Slack on Success
+        if: ${{ steps.verify.outputs.status == 'success' }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' --data '{
+            "description": "✅ No open release-blocker PRs in `${{ matrix.repo }}`",
+            "tag": "verify-release-blockers-success"
+          }' $SLACK_WEBHOOK_URL
+
+      - name: Notify Slack on Failure
+        if: ${{ failure() }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          PR_LINKS: ${{ steps.verify.outputs.links }}
+        run: |
+          pr_links_formatted=$(echo "$PR_LINKS" | jq -r '.[]' | awk '{print "- " $0}' | tr '\n' '\n')
+          curl -X POST -H 'Content-type: application/json' --data "{
+            \"description\": \"❌ ERROR: Open release-blocker PRs found in \`${{ matrix.repo }}\`\n\n$pr_links_formatted\",
+            \"link\": \"https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}\",
+            \"tag\": \"verify-release-blockers-failure\"
+          }" $SLACK_WEBHOOK_URL
+
   print-tag:
     needs: verify-dependencies-sync
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

This allows maintainers to add the `release-blocker` label to a PR to prevent a release from being published without that PR.

Other maintainers can always remove the `release-blocker` label if the release is urgent and doesn't depend on that PR

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
