### PR TITLE
feat: improve odiglet init phase

### DIFF
--- a/cli/cmd/resources/odiglet.go
+++ b/cli/cmd/resources/odiglet.go
@@ -455,8 +455,25 @@ func NewOdigletDaemonSet(ns string, version string, imagePrefix string, imageNam
 										},
 									},
 								},
+								{
+									// let the Go runtime know how many CPUs are available,
+									// without this, Go will assume all the cores are available.
+									Name: "GOMAXPROCS",
+									ValueFrom: &corev1.EnvVarSource{
+										ResourceFieldRef: &corev1.ResourceFieldSelector{
+											ContainerName: "init",
+											// limitCPU, Kubernetes automatically rounds up the value to an integer
+											// (700m -> 1, 1200m -> 2)
+											Resource: "limits.cpu",
+										},
+									},
+								},
 							},
-							Resources: corev1.ResourceRequirements{},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									"cpu": resource.MustParse("100m"),
+								},
+							},
 							VolumeMounts: append([]corev1.VolumeMount{
 								{
 									Name:      "odigos",

--- a/helm/odigos/templates/odiglet/daemonset.yaml
+++ b/helm/odigos/templates/odiglet/daemonset.yaml
@@ -71,6 +71,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: init
+                  resource: limits.cpu
+          resources:
+            limits:
+              cpu: 100m
 
       containers:
         - name: odiglet

--- a/odiglet/pkg/instrumentation/fs/copy_test.go
+++ b/odiglet/pkg/instrumentation/fs/copy_test.go
@@ -16,7 +16,7 @@ func TestGetFiles(t *testing.T) {
 	}
 
 	filesToKeep := make(map[string]struct{})
-	gotFiles, err := getFiles(tempDir+"/dir1", false, filesToKeep)
+	gotFiles, err := getFiles(tempDir+"/dir1", false, filesToKeep, filesToKeep)
 	if err != nil {
 		t.Fatalf("getFiles failed: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestCopyDirectories(t *testing.T) {
 		t.Fatalf("createTestFiles failed: %v", err)
 	}
 
-	err = copyDirectories(src, dest, filesToKeep)
+	err = copyDirectories(src, dest, filesToKeep, filesToKeep)
 	if err != nil {
 		t.Fatalf("copyDirectories failed: %v", err)
 	}
@@ -110,7 +110,7 @@ func BenchmarkCopyDirectories(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		err = copyDirectories(src, dest, filesToKeep)
+		err = copyDirectories(src, dest, filesToKeep, filesToKeep)
 		if err != nil {
 			b.Fatalf("copyDirectories failed: %v", err)
 		}

--- a/odiglet/pkg/instrumentation/fs/remove.go
+++ b/odiglet/pkg/instrumentation/fs/remove.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,21 +10,13 @@ import (
 	"github.com/odigos-io/odigos/odiglet/pkg/log"
 )
 
-func removeFilesInDir(hostDir string, filesToKeep map[string]struct{}) error {
+func removeFilesInDir(hostDir string, unchangedFiles map[string]struct{}, filesToKeep map[string]struct{}) error {
 	log.Logger.V(0).Info("Removing files in the host directory", "hostDir", hostDir)
 
-	// Mark directories as protected if they contain a file that needs to be preserved.
-	protectedDirs := make(map[string]bool)
-	for file := range filesToKeep {
-		dir := filepath.Dir(file)
-		for dir != hostDir {
-			protectedDirs[dir] = true
-			dir = filepath.Dir(dir)
-		}
-		protectedDirs[hostDir] = true // Protect the main directory
-	}
+	// Protect directories that contain files we want to keep and unchanged files
+	protectedDirs := calculateProtectedDirs(hostDir, filesToKeep, unchangedFiles)
 
-	return filepath.Walk(hostDir, func(path string, info os.FileInfo, err error) error {
+	return filepath.WalkDir(hostDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -32,9 +25,9 @@ func removeFilesInDir(hostDir string, filesToKeep map[string]struct{}) error {
 			return nil
 		}
 
-		// Skip removing any files listed in filesToKeepMap
-		if !info.IsDir() {
-			if _, found := filesToKeep[path]; found {
+		// Skip removing files that are either in the filesToKeep map, have a versioning suffix, or not changed
+		if !d.IsDir() {
+			if _, keep := filesToKeep[path]; keep {
 				log.Logger.V(0).Info("Skipping protected file", "file", path)
 				return nil
 			}
@@ -43,24 +36,54 @@ func removeFilesInDir(hostDir string, filesToKeep map[string]struct{}) error {
 				log.Logger.V(0).Info("Skipping file with versioning suffix", "file", path)
 				return nil
 			}
+			if _, isUnchanged := unchangedFiles[path]; isUnchanged {
+				log.Logger.V(1).Info("Skipping unchanged file", "file", path)
+				return nil
+			}
 		}
 
-		// Skip removing protected directories
-		if info.IsDir() && protectedDirs[path] {
-			log.Logger.V(0).Info("Skipping protected directory", "directory", path)
-			return nil
+		if d.IsDir() {
+			if _, protected := protectedDirs[path]; protected {
+				log.Logger.V(1).Info("Skipping protected directory", "directory", path)
+				return nil
+			}
 		}
 
-		// Remove removing unprotected files and directories
-		if err := os.RemoveAll(path); err != nil {
+		err = os.RemoveAll(path)
+		if err != nil {
 			return fmt.Errorf("error removing %s: %w", path, err)
 		}
 
 		// Skip further processing in this directory since it has been removed
-		if info.IsDir() {
+		if d.IsDir() {
 			return filepath.SkipDir
 		}
 
 		return nil
 	})
+}
+
+func calculateProtectedDirs(hostDir string, filesToKeep, unchangedFiles map[string]struct{}) map[string]struct{} {
+	protectedDirs := make(map[string]struct{})
+
+	// Always protect the root hostDir itself
+	protectedDirs[hostDir] = struct{}{}
+
+	addDirs := func(file string) {
+		dir := filepath.Dir(file)
+		for dir != hostDir {
+			protectedDirs[dir] = struct{}{}
+			dir = filepath.Dir(dir)
+		}
+	}
+
+	for file := range filesToKeep {
+		addDirs(file)
+	}
+
+	for file := range unchangedFiles {
+		addDirs(file)
+	}
+
+	return protectedDirs
 }


### PR DESCRIPTION
## Description

This PR introduces several performance and efficiency improvements to the init container logic in the Odiglet:

1. Smarter Worker Allocation via GOMAXPROCS
Worker count for parallel file copying is now based on runtime.GOMAXPROCS, reflecting the container’s CPU limit. This gives users control over the tradeoff between copy speed and CPU usage.

2. Avoid Redundant File Copying
Files that are unchanged (based on size) are now preserved instead of being deleted and recopied, reducing unnecessary I/O and improving startup time.

3. Optimized eBPF Directory Detection
Replaces recursive filepath.Walk with a faster os.ReadDir to check only top-level directories for ebpf, avoiding deep filesystem scans.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
