### PR TITLE
fix: update PotentialDestinations resolver to return empty slice instead of error

### DIFF
--- a/frontend/graph/schema.resolvers.go
+++ b/frontend/graph/schema.resolvers.go
@@ -1205,15 +1205,14 @@ func (r *queryResolver) DestinationCategories(ctx context.Context) (*model.GetDe
 
 // PotentialDestinations is the resolver for the potentialDestinations field.
 func (r *queryResolver) PotentialDestinations(ctx context.Context) ([]*model.DestinationDetails, error) {
+	result := make([]*model.DestinationDetails, 0)
+
 	potentialDestinations := services.PotentialDestinations(ctx)
 	if potentialDestinations == nil {
-		return nil, fmt.Errorf("failed to fetch potential destinations")
+		return result, nil
 	}
 
-	// Convert []destination_recognition.DestinationDetails to []*DestinationDetails
-	var result []*model.DestinationDetails
 	for _, dest := range potentialDestinations {
-
 		fieldsString, err := json.Marshal(dest.Fields)
 		if err != nil {
 			return nil, fmt.Errorf("error marshalling fields: %v", err)


### PR DESCRIPTION
Modified the PotentialDestinations resolver to return an empty slice when potential destinations cannot be fetched, improving error handling and ensuring consistent return types.

emergency-ticket id: EMR-46
