### PR TITLE
Avoid adding deployments/replicaset metadata in logs pipeline by default

### DIFF
--- a/autoscaler/controllers/nodecollector/configmap.go
+++ b/autoscaler/controllers/nodecollector/configmap.go
@@ -119,6 +119,10 @@ func getDesiredConfigMap(sources *odigosv1.InstrumentationConfigList, signals []
 	return &desired, nil
 }
 
+// using the k8sattributes processor to add deployment, statefulset and daemonset metadata
+// has a high memory consumption in large clusters since it brings all the replicasets in the cluster into the cache.
+// this has been disabled for logs, until further investigation is done on how to reduce memory consumption.
+// The side effect is that logs record will lack deployment/statefulset/daemonset names and service name that could have been derived from them.
 func updateOrCreateK8sAttributesForLogs(cfg *config.Config) error {
 
 	_, k8sProcessorExists := cfg.Processors[k8sAttributesProcessorName]
@@ -411,39 +415,44 @@ func calculateConfigMapData(nodeCG *odigosv1.CollectorsGroup, sources *odigosv1.
 			},
 		}
 
-		err := updateOrCreateK8sAttributesForLogs(&cfg)
-		if err != nil {
-			return "", err
-		}
-		// remove logs processors from CRD logsProcessors in case it is there so not to add it twice
-		for i, processor := range logsProcessors {
-			if processor == k8sAttributesProcessorName {
-				logsProcessors = append(logsProcessors[:i], logsProcessors[i+1:]...)
-				break
-			}
-		}
+		// err := updateOrCreateK8sAttributesForLogs(&cfg)
+		// if err != nil {
+		// 	return "", err
+		// }
+		// // remove logs processors from CRD logsProcessors in case it is there so not to add it twice
+		// for i, processor := range logsProcessors {
+		// 	if processor == k8sAttributesProcessorName {
+		// 		logsProcessors = append(logsProcessors[:i], logsProcessors[i+1:]...)
+		// 		break
+		// 	}
+		// }
 
 		// set "service.name" for logs same as the workload name.
 		// note: this does not respect the override service name a user can set in sources.
-		cfg.Processors[logsServiceNameProcessorName] = config.GenericMap{
-			"attributes": []config.GenericMap{
-				{
-					"key":            string(semconv.ServiceNameKey),
-					"from_attribute": string(semconv.K8SDeploymentNameKey),
-					"action":         "insert", // avoid overwriting existing value
-				},
-				{
-					"key":            string(semconv.ServiceNameKey),
-					"from_attribute": string(semconv.K8SStatefulSetNameKey),
-					"action":         "insert", // avoid overwriting existing value
-				},
-				{
-					"key":            string(semconv.ServiceNameKey),
-					"from_attribute": string(semconv.K8SDaemonSetNameKey),
-					"action":         "insert", // avoid overwriting existing value
-				},
-			},
-		}
+		// cfg.Processors[logsServiceNameProcessorName] = config.GenericMap{
+		// 	"attributes": []config.GenericMap{
+		// 		{
+		// 			"key":            string(semconv.ServiceNameKey),
+		// 			"from_attribute": string(semconv.K8SDeploymentNameKey),
+		// 			"action":         "insert", // avoid overwriting existing value
+		// 		},
+		// 		{
+		// 			"key":            string(semconv.ServiceNameKey),
+		// 			"from_attribute": string(semconv.K8SStatefulSetNameKey),
+		// 			"action":         "insert", // avoid overwriting existing value
+		// 		},
+		// 		{
+		// 			"key":            string(semconv.ServiceNameKey),
+		// 			"from_attribute": string(semconv.K8SDaemonSetNameKey),
+		// 			"action":         "insert", // avoid overwriting existing value
+		// 		},
+		// 		{
+		// 			"key":            string(semconv.ServiceNameKey),
+		// 			"from_attribute": string(semconv.K8SCronJobNameKey),
+		// 			"action":         "insert", // avoid overwriting existing value
+		// 		},
+		// 	},
+		// }
 
 		cfg.Service.Pipelines["logs"] = config.Pipeline{
 			Receivers:  []string{"filelog"},
@@ -589,7 +598,7 @@ func getFileLogPipelineProcessors() []string {
 	// no need to batch, as the stanza receiver already batches the data, and so is the gateway.
 	// batch processor will also mask and hide any back-pressure from receivers which we want propagated to the source.
 	return append(
-		[]string{"memory_limiter", k8sAttributesProcessorName, logsServiceNameProcessorName},
+		[]string{"memory_limiter" /*k8sAttributesProcessorName, logsServiceNameProcessorName*/},
 		getCommonProcessors()...,
 	)
 }


### PR DESCRIPTION
Using the `k8sattributes` processor - collecting deployment metadata can be memory expensive in big clusters. This is because the processor will pull into a cache all the replicasets from the cluster. As opposed to pod metadata this can't be filtered to only pull the node objects.

For logs, disable this collection by default. For traces we have these attributes from each instrumentation so no need to add them in the collector.

If a user wants to keep those attributes for logs, it still can be done by adding the `k8sattributes` action.

emergency-ticket id: EMR-117
