### PR TITLE
fix: reject data in memory limit before grpc decode (#3420)

### DIFF
--- a/collector/config/configgrpc/configgrpc_test.go
+++ b/collector/config/configgrpc/configgrpc_test.go
@@ -303,7 +303,7 @@ func TestDefaultGrpcServerSettings(t *testing.T) {
 	}
 	opts, err := gss.getGrpcServerOptions(context.Background(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings(), []ToServerOption{})
 	require.NoError(t, err)
-	assert.Len(t, opts, 3)
+	assert.Len(t, opts, 4)
 }
 
 func TestGrpcServerExtraOption(t *testing.T) {
@@ -320,8 +320,8 @@ func TestGrpcServerExtraOption(t *testing.T) {
 		[]ToServerOption{WithGrpcServerOption(extraOpt)},
 	)
 	require.NoError(t, err)
-	assert.Len(t, opts, 4)
-	assert.Equal(t, opts[3], extraOpt)
+	assert.Len(t, opts, 5)
+	assert.Equal(t, opts[4], extraOpt)
 }
 
 func TestGrpcServerValidate(t *testing.T) {
@@ -406,7 +406,7 @@ func TestAllGrpcServerSettingsExceptAuth(t *testing.T) {
 	}
 	opts, err := gss.getGrpcServerOptions(context.Background(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings(), []ToServerOption{})
 	require.NoError(t, err)
-	assert.Len(t, opts, 10)
+	assert.Len(t, opts, 11)
 }
 
 func TestGrpcServerAuthSettings(t *testing.T) {


### PR DESCRIPTION
Fixes: CORE-194

Until now, we were using interceptors which runs after gRPC has already decoded the export request into memory.

This can dramatically increase the memory usage even when under memory pressure.

This PR move the memory pressure check to happen before the gRPC decode which increases the stability

---------

## Description

<!-- Short summary of the changes -->

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
