### PR TITLE
fix: rollback odigos pods and namespace labels if exists before removing the sources

### DIFF
--- a/docs/cli/odigos.mdx
+++ b/docs/cli/odigos.mdx
@@ -41,7 +41,7 @@ Get started with Odigos today to effortlessly improve the observability of your 
 * [odigos uninstall](/cli/odigos_uninstall)	 - Revert all the changes made by the `odigos install` command.
 This command will uninstall Odigos from your cluster. It will delete all Odigos objects
 and rollback any metadata changes made to your objects.
- 
+
 Note: Namespaces created during Odigos CLI installation will be deleted during uninstallation. This applies only to CLI installs, not Helm.
 * [odigos upgrade](/cli/odigos_upgrade)	 - Upgrade odigos version in your cluster.
 * [odigos version](/cli/odigos_version)	 - Print odigos version.

--- a/docs/cli/odigos_uninstall.mdx
+++ b/docs/cli/odigos_uninstall.mdx
@@ -7,7 +7,7 @@ sidebarTitle: "odigos uninstall"
 Revert all the changes made by the `odigos install` command.
 This command will uninstall Odigos from your cluster. It will delete all Odigos objects
 and rollback any metadata changes made to your objects.
- 
+
 Note: Namespaces created during Odigos CLI installation will be deleted during uninstallation. This applies only to CLI installs, not Helm.
 
 ```


### PR DESCRIPTION
## Description

<!-- Short summary of the changes -->

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-87
