### PR TITLE
feat: expose readiness and liveness probes of odiglet in the yaml

### DIFF
--- a/helm/odigos/templates/odiglet/daemonset.yaml
+++ b/helm/odigos/templates/odiglet/daemonset.yaml
@@ -89,7 +89,7 @@ spec:
           image: {{ template "utils.imageName" (dict "Values" .Values "Component" "odiglet" "Tag" $imageTag) }}
           {{- end }}
           args:
-            - --health-probe-bind-port={{ .Values.odiglet.readinessAndLivenessProbePort }}
+            - --health-probe-bind-port={{ .Values.odiglet.odiglet.livenessProbe.httpGet.port }}
           command:
             - /root/odiglet
           imagePullPolicy: IfNotPresent
@@ -99,16 +99,9 @@ spec:
               add:
                 - SYS_PTRACE
           livenessProbe:
-            httpGet:
-              path: /healthz
-              port: {{ .Values.odiglet.readinessAndLivenessProbePort }}
-            initialDelaySeconds: 15
-            periodSeconds: 20
+{{ toYaml .Values.odiglet.odiglet.livenessProbe | indent 12 }}
           readinessProbe:
-            httpGet:
-              path: /readyz
-              port: {{ .Values.odiglet.readinessAndLivenessProbePort }}
-            periodSeconds: 10
+{{ toYaml .Values.odiglet.odiglet.readinessProbe | indent 12 }}
           resources:
 {{ include "odigos.odiglet.resolvedResources" . | indent 12 }}
           env:

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -252,6 +252,22 @@ instrumentor:
   agentEnvVarsInjectionMethod: ''
 
 odiglet:
+  odiglet:
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        # Prior to Kubernetes v1.26, Odigos uses host networking.
+        # In some environments, different ports may already be in use on the host (e.g., due to other daemons or networking constraints).
+        # Use the following values to configure the readiness and liveness probe ports to avoid conflicts.
+        port: 55683
+      initialDelaySeconds: 15
+      periodSeconds: 20
+      timeoutSeconds: 10
+    readinessProbe:
+      httpGet:
+        path: /readyz
+        port: 55683
+      periodSeconds: 10
   nodeSelector:
     kubernetes.io/os: linux
   tolerations:
@@ -291,11 +307,6 @@ odiglet:
   # In these cases, you should mount the correct socket location (e.g., /var/lib/rancher/rke2/agent/containerd/containerd.sock)
   # into the Odiglet to ensure it can access the container runtime unix socket.
   customContainerRuntimeSocketPath: ''
-
-  # Prior to Kubernetes v1.26, Odigos uses host networking.
-  # In some environments, different ports may already be in use on the host (e.g., due to other daemons or networking constraints).
-  # Use the following values to configure the readiness and liveness probe ports to avoid conflicts.
-  readinessAndLivenessProbePort: 55683
 
 centralProxy:
   enabled: false


### PR DESCRIPTION
## Description

<!-- Short summary of the changes -->

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-33
