### PR TITLE
CORE-105 chore: specify the container once streaming logs

### DIFF
--- a/cli/cmd/diagnose_util/logs_util.go
+++ b/cli/cmd/diagnose_util/logs_util.go
@@ -76,7 +76,7 @@ func fetchingContainerLogs(ctx context.Context, client *kube.Client, odigosNames
 	}
 	defer logFile.Close()
 
-	req := client.CoreV1().Pods(odigosNamespace).GetLogs(pod.Name, &v1.PodLogOptions{Previous: previous})
+	req := client.CoreV1().Pods(odigosNamespace).GetLogs(pod.Name, &v1.PodLogOptions{Previous: previous, Container: container.Name})
 	logStream, err := req.Stream(ctx)
 	if err != nil {
 		klog.V(1).ErrorS(err, "Failed to create log stream", "logFilePath", logFilePath)


### PR DESCRIPTION
## Description

Since adding the deviceplugin container, we were not able to fetch odiglet logs since the container must be specified
```bash
container name must be specified for pod odiglet-rdzjz, choose one of: [init deviceplugin odiglet]
```

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
