### PR TITLE
ci: promote release candidate to stable workflow

### DIFF
--- a/.github/workflows/promote-to-stable.yml
+++ b/.github/workflows/promote-to-stable.yml
@@ -165,7 +165,7 @@ jobs:
           git push origin ${{ env.STABLE_TAG }} 
           echo "Successfully created and pushed stable tag ${{ env.STABLE_TAG }}"
 
-      - name: Set env
+      - name: Set Artifact Variables
         id: vars
         run: |
           SHORT_COMMIT=$(git rev-parse --short HEAD)

--- a/.github/workflows/promote-to-stable.yml
+++ b/.github/workflows/promote-to-stable.yml
@@ -169,7 +169,7 @@ jobs:
         id: vars
         run: |
           SHORT_COMMIT=$(git rev-parse --short HEAD)
-          echo "short_commit=${SHORT_COMMIT}" >> $GITHUB_ENV
+          echo "short_commit=${SHORT_COMMIT}" >> $GITHUB_OUTPUT
           echo "date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
 
       - uses: actions/setup-go@v5

--- a/.github/workflows/promote-to-stable.yml
+++ b/.github/workflows/promote-to-stable.yml
@@ -1,0 +1,270 @@
+name: Promote to Stable
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release Candidate Tag"
+        required: true
+
+permissions:
+  contents: write
+  packages: write
+  id-token: 'write'
+
+env:
+  DOCKERHUB_REPO: "keyval"
+  GCR_REPO: "us-central1-docker.pkg.dev/odigos-cloud/components"
+  GHCR_REPO: "ghcr.io/odigos-io"
+
+jobs:
+
+  release-images-and-cli:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Verify the tag is a release candidate
+        run: |
+          # =~ is a bash operator that checks if a string matches a regular expression pattern
+          # Here we check if the tag matches the format vX.Y.Z-rcN where X,Y,Z,N are numbers
+          if [[ "${{ github.event.inputs.tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$ ]]; then
+            echo "Tag is a release candidate"
+            echo "RC_TAG=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
+          else
+            echo "Tag is not a release candidate"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # need to fetch all tags for goreleaser to calculate the changelog
+          ref: ${{ env.RC_TAG }} # checkout the tag we are releasing (main might have been updated since the tag was created)
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "bot@odigos.io"
+          git config --global user.name "Odigos Release Bot"  
+
+      - name: Get Stable Tag From Release Candidate
+        run: |
+          # remove the -rc part and number from the tag
+          STABLE_TAG=$(echo "${{ env.RC_TAG }}" | sed 's/-rc[0-9]*$//')
+          
+          # Validate the stable tag format
+          if [[ ! "$STABLE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: Invalid stable tag format: $STABLE_TAG"
+            exit 1
+          fi
+          
+          echo "STABLE_TAG=${STABLE_TAG}" >> $GITHUB_ENV
+          echo "Extracted stable tag: $STABLE_TAG"
+
+      - name: Check if stable tag already exists
+        run: |
+          if git tag -l | grep -q "^${{ env.STABLE_TAG }}$"; then
+            echo "ERROR: Stable tag ${{ env.STABLE_TAG }} already exists"
+            echo "This workflow has likely already been run for this release candidate"
+            exit 1
+          else
+            echo "Stable tag ${{ env.STABLE_TAG }} does not exist, proceeding with promotion"
+          fi
+
+      - name: Get Latest Stable Tag
+        run: |
+          # Get all tags and filter for stable versions (no -rc or other suffixes)
+          # Sort them and get the latest one
+          LATEST_STABLE=$(git tag -l | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1 || echo "")
+          if [ -z "$LATEST_STABLE" ]; then
+            echo "No previous stable tags found"
+            exit 1
+          else
+            echo "Latest stable version is: $LATEST_STABLE"
+          fi
+          echo "LATEST_STABLE=$LATEST_STABLE" >> $GITHUB_ENV
+
+      - name: Notify Slack Start
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' --data '{"description":"Starting to promote release candidate ${{ env.RC_TAG }} to stable ${{ env.STABLE_TAG }} (current stable: ${{ env.LATEST_STABLE }})", "tag":"${{ env.RC_TAG }}"}' ${{ env.SLACK_WEBHOOK_URL }}  
+
+      - name: Install crane
+        uses: imjasonh/setup-crane@v0.4
+
+      - id: gcp-auth
+        name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          access_token_lifetime: 1200s
+      - name: Login to Artifact Registry
+        uses: docker/login-action@v3
+        with:
+          registry: us-central1-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}  
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+    
+      - name: Retag existing images to stable
+        run: |
+          IMAGE_NAMES=("odigos-agents" "odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-enterprise-odiglet" "odigos-ui" "odigos-enterprise-instrumentor")
+          REPOS=(${GCR_REPO} ${GHCR_REPO} ${DOCKERHUB_REPO})
+          UBI9_SUFFIXES=("" "-ubi9")
+          
+          # Track failed copies for potential rollback
+          FAILED_COPIES=()
+          
+          for REPO in "${REPOS[@]}"; do
+            for IMAGE_NAME in "${IMAGE_NAMES[@]}"; do
+              for SUFFIX in "${UBI9_SUFFIXES[@]}"; do
+                echo "Copying ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.RC_TAG }} to ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.STABLE_TAG }}"
+                
+                if ! crane copy ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.RC_TAG }} ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.STABLE_TAG }}; then
+                  echo "ERROR: Failed to copy ${REPO}/${IMAGE_NAME}${SUFFIX}"
+                  FAILED_COPIES+=("${REPO}/${IMAGE_NAME}${SUFFIX}")
+                else
+                  echo "Successfully copied ${REPO}/${IMAGE_NAME}${SUFFIX}"
+                fi
+              done
+            done
+          done
+          
+          # Check if any copies failed
+          if [ ${#FAILED_COPIES[@]} -gt 0 ]; then
+            echo "ERROR: The following image copies failed:"
+            printf '%s\n' "${FAILED_COPIES[@]}"
+            echo "Stable tag creation will be aborted"
+            exit 1
+          fi
+          
+          echo "All image copies completed successfully"
+
+      - name: Tag Stable Release in GitHub
+        run: |
+          # Double-check that the tag doesn't exist before creating it
+          if git tag -l | grep -q "^${{ env.STABLE_TAG }}$"; then
+            echo "ERROR: Stable tag ${{ env.STABLE_TAG }} already exists - this should not happen"
+            exit 1
+          fi
+          
+          git tag ${{ env.STABLE_TAG }}
+          # this is using github actions token which will not not trigger the release which is good
+          # since we don't need a brand new release here.
+          git push origin ${{ env.STABLE_TAG }} 
+          echo "Successfully created and pushed stable tag ${{ env.STABLE_TAG }}"
+
+      - name: Set env
+        id: vars
+        run: |
+          SHORT_COMMIT=$(git rev-parse --short HEAD)
+          echo "short_commit=${SHORT_COMMIT}" >> $GITHUB_ENV
+          echo "date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      # we need to run the goreleaser again for the "stable" release:
+      # - cli is compiled with it's version built in, thus we need to release it again
+      # - create a new release in github with relevant changelog
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          IS_PRERELEASE: false # this is a stable release
+          GORELEASER_CURRENT_TAG: ${{ env.STABLE_TAG }}
+          GORELEASER_PREVIOUS_TAG: ${{ env.LATEST_STABLE }}
+
+      - uses: ko-build/setup-ko@v0.9
+
+      - name: publish cli image to docker registries
+        working-directory: ./cli
+        env:
+          KO_DOCKER_REPO: us-central1-docker.pkg.dev/odigos-cloud/components/odigos-cli
+          KO_CONFIG_PATH: ./.ko.yaml
+          VERSION: ${{ env.STABLE_TAG }}
+          SHORT_COMMIT: ${{ steps.vars.outputs.short_commit }}
+          DATE: ${{ steps.vars.outputs.date }}
+        run: |
+          ko build --bare --tags latest --tags ${{ env.STABLE_TAG }} --platform=all .
+
+      - name: Copy CLI image to Docker Hub and ghcr
+        run: |
+          echo "Copying CLI image to Docker Hub and GHCR..."
+          
+          # Copy to Docker Hub
+          if ! crane copy ${GCR_REPO}/odigos-cli:${{ env.STABLE_TAG }} ${DOCKERHUB_REPO}/odigos-cli:${{ env.STABLE_TAG }}; then
+            echo "ERROR: Failed to copy CLI image to Docker Hub (stable tag)"
+            exit 1
+          fi
+          if ! crane copy ${GCR_REPO}/odigos-cli:latest ${DOCKERHUB_REPO}/odigos-cli:latest; then
+            echo "ERROR: Failed to copy CLI image to Docker Hub (latest tag)"
+            exit 1
+          fi
+          
+          # Copy to GHCR
+          if ! crane copy ${GCR_REPO}/odigos-cli:${{ env.STABLE_TAG }} ${GHCR_REPO}/odigos-cli:${{ env.STABLE_TAG }}; then
+            echo "ERROR: Failed to copy CLI image to GHCR (stable tag)"
+            exit 1
+          fi
+          if ! crane copy ${GCR_REPO}/odigos-cli:latest ${GHCR_REPO}/odigos-cli:latest; then
+            echo "ERROR: Failed to copy CLI image to GHCR (latest tag)"
+            exit 1
+          fi
+          
+          echo "Successfully copied CLI image to all registries"
+
+      - name: Trigger OpenShift Preflight Job for Stable Release
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.RELEASE_BOT_TOKEN }}" \
+            https://api.github.com/repos/odigos-io/odigos/dispatches \
+            -d '{"event_type": "openshift_preflight", "client_payload": {"tag": "${{ env.STABLE_TAG }}"}}'
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4.2.0
+        with:
+          version: v3.15.2
+    
+      - name: Release Helm charts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ env.STABLE_TAG }}
+        run: bash ./scripts/release-charts.sh
+    
+      - name: Notify Slack End
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+        run: |
+          DESCRIPTION="Odigos CLI stable release promotion completed successfully"
+          curl -X POST -H 'Content-type: application/json' --data "{\"description\":\"$DESCRIPTION\", \"tag\":\"${{ env.RC_TAG }}\"}" ${{ env.SLACK_WEBHOOK_URL }}
+
+      - name: Notify Slack on Failure
+        if: ${{ failure() || cancelled() }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' --data '{"link":"https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}", "description":"ERROR: failed to promote release candidate to stable", "tag":"${{ env.RC_TAG }}"}' ${{ env.SLACK_WEBHOOK_URL }}

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,10 +1,37 @@
 # Versioning
 
-Odigos publishes 2 release types:
--  stable releases (`v1.0.X`)
--  release candidates (`v1.0.x-rcY`)
+## Release Types
 
-Stable releases are the default and recommended version to install. Release candidates are opt-in and require the user to explicitly take an action to install them.
+### Stable Releases
+
+Version of the form `v1.0.X` where X is a number, is a stable release.
+
+This is the default and recommended version to install. For production clusters, it is recommended to use only stable releases.
+
+These are versions which run the full test suite, and also been manually verified for few days by odigos team and the community.
+
+Stable releases are published once a week on Sunday, if no blockers are found.
+
+### Release Candidates
+
+Version of the form `v1.0.X-rcY` where X is a number and Y is a number starting from 0, is a release candidate.
+
+Release candidate for the next stable release is published once a week on Thursday. It includes the current state of odigos "main" branch at the time of the release candidate first initiation.
+
+Once a release candidate is published, it is used, tested, and verified by odigos team and the community. Any issue found during this process should be fixed and cherry-picked to the release branch, and a new release candidate should be published that includes the fix.
+
+Any new feature, or non-critical bug fixes during the release candidate period are merged to "main" branch normally and scheduled for the following stable release.
+
+### "Preview" or "Pre-release" Versions
+
+Version of the form `v1.0.X-prY` where X is a number and Y is a number starting from 0, is a "preview" or "pre-release" version.
+
+These versions allow a user to opt-in and test the latest features and bug fixes which are not yet scheduled for any stable release.
+
+Preview versions are published directly off the "main" branch, and are thus less stable. They should be used for testing only when the cutting edge features and bug fixes are needed.
+
+Preview versions are published on demand by odigos team based on the need.
+
 
 ## Release Process
 
@@ -15,15 +42,31 @@ The “next stable” version is currently defined as the latest version with it
 
 A stable version is a release candidate that has successfully completed the release‑candidate process and is then promoted to stable.
 
+To promote a release candidate to a stable release, trigger the [promote-to-stable](https://github.com/odigos-io/odigos/actions/workflows/promote-to-stable.yml) workflow with the tag of the release candidate.
+
+Promoting a release candidate to a stable release will:
+
+- Copy all existing images of the relevant release-candidate tag to the new stable tag.
+- Create a new stable tag (on the same commit as the release candidate tag)
+- Release odigos-cli (with the relevant embedded version and date)
+- Create a new release on github with changelog based on latest stable.
+- Trigger OpenShift Preflight and helm release.
+
 ### Release Candidate Process
 
-Before releasing a new stable version, we release a new "release candidate" (rc) version. This allows the odigos team to test and validate the new version, and for the community to pull in latest bug fixes and features and provide feedback.
+Use the [create-release-candidate](https://github.com/odigos-io/odigos/actions/workflows/create-release-candidate.yml) workflow to create a new release candidate for the next stable version.
 
-If any bugs are found in the release candidate, they should be fixed and a new release candidate should be released with the "rc" suffix incremented by 1.
+Release candidates are made from release branch in the formath "releases/v1.0.X". the first time a release candidate is triggered for a stable version, the release branch is created off the "main" branch and any future commits to the "main" branch will not be included by default in the next release.
 
-After a release candidate is tested and validated, it is promoted to a stable release.
+The workflow will check what the next stable version is, and if a release branch already exists for that version, it will use it. It will calculate the next release candidate number, and create a "Release Candidate Pull Request" to the release branch.
 
-Release candidates are always made against the next stable version, with the "-rcY" suffix, where Y is the release candidate number, starting from 0 and incrementing by 1 on every new release candidate to the same stable release version.
+This Pull Request will run the full suite of tests and validations, and requires an approver to review and approve it. Once merged, the CI will create and push a tag for the release candidate, which will trigger odigos release process.
+
+### Preview or Pre-release Process
+
+Currently it is triggered manually by pushing a tag to the repo.
+
+When triggering this release, check what the next stable version is (not the current stable), and check if there are any existing "-pr" tags. then use "-pr0" for first preview, or increment the number for the next preview.
 
 ## Consuming Odigos Versions
 


### PR DESCRIPTION
Add a workflow to ci to promote a release candidate to stable release:

- retag existing images to new stable tag (instead of building them all from scratch). this also guarantees that the stable release is exactly the release candidate and no additional changes sneak in,
- run the go releaser with the relevant  `GORELEASER_PREVIOUS_TAG` so that changelog is created correctly (based on latest stable and not latest tag which can be pre-release).

This workflow is currently triggered manually and the user should supply the relevant rc tag to promote to stable

emergency-ticket id: EMR-4
