### PR TITLE
ci: checkout to the relevant tag before release

### DIFF
--- a/.github/workflows/release-artifactregistry.yml
+++ b/.github/workflows/release-artifactregistry.yml
@@ -46,6 +46,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ env.TAG }} # checkout the tag we are releasing (main might have been updated since the tag was created)
 
       - name: Set env
         id: vars


### PR DESCRIPTION
If someone pushed to main after we created the tag and before the release cli workflow is initiated, we get errors from goreleaser saying:

```
    • git state                                      commit=f2229e3595e7ca3a2b8a6ea2cf8f1fc448a840fa branch=main current_tag=api/v1.0.213-rc1 previous_tag=v1.0.213-rc0 dirty=false
git tag api/v1.0.213-rc1 was not made against commit f2229e3595e7ca3a2b8a6ea2cf8f1fc448a840fa
```

This PR makes sure we are checked out to the right tag before releasing