### PR TITLE
test: fix isHelm check to support running tests locally

### DIFF
--- a/tests/common/assert/odigos-upgraded.yaml
+++ b/tests/common/assert/odigos-upgraded.yaml
@@ -236,7 +236,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    (($values.isHelm == `false` && odigos.io/config == "2") || ($values.isHelm == `true` && odigos.io/config == null)): true
+    (($values.isHelm == `true` && odigos.io/config == null) || ($values.isHelm != `true` && odigos.io/config == "2")): true
     odigos.io/system-object: "true"
   name: destinations.odigos.io
 ---
@@ -244,6 +244,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    (($values.isHelm == `false` && odigos.io/config == "2") || ($values.isHelm == `true` && odigos.io/config == null)): true
+    (($values.isHelm == `true` && odigos.io/config == null) || ($values.isHelm != `true` && odigos.io/config == "2")): true
     odigos.io/system-object: "true"
   name: processors.odigos.io


### PR DESCRIPTION
When running locally, the chainsaw values are empty, thus `isHelm` in values does not equal `"false"` and the assert fails

emergency-ticket id: EMR-63
