### PR TITLE
ci: use slash for release branches names

### DIFF
--- a/.github/workflows/create-release-candidate.yml
+++ b/.github/workflows/create-release-candidate.yml
@@ -64,7 +64,7 @@ jobs:
           STABLE_RELEASE_BRANCH_NAME="releases/${{ steps.next_version.outputs.next_stable }}"
           echo "stable_release_branch_name=$STABLE_RELEASE_BRANCH_NAME" >> $GITHUB_OUTPUT
           # Escape all regex metacharacters properly
-          ESCAPED_BRANCH_NAME=$(echo "$STABLE_RELEASE_BRANCH_NAME" | sed 's/[[\.*^$()+?{|]/\\&/g')
+          ESCAPED_BRANCH_NAME=$(echo "$STABLE_RELEASE_BRANCH_NAME" | sed 's/[[\.*^$()+?{|/]/\\&/g')
           if ! git ls-remote --heads origin $STABLE_RELEASE_BRANCH_NAME | grep -q "^[0-9a-f]*\s*refs/heads/${ESCAPED_BRANCH_NAME}$"; then
             echo "Creating new branch $STABLE_RELEASE_BRANCH_NAME from main"
             git checkout main
@@ -91,7 +91,7 @@ jobs:
           PR_TITLE="Pre-release PR for ${{ steps.rc_version.outputs.rc_version }}"
           
           # Escape all regex metacharacters properly for branch detection
-          ESCAPED_PR_BRANCH=$(echo "$PR_BRANCH" | sed 's/[[\.*^$()+?{|]/\\&/g')
+          ESCAPED_PR_BRANCH=$(echo "$PR_BRANCH" | sed 's/[[\.*^$()+?{|/]/\\&/g')
           
           # Check if the PR branch already exists
           if git ls-remote --heads origin $PR_BRANCH | grep -q "^[0-9a-f]*\s*refs/heads/${ESCAPED_PR_BRANCH}$"; then

--- a/.github/workflows/create-release-candidate.yml
+++ b/.github/workflows/create-release-candidate.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Create release branch if not exists
         id: create_branch
         run: |
-          STABLE_RELEASE_BRANCH_NAME="release-${{ steps.next_version.outputs.next_stable }}"
+          STABLE_RELEASE_BRANCH_NAME="releases/${{ steps.next_version.outputs.next_stable }}"
           echo "stable_release_branch_name=$STABLE_RELEASE_BRANCH_NAME" >> $GITHUB_OUTPUT
           # Escape all regex metacharacters properly
           ESCAPED_BRANCH_NAME=$(echo "$STABLE_RELEASE_BRANCH_NAME" | sed 's/[[\.*^$()+?{|]/\\&/g')
@@ -87,7 +87,7 @@ jobs:
           git config --global user.name "${{ github.actor }}"
           
           RELEASE_BRANCH="${{ steps.create_branch.outputs.stable_release_branch_name }}"
-          PR_BRANCH="pre-release-${{ steps.rc_version.outputs.rc_version }}"
+          PR_BRANCH="pre-releases/${{ steps.rc_version.outputs.rc_version }}"
           PR_TITLE="Pre-release PR for ${{ steps.rc_version.outputs.rc_version }}"
           
           # Escape all regex metacharacters properly for branch detection

--- a/.github/workflows/full-build.yaml
+++ b/.github/workflows/full-build.yaml
@@ -3,7 +3,7 @@ name: full odigos build
 on:
   pull_request:
     branches:
-      - 'release-**'
+      - 'releases/**'
 
 jobs:
   build-all-services:


### PR DESCRIPTION
For the release branch, instead of naming it "release-v1.0.x", use "releases/v1.0.x".

Update in few places