### PR TITLE
chore: make aks cluster node a bit bigger - CORE-199

### DIFF
--- a/tests-infrastructure/terraform/aks/main.tf
+++ b/tests-infrastructure/terraform/aks/main.tf
@@ -11,7 +11,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
   default_node_pool {
     name       = "default"
     node_count = var.node_count
-    vm_size    = "Standard_B2s"
+    vm_size    = "Standard_B4ms"
   }
 
   identity {


### PR DESCRIPTION
## Description

In aks we dont have enough resources to deploy odigos with the test apps
```
odigos-test   48s         Warning   FailedScheduling               pod/odigos-gateway-675b9dc8bb-9wpxs                    0/2 nodes are available: 1 Insufficient memory, 2 Insufficient cpu. preemption: 0/2 nodes are available: 2 No preemption victims found for incoming pod.
```
## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
