### PR TITLE
[RUN-104] bump runtime-detector to v0.0.16, now supports kernel 4.19

### DIFF
--- a/instrumentation/go.mod
+++ b/instrumentation/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/go-logr/logr v1.4.3
 	github.com/odigos-io/odigos/distros v0.0.0
-	github.com/odigos-io/runtime-detector v0.0.15
+	github.com/odigos-io/runtime-detector v0.0.16
 	go.opentelemetry.io/otel v1.37.0
 	go.opentelemetry.io/otel/metric v1.37.0
 	golang.org/x/sync v0.16.0

--- a/instrumentation/go.sum
+++ b/instrumentation/go.sum
@@ -25,8 +25,8 @@ github.com/mdlayher/netlink v1.7.2 h1:/UtM3ofJap7Vl4QWCPDGXY8d3GIY2UGSDbK+QWmY8/
 github.com/mdlayher/netlink v1.7.2/go.mod h1:xraEF7uJbxLhc5fpHL4cPe221LI2bdttWlU+ZGLfQSw=
 github.com/mdlayher/socket v0.4.1 h1:eM9y2/jlbs1M615oshPQOHZzj6R6wMT7bX5NPiQvn2U=
 github.com/mdlayher/socket v0.4.1/go.mod h1:cAqeGjoufqdxWkD7DkpyS+wcefOtmu5OQ8KuoJGIReA=
-github.com/odigos-io/runtime-detector v0.0.15 h1:KyexMNclA1qUF804cF7cQ4aIIMIQt+YH/kQm9oIyuZ0=
-github.com/odigos-io/runtime-detector v0.0.15/go.mod h1:K1EaeI2hpR/SmDUNredYgQocqw6wdJeaBLFlMqUVKwA=
+github.com/odigos-io/runtime-detector v0.0.16 h1:gsTIRasYtz3yd25vQAkSZW9J5QM1PjKsVnySuIOuYwg=
+github.com/odigos-io/runtime-detector v0.0.16/go.mod h1:K1EaeI2hpR/SmDUNredYgQocqw6wdJeaBLFlMqUVKwA=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=

--- a/odiglet/go.mod
+++ b/odiglet/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/odigos-io/odigos/opampserver v0.0.0
 	github.com/odigos-io/odigos/procdiscovery v0.0.0
 	github.com/odigos-io/opentelemetry-zap-bridge v0.0.5
-	github.com/odigos-io/runtime-detector v0.0.15
+	github.com/odigos-io/runtime-detector v0.0.16
 	go.opentelemetry.io/auto v0.21.0
 	go.opentelemetry.io/otel v1.37.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.37.0

--- a/odiglet/go.sum
+++ b/odiglet/go.sum
@@ -100,8 +100,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/odigos-io/opentelemetry-zap-bridge v0.0.5 h1:UDEKtgab42nGVSvA/F3lLKUYFPETtpl7kpxM9BKBlWk=
 github.com/odigos-io/opentelemetry-zap-bridge v0.0.5/go.mod h1:K98wHhktQ6vCTqeFztcpBDtPTe88vxVgZFlbeGobt24=
-github.com/odigos-io/runtime-detector v0.0.15 h1:KyexMNclA1qUF804cF7cQ4aIIMIQt+YH/kQm9oIyuZ0=
-github.com/odigos-io/runtime-detector v0.0.15/go.mod h1:K1EaeI2hpR/SmDUNredYgQocqw6wdJeaBLFlMqUVKwA=
+github.com/odigos-io/runtime-detector v0.0.16 h1:gsTIRasYtz3yd25vQAkSZW9J5QM1PjKsVnySuIOuYwg=
+github.com/odigos-io/runtime-detector v0.0.16/go.mod h1:K1EaeI2hpR/SmDUNredYgQocqw6wdJeaBLFlMqUVKwA=
 github.com/onsi/ginkgo/v2 v2.22.0 h1:Yed107/8DjTr0lKCNt7Dn8yQ6ybuDRQoMGrNFKzMfHg=
 github.com/onsi/ginkgo/v2 v2.22.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/onsi/gomega v1.36.1 h1:bJDPBO7ibjxcbHMgSCoo4Yj18UWbKDlLwX1x9sybDcw=


### PR DESCRIPTION
Latest version of runtime-detector supports running on kernels 4.19 and above