### PR TITLE
ci: ignore mint.json from the git status check

### DIFF
--- a/.github/workflows/generated-docs.yaml
+++ b/.github/workflows/generated-docs.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: "3.x"
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
@@ -77,7 +77,8 @@ jobs:
           python sync-dest-doc.py
       - name: Check for changes in Destinations docs
         run: |
-          if [[ -n $(git status --porcelain) ]]; then
+          # Exclude mint.json from the git status check (the script applies a formatting change, which is not relevant to the actual docs generation)
+          if [[ -n $(git status --porcelain -- . ':!docs/mint.json') ]]; then
             git diff
             echo "Destinations docs need to be updated. Please run 'cd docs && python sync-dest-doc.py', then commit the changes."
             exit 1
@@ -91,7 +92,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: "3.x"
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Description

The destination docs generation script applies a formatting to the `mint.json` file.

Sometimes when we manually add doc pages (for example PR #3167), the CI fails due to formatting change (see job https://github.com/odigos-io/odigos/actions/runs/16250264278/job/45878946842?pr=3167), this change is not relevant to the actual generation of docs, and should not be a reason to fail the CI.

This PR makes sure we ignore the file in the git status check.
