### PR TITLE
RUN-93: Transform DynamoDB tables to db.collection in Kratos

### DIFF
--- a/profiles/aggregators/kratos.go
+++ b/profiles/aggregators/kratos.go
@@ -25,6 +25,7 @@ var KratosProfile = profile.Profile{
 		"reduce-span-name-cardinality",
 		"disable-gin",
 		"semconvdynamo",
+		"transformdynamo",
 		"semconvredis",
 	},
 	ModifyConfigFunc: func(config *common.OdigosConfiguration) {

--- a/profiles/allprofiles.go
+++ b/profiles/allprofiles.go
@@ -24,6 +24,7 @@ var AllProfiles = []profile.Profile{
 	attributes.QueryOperationDetector,
 	attributes.SemconvUpgraderProfile,
 	attributes.SemconvDynamoProfile,
+	attributes.TransformDynamoProfile,
 	attributes.SemconvRedisProfile,
 	attributes.ReduceSpanNameCardinalityProfile,
 

--- a/profiles/attributes/transformdynamo.go
+++ b/profiles/attributes/transformdynamo.go
@@ -1,0 +1,12 @@
+package attributes
+
+import (
+	"github.com/odigos-io/odigos/common"
+	"github.com/odigos-io/odigos/profiles/profile"
+)
+
+var TransformDynamoProfile = profile.Profile{
+	ProfileName:      common.ProfileName("transformdynamo"),
+	MinimumTier:      common.CommunityOdigosTier,
+	ShortDescription: "Convert aws.dynamodb.table_names to db.collection.name for AWS DynamoDB spans",
+}

--- a/profiles/manifests/transformdynamo.yaml
+++ b/profiles/manifests/transformdynamo.yaml
@@ -1,0 +1,30 @@
+apiVersion: odigos.io/v1alpha1
+kind: Processor
+metadata:
+  name: transformdynamo
+spec:
+  type: transform
+  processorName: "transformdynamo-transform"
+  notes: "Auto generated rule from transformdynamo profile. Converts aws.dynamodb.table_names to db.collection.name for AWS DynamoDB spans."
+  processorConfig:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements:
+          # Remove brackets and quotes, keep a simple comma-separated list
+          - set(attributes["db.collection.name"],
+                replace_all_patterns(
+                  replace_all_patterns(
+                    replace_all_patterns(
+                      String(attributes["aws.dynamodb.table_names"]),
+                      "[\\[\\]\\s]", ""       # drop [ ] and spaces
+                    ),
+                    "\"", ""                  # drop quotes
+                  ),
+                  ",,", ","                   # normalize any accidental double-commas
+                )
+            ) where attributes["aws.dynamodb.table_names"] != nil
+  signals:
+    - TRACES
+  collectorRoles:
+    - CLUSTER_GATEWAY


### PR DESCRIPTION
## Description

Following support for DynamoDB tables in https://github.com/odigos-io/enterprise-go-instrumentation/pull/1684, this copies the list value attributes of the tables attribute (as specified in the DynamoDB semconv) to the single value db.collection.name, concatenating with a comma

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
