### PR TITLE
ci: add empty commit message for PR to be allowed

### DIFF
--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -67,7 +67,7 @@ else
         git checkout "release/$NEXT_VERSION"
         git pull origin "release/$NEXT_VERSION" 2>/dev/null || true
         # Update the branch to latest main
-        git merge main --no-edit
+        git reset --hard origin/main
     else
         echo "Creating new branch release/$NEXT_VERSION"
         git checkout -b "release/$NEXT_VERSION"

--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -72,6 +72,9 @@ else
         echo "Creating new branch release/$NEXT_VERSION"
         git checkout -b "release/$NEXT_VERSION"
     fi
+
+    # Create empty commit to ensure there are changes for the PR
+    git commit --allow-empty -m "Release $NEXT_VERSION"
     
     git push origin "release/$NEXT_VERSION"
     if ! gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base main --head "release/$NEXT_VERSION" --label "release" --label "automated"; then


### PR DESCRIPTION
Trying to fix this error in ci for a new process (create release PR instead of doing it from our machines):

```
pull request create failed: GraphQL: No commits between main and release/v1.0.206 (createPullRequest)
Error: Failed to create PR for v1.0.206
```

this PR adds an empty commit to try and bypass this.
In the future we might also want to write some changelog or sometime like that, which will make this commit unneeded 