### PR TITLE
fix(scheduler): use force to apply odigos config if conflict

### DIFF
--- a/scheduler/controllers/odigosconfiguration/odigosconfiguration_controller.go
+++ b/scheduler/controllers/odigosconfiguration/odigosconfiguration_controller.go
@@ -156,7 +156,7 @@ func (r *odigosConfigurationController) persistEffectiveConfig(ctx context.Conte
 	if err != nil {
 		return err
 	}
-	
+
 	err = r.Client.Patch(ctx, &effectiveConfigMap, client.RawPatch(types.ApplyYAMLPatchType, objApplyBytes), client.ForceOwnership, client.FieldOwner("scheduler-odigosconfiguration"))
 	if err != nil {
 		return err
@@ -260,6 +260,7 @@ func (r *odigosConfigurationController) applySingleProfileManifest(ctx context.C
 	resourceClient := r.DynamicClient.Resource(gvr).Namespace(env.GetCurrentNamespace())
 	_, err = resourceClient.Apply(ctx, obj.GetName(), obj, metav1.ApplyOptions{
 		FieldManager: "scheduler-odigosconfiguration",
+		Force:        true,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
#3068  changed `odigos-config` to `odigos-configuration`.

It was also changed in the `FieldManager` to a different value. since the value is cahnged, we now get this error in scheduler:

```
Apply failed with 1 conflict: conflict with \"scheduler-odigosconfig\": .metadata.labels.odigos.io/profiles-hash"
```

This PR fixes the issue by using `Force: true`.

I reproduced it with a profile that has instrumentation rules and actions, saw this error, then deployed the fix and observed it resolved
