### PR TITLE
ci: add permissions to publish packages from workflow

### DIFF
--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -250,6 +250,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
+      packages: 'write'
     strategy:
       matrix:
         dockerfile: ['Dockerfile', 'Dockerfile.rhel']


### PR DESCRIPTION
Add missing permissions to publish packages from github actions