### PR TITLE
ci: update existing release candidate branch and pr if they already exist

### DIFF
--- a/.github/workflows/create-release-candidate.yml
+++ b/.github/workflows/create-release-candidate.yml
@@ -63,7 +63,9 @@ jobs:
         run: |
           STABLE_RELEASE_BRANCH_NAME="release-${{ steps.next_version.outputs.next_stable }}"
           echo "stable_release_branch_name=$STABLE_RELEASE_BRANCH_NAME" >> $GITHUB_OUTPUT
-          if ! git ls-remote --heads origin $STABLE_RELEASE_BRANCH_NAME | grep -q "^[0-9a-f]*\s*refs/heads/$(echo "$STABLE_RELEASE_BRANCH_NAME" | sed 's/\./\\./g')$"; then
+          # Escape all regex metacharacters properly
+          ESCAPED_BRANCH_NAME=$(echo "$STABLE_RELEASE_BRANCH_NAME" | sed 's/[[\.*^$()+?{|]/\\&/g')
+          if ! git ls-remote --heads origin $STABLE_RELEASE_BRANCH_NAME | grep -q "^[0-9a-f]*\s*refs/heads/${ESCAPED_BRANCH_NAME}$"; then
             echo "Creating new branch $STABLE_RELEASE_BRANCH_NAME from main"
             git checkout main
             git pull origin main
@@ -88,12 +90,19 @@ jobs:
           PR_BRANCH="pre-release-${{ steps.rc_version.outputs.rc_version }}"
           PR_TITLE="Pre-release PR for ${{ steps.rc_version.outputs.rc_version }}"
           
+          # Escape all regex metacharacters properly for branch detection
+          ESCAPED_PR_BRANCH=$(echo "$PR_BRANCH" | sed 's/[[\.*^$()+?{|]/\\&/g')
+          
           # Check if the PR branch already exists
-          if git ls-remote --heads origin $PR_BRANCH | grep -q "^[0-9a-f]*\s*refs/heads/$(echo "$PR_BRANCH" | sed 's/\./\\./g')$"; then
+          if git ls-remote --heads origin $PR_BRANCH | grep -q "^[0-9a-f]*\s*refs/heads/${ESCAPED_PR_BRANCH}$"; then
             echo "PR branch $PR_BRANCH already exists, updating it..."
             
-            # Check out the existing PR branch
-            git checkout $PR_BRANCH
+            # Check out the existing PR branch (create local tracking branch if needed)
+            if git show-ref --verify --quiet refs/heads/$PR_BRANCH; then
+              git checkout $PR_BRANCH
+            else
+              git checkout -b $PR_BRANCH origin/$PR_BRANCH
+            fi
             git pull origin $PR_BRANCH
             
             # Reset the branch to point to the current release branch head
@@ -104,6 +113,18 @@ jobs:
             git push origin $PR_BRANCH --force
             
             echo "Updated existing PR branch $PR_BRANCH"
+            
+            # Check if PR exists for this branch, recreate if it doesn't
+            if ! gh pr list --head $PR_BRANCH --json number --jq '.[0].number' | grep -q '[0-9]'; then
+              echo "PR for branch $PR_BRANCH doesn't exist, creating new PR..."
+              gh pr create \
+                --base $RELEASE_BRANCH \
+                --head $PR_BRANCH \
+                --title "$PR_TITLE" \
+                --body "This is an automated PR for the release candidate ${{ steps.rc_version.outputs.rc_version }}"
+            else
+              echo "PR for branch $PR_BRANCH already exists"
+            fi
           else
             echo "Creating new PR branch $PR_BRANCH..."
             


### PR DESCRIPTION
Current code for release candidate PR creation assumes that the branch for the release candidate is not yet created. If this is run again, the following error fails the update:

```
Run # Configure Git user identity for the workflow using the actor who triggered it
Already on 'release-v1.0.213'
Your branch is up to date with 'origin/release-v1.0.213'.
Switched to a new branch 'pre-release-v1.0.213-rc5'
[pre-release-v1.0.213-rc5 eae79a94] Pre-release commit for v1.0.213-rc5
To https://github.com/odigos-io/odigos
 ! [rejected]          pre-release-v1.0.213-rc5 -> pre-release-v1.0.213-rc5 (non-fast-forward)
error: failed to push some refs to 'https://github.com/odigos-io/odigos'
hint: Updates were rejected because the tip of your current branch is behind
hint: its remote counterpart. If you want to integrate the remote changes,
hint: use 'git pull' before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
Error: Process completed with exit code 1.
```

This PR handles both cases:
-  release branch exist (update it to point to the release branch HEAD)
- release branch not exist (create it from release branch HEAD)