### PR TITLE
Topdown_metrics_config

### DIFF
--- a/instrumentation/manager.go
+++ b/instrumentation/manager.go
@@ -424,7 +424,6 @@ func (m *manager[ProcessDetails, ConfigGroup]) applyInstrumentationConfiguration
 			continue
 		}
 		m.logger.Info("applying configuration to instrumentation", "process group details", instDetails.pd, "configGroup", configGroup)
-		fmt.Printf("@@ applying configuration to instrumentation %T for process group details %v with config group %v config[%+v]\n", instDetails.inst, instDetails.pd, configGroup, config)
 		applyErr := instDetails.inst.ApplyConfig(ctx, config)
 		err = errors.Join(err, applyErr)
 	}

--- a/odiglet/pkg/ebpf/sdks/go.go
+++ b/odiglet/pkg/ebpf/sdks/go.go
@@ -79,7 +79,6 @@ func (g *GoOtelEbpfSdk) Close(_ context.Context) error {
 }
 
 func (g *GoOtelEbpfSdk) ApplyConfig(ctx context.Context, sdkConfig instrumentation.Config) error {
-	fmt.Println("@@@ Applying config to Go instrumentation")
 	updatedConfig, err := convertToGoInstrumentationConfig(sdkConfig)
 	if err != nil {
 		return err
@@ -91,7 +90,6 @@ func (g *GoOtelEbpfSdk) ApplyConfig(ctx context.Context, sdkConfig instrumentati
 func convertToGoInstrumentationConfig(sdkConfig instrumentation.Config) (auto.InstrumentationConfig, error) {
 	initialConfig, ok := sdkConfig.(*ebpf.ExtConfig)
 	if !ok {
-		fmt.Errorf("invalid initial config type, expected *ebpf.ExtConfig, got %T", sdkConfig)
 		return auto.InstrumentationConfig{}, fmt.Errorf("invalid initial config type, expected *ebpf.ExtConfig, got %T", sdkConfig)
 	}
 	ic := auto.InstrumentationConfig{}

--- a/odiglet/pkg/ebpf/settings_getter.go
+++ b/odiglet/pkg/ebpf/settings_getter.go
@@ -39,14 +39,11 @@ func (ksg *k8sSettingsGetter) Settings(ctx context.Context, kd K8sProcessDetails
 		OtelServiceName = kd.pw.Name
 	}
 
-	settings := instrumentation.Settings{
+	return instrumentation.Settings{
 		ServiceName:        OtelServiceName,
 		ResourceAttributes: getResourceAttributes(kd.pw, kd.pod.Name, kd.procEvent),
 		InitialConfig:      sdkConfig,
-	}
-	fmt.Printf("@@ Returning settings with InitialConfig type: %T\n", settings.InitialConfig)
-	fmt.Printf("@@ InitialConfig value: %+v\n", settings.InitialConfig)
-	return settings, nil
+	}, nil
 }
 
 func (ksg *k8sSettingsGetter) instrumentationSDKConfig(ctx context.Context, kd K8sProcessDetails, lang common.ProgrammingLanguage) (*ExtConfig, string, error) {
@@ -63,7 +60,6 @@ func (ksg *k8sSettingsGetter) instrumentationSDKConfig(ctx context.Context, kd K
 	for _, config := range instrumentationConfig.Spec.Containers {
 		if config.ContainerName == kd.containerName {
 			isMetricsEnabled = config.Metrics != nil
-			fmt.Printf("Metrics enabled for container %s in workload %s/%s: %v isMetricsEnabled %t\n", kd.containerName, kd.pw.Namespace, kd.pw.Name, config.Metrics, isMetricsEnabled)
 		}
 	}
 	for _, config := range instrumentationConfig.Spec.SdkConfigs {
@@ -72,7 +68,6 @@ func (ksg *k8sSettingsGetter) instrumentationSDKConfig(ctx context.Context, kd K
 				SdkConfig:        config,
 				IsMetricsEnabled: isMetricsEnabled,
 			}
-			fmt.Printf("Returning SDK config for language %s: Metrics enabled %v\n", lang, extConfig.IsMetricsEnabled)
 			return extConfig, instrumentationConfig.Spec.ServiceName, nil
 		}
 	}

--- a/odiglet/pkg/kube/instrumentation_ebpf/instrumentationconfig.go
+++ b/odiglet/pkg/kube/instrumentation_ebpf/instrumentationconfig.go
@@ -3,7 +3,6 @@ package instrumentation_ebpf
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
@@ -32,7 +31,7 @@ func (i *InstrumentationConfigReconciler) Reconcile(ctx context.Context, req ctr
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	fmt.Printf("@@@@ Reconciling InstrumentationConfig for workload: %s/%s\n", podWorkload.Namespace, podWorkload.Name)
+
 	// Fetch the InstrumentationConfig instrumentationConfig
 	instrumentationConfig := &odigosv1.InstrumentationConfig{}
 	err = i.Get(ctx, req.NamespacedName, instrumentationConfig)
@@ -58,9 +57,6 @@ func (i *InstrumentationConfigReconciler) Reconcile(ctx context.Context, req ctr
 		isMetricsEnabled := false
 		for _, config := range instrumentationConfig.Spec.Containers {
 			isMetricsEnabled = config.Metrics != nil
-			if isMetricsEnabled {
-				fmt.Printf("Metrics collection is enabled for InstrumentationConfig %s\n", config.ContainerName)
-			}
 		}
 		for _, sdkConfig := range instrumentationConfig.Spec.SdkConfigs {
 			extConfig := ebpf.ExtConfig{


### PR DESCRIPTION
## Description
This PR adds comprehensive Java heap memory monitoring capabilities using eBPF instrumentation. The implementation provides real-time visibility into JVM memory usage by attaching to JVM internal functions and collecting heap statistics during garbage collection events.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
