### PR TITLE
fix: prevent duplicate instrumentation instance components

### DIFF
--- a/frontend/graph/schema.resolvers.go
+++ b/frontend/graph/schema.resolvers.go
@@ -1336,6 +1336,8 @@ func (r *queryResolver) InstrumentationInstanceComponents(ctx context.Context, n
 	}
 
 	components := make([]*model.InstrumentationInstanceComponent, 0)
+	seenNames := make(map[string]bool)
+
 	for _, instance := range instances {
 		for _, component := range instance.Status.Components {
 			nonIdentifyingAttributes := make([]*model.NonIdentifyingAttribute, 0)
@@ -1347,10 +1349,13 @@ func (r *queryResolver) InstrumentationInstanceComponents(ctx context.Context, n
 				})
 			}
 
-			components = append(components, &model.InstrumentationInstanceComponent{
-				Name:                     component.Name,
-				NonIdentifyingAttributes: nonIdentifyingAttributes,
-			})
+			if _, ok := seenNames[component.Name]; !ok {
+				seenNames[component.Name] = true
+				components = append(components, &model.InstrumentationInstanceComponent{
+					Name:                     component.Name,
+					NonIdentifyingAttributes: nonIdentifyingAttributes,
+				})
+			}
 		}
 	}
 


### PR DESCRIPTION
- Introduced a map to track seen component names, ensuring that each component is only added once to the list of `InstrumentationInstanceComponents`.

emergency-ticket id: EMR-88
