### PR TITLE
cli(fix): missing fallback query in getOdigosNamespace function

### DIFF
--- a/cli/cmd/resources/namespace.go
+++ b/cli/cmd/resources/namespace.go
@@ -23,24 +23,47 @@ func NewNamespace(name string) *v1.Namespace {
 	}
 }
 
-func GetOdigosNamespace(client *kube.Client, ctx context.Context) (string, error) {
+func getNamespaceFromConfigMap(client *kube.Client, ctx context.Context, configMapName string) (string, error) {
 	configMap, err := client.CoreV1().ConfigMaps("").List(ctx, metav1.ListOptions{
 		LabelSelector: metav1.FormatLabelSelector(&metav1.LabelSelector{
 			MatchLabels: labels.OdigosSystem,
 		}),
-		FieldSelector: fmt.Sprintf("metadata.name=%s", consts.OdigosConfigurationName),
+		FieldSelector: fmt.Sprintf("metadata.name=%s", configMapName),
 	})
+
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to get odigos namespace: %w", err)
 	}
 
 	if len(configMap.Items) == 0 {
 		return "", errNoOdigosNamespaceFound
-	} else if len(configMap.Items) != 1 {
+	}
+	if len(configMap.Items) != 1 {
 		return "", fmt.Errorf("expected to get 1 namespace got %d", len(configMap.Items))
 	}
 
 	return configMap.Items[0].Namespace, nil
+}
+
+func GetOdigosNamespace(client *kube.Client, ctx context.Context) (string, error) {
+	configMapName, err := getNamespaceFromConfigMap(client, ctx, consts.OdigosConfigurationName)
+	if err == nil {
+		return configMapName, nil
+	}
+	if !IsErrNoOdigosNamespaceFound(err) {
+		return "", fmt.Errorf("failed to get odigos namespace: %w", err)
+	}
+	// we need this fallback because old versions of odigos has legacy config map called "odigos-config", and 
+	// several commands needs to get current namespace from it.
+	legacyConfigMap, err := getNamespaceFromConfigMap(client, ctx, consts.OdigosLegacyConfigName)
+	if err == nil {
+		return legacyConfigMap, nil
+	}
+	if !IsErrNoOdigosNamespaceFound(err) {
+		return "", fmt.Errorf("failed to get odigos namespace: %w", err)
+	}
+
+	return "", errNoOdigosNamespaceFound
 }
 
 func IsErrNoOdigosNamespaceFound(err error) bool {


### PR DESCRIPTION
## Description

<!-- Short summary of the changes -->
fixing missing fallback query for getting old `odigos-config` ConfigMap.
## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
