### PR TITLE
ci: allow empty prs to trigger build

### DIFF
--- a/.github/workflows/full-build.yaml
+++ b/.github/workflows/full-build.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - 'releases/**'
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   build-all-services:


### PR DESCRIPTION
At the moment, the `full-build` workflow isn't running for release candidate PRs, probably since this PR has no changed files.

This should fix the issue and always run the workflow even if this PR has no changes