### PR TITLE
fix: reconcile cronjob in instrumentor source creation

### DIFF
--- a/instrumentor/controllers/manager.go
+++ b/instrumentor/controllers/manager.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/version"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -164,13 +165,13 @@ func durationPointer(d time.Duration) *time.Duration {
 	return &d
 }
 
-func SetupWithManager(mgr manager.Manager, dp *distros.Provider) error {
+func SetupWithManager(mgr manager.Manager, dp *distros.Provider, k8sVersion *version.Version) error {
 	err := agentenabled.SetupWithManager(mgr, dp)
 	if err != nil {
 		return fmt.Errorf("failed to create controller for agent enabled: %w", err)
 	}
 
-	err = sourceinstrumentation.SetupWithManager(mgr)
+	err = sourceinstrumentation.SetupWithManager(mgr, k8sVersion)
 	if err != nil {
 		return fmt.Errorf("failed to create controller for start language detection: %w", err)
 	}

--- a/instrumentor/controllers/sourceinstrumentation/workload_controllers.go
+++ b/instrumentor/controllers/sourceinstrumentation/workload_controllers.go
@@ -52,3 +52,17 @@ func (r *StatefulSetReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 	return syncWorkload(ctx, r.Client, r.Scheme, pw)
 }
+
+type CronJobReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	pw := k8sconsts.PodWorkload{
+		Namespace: req.Namespace,
+		Kind:      k8sconsts.WorkloadKindCronJob,
+		Name:      req.Name,
+	}
+	return syncWorkload(ctx, r.Client, r.Scheme, pw)
+}

--- a/instrumentor/instrumentor.go
+++ b/instrumentor/instrumentor.go
@@ -17,6 +17,7 @@ import (
 	"github.com/odigos-io/odigos/instrumentor/controllers"
 	"github.com/odigos-io/odigos/instrumentor/report"
 	"github.com/odigos-io/odigos/k8sutils/pkg/certs"
+	"github.com/odigos-io/odigos/k8sutils/pkg/utils"
 
 	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	"github.com/odigos-io/odigos/k8sutils/pkg/feature"
@@ -91,8 +92,13 @@ func New(opts controllers.KubeManagerOptions, dp *distros.Provider) (*Instrument
 		return nil, fmt.Errorf("unable to add cert rotator: %w", err)
 	}
 
+	k8sVersion, err := utils.ClusterVersion()
+	if err != nil {
+		return nil, err
+	}
+
 	// wire up the controllers and webhooks
-	err = controllers.SetupWithManager(mgr, dp)
+	err = controllers.SetupWithManager(mgr, dp, k8sVersion)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

There are reconcilers for each workload type under instrumentor "sourceinstrumentaiton" controllers, but CronJob is missing.

Before this PR, if a cronjob was removed and added, there was no instrumentation config generated for it. This PR fixes the bug by applying the same sync to CronJob as we do for other types.

## How Has This Been Tested?

- [x] Manual Testing

## Kubernetes Checklist

- [x] Changes how Odigos interacts with Kubernetes - reconcile more objects where appropriate
~~- [ ] Introduces additional calls to the API Server (potential performance impact)~~
- [x] New Query/feature supported in all the k8s versions supported by Odigos - added branch base on k8s version to handle the cronjob api version based on k8s version
~~- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)~~ 
~~- [ ] Changes RBAC permissions~~ all RBAC permissions are already set correctly regarldless of this change

## User Facing Changes

Fix edge case bug in very rare scenario
