### PR TITLE
feat: odiglet will communicate with data collection using localhost - CORE-195

### DIFF
--- a/odiglet/pkg/ebpf/sdks/go.go
+++ b/odiglet/pkg/ebpf/sdks/go.go
@@ -6,10 +6,9 @@ import (
 
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/common"
-	"github.com/odigos-io/odigos/k8sutils/pkg/service"
+	"github.com/odigos-io/odigos/common/consts"
 
 	"github.com/odigos-io/odigos/instrumentation"
-	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	"github.com/odigos-io/odigos/odiglet/pkg/ebpf"
 
 	"github.com/odigos-io/odigos/odiglet/pkg/log"
@@ -36,7 +35,7 @@ func (g *GoInstrumentationFactory) CreateInstrumentation(ctx context.Context, pi
 	defaultExporter, err := otlptracegrpc.New(
 		ctx,
 		otlptracegrpc.WithInsecure(),
-		otlptracegrpc.WithEndpoint(service.LocalTrafficOTLPGrpcDataCollectionEndpoint(env.Current.NodeIP)),
+		otlptracegrpc.WithEndpoint(fmt.Sprintf("localhost:%d", consts.OTLPPort)),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create exporter: %w", err)


### PR DESCRIPTION
## Description

Since data collection and odiglet are now two containers in the same pod we can use localhost for them to communicate and by that solve reported issues about local services problems.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
