### PR TITLE
fix: update demo video links in README and mint.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
     <h2>Generate distributed traces for any application without code changes.</h2>
     <h4>If you find Odigos helpful, please ⭐ this repository to show your support!</h4>
     <h2>
-        <a href="https://www.youtube.com/watch?v=nynyV7FC4VI">Demo Video</a>
+        <a href="https://odigos.io/?demo">Demo Video</a>
         • <a href="https://docs.odigos.io">Documentation</a>
         • <a href="https://join.slack.com/t/odigos/shared_invite/zt-1d7egaz29-Rwv2T8kyzc3mWP8qKobz~A">Join Slack Community</a>
     </h2>

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -26,7 +26,7 @@
     {
       "name": "Demo",
       "icon": "circle-play",
-      "url": "https://www.youtube.com/watch?v=nynyV7FC4VI"
+      "url": "https://odigos.io/?demo"
     },
     {
       "name": "Blog",


### PR DESCRIPTION
Depends on:
- https://github.com/odigos-io/landing-page/pull/196

---
Replaced the YouTube demo video link with a new link to the Odigos demo page in both README.md and mint.json files for better accessibility and consistency.

emergency-ticket id: EMR-47
