### PR TITLE
fix: add ext java jar files to keep list in rsync

### DIFF
--- a/odiglet/pkg/instrumentation/fs/agents.go
+++ b/odiglet/pkg/instrumentation/fs/agents.go
@@ -38,6 +38,8 @@ func CopyAgentsDirectoryToHost() error {
 		"/var/odigos/nodejs-ebpf/build/Release/.deps/Release/obj.target/dtrace-injector-native.node.d": {},
 		"/var/odigos/java-ebpf/tracing_probes.so":                                                      {},
 		"/var/odigos/java-ext-ebpf/end_span_usdt.so":                                                   {},
+		"/var/odigos/java-ext-ebpf/javaagent.jar":                                                      {},
+		"/var/odigos/java-ext-ebpf/otel_agent_extension.jar":                                           {},
 		"/var/odigos/python-ebpf/pythonUSDT.abi3.so":                                                   {},
 	}
 	empty, err := isDirEmptyOrNotExist(k8sconsts.OdigosAgentsDirectory)


### PR DESCRIPTION
While upgrading odigos version, we need to take into account the different `.jar` files that might have change between the versions. This PR adds jars that we manage to the keep list passed to rsync.
Not having these files in the keep list can cause running process to have their underlying jar being changed in runtime.
This caused errors like:
`invalid LOC header (bad signature) `

emergency-ticket id: EMR-127
