### PR TITLE
fix(collector): increase the livness probe to 5 sec

### DIFF
--- a/autoscaler/controllers/clustercollector/deployment.go
+++ b/autoscaler/controllers/clustercollector/deployment.go
@@ -224,6 +224,10 @@ func getDesiredDeployment(ctx context.Context, c client.Client, dests *odigosv1.
 										Port: intstr.FromInt(13133),
 									},
 								},
+								FailureThreshold: 3,
+								PeriodSeconds:    10,
+								SuccessThreshold: 1,
+								TimeoutSeconds:   5,
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
@@ -232,6 +236,10 @@ func getDesiredDeployment(ctx context.Context, c client.Client, dests *odigosv1.
 										Port: intstr.FromInt(13133),
 									},
 								},
+								FailureThreshold: 3,
+								PeriodSeconds:    10,
+								SuccessThreshold: 1,
+								TimeoutSeconds:   5,
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{


### PR DESCRIPTION
Fixes: CORE-188


Our gateway collector, under load, will have it's CPU and memory under pressure. If the CPU is the limiting factor, then the endpoint for the health_check might take time to response, and can timeout the kubelet caller, and fail the check.

After 2 failed check the collector will be restarted.

This PR increase the value to 5 seconds (which is still an arbitrary number, but less likely to fail). 