### PR TITLE
fix: set golangg-community distro min version to 1.19

### DIFF
--- a/distros/yamls/golang-community.yaml
+++ b/distros/yamls/golang-community.yaml
@@ -7,7 +7,7 @@ spec:
   language: go
   runtimeEnvironments:
     - name: go-runtime
-      supportedVersions: '>= 1.17'
+      supportedVersions: '>= 1.19'
   displayName: Golang Community eBPF Instrumentation
   description: |
     This distribution is for Golang applications using OpenTelemetry eBPF-based SDK and eBPF-based instrumentation libraries from the OpenTelemetry community.

--- a/docs/instrumentations/golang/ebpf.mdx
+++ b/docs/instrumentations/golang/ebpf.mdx
@@ -16,7 +16,7 @@ import EbpfKernelVersionNote from '/snippets/ebpf-kernel-version-note.mdx';
 
 Odigos uses the official [opentelemetry-go-instrumentation](https://github.com/open-telemetry/opentelemetry-go-instrumentation) OpenTelemetry Auto Instrumentation using eBPF, thus it supports the same golang versions as this project.
 
-- Go runtime versions **1.17** and above are supported.
+- Go runtime versions **1.19** and above are supported.
 
 <EbpfKernelVersionNote />
 


### PR DESCRIPTION
## Description

our min version for golang-community distro is set to `1.17` but the upstream is `1.19`: 
https://github.com/open-telemetry/opentelemetry-go-instrumentation/blob/main/COMPATIBILITY.md

When I tested it locally, versions 1.17 and 1.18 fails with the following offsets error:

<img width="479" height="71" alt="image" src="https://github.com/user-attachments/assets/989d653e-b227-4333-96a5-3eae1b0195c3" />

This PR aligns our minimum version to the actual value we support.

