### PR TITLE
feat: calculate env injection method in reconcile 

### DIFF
--- a/api/config/crd/bases/odigos.io_instrumentationconfigs.yaml
+++ b/api/config/crd/bases/odigos.io_instrumentationconfigs.yaml
@@ -93,6 +93,20 @@ spec:
                       - RuntimeDetailsUnavailable
                       - CrashLoopBackOff
                       type: string
+                    agentInjectionMethod:
+                      description: |-
+                        the reconciler resolves which injection method to use for this container.
+                        it is affected (at the moment) by config, runtime inspection and the user defined overrides.
+                        This field carries the following semantics:
+                        - nil: do not inject any "append variables" (PYTHONPATH, NODE_OPTIONS, etc.) at all.
+                        - "loader": inject the LD_PRELOAD env var to the pod manifest which will trigger the odigos loader.
+                        - "pod-manifest": inject the runtime specific agent loading env vars (e.g PYTHONPATH, NODE_OPTIONS) as specified in the distro manifest.
+                        - "loader-fallback-to-pod-manifest": use "pod-manifest". it means we tried LD_PRELOAD and it failed, so we falled-back to the pod manifest.
+                      enum:
+                      - loader
+                      - pod-manifest
+                      - loader-fallback-to-pod-manifest
+                      type: string
                     containerName:
                       description: The name of the container to which this configuration
                         applies.

--- a/api/generated/odigos/applyconfiguration/odigos/v1alpha1/containeragentconfig.go
+++ b/api/generated/odigos/applyconfiguration/odigos/v1alpha1/containeragentconfig.go
@@ -19,6 +19,7 @@ package v1alpha1
 
 import (
 	odigosv1alpha1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	common "github.com/odigos-io/odigos/common"
 )
 
 // ContainerAgentConfigApplyConfiguration represents a declarative configuration of the ContainerAgentConfig type for use
@@ -30,6 +31,7 @@ type ContainerAgentConfigApplyConfiguration struct {
 	AgentEnabledMessage *string                            `json:"agentEnabledMessage,omitempty"`
 	OtelDistroName      *string                            `json:"otelDistroName,omitempty"`
 	DistroParams        map[string]string                  `json:"distroParams,omitempty"`
+	EnvInjectionMethod  *common.EnvInjectionMethod         `json:"agentInjectionMethod,omitempty"`
 	Traces              *odigosv1alpha1.AgentTracesConfig  `json:"traces,omitempty"`
 	Metrics             *odigosv1alpha1.AgentMetricsConfig `json:"metrics,omitempty"`
 	Logs                *odigosv1alpha1.AgentLogsConfig    `json:"logs,omitempty"`
@@ -92,6 +94,14 @@ func (b *ContainerAgentConfigApplyConfiguration) WithDistroParams(entries map[st
 	for k, v := range entries {
 		b.DistroParams[k] = v
 	}
+	return b
+}
+
+// WithEnvInjectionMethod sets the EnvInjectionMethod field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the EnvInjectionMethod field is set to the value of the last call.
+func (b *ContainerAgentConfigApplyConfiguration) WithEnvInjectionMethod(value common.EnvInjectionMethod) *ContainerAgentConfigApplyConfiguration {
+	b.EnvInjectionMethod = &value
 	return b
 }
 

--- a/api/odigos/v1alpha1/instrumentationconfig_types.go
+++ b/api/odigos/v1alpha1/instrumentationconfig_types.go
@@ -290,6 +290,15 @@ type ContainerAgentConfig struct {
 	// Keys are parameter names (like "libc") and values are the value to use for that parameter (glibc / musl)
 	DistroParams map[string]string `json:"distroParams,omitempty"`
 
+	// the reconciler resolves which injection method to use for this container.
+	// it is affected (at the moment) by config, runtime inspection and the user defined overrides.
+	// This field carries the following semantics:
+	// - nil: do not inject any "append variables" (PYTHONPATH, NODE_OPTIONS, etc.) at all.
+	// - "loader": inject the LD_PRELOAD env var to the pod manifest which will trigger the odigos loader.
+	// - "pod-manifest": inject the runtime specific agent loading env vars (e.g PYTHONPATH, NODE_OPTIONS) as specified in the distro manifest.
+	// - "loader-fallback-to-pod-manifest": use "pod-manifest". it means we tried LD_PRELOAD and it failed, so we falled-back to the pod manifest.
+	EnvInjectionMethod *common.EnvInjectionMethod `json:"agentInjectionMethod,omitempty"`
+
 	// Each enabled signal must be set with a non-nil value (even if the config content is empty).
 	// nil means that the signal is disabled and should not be instrumented/collected by the agent.
 	Traces  *AgentTracesConfig  `json:"traces,omitempty"`

--- a/api/odigos/v1alpha1/zz_generated.deepcopy.go
+++ b/api/odigos/v1alpha1/zz_generated.deepcopy.go
@@ -388,6 +388,11 @@ func (in *ContainerAgentConfig) DeepCopyInto(out *ContainerAgentConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.EnvInjectionMethod != nil {
+		in, out := &in.EnvInjectionMethod, &out.EnvInjectionMethod
+		*out = new(common.EnvInjectionMethod)
+		**out = **in
+	}
 	if in.Traces != nil {
 		in, out := &in.Traces, &out.Traces
 		*out = new(AgentTracesConfig)

--- a/distros/yamls/java-community.yaml
+++ b/distros/yamls/java-community.yaml
@@ -22,3 +22,4 @@ spec:
       - "{{ODIGOS_AGENTS_DIR}}/java"
     k8sAttrsViaEnvVars: true
     device: 'instrumentation.odigos.io/generic'
+    ldPreloadInjectionSupported: true

--- a/distros/yamls/nodejs-community.yaml
+++ b/distros/yamls/nodejs-community.yaml
@@ -23,3 +23,4 @@ spec:
       - "{{ODIGOS_AGENTS_DIR}}/opentelemetry-node"
     device: 'instrumentation.odigos.io/generic'
     k8sAttrsViaEnvVars: true
+    ldPreloadInjectionSupported: true

--- a/distros/yamls/python-community.yaml
+++ b/distros/yamls/python-community.yaml
@@ -25,3 +25,4 @@ spec:
       - "{{ODIGOS_AGENTS_DIR}}/python"
     device: 'instrumentation.odigos.io/generic'
     k8sAttrsViaEnvVars: true
+    ldPreloadInjectionSupported: true

--- a/helm/odigos/templates/crds/odigos.io_instrumentationconfigs.yaml
+++ b/helm/odigos/templates/crds/odigos.io_instrumentationconfigs.yaml
@@ -93,6 +93,20 @@ spec:
                       - RuntimeDetailsUnavailable
                       - CrashLoopBackOff
                       type: string
+                    agentInjectionMethod:
+                      description: |-
+                        the reconciler resolves which injection method to use for this container.
+                        it is affected (at the moment) by config, runtime inspection and the user defined overrides.
+                        This field carries the following semantics:
+                        - nil: do not inject any "append variables" (PYTHONPATH, NODE_OPTIONS, etc.) at all.
+                        - "loader": inject the LD_PRELOAD env var to the pod manifest which will trigger the odigos loader.
+                        - "pod-manifest": inject the runtime specific agent loading env vars (e.g PYTHONPATH, NODE_OPTIONS) as specified in the distro manifest.
+                        - "loader-fallback-to-pod-manifest": use "pod-manifest". it means we tried LD_PRELOAD and it failed, so we falled-back to the pod manifest.
+                      enum:
+                      - loader
+                      - pod-manifest
+                      - loader-fallback-to-pod-manifest
+                      type: string
                     containerName:
                       description: The name of the container to which this configuration
                         applies.

--- a/instrumentor/controllers/manager.go
+++ b/instrumentor/controllers/manager.go
@@ -203,13 +203,13 @@ func RegisterWebhooks(mgr manager.Manager, dp *distros.Provider) error {
 	}
 
 	err = builder.
-	WebhookManagedBy(mgr).
-	For(&corev1.Pod{}).
-	WithDefaulter(&agentenabled.PodsWebhook{
-		Client:        mgr.GetClient(),
-		DistrosGetter: dp.Getter,
-	}).
-	Complete()
+		WebhookManagedBy(mgr).
+		For(&corev1.Pod{}).
+		WithDefaulter(&agentenabled.PodsWebhook{
+			Client:        mgr.GetClient(),
+			DistrosGetter: dp.Getter,
+		}).
+		Complete()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

This is another step in the journey for deprecating otel-sdk and env-overwite.

Today, pods webhook applies some logic deciding which env injection to use, based on:
- odigos configuration (`agentEnvVarsInjectionMethod` which can have 3 values)
- runtime detection (`securedEcecution` and `LD_PRELOAD` in EnvVars)
- `otelSdk` as this logic will only run for languages found in this static map in code.

The initiative is to move this calculation to the reconcile phase, and only storing single enum on each container agent configuration to instruct it what to use in injection:
- less complexity in webhook which is sensitive component that might get run frequently
- better visibility in ui and instrumentation config to what odigos is doing
- less dependencies in the webhook - consolidate all it's inputs into a single place which gets updated atomically in reconcile which is less room for race conditions and conflicts.
- one more place where we don't rely on otelSdk and migrate to use distro manifests. this will help us deprecate it and cleanup our code a bit.

## How Has This Been Tested?

- [x] Manual Testing

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [x] Changes how Odigos interacts with Kubernetes
writes one more enum into each agent config in "InstrumentationConfig" object

~~- [ ] Introduces additional calls to the API Server (potential performance impact)~~
~~- [ ] New Query/feature supported in all the k8s versions supported by Odigos~~
- [x] Modifies Odigos manifests (addressed in both CLI and Helm)
added to CRD

~~- [ ] Changes RBAC permissions~~

## User Facing Changes

Internal refactor. 