### PR TITLE
fix: pass init error to reporter.OnInit

### DIFF
--- a/instrumentation/manager.go
+++ b/instrumentation/manager.go
@@ -330,7 +330,7 @@ func (m *manager[ProcessDetails, ConfigGroup]) tryInstrument(ctx context.Context
 	}
 
 	inst, initErr := factory.CreateInstrumentation(ctx, e.PID, settings)
-	reporterErr := m.handler.Reporter.OnInit(ctx, e.PID, err, pd)
+	reporterErr := m.handler.Reporter.OnInit(ctx, e.PID, initErr, pd)
 	if reporterErr != nil {
 		m.logger.Error(reporterErr, "failed to report instrumentation init", "initialized", initErr == nil, "pid", e.PID, "process group details", pd)
 	}


### PR DESCRIPTION
## Description

Pass the init error to the `reporte.OnInit` call from the instrumentation manager.
This bug could have caused instrumentation errors to get un reported via the instrumentation instances - resulting in "no instances" situation in the UI.

