### PR TITLE
chore: add label-attribute profile and attach to greatwall

### DIFF
--- a/profiles/aggregators/greatwall.go
+++ b/profiles/aggregators/greatwall.go
@@ -15,6 +15,7 @@ var GreatwallProfile = profile.Profile{
 		"legacy-dotnet-instrumentation",
 		"mount-method-k8s-virtual-device",
 		"pod-manifest-env-var-injection",
+		"label-attributes",
 	},
 	ModifyConfigFunc: func(config *common.OdigosConfiguration) {
 		// temporary set in profile until we add auto discovery for /var/log symlink target

--- a/profiles/allprofiles.go
+++ b/profiles/allprofiles.go
@@ -24,6 +24,7 @@ var AllProfiles = []profile.Profile{
 	attributes.QueryOperationDetector,
 	attributes.SemconvUpgraderProfile,
 	attributes.ReduceSpanNameCardinalityProfile,
+	attributes.LabelAttributeProfile,
 
 	instrumentation.AllowConcurrentAgents,
 	instrumentation.JavaEbpfInstrumentationsProfile,

--- a/profiles/attributes/labelsattributes.go
+++ b/profiles/attributes/labelsattributes.go
@@ -1,0 +1,12 @@
+package attributes
+
+import (
+	"github.com/odigos-io/odigos/common"
+	"github.com/odigos-io/odigos/profiles/profile"
+)
+
+var LabelAttributeProfile = profile.Profile{
+	ProfileName:      common.ProfileName("label-attributes"),
+	MinimumTier:      common.OnPremOdigosTier,
+	ShortDescription: "Add pod's labels attributes to the spans",
+}

--- a/profiles/manifests/label-attributes.yaml
+++ b/profiles/manifests/label-attributes.yaml
@@ -1,0 +1,33 @@
+apiVersion: odigos.io/v1alpha1
+kind: Processor
+metadata:
+  name: label-attributes
+  namespace: odigos-system
+spec:
+  type: k8sattributes
+  processorName: Unified Kubernetes Attributes
+  notes: "Collect Kubernetes attributes for observability"
+  disabled: false
+  orderHint: 0
+  collectorRoles:
+    - NODE_COLLECTOR
+  signals:
+    - TRACES
+  processorConfig:
+    auth_type: serviceAccount
+    passthrough: false
+    extract:
+      labels:
+        - tag_name: vm.app
+          key: vm.app
+          from: pod
+        - tag_name: vm.env
+          key: vm.env
+          from: pod
+    pod_association:
+      - sources:
+        - from: resource_attribute
+          name: k8s.pod.name
+        - from: resource_attribute
+          name: k8s.namespace.name
+


### PR DESCRIPTION
## Description
Add all relevant files for generating the `label-attributes` processor, and append the corresponding manifest to a new `label-attributes` profile, which now aggregated into the `greatwall` profile.
<!-- Short summary of the changes -->

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
