### PR TITLE
Initial setup of release candidate subdirectory

### DIFF
--- a/rc/README.md
+++ b/rc/README.md
@@ -1,0 +1,28 @@
+# Odigos Release Candidate Helm Charts
+
+This directory contains release candidate versions of Odigos Helm charts.
+
+## Usage
+
+To add this repository for release candidates:
+
+```bash
+helm repo add odigos-rc https://odigos-io.github.io/odigos/rc/
+helm repo update
+```
+
+## Installing Release Candidates
+
+```bash
+helm install odigos odigos-rc/odigos --version <rc-version>
+```
+
+## Warning
+
+⚠️ **Release candidates are pre-release versions and may contain bugs or incomplete features.**
+⚠️ **Do not use in production environments.**
+
+For stable releases, use the main repository:
+```bash
+helm repo add odigos https://odigos-io.github.io/odigos/
+```

--- a/rc/index.yaml
+++ b/rc/index.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+entries: {}
+generated: "2025-07-15T17:24:51Z"


### PR DESCRIPTION
Adding a directory to our gh-pages branch to server release candidate charts