### PR TITLE
ci: use the odigos slack-release-notification action for publish modules

### DIFF
--- a/.github/workflows/create-patch.yml
+++ b/.github/workflows/create-patch.yml
@@ -111,16 +111,11 @@ jobs:
                 --body "This is an automated PR for the patch release ${{ steps.calculate_patch_version.outputs.patch_version }}"
             fi
 
-      - name: Notify Slack Success
-        if: success()
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-        run: |
-              curl -X POST -H 'Content-type: application/json' --data '{"description":"Successfully created patch release PR for ${{ steps.calculate_patch_version.outputs.patch_version }}", "tag":"${{ steps.calculate_patch_version.outputs.patch_version }}"}' ${{ env.SLACK_WEBHOOK_URL }}
-
-      - name: Notify Slack Error
-        if: failure()
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"description":"ERROR: Failed to create patch release PR for ${{ steps.calculate_patch_version.outputs.patch_version }}", "tag":"${{ steps.calculate_patch_version.outputs.patch_version }}"}' ${{ env.SLACK_WEBHOOK_URL }}
+      - name: Notify Slack
+        if: always()
+        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
+        with: 
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          success-description: "Successfully created patch release PR for ${{ steps.calculate_patch_version.outputs.patch_version }}"
+          failure-description: "ERROR: Failed to create patch release PR for ${{ steps.calculate_patch_version.outputs.patch_version }}"
+          tag: ${{ steps.calculate_patch_version.outputs.patch_version }}

--- a/.github/workflows/create-release-candidate.yml
+++ b/.github/workflows/create-release-candidate.yml
@@ -173,3 +173,12 @@ jobs:
               --title "$PR_TITLE" \
               --body "This is an automated PR for the release candidate ${{ steps.rc_version.outputs.rc_version }}"
           fi
+
+      - name: Notify Slack
+        if: always()
+        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
+        with: 
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          success-description: "Successfully created release candidate PR for ${{ steps.rc_version.outputs.rc_version }}"
+          failure-description: "ERROR: Failed to create release candidate PR for ${{ steps.rc_version.outputs.rc_version }}"
+          tag: ${{ steps.rc_version.outputs.rc_version }}

--- a/.github/workflows/openshift-preflight.yml
+++ b/.github/workflows/openshift-preflight.yml
@@ -29,10 +29,13 @@ jobs:
             exit 1
           fi
       - name: Notify Slack Start
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"description":"Starting Odigos OpenShift Preflight submission", "tag":"${{ env.TAG }}"}' ${{ env.SLACK_WEBHOOK_URL }}
+        if: always()
+        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
+        with: 
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          success-description: "Starting Odigos OpenShift Preflight submission"
+          failure-description: "ERROR: Starting Odigos OpenShift Preflight submission"
+          tag: ${{ env.TAG }}
       - name: Download OpenShift Preflight binary
         run: |
           curl -OL https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.14.1/preflight-linux-amd64
@@ -91,17 +94,12 @@ jobs:
         run: |
           ./preflight-linux-amd64 check container registry.odigos.io/odigos-${{ matrix.service }}-ubi9:${{ env.TAG }} --pyxis-api-token=${{ secrets.OPENSHIFT_PYXIS_TOKEN }} --certification-project-id ${{ matrix.project_id }} --submit
 
-      - name: Notify Slack End
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"description":"Component ${{ matrix.service }} submitted to OpenShift Certification successfully", "tag":"${{ env.TAG }}"}' ${{ env.SLACK_WEBHOOK_URL }}
 
-      - name: Notify Slack on Failure
-        if: ${{ failure() || cancelled() }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"link":"https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}", "description":"ERROR: failed to submit component ${{ matrix.service }} to OpenShift Certification", "tag":"${{ env.TAG }}"}' ${{ env.SLACK_WEBHOOK_URL }}
+      - name: Notify Slack
+        if: always()
+        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
+        with: 
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          success-description: "Component ${{ matrix.service }} submitted to OpenShift Certification successfully"
+          failure-description: "ERROR: failed to submit component ${{ matrix.service }} to OpenShift Certification"
+          tag: ${{ env.TAG }}

--- a/.github/workflows/promote-rc-to-stable.yml
+++ b/.github/workflows/promote-rc-to-stable.yml
@@ -64,11 +64,15 @@ jobs:
                 echo "Stable tag ${{ env.STABLE_TAG }} does not exist, proceeding with promotion"
             fi
 
+
       - name: Notify Slack Start
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"description":"Starting to promote release candidate ${{ env.RC_TAG }} to stable ${{ env.STABLE_TAG }}", "tag":"${{ env.RC_TAG }}"}' ${{ env.SLACK_WEBHOOK_URL }}
+        if: always()
+        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
+        with: 
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          success-description: "Starting to promote release candidate ${{ env.RC_TAG }} to stable ${{ env.STABLE_TAG }}"
+          failure-description: "ERROR: Failed to promote release candidate ${{ env.RC_TAG }} to stable ${{ env.STABLE_TAG }}"
+          tag: ${{ env.RC_TAG }}
 
       - name: Install crane
         uses: imjasonh/setup-crane@v0.4
@@ -157,16 +161,11 @@ jobs:
             https://api.github.com/repos/odigos-io/odigos/dispatches \
             -d '{"event_type": "release_cli", "client_payload": {"tag": "${{ env.STABLE_TAG }}"}}'
 
-      - name: Notify Slack Success
-        if: success()
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"description":"Successfully re-tagged release candidate ${{ env.RC_TAG }} to stable ${{ env.STABLE_TAG }}", "tag":"${{ env.STABLE_TAG }}"}' ${{ env.SLACK_WEBHOOK_URL }}
-
-      - name: Notify Slack Error
-        if: failure()
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"description":"ERROR: Failed to re-tag release candidate ${{ env.RC_TAG }} to stable ${{ env.STABLE_TAG }}", "tag":"${{ env.STABLE_TAG }}"}' ${{ env.SLACK_WEBHOOK_URL }}
+      - name: Notify Slack
+        if: always()
+        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
+        with: 
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          success-description: "Successfully re-tagged release candidate ${{ env.RC_TAG }} to stable ${{ env.STABLE_TAG }}"
+          failure-description: "ERROR: Failed to re-tag release candidate ${{ env.RC_TAG }} to stable ${{ env.STABLE_TAG }}"
+          tag: ${{ env.STABLE_TAG }}

--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -47,7 +47,7 @@ jobs:
       
       - name: Notify Slack
         if: always()
-        uses: odigos-io/github-actions/.github/actions/slack-release-notification@main
+        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
         with: 
           webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
           success-description: "No open offset PRs in `${{ matrix.repo }}`"
@@ -90,7 +90,7 @@ jobs:
 
       - name: Notify Slack
         if: always()
-        uses: odigos-io/github-actions/.github/actions/slack-release-notification@main
+        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
         with: 
           webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
           success-description: "No open dependencies-syncer-bot PRs in `${{ matrix.repo }}`"
@@ -133,7 +133,7 @@ jobs:
 
       - name: Notify Slack
         if: always()
-        uses: odigos-io/github-actions/.github/actions/slack-release-notification@main
+        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
         with: 
           webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
           success-description: "No open release-blocker PRs in `${{ matrix.repo }}`"
@@ -149,7 +149,7 @@ jobs:
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
       - name: Notify Slack Start
-        uses: odigos-io/github-actions/.github/actions/slack-release-notification@main
+        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
         with: 
           webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
           success-description: "detected new git tag ${{ steps.extract_tag.outputs.tag }}, starting a release"
@@ -172,7 +172,7 @@ jobs:
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
       - name: Notify Slack Start
-        uses: odigos-io/github-actions/.github/actions/slack-release-notification@main
+        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
         with: 
           webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
           success-description: "start tagging odigos modules so they can be consumed as libraries"
@@ -203,7 +203,7 @@ jobs:
 
       - name: Notify Slack Success
         if: always()
-        uses: odigos-io/github-actions/.github/actions/slack-release-notification@main
+        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
         with: 
           webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
           success-description: "Odigos go modules tagged successfully"
@@ -264,7 +264,7 @@ jobs:
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
       - name: Notify Slack Start
-        uses: odigos-io/github-actions/.github/actions/slack-release-notification@main
+        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
         with: 
           webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
           success-description: "start publishing docker image for component ${{ matrix.service }} and dockerfile ${{ matrix.dockerfile }}"
@@ -336,7 +336,7 @@ jobs:
 
       - name: Notify Slack
         if: always()
-        uses: odigos-io/github-actions/.github/actions/slack-release-notification@main
+        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
         with: 
           webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
           success-description: "Odigos component ${{ matrix.service }} with dockerfile ${{ matrix.dockerfile }} released successfully"
@@ -354,7 +354,7 @@ jobs:
 
       - name: Notify Slack Start
         if: always()
-        uses: odigos-io/github-actions/.github/actions/slack-release-notification@main
+        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
         with: 
           webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
           success-description: "start releasing odigos collector as linux packages"
@@ -391,7 +391,7 @@ jobs:
 
       - name: Notify Slack Success
         if: always()
-        uses: odigos-io/github-actions/.github/actions/slack-release-notification@main
+        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
         with: 
           webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
           success-description: "Odigos collector linux packages released successfully"

--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -31,40 +31,27 @@ jobs:
 
           count=$(echo "$pr_links" | wc -w)
           if [ "$count" -gt 0 ]; then
+            # Format PR links for display
+            pr_links_formatted=$(echo "$pr_links" | tr ' ' '\n' | awk '{print "- " $0}' | tr '\n' '\n')
+            
             # Write outputs to GITHUB_OUTPUT instead of using ::set-output
             echo "status=failed" >> $GITHUB_OUTPUT
             echo "links=$pr_links" >> $GITHUB_OUTPUT
+            echo "links_formatted=$pr_links_formatted" >> $GITHUB_OUTPUT
             echo "❌ Error: Open PRs with label \"offsets\" found!" >&2
             exit 1
           else
             echo "status=success" >> $GITHUB_OUTPUT
             echo "✅ No open PRs with label \"offsets\"."
           fi
-
-      - name: Notify Slack on Success
-        if: ${{ steps.verify.outputs.status == 'success' }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{
-            "description": "✅ No open offset PRs in `${{ matrix.repo }}`",
-            "tag": "verify-offsets-success"
-          }' $SLACK_WEBHOOK_URL
-
-      - name: Notify Slack on Failure
-        if: ${{ failure() }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          PR_LINKS: ${{ steps.verify.outputs.links }}
-        run: |
-          pr_links_formatted=$(echo "$PR_LINKS" | tr ' ' '\n' | awk '{print "- " $0}' | tr '\n' '\n')
-          curl -X POST -H 'Content-type: application/json' --data "{
-            \"description\": \"❌ ERROR: Open offset PRs found in \`${{ matrix.repo }}\`\n\n$pr_links_formatted\",
-            \"link\": \"https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}\",
-            \"tag\": \"verify-offsets-failure\"
-          }" $SLACK_WEBHOOK_URL
+      
+      - name: Notify Slack
+        if: always()
+        uses: odigos-io/github-actions/.github/actions/slack-release-notification@main
+        with: 
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          success-description: "No open offset PRs in `${{ matrix.repo }}`"
+          failure-description: "ERROR: Open offset PRs found in `${{ matrix.repo }}`\n\n${{ steps.verify.outputs.links_formatted }}"
 
   verify-dependencies-sync:
     if: github.actor != 'keyval-release-bot'
@@ -87,9 +74,13 @@ jobs:
 
           count=$(echo "$pr_links" | wc -w)
           if [ "$count" -gt 0 ]; then
+            # Format PR links for display
+            pr_links_formatted=$(echo "$pr_links" | tr ' ' '\n' | awk '{print "- " $0}' | tr '\n' '\n')
+            
             # Write outputs to GITHUB_OUTPUT instead of using ::set-output
             echo "status=failed" >> $GITHUB_OUTPUT
             echo "links=$pr_links" >> $GITHUB_OUTPUT
+            echo "pr_links_formatted=$pr_links_formatted" >> $GITHUB_OUTPUT
             echo "❌ Error: Open PRs with label \"dependencies-syncer-bot\" found!" >&2
             exit 1
           else
@@ -97,30 +88,13 @@ jobs:
             echo "✅ No open PRs with label \"dependencies-syncer-bot\"."
           fi
 
-      - name: Notify Slack on Success
-        if: ${{ steps.verify.outputs.status == 'success' }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{
-            "description": "✅ No open dependencies-syncer-bot PRs in `${{ matrix.repo }}`",
-            "tag": "verify-dependencies-sync-success"
-          }' $SLACK_WEBHOOK_URL
-
-      - name: Notify Slack on Failure
-        if: ${{ failure() }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          PR_LINKS: ${{ steps.verify.outputs.links }}
-        run: |
-          pr_links_formatted=$(echo "$PR_LINKS" | tr ' ' '\n' | awk '{print "- " $0}' | tr '\n' '\n')
-          curl -X POST -H 'Content-type: application/json' --data "{
-            \"description\": \"❌ ERROR: Open depenencies-syncer-bot PRs found in \`${{ matrix.repo }}\`\n\n$pr_links_formatted\",
-            \"link\": \"https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}\",
-            \"tag\": \"verify-dependencies-sync-failure\"
-          }" $SLACK_WEBHOOK_URL
+      - name: Notify Slack
+        if: always()
+        uses: odigos-io/github-actions/.github/actions/slack-release-notification@main
+        with: 
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          success-description: "No open dependencies-syncer-bot PRs in `${{ matrix.repo }}`"
+          failure-description: "ERROR: Open dependencies-syncer-bot PRs found in `${{ matrix.repo }}`\n\n${{ steps.verify.outputs.pr_links_formatted }}"
 
   verify-release-blockers:
     if: github.actor != 'keyval-release-bot'
@@ -143,9 +117,13 @@ jobs:
 
           count=$(echo "$pr_links" | wc -w)
           if [ "$count" -gt 0 ]; then
+            # Format PR links for display
+            pr_links_formatted=$(echo "$pr_links" | tr ' ' '\n' | awk '{print "- " $0}' | tr '\n' '\n')
+            
             # Write outputs to GITHUB_OUTPUT instead of using ::set-output
             echo "status=failed" >> $GITHUB_OUTPUT
             echo "links=$pr_links" >> $GITHUB_OUTPUT
+            echo "pr_links_formatted=$pr_links_formatted" >> $GITHUB_OUTPUT
             echo "❌ Error: Open PRs with label \"release-blocker\" found!" >&2
             exit 1
           else
@@ -153,31 +131,14 @@ jobs:
             echo "✅ No open PRs with label \"release-blocker\"."
           fi
 
-      - name: Notify Slack on Success
-        if: ${{ steps.verify.outputs.status == 'success' }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{
-            "description": "✅ No open release-blocker PRs in `${{ matrix.repo }}`",
-            "tag": "verify-release-blockers-success"
-          }' $SLACK_WEBHOOK_URL
-
-      - name: Notify Slack on Failure
-        if: ${{ failure() }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          PR_LINKS: ${{ steps.verify.outputs.links }}
-        run: |
-          pr_links_formatted=$(echo "$PR_LINKS" | tr ' ' '\n' | awk '{print "- " $0}' | tr '\n' '\n')
-          curl -X POST -H 'Content-type: application/json' --data "{
-            \"description\": \"❌ ERROR: Open release-blocker PRs found in \`${{ matrix.repo }}\`\n\n$pr_links_formatted\",
-            \"link\": \"https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}\",
-            \"tag\": \"verify-release-blockers-failure\"
-          }" $SLACK_WEBHOOK_URL
-
+      - name: Notify Slack
+        if: always()
+        uses: odigos-io/github-actions/.github/actions/slack-release-notification@main
+        with: 
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          success-description: "No open release-blocker PRs in `${{ matrix.repo }}`"
+          failure-description: "ERROR: Open release-blocker PRs found in `${{ matrix.repo }}`\n\n${{ steps.verify.outputs.pr_links_formatted }}"
+          
   print-tag:
     if: github.actor != 'keyval-release-bot'
     needs: verify-release-blockers
@@ -188,10 +149,12 @@ jobs:
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
       - name: Notify Slack Start
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"description":"Detected new git tag. initializing a release", "tag":"${{ steps.extract_tag.outputs.tag }}"}' ${{ env.SLACK_WEBHOOK_URL }}
+        uses: odigos-io/github-actions/.github/actions/slack-release-notification@main
+        with: 
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          success-description: "detected new git tag ${{ steps.extract_tag.outputs.tag }}, starting a release"
+          failure-description: "error during detection of new git tag ${{ steps.extract_tag.outputs.tag }}"
+          tag: ${{ steps.extract_tag.outputs.tag }}
 
   tag-modules:
     if: github.actor != 'keyval-release-bot'
@@ -208,11 +171,13 @@ jobs:
         id: extract_tag
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
-      - name: Notify Modules Tagging
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"description":"Tagging odigos modules so they can be consumed as libraries", "tag":"${{ steps.extract_tag.outputs.tag }}"}' ${{ env.SLACK_WEBHOOK_URL }}
+      - name: Notify Slack Start
+        uses: odigos-io/github-actions/.github/actions/slack-release-notification@main
+        with: 
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          success-description: "start tagging odigos modules so they can be consumed as libraries"
+          failure-description: "error during tagging of odigos modules"
+          tag: ${{ steps.extract_tag.outputs.tag }}
 
       - name: tag modules
         run: |
@@ -236,20 +201,14 @@ jobs:
           https://api.github.com/repos/odigos-io/odigos-enterprise/dispatches \
             -d '{"event_type": "create_release_pr", "client_payload": {"tag": "${{ steps.extract_tag.outputs.tag }}"}}'
 
-      - name: Notify Slack End
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"description":"Odigos go modules tagged successfully", "tag":"${{ steps.extract_tag.outputs.tag }}"}' ${{ env.SLACK_WEBHOOK_URL }}
-
-      - name: Notify Slack on Failure
-        if: ${{ failure() || cancelled() }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"link":"https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}", "description":"ERROR: Odigos go modules release failed", "tag":"${{ steps.extract_tag.outputs.tag }}"}' ${{ env.SLACK_WEBHOOK_URL }}
+      - name: Notify Slack Success
+        if: always()
+        uses: odigos-io/github-actions/.github/actions/slack-release-notification@main
+        with: 
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          success-description: "Odigos go modules tagged successfully"
+          failure-description: "ERROR: Odigos go modules tagging failed"
+          tag: ${{ steps.extract_tag.outputs.tag }}
 
   publish-images:
     if: github.actor != 'keyval-release-bot'
@@ -304,11 +263,13 @@ jobs:
         id: extract_tag
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
-      - name: Notify Modules Tagging
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"description":"Start building docker image for component ${{ matrix.service }}", "tag":"${{ steps.extract_tag.outputs.tag }}"}' ${{ env.SLACK_WEBHOOK_URL }}
+      - name: Notify Slack Start
+        uses: odigos-io/github-actions/.github/actions/slack-release-notification@main
+        with: 
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          success-description: "start publishing docker image for component ${{ matrix.service }} and dockerfile ${{ matrix.dockerfile }}"
+          failure-description: "error during building or publishing of docker image for component ${{ matrix.service }} and dockerfile ${{ matrix.dockerfile }}"
+          tag: ${{ steps.extract_tag.outputs.tag }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -373,20 +334,14 @@ jobs:
                 matrix.service == 'agents' && format('agents/{0}', matrix.dockerfile) ||
                 matrix.dockerfile }}
 
-      - name: Notify Slack End
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"description":"Odigos component ${{ matrix.service }} released successfully", "tag":"${{ steps.extract_tag.outputs.tag }}"}' ${{ env.SLACK_WEBHOOK_URL }}
-
-      - name: Notify Slack on Failure
-        if: ${{ failure() || cancelled() }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"link":"https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}", "description":"ERROR: odigos component ${{ matrix.service }} release failed", "tag":"${{ steps.extract_tag.outputs.tag }}"}' ${{ env.SLACK_WEBHOOK_URL }}
+      - name: Notify Slack
+        if: always()
+        uses: odigos-io/github-actions/.github/actions/slack-release-notification@main
+        with: 
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          success-description: "Odigos component ${{ matrix.service }} with dockerfile ${{ matrix.dockerfile }} released successfully"
+          failure-description: "ERROR: Odigos component ${{ matrix.service }} with dockerfile ${{ matrix.dockerfile }} release failed"
+          tag: ${{ steps.extract_tag.outputs.tag }}
 
   publish-collector-linux-packages:
     if: github.actor != 'keyval-release-bot'
@@ -398,10 +353,13 @@ jobs:
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
       - name: Notify Slack Start
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"description":"Start releasing odigos collector as linux packages", "tag":"${{ steps.extract_tag.outputs.tag }}"}' ${{ env.SLACK_WEBHOOK_URL }}
+        if: always()
+        uses: odigos-io/github-actions/.github/actions/slack-release-notification@main
+        with: 
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          success-description: "start releasing odigos collector as linux packages"
+          failure-description: "error during releasing of odigos collector as linux packages"
+          tag: ${{ steps.extract_tag.outputs.tag }}
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -431,17 +389,11 @@ jobs:
           FURY_ACCOUNT: ${{ secrets.FURY_ACCOUNT }}
           FURY_API_TOKEN: ${{ secrets.FURY_API_TOKEN }}
 
-      - name: Notify Slack End
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"description":"Odigos collector linux packages released successfully", "tag":"${{ steps.extract_tag.outputs.tag }}"}' ${{ env.SLACK_WEBHOOK_URL }}
-
-      - name: Notify Slack on Failure
-        if: ${{ failure() || cancelled() }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"link":"https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}", "description":"ERROR: failed to publish odigos collector linux packages", "tag":"${{ steps.extract_tag.outputs.tag }}"}' ${{ env.SLACK_WEBHOOK_URL }}
+      - name: Notify Slack Success
+        if: always()
+        uses: odigos-io/github-actions/.github/actions/slack-release-notification@main
+        with: 
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          success-description: "Odigos collector linux packages released successfully"
+          failure-description: "ERROR: Odigos collector linux packages release failed"
+          tag: ${{ steps.extract_tag.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,10 +59,12 @@ jobs:
           echo "date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
 
       - name: Notify Slack Start
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"description":"Starting Odigos CLI release", "tag":"${{ env.TAG }}"}' ${{ env.SLACK_WEBHOOK_URL }}
+        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
+        with: 
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          success-description: "Starting Odigos CLI release for tag ${{ env.TAG }}"
+          failure-description: "ERROR: Failed to start Odigos CLI release"
+          tag: ${{ env.TAG }}
 
       - name: Verify Components Image Ready
         run: |
@@ -151,26 +153,23 @@ jobs:
           crane copy ${SOURCE_IMAGE}:${{ env.TAG }} ${DEST_IMAGE}:${{ env.TAG }}
           crane copy ${SOURCE_IMAGE}:latest ${DEST_IMAGE}:latest
 
-      - name: Notify Slack End
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+      - name: Set notification messages
         run: |
-          if [[ "${{ env.IS_PRERELEASE }}" == "false" ]]; then
-            DESCRIPTION="Odigos CLI stable release completed successfully"
+          if [ "${{ env.IS_PRERELEASE }}" = "false" ]; then
+            echo "SUCCESS_MSG=Odigos CLI stable release completed successfully" >> $GITHUB_ENV
+            echo "FAILURE_MSG=ERROR: Failed to publish Odigos CLI image to Docker Hub" >> $GITHUB_ENV
           else
-            DESCRIPTION="Odigos CLI pre-release completed successfully"
+            echo "SUCCESS_MSG=Odigos CLI pre-release completed successfully" >> $GITHUB_ENV
+            echo "FAILURE_MSG=ERROR: Failed to publish Odigos CLI image to Docker Hub" >> $GITHUB_ENV
           fi
-          
-          curl -X POST -H 'Content-type: application/json' --data "{\"description\":\"$DESCRIPTION\", \"tag\":\"${{ env.TAG }}\"}" ${{ env.SLACK_WEBHOOK_URL }}
 
-      - name: Notify Slack on Failure
-        if: ${{ failure() || cancelled() }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"link":"https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}", "description":"ERROR: failed to publish odigos CLI", "tag":"${{ env.TAG }}"}' ${{ env.SLACK_WEBHOOK_URL }}
+      - name: Notify Slack
+        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
+        with: 
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          success-description: ${{ env.SUCCESS_MSG }}
+          failure-description: ${{ env.FAILURE_MSG }}
+          tag: ${{ env.TAG }}
 
   trigger-openshift-certification:
     needs: release-cli
@@ -231,17 +230,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: bash ./scripts/release-charts.sh
 
-      - name: Notify Slack End
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"description":"Helm charts released successfully. new version is ready", "tag":"${{ env.TAG }}"}' ${{ env.SLACK_WEBHOOK_URL }}
 
-      - name: Notify Slack on Failure
-        if: ${{ failure() || cancelled() }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"link":"https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}", "description":"ERROR: failed to release Helm charts", "tag":"${{ env.TAG }}"}' ${{ env.SLACK_WEBHOOK_URL }}
+      - name: Notify Slack
+        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
+        with: 
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          success-description: "Helm charts released successfully. new version is ready"
+          failure-description: "ERROR: Failed to release Helm charts"
+          tag: ${{ env.TAG }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,7 @@ jobs:
         run: |
           if [ "${{ env.IS_PRERELEASE }}" = "false" ]; then
             echo "SUCCESS_MSG=Odigos CLI stable release completed successfully" >> $GITHUB_ENV
-            echo "FAILURE_MSG=ERROR: Failed to publish Odigos CLI image to Docker Hub" >> $GITHUB_ENV
+            echo "FAILURE_MSG=ERROR: Failed to publish Odigos CLI image to registries" >> $GITHUB_ENV
           else
             echo "SUCCESS_MSG=Odigos CLI pre-release completed successfully" >> $GITHUB_ENV
             echo "FAILURE_MSG=ERROR: Failed to publish Odigos CLI image to registries" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
             echo "FAILURE_MSG=ERROR: Failed to publish Odigos CLI image to Docker Hub" >> $GITHUB_ENV
           else
             echo "SUCCESS_MSG=Odigos CLI pre-release completed successfully" >> $GITHUB_ENV
-            echo "FAILURE_MSG=ERROR: Failed to publish Odigos CLI image to Docker Hub" >> $GITHUB_ENV
+            echo "FAILURE_MSG=ERROR: Failed to publish Odigos CLI image to registries" >> $GITHUB_ENV
           fi
 
       - name: Notify Slack


### PR DESCRIPTION
Fixes: CORE-186

nit improvement to the CI release. it is currently clattered with many individual "curl"s to update slack for release notifications.

This logic is now extracted to https://github.com/odigos-io/github-actions where it's abstracted and reusable, and also guarantee consistent formating
