### PR TITLE
fix: do not inject instrumentation to pod if odiglet is not ready

### DIFF
--- a/cli/cmd/resources/instrumentor.go
+++ b/cli/cmd/resources/instrumentor.go
@@ -91,6 +91,12 @@ func NewInstrumentorRole(ns string) *rbacv1.Role {
 				ResourceNames: []string{k8sconsts.DeprecatedInstrumentorWebhookSecretName},
 				Verbs:         []string{"delete"},
 			},
+			{ // check for odiglet daemonset ready before starting the instrumentation
+				APIGroups:     []string{"apps"},
+				Resources:     []string{"daemonsets"},
+				ResourceNames: []string{k8sconsts.OdigletDaemonSetName},
+				Verbs:         []string{"get", "list", "watch"},
+			},
 			{
 				APIGroups: []string{"odigos.io"},
 				Resources: []string{"collectorsgroups"},

--- a/docs/permissions.mdx
+++ b/docs/permissions.mdx
@@ -153,6 +153,7 @@ Below are the Roles used by Odigos components. These Roles are only scoped to th
 | \* | secrets | \* | get<br />list<br />watch |
 | \* | secrets | instrumentor-webhooks-cert | update |
 | \* | secrets | webhook-cert | delete |
+| apps | daemonsets | odiglet | get<br />list<br />watch |
 
 ### odigos-leader-election-role
 

--- a/helm/odigos/templates/instrumentor/role.yaml
+++ b/helm/odigos/templates/instrumentor/role.yaml
@@ -73,3 +73,13 @@ rules:
       - webhook-cert
     verbs:
       - delete
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+    resourceNames:
+      - odiglet
+    verbs:
+      - get
+      - list
+      - watch

--- a/instrumentor/controllers/agentenabled/pods_webhook.go
+++ b/instrumentor/controllers/agentenabled/pods_webhook.go
@@ -17,8 +17,10 @@ import (
 	podutils "github.com/odigos-io/odigos/instrumentor/internal/pod"
 	webhookenvinjector "github.com/odigos-io/odigos/instrumentor/internal/webhook_env_injector"
 	"github.com/odigos-io/odigos/instrumentor/sdks"
+	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	k8sutils "github.com/odigos-io/odigos/k8sutils/pkg/utils"
 	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -41,6 +43,24 @@ func (p *PodsWebhook) Default(ctx context.Context, obj runtime.Object) error {
 
 	if !ok {
 		logger.Error(errors.New("expected a Pod but got a %T"), "failed to inject odigos agent")
+		return nil
+	}
+
+	// the following check is another safety guard which is meant to avoid injecting the agent any instrumentation
+	// (including the device) in case the odiglet daemonset is not ready.
+	// it can cover cases like that odiglet is deleted and no replicas are ready.
+	odigosNamespace := env.GetCurrentNamespace()
+	odigletDaemonset := &appsv1.DaemonSet{}
+	if err := p.Get(ctx, client.ObjectKey{Namespace: odigosNamespace, Name: k8sconsts.OdigletDaemonSetName}, odigletDaemonset); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("odiglet daemonset not found, skipping Injection of ODIGOS agent")
+		} else {
+			logger.Error(err, "failed to verify odiglet daemonset ready for instrumented pod. Skipping Injection of ODIGOS agent")
+		}
+		return nil
+	}
+	if odigletDaemonset.Status.NumberReady == 0 {
+		logger.Error(errors.New("odiglet daemonset is not ready. Skipping Injection of ODIGOS agent"), "failed to verify odiglet daemonset ready for instrumented pod")
 		return nil
 	}
 

--- a/instrumentor/controllers/manager.go
+++ b/instrumentor/controllers/manager.go
@@ -31,6 +31,7 @@ import (
 
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
@@ -57,6 +58,9 @@ func CreateManager(opts KubeManagerOptions) (ctrl.Manager, error) {
 	nsSelector := client.InNamespace(odigosNs).AsSelector()
 	odigosEffectiveConfigNameSelector := fields.OneTermEqualSelector("metadata.name", consts.OdigosEffectiveConfigName)
 	odigosEffectiveConfigSelector := fields.AndSelectors(nsSelector, odigosEffectiveConfigNameSelector)
+
+	odigletDaemonsetNameSelector := fields.OneTermEqualSelector("metadata.name", k8sconsts.OdigletDaemonSetName)
+	odigletDaemonsetSelector := fields.AndSelectors(nsSelector, odigletDaemonsetNameSelector)
 
 	instrumentedPodReq, _ := labels.NewRequirement(k8sconsts.OdigosAgentsMetaHashLabel, selection.Exists, []string{})
 	instrumentedPodSelector := labels.NewSelector().Add(*instrumentedPodReq)
@@ -126,6 +130,9 @@ func CreateManager(opts KubeManagerOptions) (ctrl.Manager, error) {
 				},
 				&corev1.ConfigMap{}: {
 					Field: odigosEffectiveConfigSelector,
+				},
+				&appsv1.DaemonSet{}: {
+					Field: odigletDaemonsetSelector,
 				},
 				&odigosv1.CollectorsGroup{}: {
 					Field: nsSelector,
@@ -204,13 +211,13 @@ func RegisterWebhooks(mgr manager.Manager, dp *distros.Provider) error {
 	}
 
 	err = builder.
-	WebhookManagedBy(mgr).
-	For(&corev1.Pod{}).
-	WithDefaulter(&agentenabled.PodsWebhook{
-		Client:        mgr.GetClient(),
-		DistrosGetter: dp.Getter,
-	}).
-	Complete()
+		WebhookManagedBy(mgr).
+		For(&corev1.Pod{}).
+		WithDefaulter(&agentenabled.PodsWebhook{
+			Client:        mgr.GetClient(),
+			DistrosGetter: dp.Getter,
+		}).
+		Complete()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

This is a safeguard, so if odiglet is deleted or have no ready replicas, the webhook will avoid to inject instrumentation into the pod.

While unlikely, if odiglet is deleted or all replicas are not ready, then the pods webhook might add the instrumentation device or the affinity and cause the pod to be unscheduled (odiglet is currently required for the pod to start on a node).

This can help us increase stability in some edge cases.

## How Has This Been Tested?

- [x] Manual Testing

## Kubernetes Checklist

pods webhook in instrumentor now need to query daemonset, and it will skip mutating the pod if odiglet is "not found"

- [x] Modifies Odigos manifests (addressed in both CLI and Helm)
- [x] Changes RBAC permissions

## User Facing Changes

Not expected