### PR TITLE
chore: consume nodejs-community distro aratifact as versioned dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,12 +174,6 @@ make deploy-ui
 
 First - make sure you clone the [nodejs agent](https://github.com/odigos-io/opentelemetry-node) repos in the same directory as the odigos repo. e.g. `../opentelemetry-node` should exist alongside the odigos repo in your local filesystem.
 
-To deploy odiglet with agents from this source directory:
-
-```bash
-make deploy-odiglet-with-agents
-```
-
 See the [Odigos docs](https://docs.odigos.io/intro) for the full steps on debugging Odigos locally.
 
 ### How to Build and run Odigos Frontend Locally

--- a/Makefile
+++ b/Makefile
@@ -116,14 +116,6 @@ build-collector:
 build-ui:
 	$(MAKE) build-image/ui DOCKERFILE=frontend/$(DOCKERFILE) SUMMARY="UI for Odigos" DESCRIPTION="UI provides the frontend webapp for managing an Odigos installation." TAG=$(TAG) ORG=$(ORG) IMG_SUFFIX=$(IMG_SUFFIX)
 
-.PHONY: build-odiglet-with-agents
-build-odiglet-with-agents:
-	docker build -t $(ORG)/odigos-odiglet$(IMG_SUFFIX):$(TAG) . -f odiglet/$(DOCKERFILE) --build-arg ODIGOS_VERSION=$(TAG) --build-context nodejs-agent-src=../opentelemetry-node \
-	--build-arg VERSION=$(TAG) \
-	--build-arg RELEASE=$(TAG) \
-	--build-arg SUMMARY="Odiglet for Odigos" \
-	--build-arg DESCRIPTION="Odiglet is the core component of Odigos managing auto-instrumentation."
-
 .PHONY: verify-nodejs-agent
 verify-nodejs-agent:
 	@if [ ! -f ../opentelemetry-node/package.json ]; then \
@@ -228,12 +220,6 @@ deploy-%:
 .PHONY: deploy
 deploy:
 	make deploy-odiglet && make deploy-autoscaler && make deploy-collector && make deploy-instrumentor && make deploy-scheduler && make deploy-ui
-
-# Use this target to deploy odiglet with local clones of the agents.
-# To work, the agents must be cloned in the same directory as the odigos (e.g. in '../opentelemetry-node')
-# There you can make code changes to the agents and deploy them with the odiglet.
-.PHONY: deploy-odiglet-with-agents
-deploy-odiglet-with-agents: verify-nodejs-agent build-odiglet-with-agents load-to-kind-odiglet restart-odiglet
 
 .PHONY: debug-odiglet
 debug-odiglet:

--- a/agents/Dockerfile
+++ b/agents/Dockerfile
@@ -7,43 +7,7 @@ COPY agents/python ./agents/configurator
 RUN pip install ./agents/configurator/  --target workspace
 RUN echo "VERSION = \"$ODIGOS_VERSION\";" > /python-instrumentation/workspace/initializer/version.py
 
-######### Node.js Native Community Agent #########
-#
-# The Node.js agent is built in multiple stages so it can be built with either upstream
-# @odigos/opentelemetry-node or with a local clone to test changes during development.
-# The implementation is based on the following blog post:
-# https://www.docker.com/blog/dockerfiles-now-support-multiple-build-contexts/
-
-# The first build stage 'nodejs-agent-clone' clones the agent sources from github main branch.
-FROM alpine AS nodejs-agent-clone
-RUN apk add git
-WORKDIR /src
-ARG NODEJS_AGENT_VERSION=main
-RUN git clone https://github.com/odigos-io/opentelemetry-node.git && cd opentelemetry-node && git checkout $NODEJS_AGENT_VERSION
-
-# The second build stage 'nodejs-agent-src' prepares the actual code we are going to compile and embed in odiglet.
-# By default, it uses the previous 'nodejs-agent-clone' stage, but one can override it by setting the
-# --build-context nodejs-agent-src=../opentelemetry-node flag in the docker build command.
-# This allows us to use the agent sources and test changes during development.
-# The output of this stage is the resolved source code to be used in the next stage.
-FROM scratch AS nodejs-agent-src
-COPY --from=nodejs-agent-clone /src/opentelemetry-node /
-
-# The third step 'nodejs-agent-build' compiles the agent sources and prepares it for
-# being dependency of the native-community agent.
-FROM node:18 AS nodejs-agent-build
-# Run yarn install to generate the production node_modules directory
-WORKDIR /opentelemetry-node-prod
-COPY --from=nodejs-agent-src package.json yarn.lock ./
-RUN yarn install --frozen-lockfile --production
-# Build the agent from typescript sources
-ARG ODIGOS_VERSION
-WORKDIR /opentelemetry-node
-COPY --from=nodejs-agent-src package.json yarn.lock ./
-RUN yarn --frozen-lockfile
-COPY --from=nodejs-agent-src / .
-RUN echo "export const VERSION = \"$ODIGOS_VERSION\";" > ./src/version.ts
-RUN yarn compile
+FROM public.ecr.aws/odigos/agents/nodejs-community:v0.0.4 AS nodejs-community
 
 FROM --platform=$BUILDPLATFORM busybox:1.36.1 AS dotnet-builder
 WORKDIR /dotnet-instrumentation
@@ -127,13 +91,8 @@ RUN chmod 644 /instrumentations/java/javaagent.jar
 COPY --from=python-builder /python-instrumentation/workspace /instrumentations/python
 
 # NodeJS
-COPY --from=nodejs-agent-build /opentelemetry-node/package.json /instrumentations/opentelemetry-node/package.json
-COPY --from=nodejs-agent-build /opentelemetry-node/LICENSE /instrumentations/opentelemetry-node/LICENSE
-COPY --from=nodejs-agent-build /opentelemetry-node/build /instrumentations/opentelemetry-node/build
-COPY --from=nodejs-agent-build /opentelemetry-node-prod/node_modules /instrumentations/opentelemetry-node/node_modules
-
-# nodejs-community
-COPY --from=nodejs-agent-build /opentelemetry-node/build/src/nodejs-community/autoinstrumentation.js /instrumentations/nodejs-community/autoinstrumentation.js
+COPY --from=nodejs-community /instrumentations/opentelemetry-node /instrumentations/opentelemetry-node
+COPY --from=nodejs-community /instrumentations/nodejs-community /instrumentations/nodejs-community
 
 # .NET
 COPY --from=dotnet-builder /dotnet-instrumentation /instrumentations/dotnet

--- a/agents/Dockerfile.rhel
+++ b/agents/Dockerfile.rhel
@@ -7,43 +7,7 @@ COPY ../agents/python ./agents/configurator
 RUN pip install ./agents/configurator/  --target workspace
 RUN echo "VERSION = \"$ODIGOS_VERSION\";" > /python-instrumentation/workspace/initializer/version.py
 
-######### Node.js Native Community Agent #########
-#
-# The Node.js agent is built in multiple stages so it can be built with either upstream
-# @odigos/opentelemetry-node or with a local clone to test changes during development.
-# The implementation is based on the following blog post:
-# https://www.docker.com/blog/dockerfiles-now-support-multiple-build-contexts/
-
-# The first build stage 'nodejs-agent-clone' clones the agent sources from github main branch.
-FROM alpine AS nodejs-agent-clone
-RUN apk add git
-WORKDIR /src
-ARG NODEJS_AGENT_VERSION=main
-RUN git clone https://github.com/odigos-io/opentelemetry-node.git && cd opentelemetry-node && git checkout $NODEJS_AGENT_VERSION
-
-# The second build stage 'nodejs-agent-src' prepares the actual code we are going to compile and embed in odiglet.
-# By default, it uses the previous 'nodejs-agent-clone' stage, but one can override it by setting the
-# --build-context nodejs-agent-src=../opentelemetry-node flag in the docker build command.
-# This allows us to use the agent sources and test changes during development.
-# The output of this stage is the resolved source code to be used in the next stage.
-FROM scratch AS nodejs-agent-src
-COPY --from=nodejs-agent-clone /src/opentelemetry-node /
-
-# The third step 'nodejs-agent-build' compiles the agent sources and prepares it for
-# being dependency of the native-community agent.
-FROM node:18 AS nodejs-agent-build
-# Run yarn install to generate the production node_modules directory
-WORKDIR /opentelemetry-node-prod
-COPY --from=nodejs-agent-src package.json yarn.lock ./
-RUN yarn install --frozen-lockfile --production
-# Build the agent from typescript sources
-ARG ODIGOS_VERSION
-WORKDIR /opentelemetry-node
-COPY --from=nodejs-agent-src package.json yarn.lock ./
-RUN yarn --frozen-lockfile
-COPY --from=nodejs-agent-src / .
-RUN echo "export const VERSION = \"$ODIGOS_VERSION\";" > ./src/version.ts
-RUN yarn compile
+FROM public.ecr.aws/odigos/agents/nodejs-community:v0.0.4 AS nodejs-community
 
 FROM --platform=$BUILDPLATFORM busybox:1.36.1 AS dotnet-builder
 WORKDIR /dotnet-instrumentation
@@ -127,13 +91,8 @@ RUN chmod 644 /instrumentations/java/javaagent.jar
 COPY --from=python-builder /python-instrumentation/workspace /instrumentations/python
 
 # NodeJS
-COPY --from=nodejs-agent-build /opentelemetry-node/package.json /instrumentations/opentelemetry-node/package.json
-COPY --from=nodejs-agent-build /opentelemetry-node/LICENSE /instrumentations/opentelemetry-node/LICENSE
-COPY --from=nodejs-agent-build /opentelemetry-node/build /instrumentations/opentelemetry-node/build
-COPY --from=nodejs-agent-build /opentelemetry-node-prod/node_modules /instrumentations/opentelemetry-node/node_modules
-
-# nodejs-community
-COPY --from=nodejs-agent-build /opentelemetry-node/build/src/nodejs-community/autoinstrumentation.js /instrumentations/nodejs-community/autoinstrumentation.js
+COPY --from=nodejs-community /instrumentations/opentelemetry-node /instrumentations/opentelemetry-node
+COPY --from=nodejs-community /instrumentations/nodejs-community /instrumentations/nodejs-community
 
 # .NET
 COPY --from=dotnet-builder /dotnet-instrumentation /instrumentations/dotnet

--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -7,43 +7,7 @@ COPY agents/python ./agents/configurator
 RUN pip install ./agents/configurator/  --target workspace
 RUN echo "VERSION = \"$ODIGOS_VERSION\";" > /python-instrumentation/workspace/initializer/version.py
 
-######### Node.js Native Community Agent #########
-#
-# The Node.js agent is built in multiple stages so it can be built with either upstream
-# @odigos/opentelemetry-node or with a local clone to test changes during development.
-# The implementation is based on the following blog post:
-# https://www.docker.com/blog/dockerfiles-now-support-multiple-build-contexts/
-
-# The first build stage 'nodejs-agent-clone' clones the agent sources from github main branch.
-FROM alpine AS nodejs-agent-clone
-RUN apk add git
-WORKDIR /src
-ARG NODEJS_AGENT_VERSION=main
-RUN git clone https://github.com/odigos-io/opentelemetry-node.git && cd opentelemetry-node && git checkout $NODEJS_AGENT_VERSION
-
-# The second build stage 'nodejs-agent-src' prepares the actual code we are going to compile and embed in odiglet.
-# By default, it uses the previous 'nodejs-agent-clone' stage, but one can override it by setting the
-# --build-context nodejs-agent-src=../opentelemetry-node flag in the docker build command.
-# This allows us to use the agent sources and test changes during development.
-# The output of this stage is the resolved source code to be used in the next stage.
-FROM scratch AS nodejs-agent-src
-COPY --from=nodejs-agent-clone /src/opentelemetry-node /
-
-# The third step 'nodejs-agent-build' compiles the agent sources and prepares it for
-# being dependency of the native-community agent.
-FROM node:18 AS nodejs-agent-build
-# Run yarn install to generate the production node_modules directory
-WORKDIR /opentelemetry-node-prod
-COPY --from=nodejs-agent-src package.json yarn.lock ./
-RUN yarn install --frozen-lockfile --production
-# Build the agent from typescript sources
-ARG ODIGOS_VERSION
-WORKDIR /opentelemetry-node
-COPY --from=nodejs-agent-src package.json yarn.lock ./
-RUN yarn --frozen-lockfile
-COPY --from=nodejs-agent-src / .
-RUN echo "export const VERSION = \"$ODIGOS_VERSION\";" > ./src/version.ts
-RUN yarn compile
+FROM public.ecr.aws/odigos/agents/nodejs-community:v0.0.4 AS nodejs-community
 
 FROM --platform=$BUILDPLATFORM busybox:1.36.1 AS dotnet-builder
 WORKDIR /dotnet-instrumentation
@@ -187,13 +151,8 @@ RUN chmod 644 /instrumentations/java/javaagent.jar
 COPY --from=python-builder /python-instrumentation/workspace /instrumentations/python
 
 # NodeJS
-COPY --from=nodejs-agent-build /opentelemetry-node/package.json /instrumentations/opentelemetry-node/package.json
-COPY --from=nodejs-agent-build /opentelemetry-node/LICENSE /instrumentations/opentelemetry-node/LICENSE
-COPY --from=nodejs-agent-build /opentelemetry-node/build /instrumentations/opentelemetry-node/build
-COPY --from=nodejs-agent-build /opentelemetry-node-prod/node_modules /instrumentations/opentelemetry-node/node_modules
-
-# nodejs-community
-COPY --from=nodejs-agent-build /opentelemetry-node/build/src/nodejs-community/autoinstrumentation.js /instrumentations/nodejs-community/autoinstrumentation.js
+COPY --from=nodejs-community /instrumentations/opentelemetry-node /instrumentations/opentelemetry-node
+COPY --from=nodejs-community /instrumentations/nodejs-community /instrumentations/nodejs-community
 
 # .NET
 COPY --from=dotnet-builder /dotnet-instrumentation /instrumentations/dotnet

--- a/odiglet/Dockerfile.rhel
+++ b/odiglet/Dockerfile.rhel
@@ -8,44 +8,7 @@ COPY ../agents/python ./agents/configurator
 RUN pip install ./agents/configurator/  --target workspace
 RUN echo "VERSION = \"$ODIGOS_VERSION\";" > /python-instrumentation/workspace/initializer/version.py
 
-######### Node.js Native Community Agent #########
-#
-# The Node.js agent is built in multiple stages so it can be built with either upstream
-# @odigos/opentelemetry-node or with a local clone to test changes during development.
-# The implementation is based on the following blog post:
-# https://www.docker.com/blog/dockerfiles-now-support-multiple-build-contexts/
-
-# The first build stage 'nodejs-agent-clone' clones the agent sources from github main branch.
-FROM alpine AS nodejs-agent-clone
-RUN apk add git
-WORKDIR /src
-ARG NODEJS_AGENT_VERSION=main
-RUN git clone https://github.com/odigos-io/opentelemetry-node.git && cd opentelemetry-node && git checkout $NODEJS_AGENT_VERSION
-
-# The second build stage 'nodejs-agent-src' prepares the actual code we are going to compile and embed in odiglet.
-# By default, it uses the previous 'nodejs-agent-clone' stage, but one can override it by setting the
-# --build-context nodejs-agent-src=../opentelemetry-node flag in the docker build command.
-# This allows us to use the agent sources and test changes during development.
-# The output of this stage is the resolved source code to be used in the next stage.
-FROM scratch AS nodejs-agent-src
-COPY --from=nodejs-agent-clone /src/opentelemetry-node /
-
-# The third step 'nodejs-agent-build' compiles the agent sources and prepares it for
-# being dependency of the native-community agent.
-FROM node:18 AS nodejs-agent-build
-# Run yarn install to generate the production node_modules directory
-WORKDIR /opentelemetry-node-prod
-COPY --from=nodejs-agent-src package.json yarn.lock ./
-RUN yarn install --frozen-lockfile --production
-# Build the agent from typescript sources
-ARG ODIGOS_VERSION
-WORKDIR /opentelemetry-node
-COPY --from=nodejs-agent-src package.json yarn.lock ./
-RUN yarn --frozen-lockfile
-COPY --from=nodejs-agent-src / .
-RUN echo "export const VERSION = \"$ODIGOS_VERSION\";" > ./src/version.ts
-RUN yarn compile
-
+FROM public.ecr.aws/odigos/agents/nodejs-community:v0.0.4 AS nodejs-community
 
 FROM --platform=$BUILDPLATFORM busybox:1.36.1 AS dotnet-builder
 WORKDIR /dotnet-instrumentation
@@ -189,13 +152,8 @@ RUN chmod 644 /instrumentations/java/javaagent.jar
 COPY --from=python-builder /python-instrumentation/workspace /instrumentations/python
 
 # NodeJS
-COPY --from=nodejs-agent-build /opentelemetry-node/package.json /instrumentations/opentelemetry-node/package.json
-COPY --from=nodejs-agent-build /opentelemetry-node/LICENSE /instrumentations/opentelemetry-node/LICENSE
-COPY --from=nodejs-agent-build /opentelemetry-node/build /instrumentations/opentelemetry-node/build
-COPY --from=nodejs-agent-build /opentelemetry-node-prod/node_modules /instrumentations/opentelemetry-node/node_modules
-
-# nodejs-community
-COPY --from=nodejs-agent-build /opentelemetry-node/build/src/nodejs-community/autoinstrumentation.js /instrumentations/nodejs-community/autoinstrumentation.js
+COPY --from=nodejs-community /instrumentations/opentelemetry-node /instrumentations/opentelemetry-node
+COPY --from=nodejs-community /instrumentations/nodejs-community /instrumentations/nodejs-community
 
 # .NET
 COPY --from=dotnet-builder /dotnet-instrumentation /instrumentations/dotnet

--- a/odiglet/debug.Dockerfile
+++ b/odiglet/debug.Dockerfile
@@ -7,54 +7,7 @@ COPY agents/python ./agents/configurator
 RUN pip install ./agents/configurator/  --target workspace
 RUN echo "VERSION = \"$ODIGOS_VERSION\";" > /python-instrumentation/workspace/initializer/version.py
 
-######### Node.js Native Community Agent #########
-#
-# The Node.js agent is built in multiple stages so it can be built with either upstream
-# @odigos/opentelemetry-node or with a local clone to test changes during development.
-# The implemntation is based on the following blog post:
-# https://www.docker.com/blog/dockerfiles-now-support-multiple-build-contexts/
-
-# The first build stage 'nodejs-agent-clone' clones the agent sources from github main branch.
-FROM alpine AS nodejs-agent-clone
-RUN apk add git
-WORKDIR /src
-ARG NODEJS_AGENT_VERSION=main
-RUN git clone https://github.com/odigos-io/opentelemetry-node.git && cd opentelemetry-node && git checkout $NODEJS_AGENT_VERSION
-
-# The second build stage 'nodejs-agent-src' prepares the actual code we are going to compile and embed in odiglet.
-# By default, it uses the previous 'nodejs-agent-src' stage, but one can override it by setting the 
-# --build-context nodejs-agent-src=../opentelemetry-node flag in the docker build command.
-# This allows us to nobe the agent sources and test changes during development.
-# The output of this stage is the resolved source code to be used in the next stage.
-FROM scratch AS nodejs-agent-src
-COPY --from=nodejs-agent-clone /src/opentelemetry-node /
-
-# The third step 'nodejs-agent-build' compiles the agent sources and prepares it for 
-# being dependency of the native-community agent.
-FROM node:18 AS nodejs-agent-build
-ARG ODIGOS_VERSION
-WORKDIR /opentelemetry-node
-COPY --from=nodejs-agent-src package.json yarn.lock ./
-# install dependencies with dev so we can build the agent
-RUN yarn --frozen-lockfile
-COPY --from=nodejs-agent-src / .
-RUN echo "export const VERSION = \"$ODIGOS_VERSION\";" > ./src/version.ts
-RUN yarn compile
-
-# The fourth step 'nodejs-agent-native-community-src' prepares the agent sources for the native-community agent.
-# it COPY the nodejs agent source from 'nodejs-agent-build' stage and then build the agent in the 'agents/nodejs-native-community' directory.
-# The output of this stage is the compiled agent code in:
-#    - package source code in '/nodejs-instrumentation/build/src' directory.
-#    - all required dependencies in '/nodejs-instrumentation/prod_node_modules' directory.
-# These artifacts are later copied into the odiglet final image to be mounted into auto-instrumented pods at runtime.
-FROM node:18 AS nodejs-agent-native-community-builder
-ARG ODIGOS_VERSION
-WORKDIR /repos
-COPY ./agents/nodejs-native-community ./odigos/agents/nodejs-native-community
-COPY --from=nodejs-agent-build /opentelemetry-node opentelemetry-node
-# prepare the production node_modules content in a separate directory
-RUN yarn --cwd ./odigos/agents/nodejs-native-community --production --frozen-lockfile
-
+FROM public.ecr.aws/odigos/agents/nodejs-community:v0.0.4 AS nodejs-community
 
 FROM --platform=$BUILDPLATFORM busybox:1.36.1 AS dotnet-builder
 WORKDIR /dotnet-instrumentation
@@ -183,7 +136,8 @@ RUN chmod 644 /instrumentations/java/javaagent.jar
 COPY --from=python-builder /python-instrumentation/workspace /instrumentations/python
 
 # NodeJS
-COPY --from=nodejs-agent-native-community-builder /repos/odigos/agents/nodejs-native-community /instrumentations/nodejs
+COPY --from=nodejs-community /instrumentations/opentelemetry-node /instrumentations/opentelemetry-node
+COPY --from=nodejs-community /instrumentations/nodejs-community /instrumentations/nodejs-community
 
 # .NET
 COPY --from=dotnet-builder /dotnet-instrumentation /instrumentations/dotnet


### PR DESCRIPTION
Fixes: CORE-200

Consume the `nodejs-community` distribution artifacts (the agent implementation) as a docker image with version number:

Pros:

- No new code is introduced into the build by pushing to upstream `main` branch (as we do now)
- We can publish from release-branch and be deterministic about the version that is being used regardless of agent repo pushes.
- Faster builds - no need to build the agent from scratch in odiglet and init-container agents image. simply copy the existing artifacts (6.5 MB) from a container where it's already ready to be used.

Cons: 

- The convenient `build-odiglet-with-agents` does not work with this new setup
- we need to remember to release the agents in the many source repos, and then bump the version here (in 5 places). Can be automated in the future, but more chore and option to forget and make mistakes.
