### PR TITLE
fix: remove odigos-system embedded ns from profiles

### DIFF
--- a/profiles/manifests/copy-scope.yaml
+++ b/profiles/manifests/copy-scope.yaml
@@ -2,7 +2,6 @@ apiVersion: odigos.io/v1alpha1
 kind: Processor
 metadata:
   name: copy-scope
-  namespace: odigos-system
 spec:
   type: transform
   processorName: "copy scope"

--- a/profiles/manifests/hostname-as-podname.yaml
+++ b/profiles/manifests/hostname-as-podname.yaml
@@ -2,7 +2,6 @@ apiVersion: odigos.io/v1alpha1
 kind: Processor
 metadata:
   name: hostname-as-podname
-  namespace: odigos-system
 spec:
   type: resource
   processorName: "host.name as pod.name"

--- a/profiles/manifests/label-attributes.yaml
+++ b/profiles/manifests/label-attributes.yaml
@@ -2,7 +2,6 @@ apiVersion: odigos.io/v1alpha1
 kind: Action
 metadata:
   name: label-attributes
-  namespace: odigos-system
 spec:
   actionName: label-attributes
   signals:

--- a/profiles/manifests/query-operation-detector.yaml
+++ b/profiles/manifests/query-operation-detector.yaml
@@ -2,7 +2,6 @@ apiVersion: odigos.io/v1alpha1
 kind: Processor
 metadata:
   name: query-operation-detector
-  namespace: odigos-system
 spec:
   type: odigossqldboperationprocessor
   processorName: query-operation-detector

--- a/profiles/manifests/reduce-span-name-cardinality.yaml
+++ b/profiles/manifests/reduce-span-name-cardinality.yaml
@@ -2,7 +2,6 @@ apiVersion: odigos.io/v1alpha1
 kind: Processor
 metadata:
   name: reduce-span-name-cardinality
-  namespace: odigos-system
 spec:
   type: transform
   processorName: "Reduce Span Name Cardinality"

--- a/profiles/manifests/semconv.yaml
+++ b/profiles/manifests/semconv.yaml
@@ -2,7 +2,6 @@ apiVersion: odigos.io/v1alpha1
 kind: Processor
 metadata:
   name: semconv
-  namespace: odigos-system
 spec:
   type: attributes
   processorName: semconv-attributes

--- a/profiles/manifests/semconvdynamo.yaml
+++ b/profiles/manifests/semconvdynamo.yaml
@@ -2,7 +2,6 @@ apiVersion: odigos.io/v1alpha1
 kind: Processor
 metadata:
   name: semconvdynamo
-  namespace: odigos-system
 spec:
   type: attributes
   processorName: "semconvdynamo-attributes"

--- a/profiles/manifests/semconvredis.yaml
+++ b/profiles/manifests/semconvredis.yaml
@@ -2,7 +2,6 @@ apiVersion: odigos.io/v1alpha1
 kind: Processor
 metadata:
   name: semconvredis
-  namespace: odigos-system
 spec:
   type: attributes
   processorName: "semconvredis-attributes"

--- a/profiles/manifests/small-batches.yaml
+++ b/profiles/manifests/small-batches.yaml
@@ -2,7 +2,6 @@ apiVersion: odigos.io/v1alpha1
 kind: Processor
 metadata:
   name: small-batches
-  namespace: odigos-system
 spec:
   type: batch
   processorConfig:

--- a/scheduler/controllers/odigosconfiguration/odigosconfiguration_controller.go
+++ b/scheduler/controllers/odigosconfiguration/odigosconfiguration_controller.go
@@ -367,6 +367,15 @@ func (r *odigosConfigurationController) applySingleProfileManifest(ctx context.C
 		return err
 	}
 
+	odigosNs := env.GetCurrentNamespace()
+
+	// profiles are read without namespace, and we need to add it ourselves.
+	// the namespace is usually odigos-system, but user can set it to anything,
+	// which is why we need to address it here.
+	// the namespace is set on the object itself, but not in the yamlbytes for the apply,
+	// which is ok and works (the applied object takes the namespace from the object)
+	obj.SetNamespace(odigosNs)
+
 	labels := obj.GetLabels()
 	if labels == nil {
 		labels = make(map[string]string)
@@ -393,7 +402,7 @@ func (r *odigosConfigurationController) applySingleProfileManifest(ctx context.C
 		Resource: resource,
 	}
 
-	resourceClient := r.DynamicClient.Resource(gvr).Namespace(env.GetCurrentNamespace())
+	resourceClient := r.DynamicClient.Resource(gvr).Namespace(odigosNs)
 	_, err = resourceClient.Apply(ctx, obj.GetName(), obj, metav1.ApplyOptions{
 		FieldManager: "scheduler-odigosconfiguration",
 		Force:        true,


### PR DESCRIPTION
## Description

Users can install odigos in any namespace, but the profile were embedded with the "odigos-system" namespace which causes this error:

```
2025-08-13T11:54:19Z	ERROR	Reconciler error	{"controller": "odigosconfiguration-odigosconfiguration", "controllerGroup": "", "controllerKind": "ConfigMap", "ConfigMap": {"name":"odigos-configuration","namespace":"sre-opus"}, "namespace": "sre-opus", "name": "odigos-configuration", "reconcileID": "ad3cb31f-9d02-4ba2-bd22-9354f390177c", "error": "the namespace of the provided object does not match the namespace sent on the request"}
```

