### PR TITLE
chore: set wrapt version - CORE-136

### DIFF
--- a/agents/python/setup.py
+++ b/agents/python/setup.py
@@ -3,10 +3,10 @@ from setuptools import setup, find_packages
 index_url = None
 
 # DEV - Local Uncomment to develop locally \/
-# index_url = 'http://host.docker.internal:8080/packages/odigos_opentelemetry_python-1.0.53-py3-none-any.whl'
+# index_url = 'http://host.docker.internal:8080/packages/odigos_opentelemetry_python-1.0.55-py3-none-any.whl'
 
 install_requires = [
-    f"odigos-opentelemetry-python @ {index_url}" if index_url else "odigos-opentelemetry-python==1.0.53"
+    f"odigos-opentelemetry-python @ {index_url}" if index_url else "odigos-opentelemetry-python==1.0.55"
 ]
 
 setup(


### PR DESCRIPTION
## Description

Had to bump python agent version, there I've set the wrapt version to avoid upgrade it during new odiglet deployments.
## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
