### PR TITLE
ci: promote release-candidate to stable

### DIFF
--- a/.github/workflows/promote-rc-to-stable.yml
+++ b/.github/workflows/promote-rc-to-stable.yml
@@ -16,7 +16,7 @@ env:
   DOCKERHUB_REPO: "keyval"
   GCR_REPO: "us-central1-docker.pkg.dev/odigos-cloud/components"
   GHCR_REPO: "ghcr.io/odigos-io"
-  
+
 jobs:
   promote-rc-to-stable:
     runs-on: ubuntu-latest
@@ -142,8 +142,6 @@ jobs:
             fi
 
             git tag ${{ env.STABLE_TAG }}
-            # this is using github actions token which will not not trigger the release which is good
-            # since we don't need a brand new release here.
             git push origin ${{ env.STABLE_TAG }} 
             echo "Successfully created and pushed stable tag ${{ env.STABLE_TAG }}"            
 

--- a/.github/workflows/promote-rc-to-stable.yml
+++ b/.github/workflows/promote-rc-to-stable.yml
@@ -12,6 +12,11 @@ permissions:
   packages: write
   id-token: 'write'
 
+env:
+  DOCKERHUB_REPO: "keyval"
+  GCR_REPO: "us-central1-docker.pkg.dev/odigos-cloud/components"
+  GHCR_REPO: "ghcr.io/odigos-io"
+  
 jobs:
   promote-rc-to-stable:
     runs-on: ubuntu-latest
@@ -21,9 +26,9 @@ jobs:
         run: |
           # =~ is a bash operator that checks if a string matches a regular expression pattern
           # Here we check if the tag matches the format vX.Y.Z-rcN where X,Y,Z,N are numbers
-          if [[ "${{ github.event.inputs.tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$ ]]; then
+          if [[ "${{ github.event.inputs.version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$ ]]; then
             echo "Tag is a release candidate"
-            echo "RC_TAG=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
+            echo "RC_TAG=${{ github.event.inputs.version }}" >> $GITHUB_ENV
           else
             echo "Tag is not a release candidate"
             exit 1

--- a/.github/workflows/promote-rc-to-stable.yml
+++ b/.github/workflows/promote-rc-to-stable.yml
@@ -1,0 +1,165 @@
+name: Promote Release-Candidate to Stable
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to promote"
+        required: true
+
+permissions:
+  contents: write
+  packages: write
+  id-token: 'write'
+
+jobs:
+  promote-rc-to-stable:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Verify the tag is a release candidate
+        run: |
+          # =~ is a bash operator that checks if a string matches a regular expression pattern
+          # Here we check if the tag matches the format vX.Y.Z-rcN where X,Y,Z,N are numbers
+          if [[ "${{ github.event.inputs.tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$ ]]; then
+            echo "Tag is a release candidate"
+            echo "RC_TAG=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
+          else
+            echo "Tag is not a release candidate"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # need to fetch all tags for goreleaser to calculate the changelog
+          ref: ${{ env.RC_TAG }} # checkout the tag we are releasing (main might have been updated since the tag was created)          
+          token: ${{ secrets.RELEASE_BOT_TOKEN }} # so we can push the new tag
+
+      - name: Get Stable Tag From Release Candidate
+        run: |
+            # remove the -rc part and number from the tag
+            STABLE_TAG=$(echo "${{ env.RC_TAG }}" | sed 's/-rc[0-9]*$//')
+            
+            # Validate the stable tag format
+            if [[ ! "$STABLE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "ERROR: Invalid stable tag format: $STABLE_TAG"
+              exit 1
+            fi
+            
+            echo "STABLE_TAG=${STABLE_TAG}" >> $GITHUB_ENV
+            echo "Extracted stable tag: $STABLE_TAG"      
+
+      - name: Check if stable tag already exists
+        run: |
+            if git tag -l | grep -q "^${{ env.STABLE_TAG }}$"; then
+                echo "ERROR: Stable tag ${{ env.STABLE_TAG }} already exists"
+                echo "This workflow has likely already been run for this release candidate"
+                exit 1
+            else
+                echo "Stable tag ${{ env.STABLE_TAG }} does not exist, proceeding with promotion"
+            fi            
+
+      - name: Notify Slack Start
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' --data '{"description":"Starting to promote release candidate ${{ env.RC_TAG }} to stable ${{ env.STABLE_TAG }}", "tag":"${{ env.RC_TAG }}"}' ${{ env.SLACK_WEBHOOK_URL }}
+
+      - name: Install crane
+        uses: imjasonh/setup-crane@v0.4
+
+      - id: gcp-auth
+        name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          access_token_lifetime: 1200s
+      - name: Login to Artifact Registry
+        uses: docker/login-action@v3
+        with:
+          registry: us-central1-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}  
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Retag existing images to stable
+        run: |
+            IMAGE_NAMES=("odigos-agents" "odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-enterprise-odiglet" "odigos-ui" "odigos-enterprise-instrumentor")
+            REPOS=(${GCR_REPO} ${GHCR_REPO} ${DOCKERHUB_REPO})
+            UBI9_SUFFIXES=("" "-ubi9")
+            
+            # Track failed copies for potential rollback
+            FAILED_COPIES=()
+            
+            for REPO in "${REPOS[@]}"; do
+              for IMAGE_NAME in "${IMAGE_NAMES[@]}"; do
+                for SUFFIX in "${UBI9_SUFFIXES[@]}"; do
+                  echo "Copying ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.RC_TAG }} to ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.STABLE_TAG }}"
+                  
+                  if ! crane copy ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.RC_TAG }} ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.STABLE_TAG }}; then
+                    echo "ERROR: Failed to copy ${REPO}/${IMAGE_NAME}${SUFFIX}"
+                    FAILED_COPIES+=("${REPO}/${IMAGE_NAME}${SUFFIX}")
+                  else
+                    echo "Successfully copied ${REPO}/${IMAGE_NAME}${SUFFIX}"
+                  fi
+                done
+              done
+            done
+            
+            # Check if any copies failed
+            if [ ${#FAILED_COPIES[@]} -gt 0 ]; then
+              echo "ERROR: The following image copies failed:"
+              printf '%s\n' "${FAILED_COPIES[@]}"
+              echo "Stable tag creation will be aborted"
+              exit 1
+            fi
+            
+            echo "All image copies completed successfully"    
+
+      - name: Tag Stable Release in GitHub
+        run: |
+            # Double-check that the tag doesn't exist before creating it
+            if git tag -l | grep -q "^${{ env.STABLE_TAG }}$"; then
+                echo "ERROR: Stable tag ${{ env.STABLE_TAG }} already exists - this should not happen"
+                exit 1
+            fi
+
+            git tag ${{ env.STABLE_TAG }}
+            # this is using github actions token which will not not trigger the release which is good
+            # since we don't need a brand new release here.
+            git push origin ${{ env.STABLE_TAG }} 
+            echo "Successfully created and pushed stable tag ${{ env.STABLE_TAG }}"            
+
+      - name: Trigger CLI Release
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.RELEASE_BOT_TOKEN }}" \
+            https://api.github.com/repos/odigos-io/odigos/dispatches \
+            -d '{"event_type": "release_cli", "client_payload": {"tag": "${{ env.STABLE_TAG }}"}}'
+
+      - name: Notify Slack Success
+        if: success()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' --data '{"description":"Successfully re-tagged release candidate ${{ env.RC_TAG }} to stable ${{ env.STABLE_TAG }}", "tag":"${{ env.STABLE_TAG }}"}' ${{ env.SLACK_WEBHOOK_URL }}              
+
+      - name: Notify Slack Error
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' --data '{"description":"ERROR: Failed to re-tag release candidate ${{ env.RC_TAG }} to stable ${{ env.STABLE_TAG }}", "tag":"${{ env.STABLE_TAG }}"}' ${{ env.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   verify-offsets:
+    if: github.actor != 'keyval-release-bot'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -66,6 +67,7 @@ jobs:
           }" $SLACK_WEBHOOK_URL
 
   verify-dependencies-sync:
+    if: github.actor != 'keyval-release-bot'
     needs: verify-offsets
     runs-on: ubuntu-latest
     strategy:
@@ -121,6 +123,7 @@ jobs:
           }" $SLACK_WEBHOOK_URL
 
   verify-release-blockers:
+    if: github.actor != 'keyval-release-bot'
     needs: verify-dependencies-sync
     runs-on: ubuntu-latest
     strategy:
@@ -176,6 +179,7 @@ jobs:
           }" $SLACK_WEBHOOK_URL
 
   print-tag:
+    if: github.actor != 'keyval-release-bot'
     needs: verify-release-blockers
     runs-on: ubuntu-latest
     steps:
@@ -190,6 +194,7 @@ jobs:
           curl -X POST -H 'Content-type: application/json' --data '{"description":"Detected new git tag. initializing a release", "tag":"${{ steps.extract_tag.outputs.tag }}"}' ${{ env.SLACK_WEBHOOK_URL }}
 
   tag-modules:
+    if: github.actor != 'keyval-release-bot'
     needs: verify-release-blockers
     runs-on: ubuntu-latest
     steps:
@@ -247,6 +252,7 @@ jobs:
           curl -X POST -H 'Content-type: application/json' --data '{"link":"https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}", "description":"ERROR: Odigos go modules release failed", "tag":"${{ steps.extract_tag.outputs.tag }}"}' ${{ env.SLACK_WEBHOOK_URL }}
 
   publish-images:
+    if: github.actor != 'keyval-release-bot'
     needs: verify-release-blockers
     permissions:
       contents: 'read'
@@ -383,6 +389,7 @@ jobs:
           curl -X POST -H 'Content-type: application/json' --data '{"link":"https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}", "description":"ERROR: odigos component ${{ matrix.service }} release failed", "tag":"${{ steps.extract_tag.outputs.tag }}"}' ${{ env.SLACK_WEBHOOK_URL }}
 
   publish-collector-linux-packages:
+    if: github.actor != 'keyval-release-bot'
     needs: verify-release-blockers
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Re-tag the rc images so it's fast, and to guarantee they are identical to what has been tested.

cli still need to be published as usual:
- cli is embedded with the version inside it (`odigos --version`)
- the cli goreleaser is the one creating the release in github
- new tag still needs helm version and openshift certification which the release-cli workflow does
