### PR TITLE
refactor: set cri error on runtime detection only when there is actual error

### DIFF
--- a/api/config/crd/bases/odigos.io_instrumentationconfigs.yaml
+++ b/api/config/crd/bases/odigos.io_instrumentationconfigs.yaml
@@ -161,9 +161,12 @@ spec:
                         containerName:
                           type: string
                         criErrorMessage:
-                          description: Stores the error message from the CRI runtime
-                            if returned to prevent instrumenting the container if
-                            an error exists.
+                          description: |-
+                            CriErrorMessage is set if the value in EnvFromContainerRuntime was not computed correctly and cannot be used safely.
+                            Sometimes, even if CRI check failed, it is possible to tell that relevant env vars are not coming from container runtime.
+                            Thus, this field is set only when there is:
+                            - Actual CRI check failed
+                            - The observed environment variables might come from container runtime
                           type: string
                         envFromContainerRuntime:
                           description: Holds the environment variables retrieved from
@@ -746,9 +749,12 @@ spec:
                     containerName:
                       type: string
                     criErrorMessage:
-                      description: Stores the error message from the CRI runtime if
-                        returned to prevent instrumenting the container if an error
-                        exists.
+                      description: |-
+                        CriErrorMessage is set if the value in EnvFromContainerRuntime was not computed correctly and cannot be used safely.
+                        Sometimes, even if CRI check failed, it is possible to tell that relevant env vars are not coming from container runtime.
+                        Thus, this field is set only when there is:
+                        - Actual CRI check failed
+                        - The observed environment variables might come from container runtime
                       type: string
                     envFromContainerRuntime:
                       description: Holds the environment variables retrieved from

--- a/api/config/crd/bases/odigos.io_sources.yaml
+++ b/api/config/crd/bases/odigos.io_sources.yaml
@@ -74,9 +74,12 @@ spec:
                         containerName:
                           type: string
                         criErrorMessage:
-                          description: Stores the error message from the CRI runtime
-                            if returned to prevent instrumenting the container if
-                            an error exists.
+                          description: |-
+                            CriErrorMessage is set if the value in EnvFromContainerRuntime was not computed correctly and cannot be used safely.
+                            Sometimes, even if CRI check failed, it is possible to tell that relevant env vars are not coming from container runtime.
+                            Thus, this field is set only when there is:
+                            - Actual CRI check failed
+                            - The observed environment variables might come from container runtime
                           type: string
                         envFromContainerRuntime:
                           description: Holds the environment variables retrieved from

--- a/api/odigos/v1alpha1/instrumentationconfig_types.go
+++ b/api/odigos/v1alpha1/instrumentationconfig_types.go
@@ -219,7 +219,11 @@ type RuntimeDetailsByContainer struct {
 	// nil means we were unable to determine the secure-execution mode.
 	SecureExecutionMode *bool `json:"secureExecutionMode,omitempty"`
 
-	// Stores the error message from the CRI runtime if returned to prevent instrumenting the container if an error exists.
+	// CriErrorMessage is set if the value in EnvFromContainerRuntime was not computed correctly and cannot be used safely.
+	// Sometimes, even if CRI check failed, it is possible to tell that relevant env vars are not coming from container runtime.
+	// Thus, this field is set only when there is:
+	// - Actual CRI check failed
+	// - The observed environment variables might come from container runtime
 	CriErrorMessage *string `json:"criErrorMessage,omitempty"`
 	// Holds the environment variables retrieved from the container runtime.
 	EnvFromContainerRuntime []EnvVar `json:"envFromContainerRuntime,omitempty"`

--- a/helm/odigos/templates/crds/odigos.io_instrumentationconfigs.yaml
+++ b/helm/odigos/templates/crds/odigos.io_instrumentationconfigs.yaml
@@ -161,9 +161,12 @@ spec:
                         containerName:
                           type: string
                         criErrorMessage:
-                          description: Stores the error message from the CRI runtime
-                            if returned to prevent instrumenting the container if
-                            an error exists.
+                          description: |-
+                            CriErrorMessage is set if the value in EnvFromContainerRuntime was not computed correctly and cannot be used safely.
+                            Sometimes, even if CRI check failed, it is possible to tell that relevant env vars are not coming from container runtime.
+                            Thus, this field is set only when there is:
+                            - Actual CRI check failed
+                            - The observed environment variables might come from container runtime
                           type: string
                         envFromContainerRuntime:
                           description: Holds the environment variables retrieved from
@@ -746,9 +749,12 @@ spec:
                     containerName:
                       type: string
                     criErrorMessage:
-                      description: Stores the error message from the CRI runtime if
-                        returned to prevent instrumenting the container if an error
-                        exists.
+                      description: |-
+                        CriErrorMessage is set if the value in EnvFromContainerRuntime was not computed correctly and cannot be used safely.
+                        Sometimes, even if CRI check failed, it is possible to tell that relevant env vars are not coming from container runtime.
+                        Thus, this field is set only when there is:
+                        - Actual CRI check failed
+                        - The observed environment variables might come from container runtime
                       type: string
                     envFromContainerRuntime:
                       description: Holds the environment variables retrieved from

--- a/helm/odigos/templates/crds/odigos.io_sources.yaml
+++ b/helm/odigos/templates/crds/odigos.io_sources.yaml
@@ -74,9 +74,12 @@ spec:
                         containerName:
                           type: string
                         criErrorMessage:
-                          description: Stores the error message from the CRI runtime
-                            if returned to prevent instrumenting the container if
-                            an error exists.
+                          description: |-
+                            CriErrorMessage is set if the value in EnvFromContainerRuntime was not computed correctly and cannot be used safely.
+                            Sometimes, even if CRI check failed, it is possible to tell that relevant env vars are not coming from container runtime.
+                            Thus, this field is set only when there is:
+                            - Actual CRI check failed
+                            - The observed environment variables might come from container runtime
                           type: string
                         envFromContainerRuntime:
                           description: Holds the environment variables retrieved from


### PR DESCRIPTION
This PR is for a change in semantics for the `CriErrorMessage` field of `RuntimeDetailsByContainer`.

Until now, we would always set it if a CRI error is detected. 
There is a branch, however - we know that env vars from container runtime will be found in `/proc`, so we check and if we don't find them there, we know that `envFromContainerRuntime` is empty even if there is an error.

Currently we set `CriErrorMessage` to the error message, and use the `runtimeUpdateState` to differentiate between the other case. This is what the webhook checks for injection.
Since the enum was meant to be temporary, and there is an ongoing effort to refactor the webhook code to make it use distros and retire the `EnvOverwriter` and `OtelSdk`, I want to introduce this change towards removing it and encode it's actual decision into the error message instead.

The `criErrorMessage` is currently not used for anything other than print message to log, thus this change is safe. [Webhook code](https://github.com/odigos-io/odigos/blob/15b77f64310b5202616d4842f78b96f7d65d706f/instrumentor/internal/webhook_env_injector/webhook_env_injector.go#L239) only uses the `RuntimeUpdateState` which is unchanged.

It's worth noting that we have never actually seen a criError in any deployment since it was introduced 8 months ago, so this change should be safe in that regard as well