### PR TITLE
fix: check length of golang regex result before accessing

### DIFF
--- a/procdiscovery/pkg/inspectors/golang/golang.go
+++ b/procdiscovery/pkg/inspectors/golang/golang.go
@@ -59,7 +59,14 @@ func (g *GolangInspector) GetRuntimeVersion(pcx *process.ProcessContext, contain
 	if err != nil || buildInfo == nil {
 		return nil
 	}
+	// versionRegex matches "go1.21.3" and captures "1.21.3" in match[1]
+	// match[0] contains the full match including "go" prefix
+	// match[1] contains just the version number we want to extract
 	match := versionRegex.FindStringSubmatch(buildInfo.GoVersion)
-
+	if len(match) < 2 {
+		// It is observed that go1.17.0 and maybe others are failing here.
+		// check the match expected length before accessing it so not to panic
+		return nil
+	}
 	return common.GetVersion(match[1])
 }


### PR DESCRIPTION
## Description

While testing the minimum golang version odigos supports (`v1.17.0`) I noticed that there is no language detection for this service. the odiglet logs has:

```
{"level":"error","ts":1752332183.664659,"caller":"controller/controller.go:347","msg":"Reconciler error","controller":"Odiglet-RuntimeDetails-Pods","controllerGroup":"","controllerKind":"Pod","Pod":{"name":"versionminimum-9f4cb6578-cd4f8","namespace":"golang-httpserver"},"namespace":"golang-httpserver","name":"versionminimum-9f4cb6578-cd4f8","reconcileID":"b0be3579-19e2-4ed0-85a4-5c88496d8dc9","error":"panic: runtime error: index out of range [1] with length 0 [recovered]","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:347\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255"}
```

When I checked the code, I saw we are indeed accessing a slice in index 2 without first verifying the length is correct.
This PR fix it, so we will not get panic if something isn't right there

