### PR TITLE
chore: introduce an enum for env injection decision and use in reconcile

### DIFF
--- a/api/config/crd/bases/odigos.io_instrumentationconfigs.yaml
+++ b/api/config/crd/bases/odigos.io_instrumentationconfigs.yaml
@@ -93,19 +93,6 @@ spec:
                       - RuntimeDetailsUnavailable
                       - CrashLoopBackOff
                       type: string
-                    agentInjectionMethod:
-                      description: |-
-                        this value is calculated (at the moment) based on the config, runtime inspection and the user defined overrides.
-                        This field carries the following semantics:
-                        - nil: do not inject any "append variables" (PYTHONPATH, NODE_OPTIONS, etc.) at all.
-                        - "loader": inject the LD_PRELOAD env var to the pod manifest which will trigger the odigos loader.
-                        - "pod-manifest": inject the runtime specific agent loading env vars (e.g PYTHONPATH, NODE_OPTIONS) to the pod manifest as specified in the distro manifest.
-                        - "loader-fallback-to-pod-manifest": use "pod-manifest". it means we tried LD_PRELOAD and it failed, so we falled-back to the pod manifest.
-                      enum:
-                      - loader
-                      - pod-manifest
-                      - loader-fallback-to-pod-manifest
-                      type: string
                     containerName:
                       description: The name of the container to which this configuration
                         applies.
@@ -117,6 +104,16 @@ spec:
                         Additional parameters to the distro that controls how it's being applied.
                         Keys are parameter names (like "libc") and values are the value to use for that parameter (glibc / musl)
                       type: object
+                    envInjectionMethod:
+                      description: |-
+                        What method to use for injecting the agent environment variables (just those covered by the loader (PYTHONPATH, JAVA_TOOLS_OPTIONS, NODE_OPTIONS))
+                        Can be either "loader" or "pod-manifest".
+                        The injection should still check the actual values in the container manifest before injecting.
+                        Nil means that this container should not have env injection (agent should not be injected, or distro does not specify "loader" injection envs).
+                      enum:
+                      - loader
+                      - pod-manifest
+                      type: string
                     logs:
                       description: |-
                         all "logs" related configuration for an agent running on any process in a specific container.

--- a/api/generated/odigos/applyconfiguration/odigos/v1alpha1/containeragentconfig.go
+++ b/api/generated/odigos/applyconfiguration/odigos/v1alpha1/containeragentconfig.go
@@ -31,7 +31,7 @@ type ContainerAgentConfigApplyConfiguration struct {
 	AgentEnabledMessage *string                            `json:"agentEnabledMessage,omitempty"`
 	OtelDistroName      *string                            `json:"otelDistroName,omitempty"`
 	DistroParams        map[string]string                  `json:"distroParams,omitempty"`
-	EnvInjectionMethod  *common.EnvInjectionMethod         `json:"agentInjectionMethod,omitempty"`
+	EnvInjectionMethod  *common.EnvInjectionDecision       `json:"envInjectionMethod,omitempty"`
 	Traces              *odigosv1alpha1.AgentTracesConfig  `json:"traces,omitempty"`
 	Metrics             *odigosv1alpha1.AgentMetricsConfig `json:"metrics,omitempty"`
 	Logs                *odigosv1alpha1.AgentLogsConfig    `json:"logs,omitempty"`
@@ -100,7 +100,7 @@ func (b *ContainerAgentConfigApplyConfiguration) WithDistroParams(entries map[st
 // WithEnvInjectionMethod sets the EnvInjectionMethod field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the EnvInjectionMethod field is set to the value of the last call.
-func (b *ContainerAgentConfigApplyConfiguration) WithEnvInjectionMethod(value common.EnvInjectionMethod) *ContainerAgentConfigApplyConfiguration {
+func (b *ContainerAgentConfigApplyConfiguration) WithEnvInjectionMethod(value common.EnvInjectionDecision) *ContainerAgentConfigApplyConfiguration {
 	b.EnvInjectionMethod = &value
 	return b
 }

--- a/api/odigos/v1alpha1/instrumentationconfig_types.go
+++ b/api/odigos/v1alpha1/instrumentationconfig_types.go
@@ -290,13 +290,11 @@ type ContainerAgentConfig struct {
 	// Keys are parameter names (like "libc") and values are the value to use for that parameter (glibc / musl)
 	DistroParams map[string]string `json:"distroParams,omitempty"`
 
-	// this value is calculated (at the moment) based on the config, runtime inspection and the user defined overrides.
-	// This field carries the following semantics:
-	// - nil: do not inject any "append variables" (PYTHONPATH, NODE_OPTIONS, etc.) at all.
-	// - "loader": inject the LD_PRELOAD env var to the pod manifest which will trigger the odigos loader.
-	// - "pod-manifest": inject the runtime specific agent loading env vars (e.g PYTHONPATH, NODE_OPTIONS) to the pod manifest as specified in the distro manifest.
-	// - "loader-fallback-to-pod-manifest": use "pod-manifest". it means we tried LD_PRELOAD and it failed, so we falled-back to the pod manifest.
-	EnvInjectionMethod *common.EnvInjectionMethod `json:"agentInjectionMethod,omitempty"`
+	// What method to use for injecting the agent environment variables (just those covered by the loader (PYTHONPATH, JAVA_TOOLS_OPTIONS, NODE_OPTIONS))
+	// Can be either "loader" or "pod-manifest".
+	// The injection should still check the actual values in the container manifest before injecting.
+	// Nil means that this container should not have env injection (agent should not be injected, or distro does not specify "loader" injection envs).
+	EnvInjectionMethod *common.EnvInjectionDecision `json:"envInjectionMethod,omitempty"`
 
 	// Each enabled signal must be set with a non-nil value (even if the config content is empty).
 	// nil means that the signal is disabled and should not be instrumented/collected by the agent.

--- a/api/odigos/v1alpha1/zz_generated.deepcopy.go
+++ b/api/odigos/v1alpha1/zz_generated.deepcopy.go
@@ -410,7 +410,7 @@ func (in *ContainerAgentConfig) DeepCopyInto(out *ContainerAgentConfig) {
 	}
 	if in.EnvInjectionMethod != nil {
 		in, out := &in.EnvInjectionMethod, &out.EnvInjectionMethod
-		*out = new(common.EnvInjectionMethod)
+		*out = new(common.EnvInjectionDecision)
 		**out = **in
 	}
 	if in.Traces != nil {

--- a/common/env_injection_method.go
+++ b/common/env_injection_method.go
@@ -25,6 +25,6 @@ type EnvInjectionDecision string
 // this decision is based on the runtime inspection, user overrides, and the distro support,
 // and reflects what odigos is actually plan to use.
 const (
-	EnvInjectionDecisionLoader      EnvInjectionDecision = "loader"
-	EnvInjectionDecisionPodManifest EnvInjectionDecision = "pod-manifest"
+	EnvInjectionDecisionLoader     =  EnvInjectionDecision(LoaderEnvInjectionMethod)
+	EnvInjectionDecisionPodManifest = EnvInjectionDecision(PodManifestEnvInjectionMethod)
 )

--- a/common/env_injection_method.go
+++ b/common/env_injection_method.go
@@ -16,3 +16,15 @@ const (
 	// and taking into account the user defined values and appending if necessary.
 	LoaderFallbackToPodManifestInjectionMethod EnvInjectionMethod = "loader-fallback-to-pod-manifest"
 )
+
+// +kubebuilder:validation:Enum=loader;pod-manifest
+type EnvInjectionDecision string
+
+// The decision on the actual injection method to use for a specific pod.
+// While the configuration allows one to choose options with fallbaks,
+// this decision is based on the runtime inspection, user overrides, and the distro support,
+// and reflects what odigos is actually plan to use.
+const (
+	EnvInjectionDecisionLoader      EnvInjectionDecision = "loader"
+	EnvInjectionDecisionPodManifest EnvInjectionDecision = "pod-manifest"
+)

--- a/common/env_injection_method.go
+++ b/common/env_injection_method.go
@@ -25,6 +25,6 @@ type EnvInjectionDecision string
 // this decision is based on the runtime inspection, user overrides, and the distro support,
 // and reflects what odigos is actually plan to use.
 const (
-	EnvInjectionDecisionLoader     =  EnvInjectionDecision(LoaderEnvInjectionMethod)
+	EnvInjectionDecisionLoader      = EnvInjectionDecision(LoaderEnvInjectionMethod)
 	EnvInjectionDecisionPodManifest = EnvInjectionDecision(PodManifestEnvInjectionMethod)
 )

--- a/docs/api-reference/odigos.io.v1alpha1.mdx
+++ b/docs/api-reference/odigos.io.v1alpha1.mdx
@@ -1139,20 +1139,16 @@ Keys are parameter names (like &quot;libc&quot;) and values are the value to use
 </tr>
 <tr>
 <td>
-<code>agentInjectionMethod</code> <B>[Required]</B>
+<code>envInjectionMethod</code> <B>[Required]</B>
 </td>
 <td>
-<a href="https://pkg.go.dev/github.com/odigos-io/odigos/common#EnvInjectionMethod"><code>common.EnvInjectionMethod</code></a>
+<a href="https://pkg.go.dev/github.com/odigos-io/odigos/common#EnvInjectionDecision"><code>common.EnvInjectionDecision</code></a>
 </td>
 <td>
-   <p>this value is calculated (at the moment) based on the config, runtime inspection and the user defined overrides.
-This field carries the following semantics:</p>
-<ul>
-<li>nil: do not inject any &quot;append variables&quot; (PYTHONPATH, NODE_OPTIONS, etc.) at all.</li>
-<li>&quot;loader&quot;: inject the LD_PRELOAD env var to the pod manifest which will trigger the odigos loader.</li>
-<li>&quot;pod-manifest&quot;: inject the runtime specific agent loading env vars (e.g PYTHONPATH, NODE_OPTIONS) to the pod manifest as specified in the distro manifest.</li>
-<li>&quot;loader-fallback-to-pod-manifest&quot;: use &quot;pod-manifest&quot;. it means we tried LD_PRELOAD and it failed, so we falled-back to the pod manifest.</li>
-</ul>
+   <p>What method to use for injecting the agent environment variables (just those covered by the loader (PYTHONPATH, JAVA_TOOLS_OPTIONS, NODE_OPTIONS))
+Can be either &quot;loader&quot; or &quot;pod-manifest&quot;.
+The injection should still check the actual values in the container manifest before injecting.
+Nil means that this container should not have env injection (agent should not be injected, or distro does not specify &quot;loader&quot; injection envs).</p>
 </td>
 </tr>
 <tr>

--- a/helm/odigos/templates/crds/odigos.io_instrumentationconfigs.yaml
+++ b/helm/odigos/templates/crds/odigos.io_instrumentationconfigs.yaml
@@ -93,19 +93,6 @@ spec:
                       - RuntimeDetailsUnavailable
                       - CrashLoopBackOff
                       type: string
-                    agentInjectionMethod:
-                      description: |-
-                        this value is calculated (at the moment) based on the config, runtime inspection and the user defined overrides.
-                        This field carries the following semantics:
-                        - nil: do not inject any "append variables" (PYTHONPATH, NODE_OPTIONS, etc.) at all.
-                        - "loader": inject the LD_PRELOAD env var to the pod manifest which will trigger the odigos loader.
-                        - "pod-manifest": inject the runtime specific agent loading env vars (e.g PYTHONPATH, NODE_OPTIONS) to the pod manifest as specified in the distro manifest.
-                        - "loader-fallback-to-pod-manifest": use "pod-manifest". it means we tried LD_PRELOAD and it failed, so we falled-back to the pod manifest.
-                      enum:
-                      - loader
-                      - pod-manifest
-                      - loader-fallback-to-pod-manifest
-                      type: string
                     containerName:
                       description: The name of the container to which this configuration
                         applies.
@@ -117,6 +104,16 @@ spec:
                         Additional parameters to the distro that controls how it's being applied.
                         Keys are parameter names (like "libc") and values are the value to use for that parameter (glibc / musl)
                       type: object
+                    envInjectionMethod:
+                      description: |-
+                        What method to use for injecting the agent environment variables (just those covered by the loader (PYTHONPATH, JAVA_TOOLS_OPTIONS, NODE_OPTIONS))
+                        Can be either "loader" or "pod-manifest".
+                        The injection should still check the actual values in the container manifest before injecting.
+                        Nil means that this container should not have env injection (agent should not be injected, or distro does not specify "loader" injection envs).
+                      enum:
+                      - loader
+                      - pod-manifest
+                      type: string
                     logs:
                       description: |-
                         all "logs" related configuration for an agent running on any process in a specific container.


### PR DESCRIPTION
Fixes: CORE-205

Just renaming the existing property, and introducing an enum for the decisions.

Using one enum for both config and decision was confusing, as the `loader-fallback-to-pod-manifest` does not feet well into this step which is what we are actually going to use