### PR TITLE
CORE-173: Enable mirrored image automatic Go offsets updates

### DIFF
--- a/api/k8sconsts/cli.go
+++ b/api/k8sconsts/cli.go
@@ -8,4 +8,7 @@ const (
 	MetricsDir = "Metrics"
 )
 
-const CliImageName = "odigos-cli"
+const (
+	CliImageName        = "odigos-cli"
+	CLIOffsetsImageName = "odigos-cli-offsets"
+)

--- a/api/k8sconsts/cli.go
+++ b/api/k8sconsts/cli.go
@@ -10,5 +10,5 @@ const (
 
 const (
 	CliImageName        = "odigos-cli"
-	CLIOffsetsImageName = "odigos-cli-offsets"
+	CliOffsetsImageName = "odigos-cli-offsets"
 )

--- a/api/k8sconsts/odiglet.go
+++ b/api/k8sconsts/odiglet.go
@@ -26,11 +26,13 @@ const (
 	OdigletDefaultHealthProbeBindPort = 55683
 
 	// ConfigMap used to store custom/updated Go instrumentation offsets
-	GoOffsetsConfigMap  = "odigos-go-offsets"
-	GoOffsetsFileName   = "go_offset_results.json"
-	GoOffsetsEnvVar     = "OTEL_GO_OFFSETS_FILE"
-	OffsetFileMountPath = "/offsets"
-	OffsetCronJobName   = "odigos-go-offsets-updater"
+	GoOffsetsConfigMap      = "odigos-go-offsets"
+	GoOffsetsFileName       = "go_offset_results.json"
+	GoOffsetsEnvVar         = "OTEL_GO_OFFSETS_FILE"
+	OffsetFileMountPath     = "/offsets"
+	OffsetCronJobName       = "odigos-go-offsets-updater"
+	OffsetCronJobModeDirect = "direct"
+	OffsetCronJobModeImage  = "image"
 
 	OdigletLocalTrafficServiceName = "odiglet-local"
 	OdigletMetricsServerPort       = 8080

--- a/api/k8sconsts/odiglet.go
+++ b/api/k8sconsts/odiglet.go
@@ -26,17 +26,39 @@ const (
 	OdigletDefaultHealthProbeBindPort = 55683
 
 	// ConfigMap used to store custom/updated Go instrumentation offsets
-	GoOffsetsConfigMap      = "odigos-go-offsets"
-	GoOffsetsFileName       = "go_offset_results.json"
-	GoOffsetsEnvVar         = "OTEL_GO_OFFSETS_FILE"
-	OffsetFileMountPath     = "/offsets"
-	OffsetCronJobName       = "odigos-go-offsets-updater"
-	OffsetCronJobModeDirect = "direct"
-	OffsetCronJobModeImage  = "image"
+	GoOffsetsConfigMap  = "odigos-go-offsets"
+	GoOffsetsFileName   = "go_offset_results.json"
+	GoOffsetsEnvVar     = "OTEL_GO_OFFSETS_FILE"
+	OffsetFileMountPath = "/offsets"
+	OffsetCronJobName   = "odigos-go-offsets-updater"
 
 	OdigletLocalTrafficServiceName = "odiglet-local"
 	OdigletMetricsServerPort       = 8080
 )
+
+// OffsetCronJobMode represents the mode for the Go offsets cron job
+type OffsetCronJobMode string
+
+const (
+	OffsetCronJobModeDirect OffsetCronJobMode = "direct"
+	OffsetCronJobModeImage  OffsetCronJobMode = "image"
+	OffsetCronJobModeOff    OffsetCronJobMode = "off"
+)
+
+// IsValid returns true if the mode is a valid OffsetCronJobMode
+func (m OffsetCronJobMode) IsValid() bool {
+	switch m {
+	case OffsetCronJobModeDirect, OffsetCronJobModeImage, OffsetCronJobModeOff:
+		return true
+	default:
+		return false
+	}
+}
+
+// String returns the string representation of the mode
+func (m OffsetCronJobMode) String() string {
+	return string(m)
+}
 
 var OdigletOSSInstalled = map[string]string{
 	OdigletOSSInstalledLabel: OdigletInstalledLabelValue,

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -442,6 +442,13 @@ func setConfigProperty(ctx context.Context, client *kube.Client, config *common.
 		intValue, _ := strconv.Atoi(value[0])
 		config.OdigletHealthProbeBindPort = intValue
 	case consts.GoAutoOffsetsCronProperty:
+		currentTier, err := odigospro.GetCurrentOdigosTier(ctx, client, namespace)
+		if err != nil {
+			return fmt.Errorf("unable to read the current Odigos tier: %w", err)
+		}
+		if currentTier == common.CommunityOdigosTier {
+			return fmt.Errorf("custom offsets support is only available in Odigos pro tier.")
+		}
 		if len(value) != 1 {
 			return fmt.Errorf("%s expects exactly one value", property)
 		}
@@ -455,6 +462,13 @@ func setConfigProperty(ctx context.Context, client *kube.Client, config *common.
 		config.GoAutoOffsetsCron = cronValue
 
 	case consts.GoAutoOffsetsModeProperty:
+		currentTier, err := odigospro.GetCurrentOdigosTier(ctx, client, namespace)
+		if err != nil {
+			return fmt.Errorf("unable to read the current Odigos tier: %w", err)
+		}
+		if currentTier == common.CommunityOdigosTier {
+			return fmt.Errorf("custom offsets support is only available in Odigos pro tier.")
+		}
 		if len(value) != 1 {
 			return fmt.Errorf("%s expects exactly one value", property)
 		}

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -459,8 +459,12 @@ func setConfigProperty(ctx context.Context, client *kube.Client, config *common.
 			return fmt.Errorf("%s expects exactly one value", property)
 		}
 		modeValue := value[0]
-		if modeValue != "" && modeValue != k8sconsts.OffsetCronJobModeDirect && modeValue != k8sconsts.OffsetCronJobModeImage {
-			return fmt.Errorf("invalid mode: %s. Must be either '%s' or '%s'", modeValue, k8sconsts.OffsetCronJobModeDirect, k8sconsts.OffsetCronJobModeImage)
+		if modeValue != "" {
+			mode := k8sconsts.OffsetCronJobMode(modeValue)
+			if !mode.IsValid() {
+				return fmt.Errorf("invalid mode: %s. Must be one of: %s, %s, %s",
+					modeValue, k8sconsts.OffsetCronJobModeDirect, k8sconsts.OffsetCronJobModeImage, k8sconsts.OffsetCronJobModeOff)
+			}
 		}
 		config.GoAutoOffsetsMode = modeValue
 

--- a/common/consts/consts.go
+++ b/common/consts/consts.go
@@ -98,6 +98,7 @@ const (
 	OdigletHealthProbeBindPortProperty = "odiglet-health-probe-bind-port"
 	ServiceGraphDisabledProperty       = "service-graph-disabled"
 	GoAutoOffsetsCronProperty          = "go-auto-offsets-cron"
+	GoAutoOffsetsModeProperty          = "go-auto-offsets-mode"
 	ClickhouseJsonTypeEnabledProperty  = "clickhouse-json-type-enabled"
 	AllowedTestConnectionHostsProperty = "allowed-test-connection-hosts"
 	EnableDataCompressionProperty      = "enable-data-compression"

--- a/common/odigos_config.go
+++ b/common/odigos_config.go
@@ -185,6 +185,7 @@ type OdigosConfiguration struct {
 	Oidc                              *OidcConfiguration       `json:"oidc,omitempty" yaml:"oidc"`
 	OdigletHealthProbeBindPort        int                      `json:"odigletHealthProbeBindPort,omitempty" yaml:"odigletHealthProbeBindPort"`
 	GoAutoOffsetsCron                 string                   `json:"goAutoOffsetsCron,omitempty" yaml:"goAutoOffsetsCron"`
+	GoAutoOffsetsMode                 string                   `json:"goAutoOffsetsMode,omitempty" yaml:"goAutoOffsetsMode"`
 	ClickhouseJsonTypeEnabledProperty *bool                    `json:"clickhouseJsonTypeEnabled,omitempty"`
 	CheckDeviceHealthBeforeInjection  *bool                    `json:"checkDeviceHealthBeforeInjection,omitempty"`
 	ResourceSizePreset                string                   `json:"resourceSizePreset,omitempty" yaml:"resourceSizePreset"`

--- a/docs/cli/odigos_config.mdx
+++ b/docs/cli/odigos_config.mdx
@@ -41,6 +41,7 @@ Manage Odigos configuration settings to customize system behavior.
 	- "odiglet-health-probe-bind-port": Sets the port for the Odiglet health probes (readiness/liveness).
   	- "service-graph-disabled": Enable or disable the service graph feature [default: false].
 	- "go-auto-offsets-cron": Cron schedule for automatic Go offsets updates (e.g. "0 0 * * *" for daily at midnight). Set to empty string to disable.
+	- "go-auto-offsets-mode": Mode for automatic Go offsets updates. Options include direct (default) and image.
 	- "clickhouse-json-type-enabled": Enable or disable ClickHouse JSON column support. When enabled, telemetry data is written using a new schema with JSON-typed columns (requires ClickHouse v25.3+). [default: false]
 	- "allowed-test-connection-hosts": List of allowed domains for test connection endpoints (e.g., "https://api.honeycomb.io", "https://otel.example.com"). Use "*" to allow all domains. Empty list allows all domains for backward compatibility.
 	- "enable-data-compression": Enable or disable data compression before sending data to the Gateway collector. [default: false],

--- a/docs/instrumentations/golang/ebpf.mdx
+++ b/docs/instrumentations/golang/ebpf.mdx
@@ -77,3 +77,37 @@ versions of instrumented libraries.
 This precompiled list is updated to be up-to-date with every release of Odigos. But, this means that you may encounter errors instrumenting applications
 that use very newly released versions of dependencies. If this occurs, it will be resolved by updating to the next release of Odigos, or alternatively
 upgrading the locally-stored offsets with the [`odigos pro update-offsets`](/cli/odigos_pro_update-offsets) command.
+
+### Updating Offsets Between Versions
+
+It is possible to pull the latest Go library support for Odigos without updating the entire Odigos installation. There are 3 ways to do so:
+
+1. Manual updates (with [`odigos pro update-offsets`](/cli/odigos_pro_update-offsets)).
+2. Direct automatic updates (recommended, see below).
+3. Mirrored image automatic updates (for disconnected environments, see below).
+
+In both automatic modes, a Kubernetes CronJob is created which updates the locally stored Go library offsets used by the Odiglet. The differences
+between these modes and how to enable them are described below.
+
+#### Direct automatic updates
+
+In "direct" mode, the CronJob will pull the latest Go library offsets directly from the Odigos cloud server and apply it to the cluster. This
+option consumes the fewest resources but requires that your cluster has direct internet access to this file hosted on the web. If you have
+restricted Internet egress policies, see "mirrored image updates" below.
+
+Enable automatic updates on any standard cron schedule by setting the [`odigos config set go-auto-offsets-cron`](/cli/odigos_config) option to
+any valid cron schedule. For example, enable nightly updates at midnight with `odigos config set go-auto-offsets-cron "0 0 * * *"`.
+
+To disable automatic updates, set the cron value to an empty string with `odigos config set go-auto-offsets-cron ""`.
+
+#### Mirrored image automatic updates
+
+For clusters with restricted traffic policies, you have the option to [mirror the Go library updates as an image](/setup/docker-registry#install-odigos-images-from-a-custom-docker-registry).
+In this mode, the CronJob will run an image that contains the latest Go library offsets bundled into the image itself. This mode
+does not require direct Internet access from the cluster, but it does require you to mirror this image into your own registry and maintain
+the latest version on your nodes.
+
+To enable mirrored image updates, run `odigos config set go-auto-offsets-mode "image"`. Then use the `go-auto-offsets-cron` option described above to set the schedule.
+
+To disable mirrored image updates, run `odigos config set go-auto-offsets-mode "direct"` (to switch back to direct mode), or set the `go-auto-offsets-cron`
+setting to an empty string (`""`) as described above to disable automatic updates entirely.

--- a/docs/setup/docker-registry.mdx
+++ b/docs/setup/docker-registry.mdx
@@ -41,6 +41,14 @@ make sure the odigos-agents image is also pulled, as it's required by the inject
 docker pull registry.odigos.io/odigos-agents:$VERSION
 ```
 
+If you are using [image mirrored Go offsets updates](/instrumentations/golang/ebpf#about-go-offsets), also mirror the offsets image:
+
+```
+docker pull registry.odigos.io/cli-offsets:latest
+```
+
+Keeping this image regularly up-to-date is necessary to pull the latest offsets into your cluster.
+
 <Warning>
 Odigos component images are published in multi-arch for ARM64 and AMD64 architectures. When pulling these images, be sure to specify the correct architecture *for the environment they will be deployed*.
 </Warning>

--- a/helm/odigos/templates/odigos-configuration-cm.yaml
+++ b/helm/odigos/templates/odigos-configuration-cm.yaml
@@ -163,3 +163,9 @@ data:
     {{- if .Values.allowConcurrentAgents.enabled }}
     allowConcurrentAgents: {{ .Values.allowConcurrentAgents.enabled }}
     {{- end }}
+    {{- if .Values.goAutoOffsetsCron }}
+    goAutoOffsetsCron: {{ .Values.goAutoOffsetsCron }}
+    {{- end }}
+    {{- if .Values.goAutoOffsetsMode }}
+    goAutoOffsetsMode: {{ .Values.goAutoOffsetsMode }}
+    {{- end }}

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -470,6 +470,8 @@ clickhouseDestinationJsonType:
 # Enable automatic Go library offsets updates.
 # See https://docs.odigos.io/pipeline/golang/ebpf#go-auto-offsets for more details.
 # cron schedule for automatic Go offsets updates (e.g. "0 0 * * *" for daily at midnight). Set to empty string to disable.
+# Custom Offsets support is only available in Odigos pro tier.
 goAutoOffsetsCron: ''
 # mode for automatic Go offsets updates. Options include direct (pull from cloud server), image (pull from local image) and off (disabled).
+# Custom Offsets support is only available in Odigos pro tier.
 goAutoOffsetsMode: 'off'

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -466,3 +466,10 @@ allowConcurrentAgents:
 # If set to false, the default schema using Map-type columns will be used instead.
 clickhouseDestinationJsonType:
   enabled: false
+
+# Enable automatic Go library offsets updates.
+# See https://docs.odigos.io/pipeline/golang/ebpf#go-auto-offsets for more details.
+# cron schedule for automatic Go offsets updates (e.g. "0 0 * * *" for daily at midnight). Set to empty string to disable.
+goAutoOffsetsCron: ''
+# mode for automatic Go offsets updates. Options include direct (pull from cloud server), image (pull from local image) and off (disabled).
+goAutoOffsetsMode: 'off'

--- a/scheduler/cmd/main.go
+++ b/scheduler/cmd/main.go
@@ -197,7 +197,7 @@ func main() {
 		setupLog.Error(err, "unable to create controllers for odigos configuration")
 		os.Exit(1)
 	}
-	err = odigospro.SetupWithManager(mgr)
+	err = odigospro.SetupWithManager(mgr, odigosVersion)
 	if err != nil {
 		setupLog.Error(err, "unable to create controller for odigos pro")
 		os.Exit(1)

--- a/scheduler/controllers/odigosconfiguration/odigosconfiguration_controller.go
+++ b/scheduler/controllers/odigosconfiguration/odigosconfiguration_controller.go
@@ -14,10 +14,7 @@ import (
 	"github.com/odigos-io/odigos/profiles"
 	"github.com/odigos-io/odigos/profiles/manifests"
 
-	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -25,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -99,12 +95,6 @@ func (r *odigosConfigurationController) Reconcile(ctx context.Context, _ ctrl.Re
 	resolveMountMethod(&odigosConfiguration)
 	resolveEnvInjectionMethod(&odigosConfiguration)
 
-	// Handle the Go offsets CronJob
-	err = r.handleGoOffsetsCronJob(ctx, &odigosConfiguration, env.GetCurrentNamespace())
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
 	err = r.persistEffectiveConfig(ctx, &odigosConfiguration, odigosConfigMap)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -174,145 +164,6 @@ func (r *odigosConfigurationController) persistEffectiveConfig(ctx context.Conte
 
 	logger := ctrl.LoggerFrom(ctx)
 	logger.Info("Successfully persisted effective configuration")
-
-	return nil
-}
-
-func (r *odigosConfigurationController) handleGoOffsetsCronJob(ctx context.Context, config *common.OdigosConfiguration, ns string) error {
-	// Get the Kubernetes server version to determine the API version to use for the CronJob
-	cfg := ctrl.GetConfigOrDie()
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
-	if err != nil {
-		return fmt.Errorf("failed to get Kubernetes server version: %v", err)
-	}
-	verInfo, err := discoveryClient.ServerVersion()
-	if err != nil {
-		return fmt.Errorf("failed to get Kubernetes server version: %v", err)
-	}
-	apiVersion := "batch/v1beta1"
-	if verInfo.Minor >= "21" {
-		apiVersion = "batch/v1"
-	}
-
-	// Determine the mode to use (default to "direct" if not specified)
-	mode := k8sconsts.OffsetCronJobMode(config.GoAutoOffsetsMode)
-	if mode == "" {
-		mode = k8sconsts.OffsetCronJobModeDirect
-	}
-
-	// Validate the mode
-	if !mode.IsValid() {
-		return fmt.Errorf("invalid go-auto-offsets-mode: %s. Must be one of: %s, %s, %s",
-			mode, k8sconsts.OffsetCronJobModeDirect, k8sconsts.OffsetCronJobModeImage, k8sconsts.OffsetCronJobModeOff)
-	}
-
-	if config.GoAutoOffsetsCron == "" || mode == k8sconsts.OffsetCronJobModeOff {
-		return deleteCronJob(ctx, r.Client, ns, apiVersion)
-	}
-
-	// Determine image name and command based on mode
-	var imageName string
-	var command []string
-
-	switch mode {
-	case k8sconsts.OffsetCronJobModeDirect:
-		imageName = k8sconsts.CliImageName
-		command = []string{"pro", "update-offsets"}
-	case k8sconsts.OffsetCronJobModeImage:
-		imageName = k8sconsts.CliOffsetsImageName
-		command = []string{"pro", "update-offsets", "--from-file", "/odigos/offset_results_min.json"}
-	}
-
-	typeMeta := metav1.TypeMeta{
-		Kind:       "CronJob",
-		APIVersion: apiVersion,
-	}
-	objectMeta := metav1.ObjectMeta{
-		Name:      k8sconsts.OffsetCronJobName,
-		Namespace: ns,
-		Labels: map[string]string{
-			k8sconsts.OdigosSystemLabelKey: k8sconsts.OdigosSystemLabelValue,
-		},
-	}
-	template := corev1.PodTemplateSpec{
-		Spec: corev1.PodSpec{
-			ServiceAccountName: k8sconsts.SchedulerServiceAccountName,
-			Containers: []corev1.Container{
-				{
-					Name:  imageName,
-					Image: fmt.Sprintf("%s/%s:%s", config.ImagePrefix, imageName, r.OdigosVersion),
-					Args:  command,
-				},
-			},
-			RestartPolicy: corev1.RestartPolicyNever,
-		},
-	}
-
-	if apiVersion == "batch/v1beta1" {
-		cronJob := &batchv1beta1.CronJob{
-			TypeMeta:   typeMeta,
-			ObjectMeta: objectMeta,
-			Spec: batchv1beta1.CronJobSpec{
-				Schedule: config.GoAutoOffsetsCron,
-				JobTemplate: batchv1beta1.JobTemplateSpec{
-					Spec: batchv1.JobSpec{
-						Template: template,
-					},
-				},
-			},
-		}
-		return applyCronJob(ctx, r.Client, ns, cronJob, config)
-	}
-	cronJob := &batchv1.CronJob{
-		TypeMeta:   typeMeta,
-		ObjectMeta: objectMeta,
-		Spec: batchv1.CronJobSpec{
-			Schedule: config.GoAutoOffsetsCron,
-			JobTemplate: batchv1.JobTemplateSpec{
-				Spec: batchv1.JobSpec{
-					Template: template,
-				},
-			},
-		},
-	}
-	return applyCronJob(ctx, r.Client, ns, cronJob, config)
-}
-
-func deleteCronJob(ctx context.Context, kubeClient client.Client, ns string, apiVersion string) error {
-	var cronJob client.Object
-	if apiVersion == "batch/v1" {
-		cronJob = &batchv1.CronJob{}
-	} else {
-		cronJob = &batchv1beta1.CronJob{}
-	}
-	err := kubeClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: k8sconsts.OffsetCronJobName}, cronJob)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-	err = kubeClient.Delete(ctx, cronJob)
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to delete go offsets CronJob: %v", err)
-		}
-		return nil
-	}
-	return nil
-}
-
-func applyCronJob(ctx context.Context, kubeClient client.Client, ns string, cronJob client.Object, config *common.OdigosConfiguration) error {
-	// Apply the CronJob
-	objApplyBytes, err := yaml.Marshal(cronJob)
-	if err != nil {
-		return err
-	}
-
-	err = kubeClient.Patch(ctx, cronJob, client.RawPatch(types.ApplyYAMLPatchType, objApplyBytes), client.ForceOwnership, client.FieldOwner("scheduler-odigosconfig"))
-	if err != nil {
-		return fmt.Errorf("failed to apply go offsets CronJob: %v", err)
-	}
 
 	return nil
 }

--- a/scheduler/controllers/odigospro/offsets_controller.go
+++ b/scheduler/controllers/odigospro/offsets_controller.go
@@ -1,0 +1,209 @@
+package odigospro
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/odigos-io/odigos/api/k8sconsts"
+	"github.com/odigos-io/odigos/k8sutils/pkg/env"
+	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	"github.com/odigos-io/odigos/common"
+	"github.com/odigos-io/odigos/common/consts"
+)
+
+type odigosproOffsetsController struct {
+	client.Client
+	OdigosVersion string
+}
+
+func (r *odigosproOffsetsController) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
+	logger := ctrl.LoggerFrom(ctx)
+	var configMap corev1.ConfigMap
+	odigosNs := env.GetCurrentNamespace()
+
+	err := r.Client.Get(ctx, types.NamespacedName{Namespace: odigosNs, Name: consts.OdigosConfigurationName}, &configMap)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	odigosConfiguration := &common.OdigosConfiguration{}
+	err = yaml.Unmarshal([]byte(configMap.Data[consts.OdigosConfigurationFileName]), odigosConfiguration)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Get the Kubernetes server version to determine the API version to use for the CronJob
+	cfg := ctrl.GetConfigOrDie()
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get Kubernetes server version: %v", err)
+	}
+	verInfo, err := discoveryClient.ServerVersion()
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get Kubernetes server version: %v", err)
+	}
+	apiVersion := "batch/v1beta1"
+	if verInfo.Minor >= "21" {
+		apiVersion = "batch/v1"
+	}
+
+	// Determine the mode to use (default to "direct" if not specified)
+	mode := k8sconsts.OffsetCronJobMode(odigosConfiguration.GoAutoOffsetsMode)
+	if mode == "" {
+		mode = k8sconsts.OffsetCronJobModeDirect
+	}
+
+	// Validate the mode
+	if !mode.IsValid() {
+		return ctrl.Result{}, fmt.Errorf("invalid go-auto-offsets-mode: %s. Must be one of: %s, %s, %s",
+			mode, k8sconsts.OffsetCronJobModeDirect, k8sconsts.OffsetCronJobModeImage, k8sconsts.OffsetCronJobModeOff)
+	}
+
+	if odigosConfiguration.GoAutoOffsetsCron == "" || mode == k8sconsts.OffsetCronJobModeOff {
+		return ctrl.Result{}, deleteCronJob(ctx, r.Client, odigosNs, apiVersion)
+	}
+
+	tier, err := getCurrentOdigosTier(ctx, r.Client, odigosNs)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get current Odigos tier: %v", err)
+	}
+	if tier == common.CommunityOdigosTier {
+		logger.Error(fmt.Errorf("custom offsets support is only available in Odigos pro tier"), "could not reconcile go offsets cron job")
+		return ctrl.Result{}, nil
+	}
+
+	// Determine image name and command based on mode
+	var imageName string
+	var command []string
+
+	switch mode {
+	case k8sconsts.OffsetCronJobModeDirect:
+		imageName = k8sconsts.CliImageName
+		command = []string{"pro", "update-offsets"}
+	case k8sconsts.OffsetCronJobModeImage:
+		imageName = k8sconsts.CliOffsetsImageName
+		command = []string{"pro", "update-offsets", "--from-file", "/odigos/offset_results_min.json"}
+	}
+
+	typeMeta := metav1.TypeMeta{
+		Kind:       "CronJob",
+		APIVersion: apiVersion,
+	}
+	objectMeta := metav1.ObjectMeta{
+		Name:      k8sconsts.OffsetCronJobName,
+		Namespace: odigosNs,
+		Labels: map[string]string{
+			k8sconsts.OdigosSystemLabelKey: k8sconsts.OdigosSystemLabelValue,
+		},
+	}
+	template := corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			ServiceAccountName: k8sconsts.SchedulerServiceAccountName,
+			Containers: []corev1.Container{
+				{
+					Name:  imageName,
+					Image: fmt.Sprintf("%s/%s:%s", odigosConfiguration.ImagePrefix, imageName, r.OdigosVersion),
+					Args:  command,
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+
+	if apiVersion == "batch/v1beta1" {
+		cronJob := &batchv1beta1.CronJob{
+			TypeMeta:   typeMeta,
+			ObjectMeta: objectMeta,
+			Spec: batchv1beta1.CronJobSpec{
+				Schedule: odigosConfiguration.GoAutoOffsetsCron,
+				JobTemplate: batchv1beta1.JobTemplateSpec{
+					Spec: batchv1.JobSpec{
+						Template: template,
+					},
+				},
+			},
+		}
+		return ctrl.Result{}, applyCronJob(ctx, r.Client, odigosNs, cronJob, odigosConfiguration)
+	}
+	cronJob := &batchv1.CronJob{
+		TypeMeta:   typeMeta,
+		ObjectMeta: objectMeta,
+		Spec: batchv1.CronJobSpec{
+			Schedule: odigosConfiguration.GoAutoOffsetsCron,
+			JobTemplate: batchv1.JobTemplateSpec{
+				Spec: batchv1.JobSpec{
+					Template: template,
+				},
+			},
+		},
+	}
+	return ctrl.Result{}, applyCronJob(ctx, r.Client, odigosNs, cronJob, odigosConfiguration)
+}
+
+func deleteCronJob(ctx context.Context, kubeClient client.Client, ns string, apiVersion string) error {
+	var cronJob client.Object
+	if apiVersion == "batch/v1" {
+		cronJob = &batchv1.CronJob{}
+	} else {
+		cronJob = &batchv1beta1.CronJob{}
+	}
+	err := kubeClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: k8sconsts.OffsetCronJobName}, cronJob)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	err = kubeClient.Delete(ctx, cronJob)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete go offsets CronJob: %v", err)
+		}
+		return nil
+	}
+	return nil
+}
+
+func applyCronJob(ctx context.Context, kubeClient client.Client, ns string, cronJob client.Object, config *common.OdigosConfiguration) error {
+	// Apply the CronJob
+	objApplyBytes, err := yaml.Marshal(cronJob)
+	if err != nil {
+		return err
+	}
+
+	err = kubeClient.Patch(ctx, cronJob, client.RawPatch(types.ApplyYAMLPatchType, objApplyBytes), client.ForceOwnership, client.FieldOwner("scheduler-odigosconfig"))
+	if err != nil {
+		return fmt.Errorf("failed to apply go offsets CronJob: %v", err)
+	}
+
+	return nil
+}
+
+func getCurrentOdigosTier(ctx context.Context, kubeClient client.Client, ns string) (common.OdigosTier, error) {
+	secret := &corev1.Secret{}
+	err := kubeClient.Get(ctx, client.ObjectKey{Namespace: ns, Name: k8sconsts.OdigosProSecretName}, secret)
+	if apierrors.IsNotFound(err) {
+		return common.CommunityOdigosTier, nil
+	}
+	if err != nil {
+		return common.CommunityOdigosTier, err
+	}
+
+	if _, exists := secret.Data[k8sconsts.OdigosCloudApiKeySecretKey]; exists {
+		return common.CloudOdigosTier, nil
+	}
+	if _, exists := secret.Data[k8sconsts.OdigosOnpremTokenSecretKey]; exists {
+		return common.OnPremOdigosTier, nil
+	}
+	return common.CommunityOdigosTier, nil
+}


### PR DESCRIPTION
## Description

This enables users to set automatic updates using our published cli-offsets docker image rather than pulling directly from the hosted file in GCS. The user still needs Internet access to pull the image, but that access is now shifted from the cluster to their own registry/image mirror, which may work better for some disconnected environments.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [x] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
