### PR TITLE
fix: build rsync in multi-arch stage

### DIFF
--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -112,6 +112,32 @@ RUN for v in ${RUBY_VERSIONS}; do \
     done
 
 
+# Compile rsync statically for distroless image
+# don't specify the platform here, since we want to compile for multi architecture natively with gcc
+FROM registry.odigos.io/odiglet-base:v1.8 AS rsync-builder
+ARG RSYNC_VERSION=3.2.7
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    wget \
+    ca-certificates \
+    libacl1-dev \
+    libattr1-dev \
+    libpopt-dev \
+    liblz4-dev \
+    libzstd-dev \
+    libxxhash-dev \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN wget https://download.samba.org/pub/rsync/src/rsync-${RSYNC_VERSION}.tar.gz \
+    && tar -xzf rsync-${RSYNC_VERSION}.tar.gz \
+    && cd rsync-${RSYNC_VERSION} \
+    && ./configure --prefix=/usr LDFLAGS="-static" \
+    && make \
+    && make install DESTDIR=/rsync-install \
+    && cd .. \
+    && rm -rf rsync-${RSYNC_VERSION}*
+
 ######### ODIGLET #########
 FROM --platform=$BUILDPLATFORM registry.odigos.io/odiglet-base:v1.8 AS builder
 WORKDIR /go/src/github.com/odigos-io/odigos
@@ -149,32 +175,6 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
     fi && \
     wget -O /tmp/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${GRPC_ARCH} && \
     chmod +x /tmp/grpc_health_probe
-
-
-# Compile rsync statically for distroless image
-ARG RSYNC_VERSION=3.2.7
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    wget \
-    ca-certificates \
-    libacl1-dev \
-    libattr1-dev \
-    libpopt-dev \
-    liblz4-dev \
-    libzstd-dev \
-    libxxhash-dev \
-    libssl-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN wget https://download.samba.org/pub/rsync/src/rsync-${RSYNC_VERSION}.tar.gz \
-    && tar -xzf rsync-${RSYNC_VERSION}.tar.gz \
-    && cd rsync-${RSYNC_VERSION} \
-    && ./configure --prefix=/usr LDFLAGS="-static" \
-    && make \
-    && make install DESTDIR=/rsync-install \
-    && cd .. \
-    && rm -rf rsync-${RSYNC_VERSION}*
-
 
 WORKDIR /instrumentations
 
@@ -220,7 +220,7 @@ COPY --from=builder /go/src/github.com/odigos-io/odigos/odiglet/odiglet /root/od
 COPY --from=builder /go/src/github.com/odigos-io/odigos/deviceplugin/deviceplugin /root/deviceplugin
 COPY --from=builder /tmp/grpc_health_probe /root/grpc_health_probe
 # Copy statically compiled rsync (no shared libraries needed)
-COPY --from=builder /rsync-install/usr/bin/rsync /usr/bin/rsync
+COPY --from=rsync-builder /rsync-install/usr/bin/rsync /usr/bin/rsync
 WORKDIR /instrumentations/
 COPY --from=builder /instrumentations/ .
 CMD ["/root/odiglet"]

--- a/odiglet/Dockerfile.rhel
+++ b/odiglet/Dockerfile.rhel
@@ -114,6 +114,31 @@ RUN for v in ${RUBY_VERSIONS}; do \
     rm -rf opentelemetry-ruby/$v/arm64; \
     done
 
+# Compile rsync statically for distroless image
+# don't specify the platform here, since we want to compile for multi architecture natively with gcc
+FROM registry.odigos.io/odiglet-base:v1.8 AS rsync-builder
+ARG RSYNC_VERSION=3.2.7
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    wget \
+    ca-certificates \
+    libacl1-dev \
+    libattr1-dev \
+    libpopt-dev \
+    liblz4-dev \
+    libzstd-dev \
+    libxxhash-dev \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN wget https://download.samba.org/pub/rsync/src/rsync-${RSYNC_VERSION}.tar.gz \
+    && tar -xzf rsync-${RSYNC_VERSION}.tar.gz \
+    && cd rsync-${RSYNC_VERSION} \
+    && ./configure --prefix=/usr LDFLAGS="-static" \
+    && make \
+    && make install DESTDIR=/rsync-install \
+    && cd .. \
+    && rm -rf rsync-${RSYNC_VERSION}*
 
 ######### ODIGLET #########
 FROM --platform=$BUILDPLATFORM registry.odigos.io/odiglet-base:v1.8 AS builder
@@ -152,30 +177,6 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
     fi && \
     wget -O /tmp/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${GRPC_ARCH} && \
     chmod +x /tmp/grpc_health_probe
-
-# Compile rsync statically for distroless image
-ARG RSYNC_VERSION=3.2.7
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    wget \
-    ca-certificates \
-    libacl1-dev \
-    libattr1-dev \
-    libpopt-dev \
-    liblz4-dev \
-    libzstd-dev \
-    libxxhash-dev \
-    libssl-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN wget https://download.samba.org/pub/rsync/src/rsync-${RSYNC_VERSION}.tar.gz \
-    && tar -xzf rsync-${RSYNC_VERSION}.tar.gz \
-    && cd rsync-${RSYNC_VERSION} \
-    && ./configure --prefix=/usr LDFLAGS="-static" \
-    && make \
-    && make install DESTDIR=/rsync-install \
-    && cd .. \
-    && rm -rf rsync-${RSYNC_VERSION}*
 
 WORKDIR /instrumentations
 
@@ -234,7 +235,7 @@ COPY --from=builder /go/src/github.com/odigos-io/odigos/odiglet/LICENSE /license
 COPY --from=builder /tmp/grpc_health_probe /root/grpc_health_probe
 COPY --from=builder /go/src/github.com/odigos-io/odigos/deviceplugin/deviceplugin /root/deviceplugin
 # Copy statically compiled rsync (no shared libraries needed)
-COPY --from=builder /rsync-install/usr/bin/rsync /usr/bin/rsync
+COPY --from=rsync-builder /rsync-install/usr/bin/rsync /usr/bin/rsync
 WORKDIR /instrumentations/
 COPY --from=builder /instrumentations/ .
 CMD ["/root/odiglet"]


### PR DESCRIPTION
When building the `rsync` binary we used the 
```
FROM --platform=$BUILDPLATFORM registry.odigos.io/odiglet-base:v1.8 AS builder
```

Since our release flow runs on amd64 this means that this step runs on amd64.
Hence when calling `make` it compiles it to `amd64` even when the target architecture is arm64.

This is fixed by separating the rsync build step, and not using an image pinned to the build platform - this way this step will run with both amd64 and arm64 images based on the target architecture. 

emergency-ticket id: EMR-19
