### PR TITLE
ci: set the relevant tag for goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
           IS_RC: ${{ env.IS_RC }}
+          GORELEASER_CURRENT_TAG: ${{ env.TAG }}
 
       - uses: ko-build/setup-ko@v0.9
 


### PR DESCRIPTION
## Description

Now that we have both release-candidate and stable release, and they can both point to the commit, goreleaser get's confused and picks the wrong one.

```
      • failed to upload artifact, will retry        try=1 artifact=checksums.txt error=POST https://uploads.github.com/repos/odigos-io/odigos/releases/234954876/assets?name=checksums.txt: 422 Validation Failed [{Resource:ReleaseAsset Field:name Code:already_exists Message:}]
scm releases: failed to publish artifacts: failed to upload cli_1.0.213-rc4_linux_amd64.tar.gz after 1 tries: POST https://uploads.github.com/repos/odigos-io/odigos/releases/234954876/assets?name=cli_1.0.213-rc4_linux_amd64.tar.gz: 422 Validation Failed [{Resource:ReleaseAsset Field:name Code:already_exists Message:}]
```

here it try to publish pr even though workflow is triggered by stable release.

I followed goreleaser official docs [here](https://goreleaser.com/cookbooks/set-a-custom-git-tag/):

> You can override the current and previous tags by setting some environment variables. This can be useful in cases where one git commit is referenced by multiple git tags, for example.

I hope it will work (we will soon find out)