### PR TITLE
CORE-171: Update OpenShift preflight binary version in CI job

### DIFF
--- a/.github/workflows/openshift-preflight.yml
+++ b/.github/workflows/openshift-preflight.yml
@@ -35,7 +35,7 @@ jobs:
           curl -X POST -H 'Content-type: application/json' --data '{"description":"Starting Odigos OpenShift Preflight submission", "tag":"${{ env.TAG }}"}' ${{ env.SLACK_WEBHOOK_URL }}
       - name: Download OpenShift Preflight binary
         run: |
-          curl -OL https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.12.0/preflight-linux-amd64
+          curl -OL https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.14.1/preflight-linux-amd64
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Description

Jobs were failing with:

```
time="2025-08-25T07:59:49Z" level=error msg=release-url error="invalid preflight version, please download the latest version and re-submit"
Error: could not submit to pyxis: could not create test results: status code: 400: body: {"type": "about:blank", "title": "Bad Request", "detail": "Validation error: 'github.com/redhat-openshift-ecosystem/openshift-preflight' version '1.12.0' is not supported. Supported versions are: ['1.13.2', '1.13.3', '1.14.0', '1.14.1']", "status": 400, "trace_id": "0xa9b2d871b769a7e382f1879949895a8f"}
2025/08/25 07:59:49 could not submit to pyxis: could not create test results: status code: 400: body: {"type": "about:blank", "title": "Bad Request", "detail": "Validation error: 'github.com/redhat-openshift-ecosystem/openshift-preflight' version '1.12.0' is not supported. Supported versions are: ['1.13.2', '1.13.3', '1.14.0', '1.14.1']", "status": 400, "trace_id": "0xa9b2d871b769a7e382f1879949895a8f"}
Error: Process completed with exit code 1.
```

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
