### PR TITLE
fix: CSRF token for local development

### DIFF
--- a/frontend/webapp/hooks/tokens/useCSRF.ts
+++ b/frontend/webapp/hooks/tokens/useCSRF.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { IS_LOCAL } from '@/utils';
 
 export interface CSRFTokenResponse {
   csrf_token: string;
@@ -8,7 +9,6 @@ export interface UseCSRF {
   token: string | null;
   isLoading: boolean;
   error: string | null;
-  fetchCSRFToken: () => Promise<void>;
 }
 
 /**
@@ -110,6 +110,10 @@ export const useCSRF = (): UseCSRF => {
   }, []);
 
   useEffect(() => {
+    if (IS_LOCAL) {
+      return;
+    }
+
     // Fetch token on mount
     if (!token) {
       fetchCSRFToken();
@@ -125,6 +129,5 @@ export const useCSRF = (): UseCSRF => {
     token,
     isLoading,
     error,
-    fetchCSRFToken,
   };
 };

--- a/frontend/webapp/utils/constants/common.ts
+++ b/frontend/webapp/utils/constants/common.ts
@@ -1,0 +1,2 @@
+export const IS_DEV = process.env.NODE_ENV === 'development';
+export const IS_LOCAL = IS_DEV && window.location.port === '3000';

--- a/frontend/webapp/utils/constants/index.ts
+++ b/frontend/webapp/utils/constants/index.ts
@@ -1,3 +1,4 @@
+export * from './common';
 export * from './keys';
 export * from './props';
 export * from './routes';


### PR DESCRIPTION
- Added IS_LOCAL constant to determine if the app is running in a local development environment.
- Updated useCSRF hook to skip token fetching in local environment.
- Modified Apollo client configuration to use 'same-origin' for credentials in local development.
- Refactored authLink to streamline header management for CSRF token.
- Ensured ApolloProvider handles token absence correctly based on environment.

emergency-ticket id: EMR-90
