### PR TITLE
fix: do not apply HTTPS_PROXY on k8s apiserver and own metrics

### DIFF
--- a/autoscaler/controllers/clustercollector/deployment.go
+++ b/autoscaler/controllers/clustercollector/deployment.go
@@ -13,6 +13,8 @@ import (
 	"github.com/odigos-io/odigos/autoscaler/controllers/common"
 	commonconfig "github.com/odigos-io/odigos/autoscaler/controllers/common"
 	"github.com/odigos-io/odigos/common/consts"
+	odigosconsts "github.com/odigos-io/odigos/common/consts"
+	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	k8sutils "github.com/odigos-io/odigos/k8sutils/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -121,9 +123,13 @@ func getDesiredDeployment(ctx context.Context, c client.Client, dests *odigosv1.
 
 	extraEnvVars := []corev1.EnvVar{}
 	if gateway.Spec.HttpsProxyAddress != nil {
+		odigosNs := env.GetCurrentNamespace()
 		extraEnvVars = append(extraEnvVars, corev1.EnvVar{
 			Name:  "HTTPS_PROXY",
 			Value: *gateway.Spec.HttpsProxyAddress,
+		}, corev1.EnvVar{ // prevent the own telemetry metrics from using the https proxy if set.
+			Name:  "NO_PROXY",
+			Value: fmt.Sprintf("%s.%s:%d", k8sconsts.UIServiceName, odigosNs, odigosconsts.OTLPPort),
 		})
 	}
 

--- a/autoscaler/controllers/clustercollector/deployment.go
+++ b/autoscaler/controllers/clustercollector/deployment.go
@@ -127,7 +127,10 @@ func getDesiredDeployment(ctx context.Context, c client.Client, dests *odigosv1.
 		extraEnvVars = append(extraEnvVars, corev1.EnvVar{
 			Name:  "HTTPS_PROXY",
 			Value: *gateway.Spec.HttpsProxyAddress,
-		}, corev1.EnvVar{ // prevent the own telemetry metrics from using the https proxy if set.
+		}, corev1.EnvVar{
+			// prevent the own telemetry metrics from using the https proxy if set.
+			// gRPC uses the HTTPS_PROXY even for non tls connections
+			// since it's always uses HTTP CONNECT, so we need to blacklist the ui service.
 			Name:  "NO_PROXY",
 			Value: fmt.Sprintf("%s.%s:%d", k8sconsts.UIServiceName, odigosNs, odigosconsts.OTLPPort),
 		})

--- a/collector/providers/odigosk8scmprovider/provider.go
+++ b/collector/providers/odigosk8scmprovider/provider.go
@@ -70,7 +70,8 @@ func (p *provider) Retrieve(ctx context.Context, uri string, wf confmap.WatcherF
 			return nil, fmt.Errorf("failed to get in-cluster config: %w", err)
 		}
 
-		// Disable proxy for k8s client to avoid using HTTPS_PROXY
+		// the `HTTPS_PROXY` we allow to set is used for exporting to https destinations.
+		// we don't want to use it for accessing k8s api.
 		config.Proxy = func(req *http.Request) (*url.URL, error) {
 			return nil, nil
 		}

--- a/collector/providers/odigosk8scmprovider/provider.go
+++ b/collector/providers/odigosk8scmprovider/provider.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
 	"strings"
 
 	"go.opentelemetry.io/collector/confmap"
@@ -67,6 +69,12 @@ func (p *provider) Retrieve(ctx context.Context, uri string, wf confmap.WatcherF
 		if err != nil {
 			return nil, fmt.Errorf("failed to get in-cluster config: %w", err)
 		}
+
+		// Disable proxy for k8s client to avoid using HTTPS_PROXY
+		config.Proxy = func(req *http.Request) (*url.URL, error) {
+			return nil, nil
+		}
+
 		p.clientset, err = kubernetes.NewForConfig(config)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create k8s client: %w", err)


### PR DESCRIPTION
## Description

Following https://github.com/odigos-io/odigos/pull/3296, it was found that the requests to the api server where also capture and using the https proxy, which made it fail. 
This PR makes it so that connecting to api server never uses a proxy, fixing the above issue.

While testing, it was found that gRPC connections, even when not encrypted, are using the HTTP CONNECT flow which is also using the HTTPS_PROXY definitions and breaks the own telemetry reporting to the ui pod. this is fixed by adding it to the `NO_PROXY` list and black-list it so proxy is disabled for it.

## How Has This Been Tested?

Setup an https proxy, set this option, and made sure the requests are passing via the proxy and gateway logs are ok

## Kubernetes Checklist


## User Facing Changes

bug fix that does not impact user

emergency-ticket id: EMR-54
