### PR TITLE
RUN-72: cli: Do not marshal/escape empty Go offsets bytes for --default

### DIFF
--- a/cli/cmd/pro.go
+++ b/cli/cmd/pro.go
@@ -190,11 +190,17 @@ odigos pro update-offsets --from-file /path/to/local/offsets.json
 			cm.Data = make(map[string]string)
 		}
 
-		escaped, err := json.Marshal(string(data))
-		if err != nil {
-			fmt.Println(fmt.Sprintf("\033[31mERROR\033[0m Unable to encode json string: %s", err))
-			os.Exit(1)
+		var escaped []byte
+		if len(data) == 0 {
+			escaped = []byte{}
+		} else {
+			escaped, err = json.Marshal(string(data))
+			if err != nil {
+				fmt.Println(fmt.Sprintf("\033[31mERROR\033[0m Unable to encode json string: %s", err))
+				os.Exit(1)
+			}
 		}
+
 		cm.Data[k8sconsts.GoOffsetsFileName] = string(escaped)
 		_, err = client.Clientset.CoreV1().ConfigMaps(ns).Update(ctx, cm, metav1.UpdateOptions{})
 		if err != nil {


### PR DESCRIPTION
## Description

When running `odigos pro update-offsets --default` (to revert to using in-memory compiled offsets), the command is meant to reset the offsets ConfigMap to an empty string, which instructs the Odiglet to fall back to in-memory offsets.

However, this empty string is being double JSON-escaped. When using real offsets JSON we need to escape the data, but marshalling/escaping the empty string creates an empty string value like `'""'` (double quotes inside single quotes):

```
$ kubectl get -o yaml cm/odigos-go-offsets -n odigos-system
apiVersion: v1
data:
  go_offset_results.json: '""'
kind: ConfigMap
metadata:
  creationTimestamp: "2025-08-27T14:21:07Z"
  labels:
    odigos.io/config: "1"
    odigos.io/system-object: "true"
  name: odigos-go-offsets
  namespace: odigos-system
  resourceVersion: "1383"
  uid: 9a344081-04b0-43de-992d-8bd109f38bf6
```

The odiglet is reading this as a "file" with the contents `""` and failing with `{"level":"error","ts":1756304955.846963,"caller":"enterprise/main.go:67","msg":"failed to set up ebpf factories","error":"Invalid file format. Signature delimiter not found.","stacktrace":"main.main\n\t/go/src/github.com/odigos-io/odigos-enterprise/odiglet/cmd/enterprise/main.go:67\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:283"}`

To add on to this, we could make the odiglet offsets file parsing more resilient to different forms of empty string.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [x] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
