### PR TITLE
chore: bump UI-Kit to v0.0.58

### DIFF
--- a/frontend/webapp/.prettierrc
+++ b/frontend/webapp/.prettierrc
@@ -8,6 +8,5 @@
   "trailingComma": "all",
   "bracketSpacing": true,
   "bracketSameLine": false,
-  "arrowParens": "always",
-  "parser": "typescript"
+  "arrowParens": "always"
 }

--- a/frontend/webapp/components/lib-imports/setup-header.tsx
+++ b/frontend/webapp/components/lib-imports/setup-header.tsx
@@ -3,12 +3,12 @@ import { useRouter } from 'next/navigation';
 import { ROUTES } from '@/utils';
 import { safeJsonParse } from '@odigos/ui-kit/functions';
 import { ArrowIcon, OdigosLogoText } from '@odigos/ui-kit/icons';
+import { DEFAULT_DATA_STREAM_NAME } from '@odigos/ui-kit/constants';
 import { Destination, DestinationFormData } from '@odigos/ui-kit/types';
 import { useDataStreamStore, useSetupStore } from '@odigos/ui-kit/store';
 import { useDataStreamsCRUD, useDestinationCRUD, useSourceCRUD } from '@/hooks';
 import { Header, NavigationButtons, NavigationButtonsProps, Text } from '@odigos/ui-kit/components';
 import { type DataStreamSelectionFormRef, ToggleDarkMode, type SourceSelectionFormRef } from '@odigos/ui-kit/containers';
-import { DEFAULT_DATA_STREAM_NAME } from '@odigos/ui-kit/constants';
 
 interface SetupHeaderProps {
   step: number;

--- a/frontend/webapp/package.json
+++ b/frontend/webapp/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@apollo/client": "^3.13.8",
     "@apollo/experimental-nextjs-app-support": "^0.12.2",
-    "@odigos/ui-kit": "^0.0.57",
+    "@odigos/ui-kit": "^0.0.58",
     "graphql": "^16.11.0",
     "next": "15.4.1",
     "react": "19.1.0",
@@ -28,7 +28,7 @@
     "@types/react": "19.1.8",
     "@types/react-dom": "19.1.6",
     "autoprefixer": "^10.4.21",
-    "cypress": "^14.5.1",
+    "cypress": "^14.5.2",
     "eslint": "9.31.0",
     "eslint-config-next": "15.4.1",
     "postcss": "^8.5.6",

--- a/frontend/webapp/yarn.lock
+++ b/frontend/webapp/yarn.lock
@@ -443,10 +443,10 @@
   resolved "https://registry.yarnpkg.com/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz#3dc35ba0f1e66b403c00b39344f870298ebb1c8e"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
-"@odigos/ui-kit@^0.0.57":
-  version "0.0.57"
-  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.57.tgz#d8356740662ed71c3c3abc8970453a4165548474"
-  integrity sha512-em2SppDOCUKIb8sijXgK2hBlL4GHcCt1H6eef6CafusJKApLCnL6hJTOBG2xWalrUmJUB+bLEq+wdYygSFbl4w==
+"@odigos/ui-kit@^0.0.58":
+  version "0.0.58"
+  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.58.tgz#58843b501b14912800d29f2e72456963817d39b9"
+  integrity sha512-FKz3YRBC+g9RsOfBwrhNYUOo/c2k/VkH2Ss4TzLube2G/kC/cNP9Fs/oqA4C7OJ9KR784hMAiL5+XedMYe7D+g==
   dependencies:
     "@xyflow/react" "^12.8.2"
     javascript-time-ago "^2.5.11"
@@ -1352,10 +1352,10 @@ csstype@3.1.3, csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
-cypress@^14.5.1:
-  version "14.5.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-14.5.1.tgz#0af3f2ce7beb82f8d88a8a3cb7d8e40326114ce2"
-  integrity sha512-vYBeZKW3UAtxwv5mFuSlOBCYhyO0H86TeDKRJ7TgARyHiREIaiDjeHtqjzrXRFrdz9KnNavqlm+z+hklC7v8XQ==
+cypress@^14.5.2:
+  version "14.5.2"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-14.5.2.tgz#b45563bf9a96b815ab6e5d028b49ce0b0fe80cb2"
+  integrity sha512-O4E4CEBqDHLDrJD/dfStHPcM+8qFgVVZ89Li7xDU0yL/JxO/V0PEcfF2I8aGa7uA2MGNLkNUAnghPM83UcHOJw==
   dependencies:
     "@cypress/request" "^3.0.8"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
### Features

* add supported languages for instrumentation rules ([#243](https://github.com/odigos-io/ui-kit/issues/243)) ([534e196](https://github.com/odigos-io/ui-kit/commit/534e196f9118bcdff5a72f05e5e42e0d5c841a6b))
* enhance useGenericForm hook with isFormDirty state ([#240](https://github.com/odigos-io/ui-kit/issues/240)) ([3cc2f2b](https://github.com/odigos-io/ui-kit/commit/3cc2f2ba0092ac8ea7652c977c564221a7c714ab))
* filter by running instances for source selection form ([#244](https://github.com/odigos-io/ui-kit/issues/244)) ([1122570](https://github.com/odigos-io/ui-kit/commit/1122570267ecb3158a944c3215d2adceea229e08))


### Bug Fixes

* dropdown values for destination during onboarding ([#242](https://github.com/odigos-io/ui-kit/issues/242)) ([bd528dd](https://github.com/odigos-io/ui-kit/commit/bd528ddb06cda7824d9960abb1e7341b352cbc64))