### PR TITLE
CI: set timeouts on downloads

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -74,25 +74,25 @@ jobs:
       fail-fast: false
       matrix:
         kube-version:
-          - '1.20.15'
-          - '1.23'
-          - '1.32'
+          - "1.20.15"
+          - "1.23"
+          - "1.32"
         test-scenario:
-          - 'ui'
-          - 'helm-chart'
-          - 'cli-upgrade'
-          - 'workload-lifecycle'
-          - 'source'
-          - 'webhooks'
-          - 'env-injection'
-          - 'data-streams'
+          - "ui"
+          - "helm-chart"
+          - "cli-upgrade"
+          - "workload-lifecycle"
+          - "source"
+          - "webhooks"
+          - "env-injection"
+          - "data-streams"
         include:
-          - kube-version: '1.20.15'
-            kind-image: 'kindest/node:v1.20.15@sha256:a32bf55309294120616886b5338f95dd98a2f7231519c7dedcec32ba29699394'
-          - kube-version: '1.23'
-            kind-image: 'kindest/node:v1.23.17@sha256:14d0a9a892b943866d7e6be119a06871291c517d279aedb816a4b4bc0ec0a5b3'
-          - kube-version: '1.32'
-            kind-image: 'kindest/node:v1.32.0@sha256:2458b423d635d7b01637cac2d6de7e1c1dca1148a2ba2e90975e214ca849e7cb'
+          - kube-version: "1.20.15"
+            kind-image: "kindest/node:v1.20.15@sha256:a32bf55309294120616886b5338f95dd98a2f7231519c7dedcec32ba29699394"
+          - kube-version: "1.23"
+            kind-image: "kindest/node:v1.23.17@sha256:14d0a9a892b943866d7e6be119a06871291c517d279aedb816a4b4bc0ec0a5b3"
+          - kube-version: "1.32"
+            kind-image: "kindest/node:v1.32.0@sha256:2458b423d635d7b01637cac2d6de7e1c1dca1148a2ba2e90975e214ca849e7cb"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -109,7 +109,7 @@ jobs:
         uses: helm/kind-action@v1.12.0
         with:
           node_image: ${{ matrix.kind-image }}
-          version: 'v0.25.0'
+          version: "v0.25.0"
           cluster_name: kind
           config: tests/common/apply/kind-config.yaml
 
@@ -117,6 +117,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: odigos-images
+        timeout-minutes: 5
 
       - name: Load Odigos Images to Kind Cluster
         run: |
@@ -127,7 +128,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: odigos-cli
-      - run: |
+        timeout-minutes: 1
+
+      - name: Move CLI binary & set permissions
+        run: |
           mv odigos cli/odigos
           chmod +x cli/odigos
 


### PR DESCRIPTION
## Description

This PR is supposed to kill the signal for workflows that have ridiculous download times (over 30-60 minutes)

<img width="1510" height="326" alt="Screenshot 2025-07-21 at 11 10 08" src="https://github.com/user-attachments/assets/4e169450-1611-4772-bb54-c8cc7c0f8b6b" />
