### PR TITLE
Remove k8s.cronjob.uid metadata key

### DIFF
--- a/autoscaler/controllers/actions/k8sattributesresolver_controller.go
+++ b/autoscaler/controllers/actions/k8sattributesresolver_controller.go
@@ -60,7 +60,6 @@ var (
 		string(semconv.K8SDeploymentUIDKey),
 		string(semconv.K8SDaemonSetUIDKey),
 		string(semconv.K8SStatefulSetUIDKey),
-		string(semconv.K8SCronJobUIDKey),
 		string(semconv.K8SJobUIDKey),
 	}
 


### PR DESCRIPTION
## Description
Fixes the gateway crashing after adding k8sAttributes Action caused by `k8s.cronjob.uid` key
<!-- Short summary of the changes -->

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [x] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-10
