### PR TITLE
feat: add Kubernetes RBAC resources for Central Backend

### DIFF
--- a/api/k8sconsts/odigoscentral.go
+++ b/api/k8sconsts/odigoscentral.go
@@ -27,6 +27,9 @@ const (
 	CentralBackendAppName = "central-backend"
 	CentralBackendName    = "central-backend"
 	CentralBackendImage   = "odigos-enterprise-central-backend"
+	CentralBackendServiceAccountName = "central-backend"
+	CentralBackendRoleName           = "central-backend"
+	CentralBackendRoleBindingName    = "central-backend"
 )
 
 const (


### PR DESCRIPTION
## Description

This commit introduces a ServiceAccount, Role, and RoleBinding for the central backend, which fixes the following error:

```json
{
  "time": "2025-07-16T17:24:24.594592007Z",
  "level": "ERROR",
  "msg": "Failed to get admin credentials",
  "error": "failed to get secret data: failed to get secret keycloak-admin-credentials in namespace odigos-central: secrets \"keycloak-admin-credentials\" is forbidden: User \"system:serviceaccount:odigos-central:default\" cannot get resource \"secrets\" in API group \"\" in the namespace \"odigos-central\""
}
```
