### PR TITLE
chore: update @odigos/ui-kit to v0.0.93 and @types/react to v19.1.11 …

### DIFF
--- a/frontend/webapp/package.json
+++ b/frontend/webapp/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@apollo/client": "^3.13.9",
     "@apollo/experimental-nextjs-app-support": "^0.12.3",
-    "@odigos/ui-kit": "^0.0.88",
+    "@odigos/ui-kit": "^0.0.93",
     "graphql": "^16.11.0",
     "next": "15.5.0",
     "react": "19.1.1",
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/node": "24.3.0",
-    "@types/react": "19.1.10",
+    "@types/react": "19.1.11",
     "@types/react-dom": "19.1.7",
     "autoprefixer": "^10.4.21",
     "cypress": "^14.5.4",

--- a/frontend/webapp/yarn.lock
+++ b/frontend/webapp/yarn.lock
@@ -436,10 +436,10 @@
   resolved "https://registry.yarnpkg.com/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz#3dc35ba0f1e66b403c00b39344f870298ebb1c8e"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
-"@odigos/ui-kit@^0.0.88":
-  version "0.0.88"
-  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.88.tgz#35f850479566dfc2b879f6389c46942f4f1b81e5"
-  integrity sha512-rbQ/dQARzu3Jke9RtedgLo09l0PKuc6BNeVzgwmsjIAKf0ke8MMccvrW+0Au95k46Z1xH5gC1Wg5DCwXBUmQ1g==
+"@odigos/ui-kit@^0.0.93":
+  version "0.0.93"
+  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.93.tgz#4c94cbc44f82a66aa6c6d8188c1d7cfb69bf426a"
+  integrity sha512-QoGprtxzkB8yFuIQr2NBDQb0ZKEva6rLuINUnLOrU4hJiL+K+Etq9Wdw+fUIstq1v2YMCZ4TCRmrBiE+dhuQdw==
   dependencies:
     "@xyflow/react" "^12.8.3"
     javascript-time-ago "^2.5.11"
@@ -546,10 +546,10 @@
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-19.1.7.tgz#2863f2aa89e023592b981204ef92c5221b286410"
   integrity sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==
 
-"@types/react@19.1.10":
-  version "19.1.10"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.1.10.tgz#a05015952ef328e1b85579c839a71304b07d21d9"
-  integrity sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==
+"@types/react@19.1.11":
+  version "19.1.11"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.1.11.tgz#a64d8ec1769fc861d22f54e6e9f360ed67b54dc8"
+  integrity sha512-lr3jdBw/BGj49Eps7EvqlUaoeA0xpj3pc0RoJkHpYaCHkVK7i28dKyImLQb3JVlqs3aYSXf7qYuWOW/fgZnTXQ==
   dependencies:
     csstype "^3.0.2"
 


### PR DESCRIPTION
…in package.json and yarn.lock (#3358)

PLAT-276

## Description

<!-- Short summary of the changes -->

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
