### PR TITLE
Detect OpenTelemetry javaagent

### DIFF
--- a/procdiscovery/pkg/process/process.go
+++ b/procdiscovery/pkg/process/process.go
@@ -33,9 +33,10 @@ var LangsVersionEnvs = map[string]struct{}{
 }
 
 const (
-	NewRelicAgentName  = "New Relic Agent"
-	DynatraceAgentName = "Dynatrace Agent"
-	DataDogAgentName   = "Datadog Agent"
+	NewRelicAgentName       = "New Relic Agent"
+	DynatraceAgentName      = "Dynatrace Agent"
+	DataDogAgentName        = "Datadog Agent"
+	OpenTelemetryAgentName  = "OpenTelemetry Agent"
 )
 
 const (
@@ -44,16 +45,19 @@ const (
 	DynatraceDynamizerExeSubString   = "oneagentdynamizer"
 	DynatraceFullStackEnvValuePrefix = "/dynatrace/"
 	DataDogAgentEnv                  = "DD_TRACE_AGENT_URL"
+	OpenTelemetryAgentEnv            = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"
 )
 
 var OtherAgentEnvs = map[string]string{
 	NewRelicAgentEnv:      NewRelicAgentName,
 	DynatraceDynamizerEnv: DynatraceAgentName,
 	DataDogAgentEnv:       DataDogAgentName,
+	OpenTelemetryAgentEnv: OpenTelemetryAgentName,
 }
 
 var OtherAgentCmdSubString = map[string]string{
-	"newrelic.jar": NewRelicAgentName,
+	"newrelic.jar":                NewRelicAgentName,
+	"opentelemetry-javaagent.jar": OpenTelemetryAgentName,
 }
 
 type Details struct {


### PR DESCRIPTION
```
## Description

Adds detection for OpenTelemetry Java agent to Odigos's process discovery. This enables Odigos to identify Java applications instrumented with the OpenTelemetry Java agent, similar to how other APM agents (Dynatrace, New Relic, Datadog) are detected.

Detection is based on:
- Presence of the `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` environment variable.
- Presence of `opentelemetry-javaagent.jar` in the process command line arguments.

## How Has This Been Tested?

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [X] Manual Testing (Verified build compiles correctly)
- [ ] Manual Load Test

## Kubernetes Checklist

- [X] Changes how Odigos interacts with Kubernetes (by enhancing process detection within pods)
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
```
