### PR TITLE
chore: in case ldpreloadinjection not supoprted do not mount dir to c…

### DIFF
--- a/distros/yamls/java-community.yaml
+++ b/distros/yamls/java-community.yaml
@@ -22,3 +22,4 @@ spec:
       - "{{ODIGOS_AGENTS_DIR}}/java"
     k8sAttrsViaEnvVars: true
     device: 'instrumentation.odigos.io/generic'
+    ldPreloadInjectionSupported: true

--- a/distros/yamls/nodejs-community.yaml
+++ b/distros/yamls/nodejs-community.yaml
@@ -23,3 +23,4 @@ spec:
       - "{{ODIGOS_AGENTS_DIR}}/opentelemetry-node"
     device: 'instrumentation.odigos.io/generic'
     k8sAttrsViaEnvVars: true
+    ldPreloadInjectionSupported: true

--- a/distros/yamls/python-community.yaml
+++ b/distros/yamls/python-community.yaml
@@ -25,3 +25,4 @@ spec:
       - "{{ODIGOS_AGENTS_DIR}}/python"
     device: 'instrumentation.odigos.io/generic'
     k8sAttrsViaEnvVars: true
+    ldPreloadInjectionSupported: true

--- a/instrumentor/controllers/agentenabled/pods_webhook.go
+++ b/instrumentor/controllers/agentenabled/pods_webhook.go
@@ -265,10 +265,11 @@ func (p *PodsWebhook) injectOdigosToContainer(containerConfig *odigosv1.Containe
 			}
 
 			// if loader is enabled, mount the loader directory
-			if config.AgentEnvVarsInjectionMethod != nil &&
+			if config.AgentEnvVarsInjectionMethod != nil && distroMetadata.RuntimeAgent.LdPreloadInjectionSupported &&
 				(*config.AgentEnvVarsInjectionMethod == common.LoaderFallbackToPodManifestInjectionMethod ||
 					*config.AgentEnvVarsInjectionMethod == common.LoaderEnvInjectionMethod) {
 				podswebhook.MountDirectory(podContainerSpec, filepath.Join(k8sconsts.OdigosAgentsDirectory, consts.OdigosLoaderDirName))
+				volumeMounted = true
 			}
 		}
 		if distroMetadata.RuntimeAgent.K8sAttrsViaEnvVars {

--- a/tests/e2e/env-injection/assert-env-vars-loader.yaml
+++ b/tests/e2e/env-injection/assert-env-vars-loader.yaml
@@ -42,8 +42,7 @@ spec:
       # LD_PRELOAD is declared in the Dockerfile, hence we can't add the loader
       # in this test the user specified the env var injection to be loader only,
       # hence we assert here that nothing is added from our side.
-      (env[?name=='JAVA_TOOL_OPTIONS']): []
-      (env[?name=='LD_PRELOAD']): []
+      (env == null): true
 ---
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
…ontainer

## Description

This PR addresses two key issues:

Missing volume mount flag: The loader volume was not being mounted at the pod level because the mounted boolean flag was not set to true.

Conditional loader mounting: The loader is now mounted only if LdPreloadInjectionSupported is enabled.
(This logic was cherry-picked from another PR by Amir.)

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
