### PR TITLE
chore: in case mount-method is not used do not mount the deviceplugin + adjust grpc healthcheck CORE-125

### DIFF
--- a/api/k8sconsts/odiglet.go
+++ b/api/k8sconsts/odiglet.go
@@ -15,8 +15,9 @@ const (
 	OdigletEnterpriseImageUBI9       = "odigos-enterprise-odiglet-ubi9"
 	OdigletImageUBI9                 = "odigos-odiglet-ubi9"
 
-	GrpcHealthProbePath  = "unix:///var/lib/kubelet/device-plugins/instrumentation.odigos.io_generic"
-	GrpcHealthBinaryPath = "/root/grpc_health_probe"
+	GrpcHealthProbePath    = "unix:///var/lib/kubelet/device-plugins/instrumentation.odigos.io_generic"
+	GrpcHealthBinaryPath   = "/root/grpc_health_probe"
+	GrpcHealthProbeTimeout = 10
 
 	// Used to indicate that the odiglet is installed on a node.
 	OdigletOSSInstalledLabel          = "odigos.io/odiglet-oss-installed"

--- a/cli/cmd/resources/odiglet.go
+++ b/cli/cmd/resources/odiglet.go
@@ -246,7 +246,7 @@ func NewResourceQuota(ns string) *corev1.ResourceQuota {
 }
 
 func NewOdigletDaemonSet(ns string, version string, imagePrefix string, imageName string,
-	odigosTier common.OdigosTier, openshiftEnabled bool, clusterDetails *autodetect.ClusterDetails, customContainerRuntimeSocketPath string, nodeSelector map[string]string, healthProbeBindPort int) *appsv1.DaemonSet {
+	odigosTier common.OdigosTier, openshiftEnabled bool, clusterDetails *autodetect.ClusterDetails, customContainerRuntimeSocketPath string, nodeSelector map[string]string, healthProbeBindPort int, mountMethod *common.MountMethod) *appsv1.DaemonSet {
 	if nodeSelector == nil {
 		nodeSelector = make(map[string]string)
 	}
@@ -479,78 +479,6 @@ func NewOdigletDaemonSet(ns string, version string, imagePrefix string, imageNam
 					},
 					Containers: []corev1.Container{
 						{
-							Name:  k8sconsts.OdigletDevicePluginContainerName,
-							Image: containers.GetImageName(imagePrefix, imageName, version),
-							Command: []string{
-								"/root/deviceplugin",
-							},
-							Env: []corev1.EnvVar{
-								{
-									Name: k8sconsts.NodeNameEnvVar,
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "spec.nodeName",
-										},
-									},
-								},
-								{
-									Name: "NODE_IP",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "status.hostIP",
-										},
-									},
-								},
-								{
-									Name: "CURRENT_NS",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "metadata.namespace",
-										},
-									},
-								},
-							},
-							Resources: corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									"cpu":    resource.MustParse("100m"),
-									"memory": resource.MustParse("300Mi"),
-								},
-								Requests: corev1.ResourceList{
-									"cpu":    resource.MustParse("40m"),
-									"memory": resource.MustParse("200Mi"),
-								},
-							},
-							LivenessProbe: &corev1.Probe{
-								ProbeHandler: corev1.ProbeHandler{
-									Exec: &corev1.ExecAction{
-										Command: []string{k8sconsts.GrpcHealthBinaryPath, "-addr=" + k8sconsts.GrpcHealthProbePath},
-									},
-								},
-								InitialDelaySeconds: 10,
-								FailureThreshold:    3,
-								PeriodSeconds:       10,
-								TimeoutSeconds:      10,
-							},
-							ReadinessProbe: &corev1.Probe{
-								ProbeHandler: corev1.ProbeHandler{
-									Exec: &corev1.ExecAction{
-										Command: []string{k8sconsts.GrpcHealthBinaryPath, "-addr=" + k8sconsts.GrpcHealthProbePath},
-									},
-								},
-								InitialDelaySeconds: 10,
-								FailureThreshold:    3,
-								PeriodSeconds:       10,
-								TimeoutSeconds:      10,
-							},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "device-plugins-dir",
-									MountPath: "/var/lib/kubelet/device-plugins",
-								},
-							},
-							ImagePullPolicy: "IfNotPresent",
-						},
-						{
 							Name: k8sconsts.OdigletContainerName,
 							Command: []string{
 								"/root/odiglet",
@@ -664,6 +592,83 @@ func NewOdigletDaemonSet(ns string, version string, imagePrefix string, imageNam
 				},
 			},
 		},
+	}
+
+	// If mount method is not set (default is k8s-virtual-device), or it is k8s-virtual-device, we need to install the device plugin
+	if mountMethod == nil || *mountMethod == common.K8sVirtualDeviceMountMethod {
+		ds.Spec.Template.Spec.Containers = append(ds.Spec.Template.Spec.Containers, corev1.Container{
+			Name:  k8sconsts.OdigletDevicePluginContainerName,
+			Image: containers.GetImageName(imagePrefix, imageName, version),
+			Command: []string{
+				"/root/deviceplugin",
+			},
+			Env: []corev1.EnvVar{
+				{
+					Name: k8sconsts.NodeNameEnvVar,
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "spec.nodeName",
+						},
+					},
+				},
+				{
+					Name: "NODE_IP",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "status.hostIP",
+						},
+					},
+				},
+				{
+					Name: "CURRENT_NS",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.namespace",
+						},
+					},
+				},
+			},
+			Resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"cpu":    resource.MustParse("100m"),
+					"memory": resource.MustParse("300Mi"),
+				},
+				Requests: corev1.ResourceList{
+					"cpu":    resource.MustParse("40m"),
+					"memory": resource.MustParse("200Mi"),
+				},
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					Exec: &corev1.ExecAction{
+						Command: []string{k8sconsts.GrpcHealthBinaryPath, "-addr=" + k8sconsts.GrpcHealthProbePath, "-connect-timeout=" + strconv.Itoa(k8sconsts.GrpcHealthProbeTimeout) + "s", "-rpc-timeout=" + strconv.Itoa(k8sconsts.GrpcHealthProbeTimeout) + "s"},
+					},
+				},
+				InitialDelaySeconds: 10,
+				FailureThreshold:    3,
+				PeriodSeconds:       10,
+				TimeoutSeconds:      10,
+			},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					Exec: &corev1.ExecAction{
+						Command: []string{k8sconsts.GrpcHealthBinaryPath, "-addr=" + k8sconsts.GrpcHealthProbePath, "-connect-timeout=" + strconv.Itoa(k8sconsts.GrpcHealthProbeTimeout) + "s", "-rpc-timeout=" + strconv.Itoa(k8sconsts.GrpcHealthProbeTimeout) + "s"},
+					},
+				},
+				InitialDelaySeconds: 10,
+				FailureThreshold:    3,
+				PeriodSeconds:       10,
+				TimeoutSeconds:      10,
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "device-plugins-dir",
+					MountPath: "/var/lib/kubelet/device-plugins",
+				},
+			},
+			ImagePullPolicy: "IfNotPresent",
+		},
+		)
 	}
 
 	// if inetrnal trffic policy is not yet supported in the cluster, fall back to host network
@@ -864,7 +869,7 @@ func (a *odigletResourceManager) InstallFromScratch(ctx context.Context) error {
 			&autodetect.ClusterDetails{
 				Kind:       clusterKind,
 				K8SVersion: k8sVersion,
-			}, a.config.CustomContainerRuntimeSocketPath, a.config.NodeSelector, a.config.OdigletHealthProbeBindPort))
+			}, a.config.CustomContainerRuntimeSocketPath, a.config.NodeSelector, a.config.OdigletHealthProbeBindPort, a.config.MountMethod))
 
 	return a.client.ApplyResources(ctx, a.config.ConfigVersion, resources, a.managerOpts)
 }

--- a/helm/odigos/templates/odiglet/daemonset.yaml
+++ b/helm/odigos/templates/odiglet/daemonset.yaml
@@ -81,6 +81,7 @@ spec:
           resources:
 {{ toYaml .Values.odiglet.initContainerResources | indent 12 }}
       containers:
+{{- if or (eq .Values.instrumentor.mountMethod "") (eq .Values.instrumentor.mountMethod "k8s-virtual-device") }}
         - name: deviceplugin
           {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
           {{- if include "odigos.secretExists" . }}
@@ -114,6 +115,8 @@ spec:
               command:
                 - /root/grpc_health_probe
                 - -addr=unix:///var/lib/kubelet/device-plugins/instrumentation.odigos.io_generic
+                - -connect-timeout=10s
+                - -rpc-timeout=10s
             initialDelaySeconds: 10
             failureThreshold: 3
             periodSeconds: 10
@@ -123,10 +126,13 @@ spec:
               command:
                 - /root/grpc_health_probe
                 - -addr=unix:///var/lib/kubelet/device-plugins/instrumentation.odigos.io_generic
+                - -connect-timeout=10s
+                - -rpc-timeout=10s
             initialDelaySeconds: 10
             failureThreshold: 3
             periodSeconds: 10
             timeoutSeconds: 10
+{{- end }}
         - name: odiglet
           {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
           {{- if include "odigos.secretExists" . }}

--- a/helm/odigos/templates/odiglet/daemonset.yaml
+++ b/helm/odigos/templates/odiglet/daemonset.yaml
@@ -169,56 +169,56 @@ spec:
               mountPath: /offsets
 {{- if or (eq .Values.instrumentor.mountMethod "") (eq .Values.instrumentor.mountMethod "k8s-virtual-device") }}
         - name: deviceplugin
-                {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
-                {{- if include "odigos.secretExists" . }}
-                image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-odiglet" "Tag" $imageTag) }}
-                {{- else }}
-                image: {{ template "utils.imageName" (dict "Values" .Values "Component" "odiglet" "Tag" $imageTag) }}
-                {{- end }}
-                imagePullPolicy: IfNotPresent
-                command:
-                  - /root/deviceplugin
-                env:
-                  - name: NODE_NAME
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: spec.nodeName
-                  - name: NODE_IP
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: status.hostIP
-                  - name: CURRENT_NS
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: metadata.namespace
-                volumeMounts:
-                  - name: device-plugins-dir
-                    mountPath: /var/lib/kubelet/device-plugins
-                resources:
-      {{ toYaml .Values.odiglet.deviceplugin.resources | indent 12 }}
-                livenessProbe:
-                  exec:
-                    command:
-                      - /root/grpc_health_probe
-                      - -addr=unix:///var/lib/kubelet/device-plugins/instrumentation.odigos.io_generic
-                      - -connect-timeout=10s
-                      - -rpc-timeout=10s
-                  initialDelaySeconds: 10
-                  failureThreshold: 3
-                  periodSeconds: 10
-                  timeoutSeconds: 10
-                readinessProbe:
-                  exec:
-                    command:
-                      - /root/grpc_health_probe
-                      - -addr=unix:///var/lib/kubelet/device-plugins/instrumentation.odigos.io_generic
-                      - -connect-timeout=10s
-                      - -rpc-timeout=10s
-                  initialDelaySeconds: 10
-                  failureThreshold: 3
-                  periodSeconds: 10
-                  timeoutSeconds: 10
-      {{- end }}
+          {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
+          {{- if include "odigos.secretExists" . }}
+          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-odiglet" "Tag" $imageTag) }}
+          {{- else }}
+          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "odiglet" "Tag" $imageTag) }}
+          {{- end }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /root/deviceplugin
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: CURRENT_NS
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: device-plugins-dir
+              mountPath: /var/lib/kubelet/device-plugins
+          resources:
+{{ toYaml .Values.odiglet.deviceplugin.resources | indent 12 }}
+          livenessProbe:
+            exec:
+              command:
+                - /root/grpc_health_probe
+                - -addr=unix:///var/lib/kubelet/device-plugins/instrumentation.odigos.io_generic
+                - -connect-timeout=10s
+                - -rpc-timeout=10s
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+            timeoutSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - /root/grpc_health_probe
+                - -addr=unix:///var/lib/kubelet/device-plugins/instrumentation.odigos.io_generic
+                - -connect-timeout=10s
+                - -rpc-timeout=10s
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+            timeoutSeconds: 10
+{{- end }}
       {{- $version := include "utils.cleanKubeVersion" . }}
       {{- if semverCompare "<1.26.0" $version }}
       hostNetwork: true

--- a/helm/odigos/templates/odiglet/daemonset.yaml
+++ b/helm/odigos/templates/odiglet/daemonset.yaml
@@ -81,58 +81,6 @@ spec:
           resources:
 {{ toYaml .Values.odiglet.initContainerResources | indent 12 }}
       containers:
-{{- if or (eq .Values.instrumentor.mountMethod "") (eq .Values.instrumentor.mountMethod "k8s-virtual-device") }}
-        - name: deviceplugin
-          {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
-          {{- if include "odigos.secretExists" . }}
-          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-odiglet" "Tag" $imageTag) }}
-          {{- else }}
-          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "odiglet" "Tag" $imageTag) }}
-          {{- end }}
-          imagePullPolicy: IfNotPresent
-          command:
-            - /root/deviceplugin
-          env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: NODE_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
-            - name: CURRENT_NS
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-          volumeMounts:
-            - name: device-plugins-dir
-              mountPath: /var/lib/kubelet/device-plugins
-          resources:
-{{ toYaml .Values.odiglet.deviceplugin.resources | indent 12 }}
-          livenessProbe:
-            exec:
-              command:
-                - /root/grpc_health_probe
-                - -addr=unix:///var/lib/kubelet/device-plugins/instrumentation.odigos.io_generic
-                - -connect-timeout=10s
-                - -rpc-timeout=10s
-            initialDelaySeconds: 10
-            failureThreshold: 3
-            periodSeconds: 10
-            timeoutSeconds: 10
-          readinessProbe:
-            exec:
-              command:
-                - /root/grpc_health_probe
-                - -addr=unix:///var/lib/kubelet/device-plugins/instrumentation.odigos.io_generic
-                - -connect-timeout=10s
-                - -rpc-timeout=10s
-            initialDelaySeconds: 10
-            failureThreshold: 3
-            periodSeconds: 10
-            timeoutSeconds: 10
-{{- end }}
         - name: odiglet
           {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
           {{- if include "odigos.secretExists" . }}
@@ -219,6 +167,58 @@ spec:
               mountPath: /sys/kernel/debug
             - name: odigos-go-offsets
               mountPath: /offsets
+{{- if or (eq .Values.instrumentor.mountMethod "") (eq .Values.instrumentor.mountMethod "k8s-virtual-device") }}
+        - name: deviceplugin
+                {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
+                {{- if include "odigos.secretExists" . }}
+                image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-odiglet" "Tag" $imageTag) }}
+                {{- else }}
+                image: {{ template "utils.imageName" (dict "Values" .Values "Component" "odiglet" "Tag" $imageTag) }}
+                {{- end }}
+                imagePullPolicy: IfNotPresent
+                command:
+                  - /root/deviceplugin
+                env:
+                  - name: NODE_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: spec.nodeName
+                  - name: NODE_IP
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: status.hostIP
+                  - name: CURRENT_NS
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.namespace
+                volumeMounts:
+                  - name: device-plugins-dir
+                    mountPath: /var/lib/kubelet/device-plugins
+                resources:
+      {{ toYaml .Values.odiglet.deviceplugin.resources | indent 12 }}
+                livenessProbe:
+                  exec:
+                    command:
+                      - /root/grpc_health_probe
+                      - -addr=unix:///var/lib/kubelet/device-plugins/instrumentation.odigos.io_generic
+                      - -connect-timeout=10s
+                      - -rpc-timeout=10s
+                  initialDelaySeconds: 10
+                  failureThreshold: 3
+                  periodSeconds: 10
+                  timeoutSeconds: 10
+                readinessProbe:
+                  exec:
+                    command:
+                      - /root/grpc_health_probe
+                      - -addr=unix:///var/lib/kubelet/device-plugins/instrumentation.odigos.io_generic
+                      - -connect-timeout=10s
+                      - -rpc-timeout=10s
+                  initialDelaySeconds: 10
+                  failureThreshold: 3
+                  periodSeconds: 10
+                  timeoutSeconds: 10
+      {{- end }}
       {{- $version := include "utils.cleanKubeVersion" . }}
       {{- if semverCompare "<1.26.0" $version }}
       hostNetwork: true

--- a/tests/common/assert/odigos-installed.yaml
+++ b/tests/common/assert/odigos-installed.yaml
@@ -75,7 +75,6 @@ metadata:
       name: odiglet
 spec:
   containers:
-    - name: deviceplugin
     - name: odiglet
       resources: {}
       securityContext:
@@ -83,6 +82,7 @@ spec:
           add:
             - SYS_PTRACE
         privileged: true
+    - name: deviceplugin
   (($values.k8sMinorVersion < `26` && hostNetwork != null) || (hostNetwork == null)): true
   hostPID: true
   nodeSelector:


### PR DESCRIPTION
## Description

If mount method is not `k8s-virtual-device` do not install device-plugin container
## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [X] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
