### PR TITLE
build: mark pre-release automataically with goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,6 +37,8 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
+release:
+  prerelease: "auto"
 brews:
   - repository:
       owner: odigos-io


### PR DESCRIPTION
Another small fix for the release candidate publishing.

At the moment, all released are published to github as "latest". for release candidates we want them to be set as "pre-release" so that they don't show up at the top of the release page section in github 

<img width="468" height="228" alt="image" src="https://github.com/user-attachments/assets/edb554f9-5961-4547-991a-c476ea20466d" />

<img width="982" height="428" alt="image" src="https://github.com/user-attachments/assets/b2db07c1-930f-432c-8fad-ed8b32e3d6cf" />
