### PR TITLE
ci: add git config for actor to fix pr creation

### DIFF
--- a/.github/workflows/create-release-candidate.yml
+++ b/.github/workflows/create-release-candidate.yml
@@ -80,6 +80,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Configure Git user identity for the workflow using the actor who triggered it
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+          git config --global user.name "${{ github.actor }}"
+          
           RELEASE_BRANCH="${{ steps.create_branch.outputs.stable_release_branch_name }}"
           PR_TITLE="Pre-release PR for ${{ steps.rc_version.outputs.rc_version }}"
           


### PR DESCRIPTION
Trying the new workflow for release candidate PRs. i run into this:
https://github.com/odigos-io/odigos/actions/runs/16535004040/job/46767756028

<img width="1454" height="514" alt="image" src="https://github.com/user-attachments/assets/b6a589ef-1d14-4d11-9fbf-05afd86ac6a6" />

This PR fixes the issue