### PR TITLE
ci: add full build for release candidate prs

### DIFF
--- a/.github/workflows/full-build.yaml
+++ b/.github/workflows/full-build.yaml
@@ -1,0 +1,92 @@
+name: full odigos build
+
+on:
+  pull_request:
+    branches:
+      - 'release-**'
+
+jobs:
+  build-all-services:
+    name: build-all-services
+    strategy:
+      matrix:
+        include:
+          - service: autoscaler
+            dockerfile: Dockerfile
+            context: .
+            build-args: SERVICE_NAME=autoscaler
+          - service: autoscaler
+            dockerfile: Dockerfile.rhel
+            context: .
+            build-args: SERVICE_NAME=autoscaler
+          - service: scheduler
+            dockerfile: Dockerfile
+            context: .
+            build-args: SERVICE_NAME=scheduler
+          - service: scheduler
+            dockerfile: Dockerfile.rhel
+            context: .
+            build-args: SERVICE_NAME=scheduler
+          - service: instrumentor
+            dockerfile: Dockerfile
+            context: .
+            build-args: SERVICE_NAME=instrumentor
+          - service: instrumentor
+            dockerfile: Dockerfile.rhel
+            context: .
+            build-args: SERVICE_NAME=instrumentor
+          - service: odigos-collector
+            dockerfile: collector/Dockerfile
+            context: .
+          - service: odigos-collector
+            dockerfile: collector/Dockerfile.rhel
+            context: .
+          - service: odiglet
+            dockerfile: odiglet/Dockerfile
+            context: .
+          - service: odiglet
+            dockerfile: odiglet/Dockerfile.rhel
+            context: .
+          - service: frontend
+            dockerfile: frontend/Dockerfile
+            context: .
+          - service: frontend
+            dockerfile: frontend/Dockerfile.rhel
+            context: .
+          - service: operator
+            dockerfile: operator/Dockerfile
+            context: .
+          - service: operator
+            dockerfile: operator/Dockerfile.rhel
+            context: .
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Build ${{ matrix.service }} Image
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: ${{ matrix.service }}:pr-${{ github.event.number }}
+          provenance: false
+          file: ${{ matrix.dockerfile }}
+          context: ${{ matrix.context }}
+          build-args: ${{ matrix.build-args }}
+
+  build-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.0'
+      - name: Set up Goreleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: build --snapshot --clean

--- a/.github/workflows/full-build.yaml
+++ b/.github/workflows/full-build.yaml
@@ -29,7 +29,7 @@ jobs:
           - service: frontend
             dockerfile_path: frontend
           - service: operator
-            dockerfile_path: operator/Dockerfile
+            dockerfile_path: operator
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/full-build.yaml
+++ b/.github/workflows/full-build.yaml
@@ -10,55 +10,26 @@ jobs:
     name: build-all-services
     strategy:
       matrix:
+        service: [autoscaler, scheduler, instrumentor, odigos-collector, odiglet, frontend, operator]
+        dockerfile_variant: [Dockerfile, Dockerfile.rhel]
         include:
           - service: autoscaler
-            dockerfile: Dockerfile
-            context: .
-            build-args: SERVICE_NAME=autoscaler
-          - service: autoscaler
-            dockerfile: Dockerfile.rhel
-            context: .
+            dockerfile_path: .
             build-args: SERVICE_NAME=autoscaler
           - service: scheduler
-            dockerfile: Dockerfile
-            context: .
-            build-args: SERVICE_NAME=scheduler
-          - service: scheduler
-            dockerfile: Dockerfile.rhel
-            context: .
+            dockerfile_path: .
             build-args: SERVICE_NAME=scheduler
           - service: instrumentor
-            dockerfile: Dockerfile
-            context: .
-            build-args: SERVICE_NAME=instrumentor
-          - service: instrumentor
-            dockerfile: Dockerfile.rhel
-            context: .
+            dockerfile_path: .
             build-args: SERVICE_NAME=instrumentor
           - service: odigos-collector
-            dockerfile: collector/Dockerfile
-            context: .
-          - service: odigos-collector
-            dockerfile: collector/Dockerfile.rhel
-            context: .
+            dockerfile_path: collector
           - service: odiglet
-            dockerfile: odiglet/Dockerfile
-            context: .
-          - service: odiglet
-            dockerfile: odiglet/Dockerfile.rhel
-            context: .
+            dockerfile_path: odiglet
           - service: frontend
-            dockerfile: frontend/Dockerfile
-            context: .
-          - service: frontend
-            dockerfile: frontend/Dockerfile.rhel
-            context: .
+            dockerfile_path: frontend
           - service: operator
-            dockerfile: operator/Dockerfile
-            context: .
-          - service: operator
-            dockerfile: operator/Dockerfile.rhel
-            context: .
+            dockerfile_path: operator/Dockerfile
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -73,8 +44,8 @@ jobs:
           push: false
           tags: ${{ matrix.service }}:pr-${{ github.event.number }}
           provenance: false
-          file: ${{ matrix.dockerfile }}
-          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile_path }}/${{ matrix.dockerfile_variant }}
+          context: .
           build-args: ${{ matrix.build-args }}
 
   build-cli:


### PR DESCRIPTION
Add a workflow to build all the services, with both rhel and regular dockerfiles, and for both arm64 and amd64.

We are currently doing this on every PR to main, and I want to do it for the release-candidate PRs as well.

Later on, we can consider to run the full builds only on release PRs, and avoid them on regular merges to main, as they take a lot of time to run, cost a lot of money, and give very little value.