### PR TITLE
feat: disable destinations

### DIFF
--- a/api/config/crd/bases/odigos.io_destinations.yaml
+++ b/api/config/crd/bases/odigos.io_destinations.yaml
@@ -47,6 +47,8 @@ spec:
                 type: object
               destinationName:
                 type: string
+              disabled:
+                type: boolean
               secretRef:
                 description: |-
                   LocalObjectReference contains enough information to let you locate the
@@ -100,6 +102,7 @@ spec:
             required:
             - data
             - destinationName
+            - disabled
             - signals
             - type
             type: object

--- a/api/config/crd/bases/odigos.io_destinations.yaml
+++ b/api/config/crd/bases/odigos.io_destinations.yaml
@@ -102,7 +102,6 @@ spec:
             required:
             - data
             - destinationName
-            - disabled
             - signals
             - type
             type: object

--- a/api/generated/odigos/applyconfiguration/odigos/v1alpha1/destinationspec.go
+++ b/api/generated/odigos/applyconfiguration/odigos/v1alpha1/destinationspec.go
@@ -30,6 +30,7 @@ type DestinationSpecApplyConfiguration struct {
 	Data            map[string]string                 `json:"data,omitempty"`
 	SecretRef       *v1.LocalObjectReference          `json:"secretRef,omitempty"`
 	Signals         []common.ObservabilitySignal      `json:"signals,omitempty"`
+	Disabled        *bool                             `json:"disabled,omitempty"`
 	SourceSelector  *SourceSelectorApplyConfiguration `json:"sourceSelector,omitempty"`
 }
 
@@ -84,6 +85,14 @@ func (b *DestinationSpecApplyConfiguration) WithSignals(values ...common.Observa
 	for i := range values {
 		b.Signals = append(b.Signals, values[i])
 	}
+	return b
+}
+
+// WithDisabled sets the Disabled field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Disabled field is set to the value of the last call.
+func (b *DestinationSpecApplyConfiguration) WithDisabled(value bool) *DestinationSpecApplyConfiguration {
+	b.Disabled = &value
 	return b
 }
 

--- a/api/odigos/v1alpha1/destination_types.go
+++ b/api/odigos/v1alpha1/destination_types.go
@@ -30,7 +30,7 @@ type DestinationSpec struct {
 	Data            map[string]string            `json:"data"`
 	SecretRef       *v1.LocalObjectReference     `json:"secretRef,omitempty"`
 	Signals         []common.ObservabilitySignal `json:"signals"`
-	Disabled        bool                         `json:"disabled"`
+	Disabled        *bool                        `json:"disabled,omitempty"`
 
 	// SourceSelector defines which sources can send data to this destination.
 	// If not specified, defaults to "all".

--- a/api/odigos/v1alpha1/destination_types.go
+++ b/api/odigos/v1alpha1/destination_types.go
@@ -30,6 +30,7 @@ type DestinationSpec struct {
 	Data            map[string]string            `json:"data"`
 	SecretRef       *v1.LocalObjectReference     `json:"secretRef,omitempty"`
 	Signals         []common.ObservabilitySignal `json:"signals"`
+	Disabled        bool                         `json:"disabled"`
 
 	// SourceSelector defines which sources can send data to this destination.
 	// If not specified, defaults to "all".

--- a/api/odigos/v1alpha1/zz_generated.deepcopy.go
+++ b/api/odigos/v1alpha1/zz_generated.deepcopy.go
@@ -529,6 +529,11 @@ func (in *DestinationSpec) DeepCopyInto(out *DestinationSpec) {
 		*out = make([]common.ObservabilitySignal, len(*in))
 		copy(*out, *in)
 	}
+	if in.Disabled != nil {
+		in, out := &in.Disabled, &out.Disabled
+		*out = new(bool)
+		**out = **in
+	}
 	if in.SourceSelector != nil {
 		in, out := &in.SourceSelector, &out.SourceSelector
 		*out = new(SourceSelector)

--- a/autoscaler/controllers/clustercollector/configmap.go
+++ b/autoscaler/controllers/clustercollector/configmap.go
@@ -136,7 +136,7 @@ func syncConfigMap(dests *odigosv1.DestinationList, allProcessors *odigosv1.Proc
 	enabledDests := &odigosv1.DestinationList{Items: []odigosv1.Destination{}}
 	for _, dest := range dests.Items {
 		// skip disabled destinations
-		if dest.Spec.Disabled {
+		if dest.Spec.Disabled != nil && *dest.Spec.Disabled {
 			continue
 		}
 		enabledDests.Items = append(enabledDests.Items, dest)

--- a/autoscaler/controllers/clustercollector/configmap.go
+++ b/autoscaler/controllers/clustercollector/configmap.go
@@ -133,18 +133,11 @@ func syncConfigMap(dests *odigosv1.DestinationList, allProcessors *odigosv1.Proc
 	logger := log.FromContext(ctx)
 	memoryLimiterConfiguration := common.GetMemoryLimiterConfig(gateway.Spec.ResourcesSettings)
 
-	var enabledDests *odigosv1.DestinationList
+	enabledDests := &odigosv1.DestinationList{Items: []odigosv1.Destination{}}
 	for _, dest := range dests.Items {
 		// skip disabled destinations
 		if dest.Spec.Disabled {
 			continue
-		}
-
-		if enabledDests == nil {
-			enabledDests = &odigosv1.DestinationList{}
-		}
-		if enabledDests.Items == nil {
-			enabledDests.Items = []odigosv1.Destination{}
 		}
 		enabledDests.Items = append(enabledDests.Items, dest)
 	}

--- a/docs/api-reference/odigos.io.v1alpha1.mdx
+++ b/docs/api-reference/odigos.io.v1alpha1.mdx
@@ -1279,6 +1279,17 @@ and the distro to use will be calculated based on this value.</p>
 </tr>
 <tr>
 <td>
+<code>disabled</code> <B>[Required]</B>
+</td>
+<td>
+<code>bool</code>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+<tr>
+<td>
 <code>sourceSelector</code>
 </td>
 <td>

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -26773,7 +26773,7 @@ func (ec *executionContext) unmarshalInputDestinationInput(ctx context.Context, 
 			it.Fields = data
 		case "disabled":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("disabled"))
-			data, err := ec.unmarshalNBoolean2bool(ctx, v)
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -26302,7 +26302,7 @@ func (ec *executionContext) unmarshalInputDestinationInput(ctx context.Context, 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"name", "type", "currentStreamName", "exportedSignals", "fields"}
+	fieldsInOrder := [...]string{"name", "type", "currentStreamName", "exportedSignals", "fields", "disabled"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -26344,6 +26344,13 @@ func (ec *executionContext) unmarshalInputDestinationInput(ctx context.Context, 
 				return it, err
 			}
 			it.Fields = data
+		case "disabled":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("disabled"))
+			data, err := ec.unmarshalNBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Disabled = data
 		}
 	}
 

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -205,6 +205,7 @@ type ComplexityRoot struct {
 		Conditions      func(childComplexity int) int
 		DataStreamNames func(childComplexity int) int
 		DestinationType func(childComplexity int) int
+		Disabled        func(childComplexity int) int
 		ExportedSignals func(childComplexity int) int
 		Fields          func(childComplexity int) int
 		ID              func(childComplexity int) int
@@ -1471,6 +1472,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Destination.DestinationType(childComplexity), true
+
+	case "Destination.disabled":
+		if e.complexity.Destination.Disabled == nil {
+			break
+		}
+
+		return e.complexity.Destination.Disabled(childComplexity), true
 
 	case "Destination.exportedSignals":
 		if e.complexity.Destination.ExportedSignals == nil {
@@ -7870,6 +7878,8 @@ func (ec *executionContext) fieldContext_ComputePlatform_destinations(_ context.
 				return ec.fieldContext_Destination_type(ctx, field)
 			case "name":
 				return ec.fieldContext_Destination_name(ctx, field)
+			case "disabled":
+				return ec.fieldContext_Destination_disabled(ctx, field)
 			case "dataStreamNames":
 				return ec.fieldContext_Destination_dataStreamNames(ctx, field)
 			case "exportedSignals":
@@ -9483,6 +9493,50 @@ func (ec *executionContext) fieldContext_Destination_name(_ context.Context, fie
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Destination_disabled(ctx context.Context, field graphql.CollectedField, obj *model.Destination) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Destination_disabled(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Disabled, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Destination_disabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Destination",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -15091,6 +15145,8 @@ func (ec *executionContext) fieldContext_Mutation_createNewDestination(ctx conte
 				return ec.fieldContext_Destination_type(ctx, field)
 			case "name":
 				return ec.fieldContext_Destination_name(ctx, field)
+			case "disabled":
+				return ec.fieldContext_Destination_disabled(ctx, field)
 			case "dataStreamNames":
 				return ec.fieldContext_Destination_dataStreamNames(ctx, field)
 			case "exportedSignals":
@@ -15164,6 +15220,8 @@ func (ec *executionContext) fieldContext_Mutation_updateDestination(ctx context.
 				return ec.fieldContext_Destination_type(ctx, field)
 			case "name":
 				return ec.fieldContext_Destination_name(ctx, field)
+			case "disabled":
+				return ec.fieldContext_Destination_disabled(ctx, field)
 			case "dataStreamNames":
 				return ec.fieldContext_Destination_dataStreamNames(ctx, field)
 			case "exportedSignals":
@@ -29025,6 +29083,11 @@ func (ec *executionContext) _Destination(ctx context.Context, sel ast.SelectionS
 			}
 		case "name":
 			out.Values[i] = ec._Destination_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "disabled":
+			out.Values[i] = ec._Destination_disabled(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -294,6 +294,7 @@ type DestinationInput struct {
 	CurrentStreamName string                `json:"currentStreamName"`
 	ExportedSignals   *ExportedSignalsInput `json:"exportedSignals"`
 	Fields            []*FieldInput         `json:"fields"`
+	Disabled          bool                  `json:"disabled"`
 }
 
 type DestinationTypesCategoryItem struct {

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -263,6 +263,7 @@ type Destination struct {
 	ID              string                        `json:"id"`
 	Type            string                        `json:"type"`
 	Name            string                        `json:"name"`
+	Disabled        bool                          `json:"disabled"`
 	DataStreamNames []*string                     `json:"dataStreamNames"`
 	ExportedSignals *ExportedSignals              `json:"exportedSignals"`
 	Fields          string                        `json:"fields"`

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -295,7 +295,7 @@ type DestinationInput struct {
 	CurrentStreamName string                `json:"currentStreamName"`
 	ExportedSignals   *ExportedSignalsInput `json:"exportedSignals"`
 	Fields            []*FieldInput         `json:"fields"`
-	Disabled          bool                  `json:"disabled"`
+	Disabled          *bool                 `json:"disabled,omitempty"`
 }
 
 type DestinationTypesCategoryItem struct {

--- a/frontend/graph/schema.graphqls
+++ b/frontend/graph/schema.graphqls
@@ -477,7 +477,7 @@ input DestinationInput {
   currentStreamName: String!
   exportedSignals: ExportedSignalsInput!
   fields: [FieldInput!]!
-  disabled: Boolean!
+  disabled: Boolean
 }
 
 input FieldInput {

--- a/frontend/graph/schema.graphqls
+++ b/frontend/graph/schema.graphqls
@@ -456,6 +456,7 @@ type Destination {
   id: ID!
   type: String!
   name: String!
+  disabled: Boolean!
   dataStreamNames: [String]!
   exportedSignals: ExportedSignals!
   fields: String!

--- a/frontend/graph/schema.graphqls
+++ b/frontend/graph/schema.graphqls
@@ -476,6 +476,7 @@ input DestinationInput {
   currentStreamName: String!
   exportedSignals: ExportedSignalsInput!
   fields: [FieldInput!]!
+  disabled: Boolean!
 }
 
 input FieldInput {

--- a/frontend/graph/schema.resolvers.go
+++ b/frontend/graph/schema.resolvers.go
@@ -673,6 +673,11 @@ func (r *mutationResolver) CreateNewDestination(ctx context.Context, destination
 	dataField, secretFields := services.TransformFieldsToDataAndSecrets(destTypeConfig, fieldsMap)
 	generateNamePrefix := "odigos.io.dest." + string(destType) + "-"
 
+	disabled := false
+	if destination.Disabled != nil {
+		disabled = *destination.Disabled
+	}
+
 	k8sDestination := v1alpha1.Destination{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: generateNamePrefix,
@@ -682,7 +687,7 @@ func (r *mutationResolver) CreateNewDestination(ctx context.Context, destination
 			DestinationName: destName,
 			Data:            dataField,
 			Signals:         services.ExportedSignalsObjectToSlice(destination.ExportedSignals),
-			Disabled:        destination.Disabled,
+			Disabled:        &disabled,
 		},
 	}
 	if destination.CurrentStreamName != "" {
@@ -811,7 +816,9 @@ func (r *mutationResolver) UpdateDestination(ctx context.Context, id string, des
 	dest.Spec.DestinationName = destName
 	dest.Spec.Data = dataFields
 	dest.Spec.Signals = services.ExportedSignalsObjectToSlice(destination.ExportedSignals)
-	dest.Spec.Disabled = destination.Disabled
+	if destination.Disabled != nil {
+		dest.Spec.Disabled = destination.Disabled
+	}
 
 	if destination.CurrentStreamName != "" {
 		// Init empty struct if nil

--- a/frontend/graph/schema.resolvers.go
+++ b/frontend/graph/schema.resolvers.go
@@ -682,6 +682,7 @@ func (r *mutationResolver) CreateNewDestination(ctx context.Context, destination
 			DestinationName: destName,
 			Data:            dataField,
 			Signals:         services.ExportedSignalsObjectToSlice(destination.ExportedSignals),
+			Disabled:        destination.Disabled,
 		},
 	}
 	if destination.CurrentStreamName != "" {
@@ -810,6 +811,7 @@ func (r *mutationResolver) UpdateDestination(ctx context.Context, id string, des
 	dest.Spec.DestinationName = destName
 	dest.Spec.Data = dataFields
 	dest.Spec.Signals = services.ExportedSignalsObjectToSlice(destination.ExportedSignals)
+	dest.Spec.Disabled = destination.Disabled
 
 	if destination.CurrentStreamName != "" {
 		// Init empty struct if nil

--- a/frontend/services/destinations.go
+++ b/frontend/services/destinations.go
@@ -230,8 +230,9 @@ func K8sDestinationToEndpointFormat(k8sDest v1alpha1.Destination, secretFields m
 
 	return model.Destination{
 		ID:              k8sDest.Name,
-		Name:            destName,
 		Type:            string(destType),
+		Name:            destName,
+		Disabled:        k8sDest.Spec.Disabled,
 		DataStreamNames: ExtractDataStreamsFromDestination(k8sDest),
 		ExportedSignals: &model.ExportedSignals{
 			Traces:  isSignalExported(k8sDest, common.TracesObservabilitySignal),

--- a/frontend/services/destinations.go
+++ b/frontend/services/destinations.go
@@ -228,11 +228,16 @@ func K8sDestinationToEndpointFormat(k8sDest v1alpha1.Destination, secretFields m
 		})
 	}
 
+	disabled := false
+	if k8sDest.Spec.Disabled != nil {
+		disabled = *k8sDest.Spec.Disabled
+	}
+
 	return model.Destination{
 		ID:              k8sDest.Name,
 		Type:            string(destType),
 		Name:            destName,
-		Disabled:        k8sDest.Spec.Disabled,
+		Disabled:        disabled,
 		DataStreamNames: ExtractDataStreamsFromDestination(k8sDest),
 		ExportedSignals: &model.ExportedSignals{
 			Traces:  isSignalExported(k8sDest, common.TracesObservabilitySignal),

--- a/frontend/webapp/components/lib-imports/setup-header.tsx
+++ b/frontend/webapp/components/lib-imports/setup-header.tsx
@@ -23,6 +23,7 @@ const getFormDataFromDestination = (dest: Destination, selectedStreamName: strin
   const payload: DestinationFormData = {
     type: dest.destinationType.type,
     name: dest.destinationType.displayName,
+    disabled: dest.disabled,
     currentStreamName: selectedStreamName,
     exportedSignals: dest.exportedSignals,
     fields: fieldsArray,

--- a/frontend/webapp/graphql/mutations/destination.ts
+++ b/frontend/webapp/graphql/mutations/destination.ts
@@ -5,6 +5,7 @@ export const CREATE_DESTINATION = gql`
     createNewDestination(destination: $destination) {
       id
       name
+      disabled
       dataStreamNames
       fields
       exportedSignals {

--- a/frontend/webapp/graphql/queries/destination.ts
+++ b/frontend/webapp/graphql/queries/destination.ts
@@ -58,6 +58,7 @@ export const GET_DESTINATIONS = gql`
       destinations {
         id
         name
+        disabled
         dataStreamNames
         fields
         exportedSignals {

--- a/frontend/webapp/package.json
+++ b/frontend/webapp/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@apollo/client": "^3.13.9",
     "@apollo/experimental-nextjs-app-support": "^0.12.3",
-    "@odigos/ui-kit": "^0.0.78",
+    "@odigos/ui-kit": "^0.0.79",
     "graphql": "^16.11.0",
     "next": "15.4.5",
     "react": "19.1.1",

--- a/frontend/webapp/package.json
+++ b/frontend/webapp/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@apollo/client": "^3.13.9",
     "@apollo/experimental-nextjs-app-support": "^0.12.3",
-    "@odigos/ui-kit": "^0.0.77",
+    "@odigos/ui-kit": "^0.0.78",
     "graphql": "^16.11.0",
     "next": "15.4.5",
     "react": "19.1.1",

--- a/frontend/webapp/package.json
+++ b/frontend/webapp/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@apollo/client": "^3.13.9",
     "@apollo/experimental-nextjs-app-support": "^0.12.3",
-    "@odigos/ui-kit": "^0.0.76",
+    "@odigos/ui-kit": "^0.0.77",
     "graphql": "^16.11.0",
     "next": "15.4.5",
     "react": "19.1.1",

--- a/frontend/webapp/yarn.lock
+++ b/frontend/webapp/yarn.lock
@@ -436,10 +436,10 @@
   resolved "https://registry.yarnpkg.com/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz#3dc35ba0f1e66b403c00b39344f870298ebb1c8e"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
-"@odigos/ui-kit@^0.0.76":
-  version "0.0.76"
-  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.76.tgz#8e59043a8d34117ca21cf67d433562eb5fc0b07c"
-  integrity sha512-G4haF3+0/aq+5SXOgLdMOd6vmbfVJP9KT4JVzCX6SwFKSVnA0fLnsdsRXhb7g0tbMTHp7tCTrMM/d+eMBdtOUw==
+"@odigos/ui-kit@^0.0.77":
+  version "0.0.77"
+  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.77.tgz#342e86a35cbc209abcfcda8ddee288355aa3f4b5"
+  integrity sha512-FUcOCtVmW/E9a/AMTqZ/4GzMAsHW2Ve+pC1aseBSgziSgLF7YfKIe6s6xeGukfoFi7Kx7JcY9KYcsx4gKY6N9A==
   dependencies:
     "@xyflow/react" "^12.8.2"
     javascript-time-ago "^2.5.11"

--- a/frontend/webapp/yarn.lock
+++ b/frontend/webapp/yarn.lock
@@ -436,10 +436,10 @@
   resolved "https://registry.yarnpkg.com/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz#3dc35ba0f1e66b403c00b39344f870298ebb1c8e"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
-"@odigos/ui-kit@^0.0.78":
-  version "0.0.78"
-  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.78.tgz#a4c7bd974bb5f3f62c68befe4c5c4e547235bb76"
-  integrity sha512-thJ9+ZoOvMCHiufAXXdMMkQv6FRf+PxNJuQWXXf0anCQU27xIL5oEJl2W1hjv6zxZjL5U4lEpaFnLmJPhVyCLw==
+"@odigos/ui-kit@^0.0.79":
+  version "0.0.79"
+  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.79.tgz#740cb661a8593eea14fff3c97eba7f61dd1eaadb"
+  integrity sha512-Fvymjf3V05eUlFcVcP/zc9OvVHmKTPjF6h4fv1VPUiMR/fCEvn+9AXPPsgMy10+HwUYrliocRfh6wktSyAtY/Q==
   dependencies:
     "@xyflow/react" "^12.8.2"
     javascript-time-ago "^2.5.11"

--- a/frontend/webapp/yarn.lock
+++ b/frontend/webapp/yarn.lock
@@ -436,10 +436,10 @@
   resolved "https://registry.yarnpkg.com/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz#3dc35ba0f1e66b403c00b39344f870298ebb1c8e"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
-"@odigos/ui-kit@^0.0.77":
-  version "0.0.77"
-  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.77.tgz#342e86a35cbc209abcfcda8ddee288355aa3f4b5"
-  integrity sha512-FUcOCtVmW/E9a/AMTqZ/4GzMAsHW2Ve+pC1aseBSgziSgLF7YfKIe6s6xeGukfoFi7Kx7JcY9KYcsx4gKY6N9A==
+"@odigos/ui-kit@^0.0.78":
+  version "0.0.78"
+  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.78.tgz#a4c7bd974bb5f3f62c68befe4c5c4e547235bb76"
+  integrity sha512-thJ9+ZoOvMCHiufAXXdMMkQv6FRf+PxNJuQWXXf0anCQU27xIL5oEJl2W1hjv6zxZjL5U4lEpaFnLmJPhVyCLw==
   dependencies:
     "@xyflow/react" "^12.8.2"
     javascript-time-ago "^2.5.11"

--- a/helm/odigos/templates/crds/odigos.io_destinations.yaml
+++ b/helm/odigos/templates/crds/odigos.io_destinations.yaml
@@ -47,6 +47,8 @@ spec:
                 type: object
               destinationName:
                 type: string
+              disabled:
+                type: boolean
               secretRef:
                 description: |-
                   LocalObjectReference contains enough information to let you locate the
@@ -100,6 +102,7 @@ spec:
             required:
             - data
             - destinationName
+            - disabled
             - signals
             - type
             type: object

--- a/helm/odigos/templates/crds/odigos.io_destinations.yaml
+++ b/helm/odigos/templates/crds/odigos.io_destinations.yaml
@@ -102,7 +102,6 @@ spec:
             required:
             - data
             - destinationName
-            - disabled
             - signals
             - type
             type: object


### PR DESCRIPTION
This PR allows the user to disable the destination without deleting the configuration.
The destination spec object now contains a `disabled` field, which controls whether or not these destinations should be filtered out by the `syncConfigMap` function for Odigos's routing system.

# Enabled
Overview
<img width="336" height="187" alt="Screenshot 2025-08-06 at 17 05 33" src="https://github.com/user-attachments/assets/6a1138e1-2535-41ac-850d-5eb1ef6e203e" />
Drawer Read
<img width="675" height="359" alt="Screenshot 2025-08-06 at 17 05 45" src="https://github.com/user-attachments/assets/0fe32f5a-9aff-483d-b419-0d44dcaaa289" />
Drawer Update
<img width="670" height="490" alt="Screenshot 2025-08-06 at 17 05 09" src="https://github.com/user-attachments/assets/7384c907-0fc1-4a6d-bcc9-64d29593b620" />

# Disabled
Overview
<img width="327" height="183" alt="Screenshot 2025-08-06 at 17 06 29" src="https://github.com/user-attachments/assets/c53fb4a4-9401-4a3a-b74f-f35026fd93ac" />
Drawer Read
<img width="675" height="359" alt="Screenshot 2025-08-06 at 17 06 16" src="https://github.com/user-attachments/assets/ea6ea560-a832-4a66-91db-4e6a8948944d" />
Drawer Update
<img width="675" height="465" alt="Screenshot 2025-08-06 at 17 06 08" src="https://github.com/user-attachments/assets/bf751a09-06d2-4825-b638-667cb19fbb2f" />