### PR TITLE
CORE-127: Add OverwriteExistingValues option to AddClusterInfo action

### DIFF
--- a/api/actions/v1alpha1/addclusterinfo_types.go
+++ b/api/actions/v1alpha1/addclusterinfo_types.go
@@ -34,7 +34,8 @@ type OtelAttributeWithValue struct {
 const ActionNameAddClusterInfo = "AddClusterInfo"
 
 type AddClusterInfoConfig struct {
-	ClusterAttributes []OtelAttributeWithValue `json:"clusterAttributes"`
+	ClusterAttributes       []OtelAttributeWithValue `json:"clusterAttributes"`
+	OverwriteExistingValues bool                     `json:"overwriteExistingValues,omitempty"`
 }
 
 func (AddClusterInfoConfig) ProcessorType() string {
@@ -53,6 +54,8 @@ type AddClusterInfoSpec struct {
 	Signals    []common.ObservabilitySignal `json:"signals"`
 
 	ClusterAttributes []OtelAttributeWithValue `json:"clusterAttributes"`
+
+	OverwriteExistingValues bool `json:"overwriteExistingValues,omitempty"`
 }
 
 // AddClusterInfoStatus defines the observed state of AddClusterInfo action

--- a/api/config/crd/bases/actions.odigos.io_addclusterinfos.yaml
+++ b/api/config/crd/bases/actions.odigos.io_addclusterinfos.yaml
@@ -67,6 +67,8 @@ spec:
                 type: boolean
               notes:
                 type: string
+              overwriteExistingValues:
+                type: boolean
               signals:
                 items:
                   enum:

--- a/api/config/crd/bases/odigos.io_actions.yaml
+++ b/api/config/crd/bases/odigos.io_actions.yaml
@@ -63,6 +63,8 @@ spec:
                       - attributeStringValue
                       type: object
                     type: array
+                  overwriteExistingValues:
+                    type: boolean
                 required:
                 - clusterAttributes
                 type: object

--- a/api/generated/actions/applyconfiguration/actions/v1alpha1/addclusterinfospec.go
+++ b/api/generated/actions/applyconfiguration/actions/v1alpha1/addclusterinfospec.go
@@ -24,11 +24,12 @@ import (
 // AddClusterInfoSpecApplyConfiguration represents a declarative configuration of the AddClusterInfoSpec type for use
 // with apply.
 type AddClusterInfoSpecApplyConfiguration struct {
-	ActionName        *string                                    `json:"actionName,omitempty"`
-	Notes             *string                                    `json:"notes,omitempty"`
-	Disabled          *bool                                      `json:"disabled,omitempty"`
-	Signals           []common.ObservabilitySignal               `json:"signals,omitempty"`
-	ClusterAttributes []OtelAttributeWithValueApplyConfiguration `json:"clusterAttributes,omitempty"`
+	ActionName              *string                                    `json:"actionName,omitempty"`
+	Notes                   *string                                    `json:"notes,omitempty"`
+	Disabled                *bool                                      `json:"disabled,omitempty"`
+	Signals                 []common.ObservabilitySignal               `json:"signals,omitempty"`
+	ClusterAttributes       []OtelAttributeWithValueApplyConfiguration `json:"clusterAttributes,omitempty"`
+	OverwriteExistingValues *bool                                      `json:"overwriteExistingValues,omitempty"`
 }
 
 // AddClusterInfoSpecApplyConfiguration constructs a declarative configuration of the AddClusterInfoSpec type for use with
@@ -81,5 +82,13 @@ func (b *AddClusterInfoSpecApplyConfiguration) WithClusterAttributes(values ...*
 		}
 		b.ClusterAttributes = append(b.ClusterAttributes, *values[i])
 	}
+	return b
+}
+
+// WithOverwriteExistingValues sets the OverwriteExistingValues field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the OverwriteExistingValues field is set to the value of the last call.
+func (b *AddClusterInfoSpecApplyConfiguration) WithOverwriteExistingValues(value bool) *AddClusterInfoSpecApplyConfiguration {
+	b.OverwriteExistingValues = &value
 	return b
 }

--- a/autoscaler/controllers/actions/action_controller.go
+++ b/autoscaler/controllers/actions/action_controller.go
@@ -29,7 +29,7 @@ type ActionConfig interface {
 func convertActionToProcessor(ctx context.Context, k8sclient client.Client, action *odigosv1.Action) (*odigosv1.Processor, error) {
 	var config any
 	if action.Spec.AddClusterInfo != nil {
-		config = addClusterInfoConfig(action.Spec.AddClusterInfo.ClusterAttributes)
+		config = addClusterInfoConfig(action.Spec.AddClusterInfo.ClusterAttributes, action.Spec.AddClusterInfo.OverwriteExistingValues)
 		return convertToDefaultProcessor(action, action.Spec.AddClusterInfo, config)
 	}
 

--- a/autoscaler/controllers/actions/addclusterinfo_controller.go
+++ b/autoscaler/controllers/actions/addclusterinfo_controller.go
@@ -113,7 +113,7 @@ func (r *AddClusterInfoReconciler) ReportReconciledToProcessor(ctx context.Conte
 
 func (r *AddClusterInfoReconciler) convertToProcessor(action *actionv1.AddClusterInfo) (*v1.Processor, error) {
 
-	config := addClusterInfoConfig(action.Spec.ClusterAttributes)
+	config := addClusterInfoConfig(action.Spec.ClusterAttributes, action.Spec.OverwriteExistingValues)
 
 	configJson, err := json.Marshal(config)
 	if err != nil {
@@ -152,7 +152,11 @@ func (r *AddClusterInfoReconciler) convertToProcessor(action *actionv1.AddCluste
 	return &processor, nil
 }
 
-func addClusterInfoConfig(cfg []actionv1.OtelAttributeWithValue) addclusterinfoConfig {
+func addClusterInfoConfig(cfg []actionv1.OtelAttributeWithValue, overwriteExistingValues bool) addclusterinfoConfig {
+	action := "insert"
+	if overwriteExistingValues {
+		action = "upsert"
+	}
 	config := addclusterinfoConfig{
 		Attributes: []addClusterInfoAttributeConfig{},
 	}
@@ -160,7 +164,7 @@ func addClusterInfoConfig(cfg []actionv1.OtelAttributeWithValue) addclusterinfoC
 		config.Attributes = append(config.Attributes, addClusterInfoAttributeConfig{
 			Key:    attr.AttributeName,
 			Value:  attr.AttributeStringValue,
-			Action: "insert",
+			Action: action,
 		})
 	}
 	return config

--- a/docs/api-reference/actions.odigos.io.v1alpha1.mdx
+++ b/docs/api-reference/actions.odigos.io.v1alpha1.mdx
@@ -537,6 +537,17 @@ as well as the sampler's current status.</p>
    <span class="text-muted">No description provided.</span>
    </td>
 </tr>
+<tr>
+<td>
+<code>overwriteExistingValues</code> <B>[Required]</B>
+</td>
+<td>
+<code>bool</code>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
 </tbody>
 </table>
 
@@ -604,6 +615,17 @@ as well as the sampler's current status.</p>
 </td>
 <td>
 <a href="#OtelAttributeWithValue"><code>[]OtelAttributeWithValue</code></a>
+</td>
+<td>
+   <span class="text-muted">No description provided.</span>
+   </td>
+</tr>
+<tr>
+<td>
+<code>overwriteExistingValues</code> <B>[Required]</B>
+</td>
+<td>
+<code>bool</code>
 </td>
 <td>
    <span class="text-muted">No description provided.</span>

--- a/helm/odigos/templates/crds/actions.odigos.io_addclusterinfos.yaml
+++ b/helm/odigos/templates/crds/actions.odigos.io_addclusterinfos.yaml
@@ -67,6 +67,8 @@ spec:
                 type: boolean
               notes:
                 type: string
+              overwriteExistingValues:
+                type: boolean
               signals:
                 items:
                   enum:

--- a/helm/odigos/templates/crds/odigos.io_actions.yaml
+++ b/helm/odigos/templates/crds/odigos.io_actions.yaml
@@ -63,6 +63,8 @@ spec:
                       - attributeStringValue
                       type: object
                     type: array
+                  overwriteExistingValues:
+                    type: boolean
                 required:
                 - clusterAttributes
                 type: object


### PR DESCRIPTION
## Description

Currently, we can only add new cluster info attributes since we hard code `insert` as the action in the resource processor. Allowing users to toggle to `upsert` gives the option to overwrite existing attributes.

A toggle was chosen for better UX, as the details of "insert" vs "upsert" may be overly technical (and users do have the option of manually creating a Processor CRD anyway).

Similarly, this option applies to the entire Action instead of individual attributes for simpler UX.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
