### PR TITLE
Added load balancer cleanup to EKS teardown

### DIFF
--- a/tests-infrastructure/terraform/eks/main.tf
+++ b/tests-infrastructure/terraform/eks/main.tf
@@ -148,7 +148,6 @@ resource "null_resource" "cleanup_lb" {
   provisioner "local-exec" {
     when    = destroy
     command = <<EOT
-      set -euo pipefail
       # Try to connect to the cluster (ok if it's already gone)
       aws eks update-kubeconfig --name ${self.triggers.cluster_name} --region ${self.triggers.region} || true
 


### PR DESCRIPTION
## Description
Delete all services with LoadBalancer type, frees VPCs for deletion
<!-- Short summary of the changes -->

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-48
