### PR TITLE
RUN-92: Downgrade DynamoDB/Redis semconv attributes in Kratos profile

### DIFF
--- a/profiles/aggregators/kratos.go
+++ b/profiles/aggregators/kratos.go
@@ -25,6 +25,7 @@ var KratosProfile = profile.Profile{
 		"reduce-span-name-cardinality",
 		"disable-gin",
 		"semconvdynamo",
+		"semconvredis",
 	},
 	ModifyConfigFunc: func(config *common.OdigosConfiguration) {
 		rollbackDisabled := true

--- a/profiles/aggregators/kratos.go
+++ b/profiles/aggregators/kratos.go
@@ -24,6 +24,7 @@ var KratosProfile = profile.Profile{
 		"mount-method-k8s-host-path",
 		"reduce-span-name-cardinality",
 		"disable-gin",
+		"semconvdynamo",
 	},
 	ModifyConfigFunc: func(config *common.OdigosConfiguration) {
 		rollbackDisabled := true

--- a/profiles/allprofiles.go
+++ b/profiles/allprofiles.go
@@ -24,6 +24,7 @@ var AllProfiles = []profile.Profile{
 	attributes.QueryOperationDetector,
 	attributes.SemconvUpgraderProfile,
 	attributes.SemconvDynamoProfile,
+	attributes.SemconvRedisProfile,
 	attributes.ReduceSpanNameCardinalityProfile,
 	attributes.LabelAttributeProfile,
 

--- a/profiles/allprofiles.go
+++ b/profiles/allprofiles.go
@@ -23,6 +23,7 @@ var AllProfiles = []profile.Profile{
 	attributes.DbPayloadCollectionProfile,
 	attributes.QueryOperationDetector,
 	attributes.SemconvUpgraderProfile,
+	attributes.SemconvDynamoProfile,
 	attributes.ReduceSpanNameCardinalityProfile,
 	attributes.LabelAttributeProfile,
 

--- a/profiles/attributes/semconvdynamo.go
+++ b/profiles/attributes/semconvdynamo.go
@@ -1,0 +1,12 @@
+package attributes
+
+import (
+	"github.com/odigos-io/odigos/common"
+	"github.com/odigos-io/odigos/profiles/profile"
+)
+
+var SemconvDynamoProfile = profile.Profile{
+	ProfileName:      common.ProfileName("semconvdynamo"),
+	MinimumTier:      common.CommunityOdigosTier,
+	ShortDescription: "Convert db.system.name to db.system for AWS DynamoDB spans",
+}

--- a/profiles/attributes/semconvredis.go
+++ b/profiles/attributes/semconvredis.go
@@ -1,0 +1,12 @@
+package attributes
+
+import (
+	"github.com/odigos-io/odigos/common"
+	"github.com/odigos-io/odigos/profiles/profile"
+)
+
+var SemconvRedisProfile = profile.Profile{
+	ProfileName:      common.ProfileName("semconvredis"),
+	MinimumTier:      common.CommunityOdigosTier,
+	ShortDescription: "Convert db.system.name to db.system for Redis spans",
+}

--- a/profiles/manifests/semconvdynamo.yaml
+++ b/profiles/manifests/semconvdynamo.yaml
@@ -1,0 +1,26 @@
+apiVersion: odigos.io/v1alpha1
+kind: Processor
+metadata:
+  name: semconvdynamo
+  namespace: odigos-system
+spec:
+  type: attributes
+  processorName: "semconvdynamo-attributes"
+  notes: "Auto generated rule from semconvdynamo profile. Converts db.system.name to db.system for AWS DynamoDB spans."
+  processorConfig:
+    include:
+      match_type: strict
+      attributes:
+        - key: db.system.name
+          value: "aws.dynamodb"
+    actions:
+      - key: db.system
+        value: "aws.dynamodb"
+        action: insert
+      - key: db.operation
+        action: insert
+        from_attribute: rpc.method
+  signals:
+    - TRACES
+  collectorRoles:
+    - CLUSTER_GATEWAY 

--- a/profiles/manifests/semconvdynamo.yaml
+++ b/profiles/manifests/semconvdynamo.yaml
@@ -20,6 +20,8 @@ spec:
       - key: db.operation
         action: insert
         from_attribute: rpc.method
+      - key: db.system.name
+        action: delete
   signals:
     - TRACES
   collectorRoles:

--- a/profiles/manifests/semconvredis.yaml
+++ b/profiles/manifests/semconvredis.yaml
@@ -17,9 +17,8 @@ spec:
       - key: db.system
         value: "redis"
         action: insert
-      - key: db.operation
-        action: insert
-        from_attribute: rpc.method
+      - key: db.system.name
+        action: delete
   signals:
     - TRACES
   collectorRoles:

--- a/profiles/manifests/semconvredis.yaml
+++ b/profiles/manifests/semconvredis.yaml
@@ -1,0 +1,26 @@
+apiVersion: odigos.io/v1alpha1
+kind: Processor
+metadata:
+  name: semconvredis
+  namespace: odigos-system
+spec:
+  type: attributes
+  processorName: "semconvredis-attributes"
+  notes: "Auto generated rule from semconvredis profile. Converts db.system.name to db.system for Redis spans."
+  processorConfig:
+    include:
+      match_type: strict
+      attributes:
+        - key: db.system.name
+          value: "redis"
+    actions:
+      - key: db.system
+        value: "redis"
+        action: insert
+      - key: db.operation
+        action: insert
+        from_attribute: rpc.method
+  signals:
+    - TRACES
+  collectorRoles:
+    - CLUSTER_GATEWAY 


### PR DESCRIPTION
## Description

Downgrades `db.system.name` to `db.system` for DynamoDB following new instrumentation added in https://github.com/odigos-io/enterprise-go-instrumentation/pull/1560

It also sets `db.operation` to the value of `rpc.method` based on https://github.com/odigos-io/enterprise-go-instrumentation/pull/1560#discussion_r2260694632

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
