### PR TITLE
ci: create pre-release action for release PR

### DIFF
--- a/.github/workflows/create-release-candidate.yml
+++ b/.github/workflows/create-release-candidate.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           STABLE_RELEASE_BRANCH_NAME="release-${{ steps.next_version.outputs.next_stable }}"
           echo "stable_release_branch_name=$STABLE_RELEASE_BRANCH_NAME" >> $GITHUB_OUTPUT
-          if ! git ls-remote --heads origin $STABLE_RELEASE_BRANCH_NAME | grep -q "^[0-9a-f]*\s*refs/heads/$STABLE_RELEASE_BRANCH_NAME$"; then
+          if ! git ls-remote --heads origin $STABLE_RELEASE_BRANCH_NAME | grep -q "^[0-9a-f]*\s*refs/heads/$(echo "$STABLE_RELEASE_BRANCH_NAME" | sed 's/\./\\./g')$"; then
             echo "Creating new branch $STABLE_RELEASE_BRANCH_NAME from main"
             git checkout main
             git pull origin main


### PR DESCRIPTION
Add a new action to create release PR from CI.

It will calculate the next stable release, then the next stable release-candidate version, and will create (if required) a release branch for the stable version, and a PR to create release candidate from this branch.

This is first iteration, we still need to tag the repo when the release PR is merged.