### PR TITLE
bump runtime-detector to v0.0.17

### DIFF
--- a/instrumentation/go.mod
+++ b/instrumentation/go.mod
@@ -5,14 +5,14 @@ go 1.24.0
 require (
 	github.com/go-logr/logr v1.4.3
 	github.com/odigos-io/odigos/distros v0.0.0
-	github.com/odigos-io/runtime-detector v0.0.16
+	github.com/odigos-io/runtime-detector v0.0.17
 	go.opentelemetry.io/otel v1.37.0
 	go.opentelemetry.io/otel/metric v1.37.0
 	golang.org/x/sync v0.16.0
 )
 
 require (
-	github.com/cilium/ebpf v0.19.0 // indirect
+	github.com/cilium/ebpf v0.19.1-0.20250818092626-ae226118949d // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/odigos-io/odigos/common v0.0.0 // indirect

--- a/instrumentation/go.sum
+++ b/instrumentation/go.sum
@@ -1,5 +1,5 @@
-github.com/cilium/ebpf v0.19.0 h1:Ro/rE64RmFBeA9FGjcTc+KmCeY6jXmryu6FfnzPRIao=
-github.com/cilium/ebpf v0.19.0/go.mod h1:fLCgMo3l8tZmAdM3B2XqdFzXBpwkcSTroaVqN08OWVY=
+github.com/cilium/ebpf v0.19.1-0.20250818092626-ae226118949d h1:53XY3TeudeY1tPentx/Uf0FLMzq1op9dwdPJ5QaTCFc=
+github.com/cilium/ebpf v0.19.1-0.20250818092626-ae226118949d/go.mod h1:GMSzJItnG6k1OEtplNHr66oI/BlTcGTS/oE7lO4kOGU=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -25,8 +25,8 @@ github.com/mdlayher/netlink v1.7.2 h1:/UtM3ofJap7Vl4QWCPDGXY8d3GIY2UGSDbK+QWmY8/
 github.com/mdlayher/netlink v1.7.2/go.mod h1:xraEF7uJbxLhc5fpHL4cPe221LI2bdttWlU+ZGLfQSw=
 github.com/mdlayher/socket v0.4.1 h1:eM9y2/jlbs1M615oshPQOHZzj6R6wMT7bX5NPiQvn2U=
 github.com/mdlayher/socket v0.4.1/go.mod h1:cAqeGjoufqdxWkD7DkpyS+wcefOtmu5OQ8KuoJGIReA=
-github.com/odigos-io/runtime-detector v0.0.16 h1:gsTIRasYtz3yd25vQAkSZW9J5QM1PjKsVnySuIOuYwg=
-github.com/odigos-io/runtime-detector v0.0.16/go.mod h1:K1EaeI2hpR/SmDUNredYgQocqw6wdJeaBLFlMqUVKwA=
+github.com/odigos-io/runtime-detector v0.0.17 h1:X5goqDkv7hOV9Cn5FEri5SOqSv3o6QRrBGrUwp5BMi4=
+github.com/odigos-io/runtime-detector v0.0.17/go.mod h1:PU48BPpW9+gHxuCBdoKFenVquqI8ScnUW8z/237TbwA=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=

--- a/odiglet/go.mod
+++ b/odiglet/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/odigos-io/odigos/opampserver v0.0.0
 	github.com/odigos-io/odigos/procdiscovery v0.0.0
 	github.com/odigos-io/opentelemetry-zap-bridge v0.0.5
-	github.com/odigos-io/runtime-detector v0.0.16
+	github.com/odigos-io/runtime-detector v0.0.17
 	go.opentelemetry.io/auto v0.21.0
 	go.opentelemetry.io/otel v1.37.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.37.0
@@ -35,7 +35,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/cilium/ebpf v0.19.0 // indirect
+	github.com/cilium/ebpf v0.19.1-0.20250818092626-ae226118949d // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect

--- a/odiglet/go.sum
+++ b/odiglet/go.sum
@@ -10,8 +10,8 @@ github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7
 github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/cilium/ebpf v0.19.0 h1:Ro/rE64RmFBeA9FGjcTc+KmCeY6jXmryu6FfnzPRIao=
-github.com/cilium/ebpf v0.19.0/go.mod h1:fLCgMo3l8tZmAdM3B2XqdFzXBpwkcSTroaVqN08OWVY=
+github.com/cilium/ebpf v0.19.1-0.20250818092626-ae226118949d h1:53XY3TeudeY1tPentx/Uf0FLMzq1op9dwdPJ5QaTCFc=
+github.com/cilium/ebpf v0.19.1-0.20250818092626-ae226118949d/go.mod h1:GMSzJItnG6k1OEtplNHr66oI/BlTcGTS/oE7lO4kOGU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -100,8 +100,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/odigos-io/opentelemetry-zap-bridge v0.0.5 h1:UDEKtgab42nGVSvA/F3lLKUYFPETtpl7kpxM9BKBlWk=
 github.com/odigos-io/opentelemetry-zap-bridge v0.0.5/go.mod h1:K98wHhktQ6vCTqeFztcpBDtPTe88vxVgZFlbeGobt24=
-github.com/odigos-io/runtime-detector v0.0.16 h1:gsTIRasYtz3yd25vQAkSZW9J5QM1PjKsVnySuIOuYwg=
-github.com/odigos-io/runtime-detector v0.0.16/go.mod h1:K1EaeI2hpR/SmDUNredYgQocqw6wdJeaBLFlMqUVKwA=
+github.com/odigos-io/runtime-detector v0.0.17 h1:X5goqDkv7hOV9Cn5FEri5SOqSv3o6QRrBGrUwp5BMi4=
+github.com/odigos-io/runtime-detector v0.0.17/go.mod h1:PU48BPpW9+gHxuCBdoKFenVquqI8ScnUW8z/237TbwA=
 github.com/onsi/ginkgo/v2 v2.22.0 h1:Yed107/8DjTr0lKCNt7Dn8yQ6ybuDRQoMGrNFKzMfHg=
 github.com/onsi/ginkgo/v2 v2.22.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/onsi/gomega v1.36.1 h1:bJDPBO7ibjxcbHMgSCoo4Yj18UWbKDlLwX1x9sybDcw=


### PR DESCRIPTION
New tag for runtime-detector is using `main` of `cilium/ebpf` since their last release has a bug in BTF parsing - hence bumping to include the fix.

emergency-ticket id: EMR-105
