### PR TITLE
chore: triggering create a release branch in the enterprise

### DIFF
--- a/.github/workflows/create-release-candidate.yml
+++ b/.github/workflows/create-release-candidate.yml
@@ -93,6 +93,14 @@ jobs:
             git pull origin main
             git checkout -b $STABLE_RELEASE_BRANCH_NAME
             git push origin $STABLE_RELEASE_BRANCH_NAME
+
+            echo "Triggering creating release branch workflow in odigos-enterprise"
+            curl -sS -X POST \
+              -H "Accept: application/vnd.github.v3+json" \
+              -H "Authorization: token ${{ secrets.RELEASE_BOT_TOKEN }}" \
+              https://api.github.com/repos/odigos-io/odigos-enterprise/dispatches \
+              -d "{\"event_type\":\"ensure-release-branch\",\"client_payload\":{\"branch\":\"$STABLE_RELEASE_BRANCH_NAME\"}}"
+
           else
             echo "Branch $STABLE_RELEASE_BRANCH_NAME already exists"
             # Check out the existing branch and pull latest changes


### PR DESCRIPTION
## Description

During the release process, we want to build the enterprise from the same release branch of the OSS.
So once creating the release branch here, we're also triggering a workflow that is doing the same on the Enterprise repo.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-141
