### PR TITLE
ci: fix owner for homebrew

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -39,7 +39,7 @@ changelog:
       - "^test:"
 brews:
   - repository:
-      owner: keyval-dev
+      owner: odigos-io
       name: '{{ if eq .Env.IS_RC "true" }}homebrew-odigos-cli-rc{{ else }}homebrew-odigos-cli{{ end }}'
       token: "{{ .Env.HOMEBREW_GITHUB_API_TOKEN }}"
     commit_msg_template: "release: {{ .Tag }}"


### PR DESCRIPTION
This PR fixes a bug in CI where we publish to brew and use owner "keyval-dev".

It causes error in ci: "homebrew formula: could not get default branch: GET https://api.github.com/repos/keyval-dev/homebrew-odigos-cli-rc: 404 Not Found []"

Seems that the new repo is created after "keyval-dev" is deprecated, and thus it should be changed to work