### PR TITLE
fix: set controller reference on collector group

### DIFF
--- a/cli/cmd/resources/scheduler.go
+++ b/cli/cmd/resources/scheduler.go
@@ -109,6 +109,12 @@ func NewSchedulerRole(ns string) *rbacv1.Role {
 				ResourceNames: []string{k8sconsts.OdigletDaemonSetName},
 				Verbs:         []string{"patch"},
 			},
+			{
+				APIGroups:     []string{"apps"},
+				Resources:     []string{"deployments"},
+				ResourceNames: []string{k8sconsts.SchedulerDeploymentName},
+				Verbs:         []string{"get", "list", "watch"},
+			},
 		},
 	}
 }

--- a/helm/odigos/templates/scheduler/role.yaml
+++ b/helm/odigos/templates/scheduler/role.yaml
@@ -96,3 +96,13 @@ rules:
       - 'odiglet'
     verbs:
       - 'patch'
+  - apiGroups:
+      - 'apps'
+    resources:
+      - 'deployments'
+    resourceNames:
+      - 'odigos-scheduler'
+    verbs:
+      - 'get'
+      - 'list'
+      - 'watch'

--- a/scheduler/controllers/clustercollectorsgroup/odigosconfig_controller.go
+++ b/scheduler/controllers/clustercollectorsgroup/odigosconfig_controller.go
@@ -14,6 +14,6 @@ type odigosConfigurationController struct {
 }
 
 func (r *odigosConfigurationController) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
-	err := sync(ctx, r.Client)
+	err := sync(ctx, r.Client, r.Scheme)
 	return ctrl.Result{}, err
 }

--- a/scheduler/controllers/nodecollectorsgroup/clustercollectorsgroup_controller.go
+++ b/scheduler/controllers/nodecollectorsgroup/clustercollectorsgroup_controller.go
@@ -15,6 +15,6 @@ type clusterCollectorsGroupController struct {
 }
 
 func (r *clusterCollectorsGroupController) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
-	err := sync(ctx, r.Client)
+	err := sync(ctx, r.Client, r.Scheme)
 	return utils.K8SNoEffectiveConfigErrorHandler(err)
 }

--- a/scheduler/controllers/nodecollectorsgroup/common.go
+++ b/scheduler/controllers/nodecollectorsgroup/common.go
@@ -8,8 +8,10 @@ import (
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/common"
 	"github.com/odigos-io/odigos/k8sutils/pkg/env"
-	"github.com/odigos-io/odigos/k8sutils/pkg/utils"
+	k8sutils "github.com/odigos-io/odigos/k8sutils/pkg/utils"
+	"github.com/odigos-io/odigos/scheduler/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -133,7 +135,7 @@ func newNodeCollectorGroup(odigosConfiguration common.OdigosConfiguration) *odig
 	}
 }
 
-func sync(ctx context.Context, c client.Client) error {
+func sync(ctx context.Context, c client.Client, scheme *runtime.Scheme) error {
 
 	namespace := env.GetCurrentNamespace()
 
@@ -146,22 +148,28 @@ func sync(ctx context.Context, c client.Client) error {
 
 	if numberOfInstrumentedApps == 0 {
 		// TODO: should we delete the collector group if cluster collector is not ready?
-		return utils.DeleteCollectorGroup(ctx, c, namespace, k8sconsts.OdigosNodeCollectorCollectorGroupName)
+		return k8sutils.DeleteCollectorGroup(ctx, c, namespace, k8sconsts.OdigosNodeCollectorCollectorGroupName)
 	}
 
-	clusterCollectorGroup, err := utils.GetCollectorGroup(ctx, c, namespace, k8sconsts.OdigosClusterCollectorCollectorGroupName)
+	clusterCollectorGroup, err := k8sutils.GetCollectorGroup(ctx, c, namespace, k8sconsts.OdigosClusterCollectorCollectorGroupName)
 	if err != nil {
 		return client.IgnoreNotFound(err)
 	}
 
-	odigosConfiguration, err := utils.GetCurrentOdigosConfiguration(ctx, c)
+	odigosConfiguration, err := k8sutils.GetCurrentOdigosConfiguration(ctx, c)
+	if err != nil {
+		return err
+	}
+
+	nodeCollectorGroup := newNodeCollectorGroup(odigosConfiguration)
+	err = utils.SetOwnerControllerToSchedulerDeployment(ctx, c, nodeCollectorGroup, scheme)
 	if err != nil {
 		return err
 	}
 
 	clusterCollectorReady := clusterCollectorGroup.Status.Ready
 	if clusterCollectorReady {
-		return utils.ApplyCollectorGroup(ctx, c, newNodeCollectorGroup(odigosConfiguration))
+		return k8sutils.ApplyCollectorGroup(ctx, c, nodeCollectorGroup)
 	}
 
 	return nil

--- a/scheduler/controllers/nodecollectorsgroup/instrumentationconfig_controller.go
+++ b/scheduler/controllers/nodecollectorsgroup/instrumentationconfig_controller.go
@@ -15,6 +15,6 @@ type instrumentationConfigController struct {
 }
 
 func (r *instrumentationConfigController) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
-	err := sync(ctx, r.Client)
+	err := sync(ctx, r.Client, r.Scheme)
 	return utils.K8SNoEffectiveConfigErrorHandler(err)
 }

--- a/scheduler/controllers/nodecollectorsgroup/odigosconfig_controller.go
+++ b/scheduler/controllers/nodecollectorsgroup/odigosconfig_controller.go
@@ -15,6 +15,6 @@ type odigosConfigurationController struct {
 }
 
 func (r *odigosConfigurationController) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
-	err := sync(ctx, r.Client)
+	err := sync(ctx, r.Client, r.Scheme)
 	return utils.K8SNoEffectiveConfigErrorHandler(err)
 }

--- a/scheduler/utils/ownerreference.go
+++ b/scheduler/utils/ownerreference.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"context"
+
+	"github.com/odigos-io/odigos/api/k8sconsts"
+	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func SetOwnerControllerToSchedulerDeployment(ctx context.Context, c client.Client, cg *odigosv1.CollectorsGroup, scheme *runtime.Scheme) error {
+	schedluerDeployment := appsv1.Deployment{}
+	err := c.Get(ctx, client.ObjectKey{Namespace: cg.GetNamespace(), Name: k8sconsts.SchedulerDeploymentName}, &schedluerDeployment)
+	if err != nil {
+		return err
+	}
+	return ctrl.SetControllerReference(&schedluerDeployment, cg, scheme)
+}


### PR DESCRIPTION
## Description

Collectors group CR currently has no owner reference, even thought it is controlled by a controller (scheduler).

This causes an issue that if argoCR is redeploying odigos in a "clean" (prune) manner, then helm will delete all the objects it controls and recreate them, but the collectors group and the collectors themselves are left untouched.
Setting the controller reference guarantees that if for any reason the scheduler is deleted, so are the resources it owns and control. When scheduler is re-created, it will reconcile the objects which will re-create the collectors groups and re-deploy the collectors as required.

## How Has This Been Tested?

- [x] Manual Testing

## Kubernetes Checklist

- [x] Changes how Odigos interacts with Kubernetes - adds a new owner reference.
- [x] Changes RBAC permissions - add deployment RBAC to scheduler in both helm and cli

## User Facing Changes

Bug fix for very specific deployment sequence