### PR TITLE
PLAT-118: Support S3 partition format field

### DIFF
--- a/destinations/data/awss3.yaml
+++ b/destinations/data/awss3.yaml
@@ -63,15 +63,23 @@ spec:
           - us-west-1
           - us-west-2
     - name: S3_PARTITION
-      displayName: Time granularity of S3 Bucket
+      displayName: Time granularity of S3 Bucket (Deprecated, use Partition Format)
       componentType: dropdown
       componentProps:
         values:
           - minute
           - hour
-        required: true
-        tooltip: Wether a new subdirectory should be created every minute or every hour
+        required: false
+        tooltip: Deprecated field for time granularity. Use S3_PARTITION_FORMAT for custom formats.
       initialValue: minute
+    - name: S3_PARTITION_FORMAT
+      displayName: S3 Partition Format
+      componentType: input
+      componentProps:
+        type: text
+        required: false
+        tooltip: Custom partition format using strftime syntax (e.g., '%Y/%m/%d/%H/%M' for minute-level, '%Y/%m/%d/%H' for hour-level). If not specified, S3_PARTITION will be used.
+        placeholder: "%Y/%m/%d/%H/%M"
     - name: S3_MARSHALER
       displayName: Marshaller (Data Format)
       componentType: dropdown

--- a/docs/backends/awss3.mdx
+++ b/docs/backends/awss3.mdx
@@ -117,8 +117,11 @@ For example, the following JSON string represents a single span in `otlp_json` f
   - This field is required
 - **S3_REGION** `string` : Bucket Region. The AWS region where the bucket is located
   - This field is required
-- **S3_PARTITION** `string` : Time granularity of S3 Bucket. Wether a new subdirectory should be created every minute or every hour
-  - This field is required and defaults to `minute`
+- **S3_PARTITION** `string` : Time granularity of S3 Bucket (Deprecated, use Partition Format). Deprecated field for time granularity. Use S3_PARTITION_FORMAT for custom formats.
+  - This field is optional and defaults to `minute`
+- **S3_PARTITION_FORMAT** `string` : S3 Partition Format. Custom partition format using strftime syntax (e.g., '%Y/%m/%d/%H/%M' for minute-level, '%Y/%m/%d/%H' for hour-level). If not specified, S3_PARTITION will be used.
+  - This field is optional
+  - Example: `%Y/%m/%d/%H/%M`
 - **S3_MARSHALER** `string` : Marshaller (Data Format). The format in which the data will be encoded. It can be either `otlp_json` or `otlp_proto`. Default is `otlp_json`
   - This field is required and defaults to `otlp_json`
 
@@ -156,14 +159,15 @@ There are two primary methods for configuring destinations in Odigos:
         S3_BUCKET: <Bucket Name>
         S3_MARSHALER: '<Marshaller (Data Format) (default: otlp_json) (options: [otlp_json,
           otlp_proto])>'
-        S3_PARTITION: '<Time granularity of S3 Bucket (default: minute) (options: [minute,
-          hour])>'
         S3_REGION: '<Bucket Region (options: [af-south-1, ap-east-1, ap-northeast-1, ap-northeast-2,
           ap-northeast-3, ap-south-1, ap-south-2, ap-southeast-1, ap-southeast-2, ap-southeast-3,
           ap-southeast-4, ap-southeast-5, ap-southeast-7, ca-central-1, ca-west-1, eu-central-1,
           eu-central-2, eu-north-1, eu-south-1, eu-south-2, eu-west-1, eu-west-2, eu-west-3,
           il-central-1, me-central-1, me-south-1, mx-central-1, sa-east-1, us-east-1,
           us-east-2, us-gov-east-1, us-gov-west-1, us-west-1, us-west-2])>'
+        # Note: The commented fields below are optional.
+        # S3_PARTITION: <Time granularity of S3 Bucket (Deprecated, use Partition Format) (default: minute) (options: [minute, hour])>
+        # S3_PARTITION_FORMAT: <S3 Partition Format>
       destinationName: s3
       signals:
       - TRACES

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -168,7 +168,9 @@
         {
           "group": "Advanced",
           "icon": "gear",
-          "pages": ["instrumentations/configuration/mount-method"]
+          "pages": [
+            "instrumentations/configuration/mount-method"
+          ]
         }
       ]
     },
@@ -320,11 +322,17 @@
     },
     {
       "group": "Feature Guidelines",
-      "pages": ["features/oidc", "features/central"]
+      "pages": [
+        "features/oidc",
+        "features/central"
+      ]
     },
     {
       "group": "Contribution Guidelines",
-      "pages": ["adding-new-dest", "debugging"]
+      "pages": [
+        "adding-new-dest",
+        "debugging"
+      ]
     },
     {
       "group": "VM Agent",


### PR DESCRIPTION
## Description

https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/37954 added a breaking change upstream where the old `s3_partition` field was removed in favor of `s3_parittion_format` which causes our collectors to crash with `'s3uploader' has invalid keys: s3_partition`.

For backward compatibility with our users, we must continue supporting the deprecated field and translating it to the new field. The old field is marked as deprecated.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [x] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
