### PR TITLE
CORE-134: Add more options for GCP exporter + K8sConfiger interface

### DIFF
--- a/api/k8sconsts/clustercollector.go
+++ b/api/k8sconsts/clustercollector.go
@@ -15,6 +15,8 @@ const (
 	OdigosClusterCollectorRoleName           = "odigos-gateway"
 	OdigosClusterCollectorRoleBindingName    = "odigos-gateway"
 
+	OdigosClusterCollectorContainerName = "gateway"
+
 	// The cluster gateway collector runs as a deployment and the pod is exposed as a service.
 	// Thus it cannot collide with other ports on the same node, and we can use an handy default port.
 	OdigosClusterCollectorOwnTelemetryPortDefault = int32(8888)

--- a/api/odigos/v1alpha1/destination_types.go
+++ b/api/odigos/v1alpha1/destination_types.go
@@ -87,6 +87,10 @@ func (dest Destination) GetSignals() []common.ObservabilitySignal {
 	return dest.Spec.Signals
 }
 
+func (dest Destination) GetSecretRef() *v1.LocalObjectReference {
+	return dest.Spec.SecretRef
+}
+
 type SourceSelector struct {
 	// If a namespace is specified, all workloads (sources) within that namespace are allowed to send data.
 	// Example:

--- a/autoscaler/controllers/clustercollector/configmap.go
+++ b/autoscaler/controllers/clustercollector/configmap.go
@@ -129,17 +129,8 @@ func addSelfTelemetryPipeline(c *config.Config, ownTelemetryPort int32, destinat
 	return nil
 }
 
-func syncConfigMap(dests *odigosv1.DestinationList, allProcessors *odigosv1.ProcessorList, gateway *odigosv1.CollectorsGroup, ctx context.Context, c client.Client, scheme *runtime.Scheme) ([]odigoscommon.ObservabilitySignal, error) {
+func syncConfigMap(enabledDests *odigosv1.DestinationList, allProcessors *odigosv1.ProcessorList, gateway *odigosv1.CollectorsGroup, ctx context.Context, c client.Client, scheme *runtime.Scheme) ([]odigoscommon.ObservabilitySignal, error) {
 	logger := log.FromContext(ctx)
-
-	enabledDests := &odigosv1.DestinationList{Items: []odigosv1.Destination{}}
-	for _, dest := range dests.Items {
-		// skip disabled destinations
-		if dest.Spec.Disabled != nil && *dest.Spec.Disabled {
-			continue
-		}
-		enabledDests.Items = append(enabledDests.Items, dest)
-	}
 
 	dataStreams, err := calculateDataStreams(ctx, c, enabledDests)
 	if err != nil {

--- a/autoscaler/controllers/clustercollector/deployment.go
+++ b/autoscaler/controllers/clustercollector/deployment.go
@@ -259,7 +259,7 @@ func getDesiredDeployment(ctx context.Context, c client.Client, enabledDests *od
 	k8sConfigers := k8sconfig.LoadK8sConfigers()
 	for _, dest := range enabledDests.Items {
 		if k8sConfiger, exists := k8sConfigers[dest.GetType()]; exists {
-			err := k8sConfiger.ModifyGatewayCollectorDeployment(dest, desiredDeployment)
+			err := k8sConfiger.ModifyGatewayCollectorDeployment(ctx, c, dest, desiredDeployment)
 			if err != nil {
 				return nil, errors.Join(err, errors.New("failed to modify gateway collector deployment"))
 			}

--- a/autoscaler/controllers/clustercollector/destination_controller_test.go
+++ b/autoscaler/controllers/clustercollector/destination_controller_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package clustercollector
+package clustercollector_test
 
 import (
 	"context"
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/odigos-io/odigos/api/k8sconsts"
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/common"
 )
@@ -39,12 +40,184 @@ const (
 var _ = Describe("Destination Controller", func() {
 	const (
 		DestinationName      = "test-destination"
-		DestinationNamespace = "default"
+		DestinationNamespace = "odigos-system"
 		SecretName           = "test-secret"
 	)
 
+	intPtr := func(n int32) *int32 {
+		return &n
+	}
+
+	BeforeEach(func() {
+		By("Creating the odigos-system namespace")
+		namespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: DestinationNamespace,
+			},
+		}
+		Expect(k8sClient.Create(context.Background(), namespace)).Should(Succeed())
+
+		By("Creating the odiglet daemonset")
+		odigletDaemonset := &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      k8sconsts.OdigletDaemonSetName,
+				Namespace: DestinationNamespace,
+			},
+			Spec: appsv1.DaemonSetSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app": k8sconsts.OdigletDaemonSetName,
+					},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app": k8sconsts.OdigletDaemonSetName,
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  k8sconsts.OdigletContainerName,
+								Image: "odigos/odiglet:latest",
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(context.Background(), odigletDaemonset)).Should(Succeed())
+
+		By("Creating the autoscaler deployment")
+		autoscalerDeployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      k8sconsts.AutoScalerDeploymentName,
+				Namespace: DestinationNamespace,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: intPtr(1),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app": k8sconsts.AutoScalerDeploymentName,
+					},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app": k8sconsts.AutoScalerDeploymentName,
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  k8sconsts.AutoScalerContainerName,
+								Image: "odigos/autoscaler:latest",
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(context.Background(), autoscalerDeployment)).Should(Succeed())
+	})
+
+	AfterEach(func() {
+		cleanupResources()
+	})
+
+	createCollectorsGroupAndDeployment := func() *odigosv1.CollectorsGroup {
+		By("Creating a CollectorsGroup for cluster collector")
+		collectorsGroup := &odigosv1.CollectorsGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      k8sconsts.OdigosClusterCollectorConfigMapName,
+				Namespace: DestinationNamespace,
+			},
+			Spec: odigosv1.CollectorsGroupSpec{
+				Role: odigosv1.CollectorsGroupRoleClusterGateway,
+				ResourcesSettings: odigosv1.CollectorsGroupResourcesSettings{
+					MemoryRequestMiB:     256,
+					MemoryLimitMiB:       512,
+					CpuRequestMillicores: 250,
+					CpuLimitMillicores:   500,
+					GomemlimitMiB:        200,
+				},
+				CollectorOwnMetricsPort: 8888,
+			},
+		}
+		Expect(k8sClient.Create(context.Background(), collectorsGroup)).Should(Succeed())
+		/*
+			By("Creating the cluster collector deployment")
+			replicas := int32(1)
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      k8sconsts.OdigosClusterCollectorDeploymentName,
+					Namespace: DestinationNamespace,
+					Labels: map[string]string{
+						k8sconsts.OdigosCollectorRoleLabel: string(k8sconsts.CollectorsRoleClusterGateway),
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &replicas,
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							k8sconsts.OdigosCollectorRoleLabel: string(k8sconsts.CollectorsRoleClusterGateway),
+						},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								k8sconsts.OdigosCollectorRoleLabel: string(k8sconsts.CollectorsRoleClusterGateway),
+							},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:    "gateway",
+									Image:   "odigos/odigosotelcol:latest",
+									Command: []string{"/odigosotelcol"},
+									Args: []string{fmt.Sprintf("--config=%s:%s/%s/%s",
+										k8sconsts.OdigosCollectorConfigMapProviderScheme,
+										DestinationNamespace,
+										k8sconsts.OdigosClusterCollectorConfigMapName,
+										k8sconsts.OdigosClusterCollectorConfigMapKey),
+									},
+									Env: []corev1.EnvVar{
+										{
+											Name: "POD_NAME",
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
+													FieldPath: "metadata.name",
+												},
+											},
+										},
+									},
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceMemory: resource.MustParse("256Mi"),
+											corev1.ResourceCPU:    resource.MustParse("250m"),
+										},
+										Limits: corev1.ResourceList{
+											corev1.ResourceMemory: resource.MustParse("512Mi"),
+											corev1.ResourceCPU:    resource.MustParse("500m"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), deployment)).Should(Succeed())
+		*/
+
+		return collectorsGroup
+	}
+
 	Context("When creating a GoogleCloud Destination with APPLICATION_CREDENTIALS", func() {
 		It("Should create a cluster collector deployment with volume, volume mount, and env var", func() {
+			By("Setting up CollectorsGroup and deployment")
+			createCollectorsGroupAndDeployment()
+
 			By("Creating a secret with GCP credentials")
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -81,7 +254,7 @@ var _ = Describe("Destination Controller", func() {
 			deployment := &appsv1.Deployment{}
 			Eventually(func() bool {
 				err := k8sClient.Get(context.Background(), types.NamespacedName{
-					Name:      "odigos-cluster-collector",
+					Name:      k8sconsts.OdigosClusterCollectorDeploymentName,
 					Namespace: DestinationNamespace,
 				}, deployment)
 				return err == nil
@@ -113,86 +286,188 @@ var _ = Describe("Destination Controller", func() {
 		})
 	})
 
-	Context("When creating multiple GoogleCloud Destinations with APPLICATION_CREDENTIALS", func() {
-		It("Should not create duplicate volumes, volume mounts, or env vars", func() {
-			By("Creating a secret with GCP credentials")
-			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      SecretName,
-					Namespace: DestinationNamespace,
-				},
-				Data: map[string][]byte{
-					"GCP_APPLICATION_CREDENTIALS": []byte("fake-gcp-credentials"),
-				},
-			}
-			Expect(k8sClient.Create(context.Background(), secret)).Should(Succeed())
+	/*
+		Context("When updating an existing cluster collector deployment with a new destination", func() {
+			It("Should update the deployment with the new destination's configuration", func() {
+				By("Setting up CollectorsGroup and initial deployment")
+				createCollectorsGroupAndDeployment()
 
-			By("Creating the first GoogleCloud destination")
-			destination1 := &odigosv1.Destination{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      DestinationName + "-1",
-					Namespace: DestinationNamespace,
-				},
-				Spec: odigosv1.DestinationSpec{
-					Type:            common.GoogleCloudDestinationType,
-					DestinationName: "test-gcp-destination-1",
-					Data: map[string]string{
-						"GCP_APPLICATION_CREDENTIALS": "fake-gcp-credentials",
+				By("Getting the initial deployment to verify its state")
+				initialDeployment := &appsv1.Deployment{}
+				Eventually(func() bool {
+					err := k8sClient.Get(context.Background(), types.NamespacedName{
+						Name:      k8sconsts.OdigosClusterCollectorDeploymentName,
+						Namespace: DestinationNamespace,
+					}, initialDeployment)
+					return err == nil
+				}, timeout, interval).Should(BeTrue())
+
+				By("Verifying the initial deployment has no volumes or volume mounts")
+				Expect(initialDeployment.Spec.Template.Spec.Volumes).To(HaveLen(0))
+				Expect(initialDeployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+				container := initialDeployment.Spec.Template.Spec.Containers[0]
+				Expect(container.VolumeMounts).To(HaveLen(0))
+
+				By("Creating a secret with GCP credentials")
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      SecretName,
+						Namespace: DestinationNamespace,
 					},
-					SecretRef: &corev1.LocalObjectReference{
-						Name: SecretName,
+					Data: map[string][]byte{
+						"GCP_APPLICATION_CREDENTIALS": []byte("fake-gcp-credentials"),
 					},
-					Signals: []common.ObservabilitySignal{common.TracesObservabilitySignal},
-				},
-			}
-			Expect(k8sClient.Create(context.Background(), destination1)).Should(Succeed())
+				}
+				Expect(k8sClient.Create(context.Background(), secret)).Should(Succeed())
 
-			By("Creating the second GoogleCloud destination with the same secret")
-			destination2 := &odigosv1.Destination{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      DestinationName + "-2",
-					Namespace: DestinationNamespace,
-				},
-				Spec: odigosv1.DestinationSpec{
-					Type:            common.GoogleCloudDestinationType,
-					DestinationName: "test-gcp-destination-2",
-					Data: map[string]string{
-						"GCP_APPLICATION_CREDENTIALS": "fake-gcp-credentials",
+				By("Creating a GoogleCloud destination with APPLICATION_CREDENTIALS")
+				destination := &odigosv1.Destination{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      DestinationName,
+						Namespace: DestinationNamespace,
 					},
-					SecretRef: &corev1.LocalObjectReference{
-						Name: SecretName,
+					Spec: odigosv1.DestinationSpec{
+						Type:            common.GoogleCloudDestinationType,
+						DestinationName: "test-gcp-destination",
+						Data: map[string]string{
+							"GCP_APPLICATION_CREDENTIALS": "fake-gcp-credentials",
+						},
+						SecretRef: &corev1.LocalObjectReference{
+							Name: SecretName,
+						},
+						Signals: []common.ObservabilitySignal{common.TracesObservabilitySignal},
 					},
-					Signals: []common.ObservabilitySignal{common.MetricsObservabilitySignal},
-				},
-			}
-			Expect(k8sClient.Create(context.Background(), destination2)).Should(Succeed())
+				}
+				Expect(k8sClient.Create(context.Background(), destination)).Should(Succeed())
 
-			By("Waiting for the cluster collector deployment to be created")
-			deployment := &appsv1.Deployment{}
-			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{
-					Name:      "odigos-cluster-collector",
-					Namespace: DestinationNamespace,
-				}, deployment)
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
+				By("Waiting for the deployment to be updated with the destination configuration")
+				updatedDeployment := &appsv1.Deployment{}
+				Eventually(func() bool {
+					err := k8sClient.Get(context.Background(), types.NamespacedName{
+						Name:      k8sconsts.OdigosClusterCollectorDeploymentName,
+						Namespace: DestinationNamespace,
+					}, updatedDeployment)
+					if err != nil {
+						return false
+					}
+					// Check if the deployment has been updated with volumes
+					return len(updatedDeployment.Spec.Template.Spec.Volumes) > 0
+				}, timeout, interval).Should(BeTrue())
 
-			By("Verifying the deployment has only one volume (no duplicates)")
-			Expect(deployment.Spec.Template.Spec.Volumes).To(HaveLen(1))
-			volume := deployment.Spec.Template.Spec.Volumes[0]
-			Expect(volume.Name).To(Equal(SecretName))
+				By("Verifying the updated deployment has the expected volume")
+				Expect(updatedDeployment.Spec.Template.Spec.Volumes).To(HaveLen(1))
+				volume := updatedDeployment.Spec.Template.Spec.Volumes[0]
+				Expect(volume.Name).To(Equal(SecretName))
+				Expect(volume.VolumeSource.Secret).NotTo(BeNil())
+				Expect(volume.VolumeSource.Secret.SecretName).To(Equal(SecretName))
+				Expect(volume.VolumeSource.Secret.Items).To(HaveLen(1))
+				Expect(volume.VolumeSource.Secret.Items[0].Key).To(Equal("GCP_APPLICATION_CREDENTIALS"))
+				Expect(volume.VolumeSource.Secret.Items[0].Path).To(Equal("GCP_APPLICATION_CREDENTIALS"))
 
-			By("Verifying the deployment has only one volume mount (no duplicates)")
-			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
-			container := deployment.Spec.Template.Spec.Containers[0]
-			Expect(container.VolumeMounts).To(HaveLen(1))
-			volumeMount := container.VolumeMounts[0]
-			Expect(volumeMount.Name).To(Equal(SecretName))
+				By("Verifying the updated deployment has the expected volume mount")
+				Expect(updatedDeployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+				updatedContainer := updatedDeployment.Spec.Template.Spec.Containers[0]
+				Expect(updatedContainer.VolumeMounts).To(HaveLen(1))
+				volumeMount := updatedContainer.VolumeMounts[0]
+				Expect(volumeMount.Name).To(Equal(SecretName))
+				Expect(volumeMount.MountPath).To(Equal("/secrets"))
 
-			By("Verifying the deployment has only one environment variable (no duplicates)")
-			Expect(container.Env).To(HaveLen(1))
-			envVar := container.Env[0]
-			Expect(envVar.Name).To(Equal("GCP_APPLICATION_CREDENTIALS"))
+				By("Verifying the updated deployment has the expected environment variable")
+				Expect(updatedContainer.Env).To(HaveLen(1))
+				envVar := updatedContainer.Env[0]
+				Expect(envVar.Name).To(Equal("GCP_APPLICATION_CREDENTIALS"))
+				Expect(envVar.Value).To(Equal("/secrets/GCP_APPLICATION_CREDENTIALS"))
+
+				By("Verifying the deployment was actually updated (not just created)")
+				// The deployment should have been updated, not recreated
+				Expect(updatedDeployment.UID).To(Equal(initialDeployment.UID))
+			})
 		})
-	})
+
+		Context("When creating multiple GoogleCloud Destinations with APPLICATION_CREDENTIALS", func() {
+			It("Should not create duplicate volumes, volume mounts, or env vars", func() {
+				By("Setting up CollectorsGroup and deployment")
+				createCollectorsGroupAndDeployment()
+
+				By("Creating a secret with GCP credentials")
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      SecretName,
+						Namespace: DestinationNamespace,
+					},
+					Data: map[string][]byte{
+						"GCP_APPLICATION_CREDENTIALS": []byte("fake-gcp-credentials"),
+					},
+				}
+				Expect(k8sClient.Create(context.Background(), secret)).Should(Succeed())
+
+				By("Creating the first GoogleCloud destination")
+				destination1 := &odigosv1.Destination{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      DestinationName + "-1",
+						Namespace: DestinationNamespace,
+					},
+					Spec: odigosv1.DestinationSpec{
+						Type:            common.GoogleCloudDestinationType,
+						DestinationName: "test-gcp-destination-1",
+						Data: map[string]string{
+							"GCP_APPLICATION_CREDENTIALS": "fake-gcp-credentials",
+						},
+						SecretRef: &corev1.LocalObjectReference{
+							Name: SecretName,
+						},
+						Signals: []common.ObservabilitySignal{common.TracesObservabilitySignal},
+					},
+				}
+				Expect(k8sClient.Create(context.Background(), destination1)).Should(Succeed())
+
+				By("Creating the second GoogleCloud destination with the same secret")
+				destination2 := &odigosv1.Destination{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      DestinationName + "-2",
+						Namespace: DestinationNamespace,
+					},
+					Spec: odigosv1.DestinationSpec{
+						Type:            common.GoogleCloudDestinationType,
+						DestinationName: "test-gcp-destination-2",
+						Data: map[string]string{
+							"GCP_APPLICATION_CREDENTIALS": "fake-gcp-credentials",
+						},
+						SecretRef: &corev1.LocalObjectReference{
+							Name: SecretName,
+						},
+						Signals: []common.ObservabilitySignal{common.MetricsObservabilitySignal},
+					},
+				}
+				Expect(k8sClient.Create(context.Background(), destination2)).Should(Succeed())
+
+				By("Waiting for the cluster collector deployment to be created")
+				deployment := &appsv1.Deployment{}
+				Eventually(func() bool {
+					err := k8sClient.Get(context.Background(), types.NamespacedName{
+						Name:      k8sconsts.OdigosClusterCollectorDeploymentName,
+						Namespace: DestinationNamespace,
+					}, deployment)
+					return err == nil
+				}, timeout, interval).Should(BeTrue())
+
+				By("Verifying the deployment has only one volume (no duplicates)")
+				Expect(deployment.Spec.Template.Spec.Volumes).To(HaveLen(1))
+				volume := deployment.Spec.Template.Spec.Volumes[0]
+				Expect(volume.Name).To(Equal(SecretName))
+
+				By("Verifying the deployment has only one volume mount (no duplicates)")
+				Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+				container := deployment.Spec.Template.Spec.Containers[0]
+				Expect(container.VolumeMounts).To(HaveLen(1))
+				volumeMount := container.VolumeMounts[0]
+				Expect(volumeMount.Name).To(Equal(SecretName))
+
+				By("Verifying the deployment has only one environment variable (no duplicates)")
+				Expect(container.Env).To(HaveLen(1))
+				envVar := container.Env[0]
+				Expect(envVar.Name).To(Equal("GCP_APPLICATION_CREDENTIALS"))
+			})
+		})
+	*/
 })

--- a/autoscaler/controllers/clustercollector/destination_controller_test.go
+++ b/autoscaler/controllers/clustercollector/destination_controller_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustercollector
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	"github.com/odigos-io/odigos/common"
+)
+
+const (
+	timeout  = time.Second * 10
+	interval = time.Millisecond * 250
+)
+
+var _ = Describe("Destination Controller", func() {
+	const (
+		DestinationName      = "test-destination"
+		DestinationNamespace = "default"
+		SecretName           = "test-secret"
+	)
+
+	Context("When creating a GoogleCloud Destination with APPLICATION_CREDENTIALS", func() {
+		It("Should create a cluster collector deployment with volume, volume mount, and env var", func() {
+			By("Creating a secret with GCP credentials")
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      SecretName,
+					Namespace: DestinationNamespace,
+				},
+				Data: map[string][]byte{
+					"GCP_APPLICATION_CREDENTIALS": []byte("fake-gcp-credentials"),
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), secret)).Should(Succeed())
+
+			By("Creating a GoogleCloud destination with APPLICATION_CREDENTIALS")
+			destination := &odigosv1.Destination{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      DestinationName,
+					Namespace: DestinationNamespace,
+				},
+				Spec: odigosv1.DestinationSpec{
+					Type:            common.GoogleCloudDestinationType,
+					DestinationName: "test-gcp-destination",
+					Data: map[string]string{
+						"GCP_APPLICATION_CREDENTIALS": "fake-gcp-credentials",
+					},
+					SecretRef: &corev1.LocalObjectReference{
+						Name: SecretName,
+					},
+					Signals: []common.ObservabilitySignal{common.TracesObservabilitySignal},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), destination)).Should(Succeed())
+
+			By("Waiting for the cluster collector deployment to be created")
+			deployment := &appsv1.Deployment{}
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), types.NamespacedName{
+					Name:      "odigos-cluster-collector",
+					Namespace: DestinationNamespace,
+				}, deployment)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			By("Verifying the deployment has the expected volume")
+			Expect(deployment.Spec.Template.Spec.Volumes).To(HaveLen(1))
+			volume := deployment.Spec.Template.Spec.Volumes[0]
+			Expect(volume.Name).To(Equal(SecretName))
+			Expect(volume.VolumeSource.Secret).NotTo(BeNil())
+			Expect(volume.VolumeSource.Secret.SecretName).To(Equal(SecretName))
+			Expect(volume.VolumeSource.Secret.Items).To(HaveLen(1))
+			Expect(volume.VolumeSource.Secret.Items[0].Key).To(Equal("GCP_APPLICATION_CREDENTIALS"))
+			Expect(volume.VolumeSource.Secret.Items[0].Path).To(Equal("GCP_APPLICATION_CREDENTIALS"))
+
+			By("Verifying the deployment has the expected volume mount")
+			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+			container := deployment.Spec.Template.Spec.Containers[0]
+			Expect(container.VolumeMounts).To(HaveLen(1))
+			volumeMount := container.VolumeMounts[0]
+			Expect(volumeMount.Name).To(Equal(SecretName))
+			Expect(volumeMount.MountPath).To(Equal("/secrets"))
+
+			By("Verifying the deployment has the expected environment variable")
+			Expect(container.Env).To(HaveLen(1))
+			envVar := container.Env[0]
+			Expect(envVar.Name).To(Equal("GCP_APPLICATION_CREDENTIALS"))
+			Expect(envVar.Value).To(Equal("/secrets/GCP_APPLICATION_CREDENTIALS"))
+		})
+	})
+
+	Context("When creating multiple GoogleCloud Destinations with APPLICATION_CREDENTIALS", func() {
+		It("Should not create duplicate volumes, volume mounts, or env vars", func() {
+			By("Creating a secret with GCP credentials")
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      SecretName,
+					Namespace: DestinationNamespace,
+				},
+				Data: map[string][]byte{
+					"GCP_APPLICATION_CREDENTIALS": []byte("fake-gcp-credentials"),
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), secret)).Should(Succeed())
+
+			By("Creating the first GoogleCloud destination")
+			destination1 := &odigosv1.Destination{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      DestinationName + "-1",
+					Namespace: DestinationNamespace,
+				},
+				Spec: odigosv1.DestinationSpec{
+					Type:            common.GoogleCloudDestinationType,
+					DestinationName: "test-gcp-destination-1",
+					Data: map[string]string{
+						"GCP_APPLICATION_CREDENTIALS": "fake-gcp-credentials",
+					},
+					SecretRef: &corev1.LocalObjectReference{
+						Name: SecretName,
+					},
+					Signals: []common.ObservabilitySignal{common.TracesObservabilitySignal},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), destination1)).Should(Succeed())
+
+			By("Creating the second GoogleCloud destination with the same secret")
+			destination2 := &odigosv1.Destination{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      DestinationName + "-2",
+					Namespace: DestinationNamespace,
+				},
+				Spec: odigosv1.DestinationSpec{
+					Type:            common.GoogleCloudDestinationType,
+					DestinationName: "test-gcp-destination-2",
+					Data: map[string]string{
+						"GCP_APPLICATION_CREDENTIALS": "fake-gcp-credentials",
+					},
+					SecretRef: &corev1.LocalObjectReference{
+						Name: SecretName,
+					},
+					Signals: []common.ObservabilitySignal{common.MetricsObservabilitySignal},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), destination2)).Should(Succeed())
+
+			By("Waiting for the cluster collector deployment to be created")
+			deployment := &appsv1.Deployment{}
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), types.NamespacedName{
+					Name:      "odigos-cluster-collector",
+					Namespace: DestinationNamespace,
+				}, deployment)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			By("Verifying the deployment has only one volume (no duplicates)")
+			Expect(deployment.Spec.Template.Spec.Volumes).To(HaveLen(1))
+			volume := deployment.Spec.Template.Spec.Volumes[0]
+			Expect(volume.Name).To(Equal(SecretName))
+
+			By("Verifying the deployment has only one volume mount (no duplicates)")
+			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+			container := deployment.Spec.Template.Spec.Containers[0]
+			Expect(container.VolumeMounts).To(HaveLen(1))
+			volumeMount := container.VolumeMounts[0]
+			Expect(volumeMount.Name).To(Equal(SecretName))
+
+			By("Verifying the deployment has only one environment variable (no duplicates)")
+			Expect(container.Env).To(HaveLen(1))
+			envVar := container.Env[0]
+			Expect(envVar.Name).To(Equal("GCP_APPLICATION_CREDENTIALS"))
+		})
+	})
+})

--- a/autoscaler/controllers/clustercollector/destination_controller_test.go
+++ b/autoscaler/controllers/clustercollector/destination_controller_test.go
@@ -84,9 +84,7 @@ var _ = Describe("Destination Controller", func() {
 				Spec: odigosv1.DestinationSpec{
 					Type:            common.GoogleCloudDestinationType,
 					DestinationName: "test-gcp-destination",
-					Data: map[string]string{
-						"GCP_APPLICATION_CREDENTIALS": "fake-gcp-credentials",
-					},
+					Data:            map[string]string{},
 					SecretRef: &corev1.LocalObjectReference{
 						Name: SecretName,
 					},
@@ -174,9 +172,7 @@ var _ = Describe("Destination Controller", func() {
 				Spec: odigosv1.DestinationSpec{
 					Type:            common.GoogleCloudDestinationType,
 					DestinationName: "test-gcp-destination-1",
-					Data: map[string]string{
-						"GCP_APPLICATION_CREDENTIALS": "fake-gcp-credentials",
-					},
+					Data:            map[string]string{},
 					SecretRef: &corev1.LocalObjectReference{
 						Name: SecretName,
 					},
@@ -205,9 +201,7 @@ var _ = Describe("Destination Controller", func() {
 				Spec: odigosv1.DestinationSpec{
 					Type:            common.GoogleCloudDestinationType,
 					DestinationName: "test-gcp-destination-2",
-					Data: map[string]string{
-						"GCP_APPLICATION_CREDENTIALS": "fake-gcp-credentials",
-					},
+					Data:            map[string]string{},
 					SecretRef: &corev1.LocalObjectReference{
 						Name: SecretName,
 					},
@@ -278,9 +272,7 @@ var _ = Describe("Destination Controller", func() {
 				Spec: odigosv1.DestinationSpec{
 					Type:            common.GoogleCloudDestinationType,
 					DestinationName: "test-gcp-destination",
-					Data: map[string]string{
-						"GCP_APPLICATION_CREDENTIALS": "fake-gcp-credentials",
-					},
+					Data:            map[string]string{},
 					SecretRef: &corev1.LocalObjectReference{
 						Name: SecretName,
 					},

--- a/autoscaler/controllers/clustercollector/destination_controller_test.go
+++ b/autoscaler/controllers/clustercollector/destination_controller_test.go
@@ -127,7 +127,7 @@ var _ = Describe("Destination Controller", func() {
 			hasName := false
 			hasValue := false
 			for _, envVar := range container.Env {
-				if envVar.Name == "GCP_APPLICATION_CREDENTIALS" {
+				if envVar.Name == "GOOGLE_APPLICATION_CREDENTIALS" {
 					hasName = true
 				}
 				if envVar.Value == "/secrets/GCP_APPLICATION_CREDENTIALS" {
@@ -242,7 +242,7 @@ var _ = Describe("Destination Controller", func() {
 			hasName := 0
 			hasValue := 0
 			for _, envVar := range container.Env {
-				if envVar.Name == "GCP_APPLICATION_CREDENTIALS" {
+				if envVar.Name == "GOOGLE_APPLICATION_CREDENTIALS" {
 					hasName++
 				}
 				if envVar.Value == "/secrets/GCP_APPLICATION_CREDENTIALS" {
@@ -325,7 +325,7 @@ var _ = Describe("Destination Controller", func() {
 			hasName := 0
 			hasValue := 0
 			for _, envVar := range container.Env {
-				if envVar.Name == "GCP_APPLICATION_CREDENTIALS" {
+				if envVar.Name == "GOOGLE_APPLICATION_CREDENTIALS" {
 					hasName++
 				}
 			}

--- a/autoscaler/controllers/clustercollector/destination_controller_test.go
+++ b/autoscaler/controllers/clustercollector/destination_controller_test.go
@@ -42,6 +42,7 @@ var _ = Describe("Destination Controller", func() {
 		DestinationName      = "test-destination"
 		DestinationNamespace = "odigos-system"
 		SecretName           = "test-secret"
+		SecretMountName      = "gcp-credentials-secret"
 	)
 
 	AfterEach(func() {
@@ -108,7 +109,7 @@ var _ = Describe("Destination Controller", func() {
 			By("Verifying the deployment has the expected volume")
 			Expect(deployment.Spec.Template.Spec.Volumes).To(HaveLen(1))
 			volume := deployment.Spec.Template.Spec.Volumes[0]
-			Expect(volume.Name).To(Equal(SecretName))
+			Expect(volume.Name).To(Equal(SecretMountName))
 			Expect(volume.VolumeSource.Secret).NotTo(BeNil())
 			Expect(volume.VolumeSource.Secret.SecretName).To(Equal(SecretName))
 			Expect(volume.VolumeSource.Secret.Items).To(HaveLen(1))
@@ -120,7 +121,7 @@ var _ = Describe("Destination Controller", func() {
 			container := deployment.Spec.Template.Spec.Containers[0]
 			Expect(container.VolumeMounts).To(HaveLen(1))
 			volumeMount := container.VolumeMounts[0]
-			Expect(volumeMount.Name).To(Equal(SecretName))
+			Expect(volumeMount.Name).To(Equal(SecretMountName))
 			Expect(volumeMount.MountPath).To(Equal("/secrets"))
 
 			By("Verifying the deployment has the expected environment variable")
@@ -229,14 +230,14 @@ var _ = Describe("Destination Controller", func() {
 			By("Verifying the deployment has only one volume (no duplicates)")
 			Expect(deployment.Spec.Template.Spec.Volumes).To(HaveLen(1))
 			volume := deployment.Spec.Template.Spec.Volumes[0]
-			Expect(volume.Name).To(Equal(SecretName))
+			Expect(volume.Name).To(Equal(SecretMountName))
 
 			By("Verifying the deployment has only one volume mount (no duplicates)")
 			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
 			container := deployment.Spec.Template.Spec.Containers[0]
 			Expect(container.VolumeMounts).To(HaveLen(1))
 			volumeMount := container.VolumeMounts[0]
-			Expect(volumeMount.Name).To(Equal(SecretName))
+			Expect(volumeMount.Name).To(Equal(SecretMountName))
 
 			By("Verifying the deployment has only one environment variable (no duplicates)")
 			hasName := 0
@@ -322,15 +323,13 @@ var _ = Describe("Destination Controller", func() {
 			Expect(container.VolumeMounts).To(HaveLen(0))
 
 			By("Verifying the deployment has no GCP environment variables")
-			hasName := 0
-			hasValue := 0
+			hasName := false
 			for _, envVar := range container.Env {
 				if envVar.Name == "GOOGLE_APPLICATION_CREDENTIALS" {
-					hasName++
+					hasName = true
 				}
 			}
-			Expect(hasName).To(Equal(0))
-			Expect(hasValue).To(Equal(0))
+			Expect(hasName).To(BeFalse())
 		})
 	})
 })

--- a/autoscaler/controllers/clustercollector/suite_test.go
+++ b/autoscaler/controllers/clustercollector/suite_test.go
@@ -14,22 +14,29 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package clustercollector
+package clustercollector_test
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	actionv1 "github.com/odigos-io/odigos/api/actions/v1alpha1"
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	"github.com/odigos-io/odigos/autoscaler/controllers/clustercollector"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -39,6 +46,8 @@ import (
 var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
+var testCtx context.Context
+var cancel context.CancelFunc
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -48,6 +57,8 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	testCtx, cancel = context.WithCancel(context.TODO())
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
@@ -64,16 +75,86 @@ var _ = BeforeSuite(func() {
 	err = odigosv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = actionv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
 	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
+	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: "0",
+		},
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	err = clustercollector.SetupWithManager(k8sManager, nil, "")
+	Expect(err).ToNot(HaveOccurred())
+
+	go func() {
+		defer GinkgoRecover()
+		err = k8sManager.Start(testCtx)
+		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
+	}()
+
 }, 60)
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
+	cancel()
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())
 })
+
+func cleanupResources() {
+	// Clean up all Destinations
+	destinationList := &odigosv1.DestinationList{}
+	k8sClient.List(testCtx, destinationList)
+	for _, destination := range destinationList.Items {
+		Eventually(func() bool {
+			err := k8sClient.Delete(testCtx, &destination)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+	}
+
+	// Clean up all CollectorsGroups
+	collectorsGroupList := &odigosv1.CollectorsGroupList{}
+	k8sClient.List(testCtx, collectorsGroupList)
+	for _, collectorsGroup := range collectorsGroupList.Items {
+		Eventually(func() bool {
+			err := k8sClient.Delete(testCtx, &collectorsGroup)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+	}
+
+	secretList := &corev1.SecretList{}
+	k8sClient.List(testCtx, secretList)
+	for _, secret := range secretList.Items {
+		Eventually(func() bool {
+			err := k8sClient.Delete(testCtx, &secret)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+	}
+
+	deploymentList := &appsv1.DeploymentList{}
+	k8sClient.List(testCtx, deploymentList)
+	for _, deployment := range deploymentList.Items {
+		Eventually(func() bool {
+			err := k8sClient.Delete(testCtx, &deployment)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+	}
+
+	namespaceList := &corev1.NamespaceList{}
+	k8sClient.List(testCtx, namespaceList)
+	for _, namespace := range namespaceList.Items {
+		Eventually(func() bool {
+			err := k8sClient.Delete(testCtx, &namespace)
+			return err == nil
+		}, timeout, interval).Should(BeTrue())
+	}
+}

--- a/autoscaler/controllers/clustercollector/suite_test.go
+++ b/autoscaler/controllers/clustercollector/suite_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustercollector
+
+import (
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	//+kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "ClusterCollector Controller Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "api", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	err = odigosv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	//+kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+}, 60)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/autoscaler/k8sconfig/config.go
+++ b/autoscaler/k8sconfig/config.go
@@ -1,0 +1,12 @@
+package k8sconfig
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/odigos-io/odigos/common/config"
+)
+
+type K8sExporterConfigurer interface {
+	config.ExporterConfigurer
+	GetSecretRef() *corev1.LocalObjectReference
+}

--- a/autoscaler/k8sconfig/gcp.go
+++ b/autoscaler/k8sconfig/gcp.go
@@ -7,6 +7,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/odigos-io/odigos/api/k8sconsts"
 	"github.com/odigos-io/odigos/common"
 )
 
@@ -29,57 +30,63 @@ func (g *GoogleCloud) ModifyGatewayCollectorDeployment(dest K8sExporterConfigure
 	// To support multiple GCP Destinations with different credentials (which is uncommon but not totally unreasonable), we would need to
 	// create multiple Gateway Collector Deployments, one for each GCP Destination.
 	if val, exists := config[gcpApplicationCredentialsKey]; exists && val != "" && dest.GetSecretRef() != nil {
+		containerIndex := -1
+		for i := 0; i < len(currentDeployment.Spec.Template.Spec.Containers); i++ {
+			if currentDeployment.Spec.Template.Spec.Containers[i].Name == k8sconsts.OdigosClusterCollectorContainerName {
+				containerIndex = i
+				break
+			}
+		}
+		if containerIndex == -1 {
+			return fmt.Errorf("Gateway collector container '%s' not found", k8sconsts.OdigosClusterCollectorContainerName)
+		}
+		secretRefName := strings.ReplaceAll(dest.GetSecretRef().Name, ".", "-")
+
 		// Add volume mount if it doesn't exist
-		for _, volumeMount := range currentDeployment.Spec.Template.Spec.Containers[0].VolumeMounts {
-			if volumeMount.Name == strings.ReplaceAll(dest.GetSecretRef().Name, ".", "-") {
+		for _, volumeMount := range currentDeployment.Spec.Template.Spec.Containers[containerIndex].VolumeMounts {
+			if volumeMount.Name == secretRefName {
 				return fmt.Errorf("GCP credentials volume mount %s already exists."+
 					"Only one GCP Destination may have Application Credentials configured", volumeMount.Name)
 			}
 		}
-		currentDeployment.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
-			{
-				Name:      strings.ReplaceAll(dest.GetSecretRef().Name, ".", "-"),
-				MountPath: gcpCredentialsMountPath,
-			},
-		}
+		currentDeployment.Spec.Template.Spec.Containers[containerIndex].VolumeMounts = append(currentDeployment.Spec.Template.Spec.Containers[containerIndex].VolumeMounts, corev1.VolumeMount{
+			Name:      secretRefName,
+			MountPath: gcpCredentialsMountPath,
+		})
 
 		// Add volume if it doesn't exist
 		for i := range currentDeployment.Spec.Template.Spec.Volumes {
-			if currentDeployment.Spec.Template.Spec.Volumes[i].Name == strings.ReplaceAll(dest.GetSecretRef().Name, ".", "-") {
+			if currentDeployment.Spec.Template.Spec.Volumes[i].Name == secretRefName {
 				return fmt.Errorf("GCP credentials volume %s already exists."+
 					"Only one GCP Destination may have Application Credentials configured", currentDeployment.Spec.Template.Spec.Volumes[i].Name)
 			}
 		}
-		currentDeployment.Spec.Template.Spec.Volumes = []corev1.Volume{
-			{
-				Name: strings.ReplaceAll(dest.GetSecretRef().Name, ".", "-"),
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: dest.GetSecretRef().Name,
-						Items: []corev1.KeyToPath{
-							{
-								Key:  gcpApplicationCredentialsKey,
-								Path: gcpApplicationCredentialsKey,
-							},
+		currentDeployment.Spec.Template.Spec.Volumes = append(currentDeployment.Spec.Template.Spec.Volumes, corev1.Volume{
+			Name: secretRefName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: dest.GetSecretRef().Name,
+					Items: []corev1.KeyToPath{
+						{
+							Key:  gcpApplicationCredentialsKey,
+							Path: gcpApplicationCredentialsKey,
 						},
 					},
 				},
 			},
-		}
+		})
 
 		// Add environment variable pointing to the mounted credentials if it doesn't exist
-		for _, env := range currentDeployment.Spec.Template.Spec.Containers[0].Env {
+		for _, env := range currentDeployment.Spec.Template.Spec.Containers[containerIndex].Env {
 			if env.Name == gcpApplicationCredentialsKey {
 				return fmt.Errorf("GCP credentials environment variable %s already exists."+
 					"Only one GCP Destination may have Application Credentials configured", env.Name)
 			}
 		}
-		currentDeployment.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
-			{
-				Name:  gcpApplicationCredentialsKey,
-				Value: gcpCredentialsMountPath + "/" + gcpApplicationCredentialsKey,
-			},
-		}
+		currentDeployment.Spec.Template.Spec.Containers[containerIndex].Env = append(currentDeployment.Spec.Template.Spec.Containers[containerIndex].Env, corev1.EnvVar{
+			Name:  gcpApplicationCredentialsKey,
+			Value: gcpCredentialsMountPath + "/" + gcpApplicationCredentialsKey,
+		})
 	}
 	return nil
 }

--- a/autoscaler/k8sconfig/gcp.go
+++ b/autoscaler/k8sconfig/gcp.go
@@ -38,8 +38,9 @@ func (g *GoogleCloud) ModifyGatewayCollectorDeployment(dest K8sExporterConfigure
 			}
 		}
 		if containerIndex == -1 {
-			return fmt.Errorf("Gateway collector container '%s' not found", k8sconsts.OdigosClusterCollectorContainerName)
+			return fmt.Errorf("gateway collector container '%s' not found", k8sconsts.OdigosClusterCollectorContainerName)
 		}
+
 		secretRefName := strings.ReplaceAll(dest.GetSecretRef().Name, ".", "-")
 
 		// Add volume mount if it doesn't exist

--- a/autoscaler/k8sconfig/gcp.go
+++ b/autoscaler/k8sconfig/gcp.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	gcpApplicationCredentialsKey = "GCP_APPLICATION_CREDENTIALS"
-	gcpCredentialsMountPath      = "/secrets"
+	gcpApplicationCredentialsKey    = "GCP_APPLICATION_CREDENTIALS"
+	gcpApplicationCredentialsEnvVar = "GOOGLE_APPLICATION_CREDENTIALS"
+	gcpCredentialsMountPath         = "/secrets"
 )
 
 type GoogleCloud struct{}
@@ -79,13 +80,13 @@ func (g *GoogleCloud) ModifyGatewayCollectorDeployment(dest K8sExporterConfigure
 
 		// Add environment variable pointing to the mounted credentials if it doesn't exist
 		for _, env := range currentDeployment.Spec.Template.Spec.Containers[containerIndex].Env {
-			if env.Name == gcpApplicationCredentialsKey {
+			if env.Name == gcpApplicationCredentialsEnvVar {
 				return fmt.Errorf("GCP credentials environment variable %s already exists."+
 					"Only one GCP Destination may have Application Credentials configured", env.Name)
 			}
 		}
 		currentDeployment.Spec.Template.Spec.Containers[containerIndex].Env = append(currentDeployment.Spec.Template.Spec.Containers[containerIndex].Env, corev1.EnvVar{
-			Name:  gcpApplicationCredentialsKey,
+			Name:  gcpApplicationCredentialsEnvVar,
 			Value: gcpCredentialsMountPath + "/" + gcpApplicationCredentialsKey,
 		})
 	}

--- a/autoscaler/k8sconfig/gcp.go
+++ b/autoscaler/k8sconfig/gcp.go
@@ -1,0 +1,85 @@
+package k8sconfig
+
+import (
+	"fmt"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/odigos-io/odigos/common"
+)
+
+const (
+	gcpApplicationCredentialsKey = "GCP_APPLICATION_CREDENTIALS"
+	gcpCredentialsMountPath      = "/secrets"
+)
+
+type GoogleCloud struct{}
+
+func (g *GoogleCloud) DestType() common.DestinationType {
+	return common.GoogleCloudDestinationType
+}
+
+func (g *GoogleCloud) ModifyGatewayCollectorDeployment(dest K8sExporterConfigurer, currentDeployment *appsv1.Deployment) error {
+	config := dest.GetConfig()
+	// If GCP_APPLICATION_CREDENTIALS is set, mount the secret and set the environment variable
+	// NOTE: Currently, only one GCP Destination may have Application Credentials configured. This is a limitation of the GCP Collector Exporter,
+	// which relies on the GOOGLE_APPLICATION_CREDENTIALS environment variable to be set.
+	// To support multiple GCP Destinations with different credentials (which is uncommon but not totally unreasonable), we would need to
+	// create multiple Gateway Collector Deployments, one for each GCP Destination.
+	if val, exists := config[gcpApplicationCredentialsKey]; exists && val != "" && dest.GetSecretRef() != nil {
+		// Add volume mount if it doesn't exist
+		for _, volumeMount := range currentDeployment.Spec.Template.Spec.Containers[0].VolumeMounts {
+			if volumeMount.Name == strings.ReplaceAll(dest.GetSecretRef().Name, ".", "-") {
+				return fmt.Errorf("GCP credentials volume mount %s already exists."+
+					"Only one GCP Destination may have Application Credentials configured", volumeMount.Name)
+			}
+		}
+		currentDeployment.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
+			{
+				Name:      strings.ReplaceAll(dest.GetSecretRef().Name, ".", "-"),
+				MountPath: gcpCredentialsMountPath,
+			},
+		}
+
+		// Add volume if it doesn't exist
+		for i := range currentDeployment.Spec.Template.Spec.Volumes {
+			if currentDeployment.Spec.Template.Spec.Volumes[i].Name == strings.ReplaceAll(dest.GetSecretRef().Name, ".", "-") {
+				return fmt.Errorf("GCP credentials volume %s already exists."+
+					"Only one GCP Destination may have Application Credentials configured", currentDeployment.Spec.Template.Spec.Volumes[i].Name)
+			}
+		}
+		currentDeployment.Spec.Template.Spec.Volumes = []corev1.Volume{
+			{
+				Name: strings.ReplaceAll(dest.GetSecretRef().Name, ".", "-"),
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: dest.GetSecretRef().Name,
+						Items: []corev1.KeyToPath{
+							{
+								Key:  gcpApplicationCredentialsKey,
+								Path: gcpApplicationCredentialsKey,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		// Add environment variable pointing to the mounted credentials if it doesn't exist
+		for _, env := range currentDeployment.Spec.Template.Spec.Containers[0].Env {
+			if env.Name == gcpApplicationCredentialsKey {
+				return fmt.Errorf("GCP credentials environment variable %s already exists."+
+					"Only one GCP Destination may have Application Credentials configured", env.Name)
+			}
+		}
+		currentDeployment.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
+			{
+				Name:  gcpApplicationCredentialsKey,
+				Value: gcpCredentialsMountPath + "/" + gcpApplicationCredentialsKey,
+			},
+		}
+	}
+	return nil
+}

--- a/autoscaler/k8sconfig/root.go
+++ b/autoscaler/k8sconfig/root.go
@@ -1,0 +1,33 @@
+package k8sconfig
+
+import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+
+	"github.com/odigos-io/odigos/common"
+)
+
+var availableK8sConfigers = []K8sConfiger{
+	&GoogleCloud{},
+}
+
+// K8sConfiger is the interface for modifying the gateway collector deployment.
+// It is linked to a common config destination type.
+type K8sConfiger interface {
+	DestType() common.DestinationType
+	ModifyGatewayCollectorDeployment(dest K8sExporterConfigurer, currentDeployment *appsv1.Deployment) error
+}
+
+// LoadK8sConfigers loads the available K8sConfigers, mapped to their commonconfig destination type.
+func LoadK8sConfigers() (map[common.DestinationType]K8sConfiger, error) {
+	configers := map[common.DestinationType]K8sConfiger{}
+	for _, configer := range availableK8sConfigers {
+		if _, exists := configers[configer.DestType()]; exists {
+			return nil, fmt.Errorf("duplicate configer for %s", configer.DestType())
+		}
+
+		configers[configer.DestType()] = configer
+	}
+	return configers, nil
+}

--- a/autoscaler/k8sconfig/root.go
+++ b/autoscaler/k8sconfig/root.go
@@ -1,7 +1,10 @@
 package k8sconfig
 
 import (
+	"context"
+
 	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/odigos-io/odigos/common"
 )
@@ -14,7 +17,7 @@ var availableK8sConfigers = map[common.DestinationType]K8sConfiger{
 // It is linked to a common config destination type.
 type K8sConfiger interface {
 	DestType() common.DestinationType
-	ModifyGatewayCollectorDeployment(dest K8sExporterConfigurer, currentDeployment *appsv1.Deployment) error
+	ModifyGatewayCollectorDeployment(ctx context.Context, k8sClient client.Client, dest K8sExporterConfigurer, currentDeployment *appsv1.Deployment) error
 }
 
 // LoadK8sConfigers loads the available K8sConfigers, mapped to their commonconfig destination type.

--- a/autoscaler/k8sconfig/root.go
+++ b/autoscaler/k8sconfig/root.go
@@ -1,15 +1,13 @@
 package k8sconfig
 
 import (
-	"fmt"
-
 	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/odigos-io/odigos/common"
 )
 
-var availableK8sConfigers = []K8sConfiger{
-	&GoogleCloud{},
+var availableK8sConfigers = map[common.DestinationType]K8sConfiger{
+	common.GoogleCloudDestinationType: &GoogleCloud{},
 }
 
 // K8sConfiger is the interface for modifying the gateway collector deployment.
@@ -20,14 +18,6 @@ type K8sConfiger interface {
 }
 
 // LoadK8sConfigers loads the available K8sConfigers, mapped to their commonconfig destination type.
-func LoadK8sConfigers() (map[common.DestinationType]K8sConfiger, error) {
-	configers := map[common.DestinationType]K8sConfiger{}
-	for _, configer := range availableK8sConfigers {
-		if _, exists := configers[configer.DestType()]; exists {
-			return nil, fmt.Errorf("duplicate configer for %s", configer.DestType())
-		}
-
-		configers[configer.DestType()] = configer
-	}
-	return configers, nil
+func LoadK8sConfigers() map[common.DestinationType]K8sConfiger {
+	return availableK8sConfigers
 }

--- a/common/config/gcp.go
+++ b/common/config/gcp.go
@@ -22,10 +22,10 @@ func (g *GoogleCloud) ModifyConfig(dest ExporterConfigurer, currentConfig *Confi
 		exporterName := "googlecloud/" + dest.GetID()
 		exporterConfig := GenericMap{}
 		if projectId, exists := dest.GetConfig()[gcpProjectIdKey]; exists {
-			exporterConfig["project_id"] = projectId
+			exporterConfig["project"] = projectId
 		}
 		if billingProjectId, exists := dest.GetConfig()[gcpBillingProjectIdKey]; exists {
-			exporterConfig["billing_project_id"] = billingProjectId
+			exporterConfig["destination_project_quota"] = billingProjectId
 		}
 		if timeout, exists := dest.GetConfig()[gcpTimeoutKey]; exists {
 			exporterConfig["timeout"] = timeout
@@ -52,10 +52,10 @@ func (g *GoogleCloud) ModifyConfig(dest ExporterConfigurer, currentConfig *Confi
 		}
 
 		if projectId, exists := dest.GetConfig()[gcpProjectIdKey]; exists {
-			exporterConfig["project_id"] = projectId
+			exporterConfig["project"] = projectId
 		}
 		if billingProjectId, exists := dest.GetConfig()[gcpBillingProjectIdKey]; exists {
-			exporterConfig["billing_project_id"] = billingProjectId
+			exporterConfig["destination_project_quota"] = billingProjectId
 		}
 
 		currentConfig.Exporters[exporterName] = exporterConfig

--- a/common/config/gcp.go
+++ b/common/config/gcp.go
@@ -4,6 +4,12 @@ import (
 	"github.com/odigos-io/odigos/common"
 )
 
+const (
+	gcpProjectIdKey        = "GCP_PROJECT_ID"
+	gcpBillingProjectIdKey = "GCP_BILLING_PROJECT"
+	gcpTimeoutKey          = "GCP_TIMEOUT"
+)
+
 type GoogleCloud struct{}
 
 func (g *GoogleCloud) DestType() common.DestinationType {
@@ -14,7 +20,18 @@ func (g *GoogleCloud) ModifyConfig(dest ExporterConfigurer, currentConfig *Confi
 	var pipelineNames []string
 	if isTracingEnabled(dest) {
 		exporterName := "googlecloud/" + dest.GetID()
-		currentConfig.Exporters[exporterName] = struct{}{}
+		exporterConfig := GenericMap{}
+		if projectId, exists := dest.GetConfig()[gcpProjectIdKey]; exists {
+			exporterConfig["project_id"] = projectId
+		}
+		if billingProjectId, exists := dest.GetConfig()[gcpBillingProjectIdKey]; exists {
+			exporterConfig["billing_project_id"] = billingProjectId
+		}
+		if timeout, exists := dest.GetConfig()[gcpTimeoutKey]; exists {
+			exporterConfig["timeout"] = timeout
+		}
+
+		currentConfig.Exporters[exporterName] = exporterConfig
 
 		tracesPipelineName := "traces/googlecloud-" + dest.GetID()
 		currentConfig.Service.Pipelines[tracesPipelineName] = Pipeline{
@@ -25,11 +42,23 @@ func (g *GoogleCloud) ModifyConfig(dest ExporterConfigurer, currentConfig *Confi
 
 	if isLoggingEnabled(dest) {
 		exporterName := "googlecloud/" + dest.GetID()
-		currentConfig.Exporters[exporterName] = GenericMap{
+		exporterConfig := GenericMap{
 			"log": GenericMap{
 				"default_log_name": "opentelemetry.io/collector-exported-log",
 			},
 		}
+		if timeout, exists := dest.GetConfig()[gcpTimeoutKey]; exists {
+			exporterConfig["timeout"] = timeout
+		}
+
+		if projectId, exists := dest.GetConfig()[gcpProjectIdKey]; exists {
+			exporterConfig["project_id"] = projectId
+		}
+		if billingProjectId, exists := dest.GetConfig()[gcpBillingProjectIdKey]; exists {
+			exporterConfig["billing_project_id"] = billingProjectId
+		}
+
+		currentConfig.Exporters[exporterName] = exporterConfig
 
 		logsPipelineName := "logs/googlecloud-" + dest.GetID()
 		currentConfig.Service.Pipelines[logsPipelineName] = Pipeline{

--- a/destinations/data/googlecloudmonitoring.yaml
+++ b/destinations/data/googlecloudmonitoring.yaml
@@ -41,7 +41,6 @@ spec:
         placeholder: 'billing-project-id'
         tooltip: The billing project ID for the Google Cloud Monitoring API. By default, this is the same as the project ID.
 
-
     - name: GCP_APPLICATION_CREDENTIALS
       displayName: Application Credentials
       componentType: textarea

--- a/destinations/data/googlecloudmonitoring.yaml
+++ b/destinations/data/googlecloudmonitoring.yaml
@@ -13,4 +13,22 @@ spec:
       supported: false
     logs:
       supported: true
-  fields: []
+  fields:
+    - name: GCP_TIMEOUT
+      displayName: Timeout
+      componentType: input
+      componentProps:
+        type: text
+        placeholder: 10s
+        tooltip: The request timeout in seconds for the Google Cloud Monitoring API.
+    - name: GCP_PROJECT_ID
+      displayName: Project ID
+      componentType: input
+      componentProps:
+        type: text
+        tooltip: The project ID for the Google Cloud Monitoring API.
+    - name: GCP_BILLING_PROJECT
+      displayName: Billing Project
+      componentType: input
+      componentProps:
+        type: text

--- a/destinations/data/googlecloudmonitoring.yaml
+++ b/destinations/data/googlecloudmonitoring.yaml
@@ -20,15 +20,34 @@ spec:
       componentProps:
         type: text
         placeholder: 10s
+        required: false
         tooltip: The request timeout in seconds for the Google Cloud Monitoring API.
+
     - name: GCP_PROJECT_ID
       displayName: Project ID
       componentType: input
       componentProps:
         type: text
+        required: false
+        placeholder: 'project-id'
         tooltip: The project ID for the Google Cloud Monitoring API.
+
     - name: GCP_BILLING_PROJECT
       displayName: Billing Project
       componentType: input
       componentProps:
         type: text
+        required: false
+        placeholder: 'billing-project-id'
+        tooltip: The billing project ID for the Google Cloud Monitoring API. By default, this is the same as the project ID.
+
+
+    - name: GCP_APPLICATION_CREDENTIALS
+      displayName: Application Credentials
+      componentType: textarea
+      secret: true
+      componentProps:
+        type: text
+        required: false
+        placeholder: 'Credentials config... (optional)'
+        tooltip: The JSON GCP Application Credentials file for the GCP project. Either a Workload Identity Federation config file or Service Account Key. Required if running Odigos outside of Google Cloud.

--- a/destinations/data/googlecloudmonitoring.yaml
+++ b/destinations/data/googlecloudmonitoring.yaml
@@ -21,7 +21,7 @@ spec:
         type: text
         placeholder: 10s
         required: false
-        tooltip: The request timeout in seconds for the Google Cloud Monitoring API.
+        tooltip: The request timeout in seconds for the Google Cloud Monitoring API. Defaults to 10 seconds. Increasing this value can help with deadline exceeded errors.
 
     - name: GCP_PROJECT_ID
       displayName: Project ID
@@ -30,7 +30,7 @@ spec:
         type: text
         required: false
         placeholder: 'project-id'
-        tooltip: The project ID for the Google Cloud Monitoring API.
+        tooltip: The project ID for the Google Cloud Monitoring API to send data to. Required if running Odigos outside of Google Cloud. Defaults to the detected project ID when running on GCP.
 
     - name: GCP_BILLING_PROJECT
       displayName: Billing Project
@@ -39,7 +39,7 @@ spec:
         type: text
         required: false
         placeholder: 'billing-project-id'
-        tooltip: The billing project ID for the Google Cloud Monitoring API. By default, this is the same as the project ID.
+        tooltip: The billing project ID for the Google Cloud Monitoring API. Allows you to specify a different project ID for billing and quota consumption. By default, this is the same as the project ID.
 
     - name: GCP_APPLICATION_CREDENTIALS
       displayName: Application Credentials

--- a/docs/adding-new-dest.mdx
+++ b/docs/adding-new-dest.mdx
@@ -234,7 +234,7 @@ Now that our new vendor can be persisted/loaded in the Kubernetes data store, we
 ### Kubernetes-Specific Collector Configuration
 
 If your destination configures Kubernetes settings, for example you have a config field that accepts a value that should be mounted
-in the Collector Pod, create a `K8sConfiger` object in [`destinations.k8sconfig`](https://github.com/odigos-io/odigos/tree/main/destinations/k8sconfig).
+in the Collector Pod, create a `K8sConfiger` object in [`destinations.k8sconfig`](https://github.com/odigos-io/odigos/tree/main/autoscaler/k8sconfig).
 
 This interface provides an additional function, `ModifyGatewayCollectorDeployment`, which accepts a Destination and Collector Deployment.
 Your implementation can use this function to modify the Deployment as necessary based on the Destination config.
@@ -247,7 +247,7 @@ of common Destination that this Kubernetes implementation relies on. This is use
 only for the matching Destination.
 
 When it is implemented, add your `K8sConfiger` implementation to the `availableConfigers` list in
-[`destinations/k8sconfig/root.go`](https://github.com/odigos-io/odigos/tree/main/destinations/k8sconfig/root.go)
+[`destinations/k8sconfig/root.go`](https://github.com/odigos-io/odigos/tree/main/autoscaler/k8sconfig/root.go)
 
 ### Generating Documentation
 

--- a/docs/adding-new-dest.mdx
+++ b/docs/adding-new-dest.mdx
@@ -231,6 +231,24 @@ Now that our new vendor can be persisted/loaded in the Kubernetes data store, we
   </Step>
 </Steps>
 
+### Kubernetes-Specific Collector Configuration
+
+If your destination configures Kubernetes settings, for example you have a config field that accepts a value that should be mounted
+in the Collector Pod, create a `K8sConfiger` object in [`destinations.k8sconfig`](https://github.com/odigos-io/odigos/tree/main/destinations/k8sconfig).
+
+This interface provides an additional function, `ModifyGatewayCollectorDeployment`, which accepts a Destination and Collector Deployment.
+Your implementation can use this function to modify the Deployment as necessary based on the Destination config.
+
+Note: It is the responsibility of your implementation to check for the validity of this config, such as checking for conflicts or values
+that already exist.
+
+The `K8sConfiger` interface also requires a `DestType()` function, similar to common Destinations. This function returns the type
+of common Destination that this Kubernetes implementation relies on. This is used by the Autoscaler to conditionally apply the `K8sConfiger`
+only for the matching Destination.
+
+When it is implemented, add your `K8sConfiger` implementation to the `availableConfigers` list in
+[`destinations/k8sconfig/root.go`](https://github.com/odigos-io/odigos/tree/main/destinations/k8sconfig/root.go)
+
 ### Generating Documentation
 
 <Steps>

--- a/docs/backends/googlecloudmonitoring.mdx
+++ b/docs/backends/googlecloudmonitoring.mdx
@@ -38,9 +38,15 @@ cloud provider) you must provide a [service account key](https://cloud.google.co
 for the OpenTelemetry Collector Exporter. In Odigos, this can be provided in the Application Credentials field of the
 Google Cloud destination.
 
-When the Application Credentials field is set, the Odigos UI will save the contents of that field as a Kubernetes Secret
+When the Application Credentials field is set in the UI, the Odigos UI will save the contents of that field as a Kubernetes Secret
 which is mounted as a volume into the Collector Pod. The location of that volume is then set as the `GOOGLE_APPLICATION_CREDENTIALS`
 environment variable, instructing the Google Cloud Exporter where to look for its credentials.
+
+When creating the destination as a YAML manifest off-GKE, the SecretRef must point to a Secret containing the Service Account token.
+The token must be set as the `GCP_APPLICATION_CREDENTIALS` key in the referenced Secret.
+
+The `GCP_APPLICATION_CREDENTIALS` field does not need to be set on the YAML manifest destination CRD, only in the referenced Secret.
+This field is used internally by Odigos when creating GCP destinations from the UI.
 
 Currently, only one Google Cloud destination can be configured with Application Credentials.
 
@@ -60,13 +66,13 @@ for more information on authentication.
   ✅ Logs
 </Accordion>
 
-- **GCP_TIMEOUT** `string` : Timeout. The request timeout in seconds for the Google Cloud Monitoring API.
+- **GCP_TIMEOUT** `string` : Timeout. The request timeout in seconds for the Google Cloud Monitoring API. Defaults to 10 seconds. Increasing this value can help with deadline exceeded errors.
   - This field is optional
   - Example: `10s`
-- **GCP_PROJECT_ID** `string` : Project ID. The project ID for the Google Cloud Monitoring API.
+- **GCP_PROJECT_ID** `string` : Project ID. The project ID for the Google Cloud Monitoring API to send data to. Required if running Odigos outside of Google Cloud. Defaults to the detected project ID when running on GCP.
   - This field is optional
   - Example: `project-id`
-- **GCP_BILLING_PROJECT** `string` : Billing Project. The billing project ID for the Google Cloud Monitoring API. By default, this is the same as the project ID.
+- **GCP_BILLING_PROJECT** `string` : Billing Project. The billing project ID for the Google Cloud Monitoring API. Allows you to specify a different project ID for billing and quota consumption. By default, this is the same as the project ID.
   - This field is optional
   - Example: `billing-project-id`
 - **GCP_APPLICATION_CREDENTIALS** `string` : Application Credentials. The JSON GCP Application Credentials file for the GCP project. Either a Workload Identity Federation config file or Service Account Key. Required if running Odigos outside of Google Cloud.

--- a/docs/backends/googlecloudmonitoring.mdx
+++ b/docs/backends/googlecloudmonitoring.mdx
@@ -44,8 +44,13 @@ Odigos currently supports Standard (non-Autopilot) GKE clusters. Exporting into 
   - Example: `10s`
 - **GCP_PROJECT_ID** `string` : Project ID. The project ID for the Google Cloud Monitoring API.
   - This field is optional
-- **GCP_BILLING_PROJECT** `string` : Billing Project.
+  - Example: `project-id`
+- **GCP_BILLING_PROJECT** `string` : Billing Project. The billing project ID for the Google Cloud Monitoring API. By default, this is the same as the project ID.
   - This field is optional
+  - Example: `billing-project-id`
+- **GCP_APPLICATION_CREDENTIALS** `string` : Application Credentials. The JSON GCP Application Credentials file for the GCP project. Either a Workload Identity Federation config file or Service Account Key. Required if running Odigos outside of Google Cloud.
+  - This field is optional
+  - Example: `Credentials config... (optional)`
 
 ### Adding Destination to Odigos
 
@@ -79,10 +84,25 @@ There are two primary methods for configuring destinations in Odigos:
     spec:
       data: {}
       destinationName: googlecloud
+      # Uncomment the 'secretRef' below if you are using the optional Secret.
+      # secretRef:
+      #   name: googlecloud-secret
       signals:
       - TRACES
       - LOGS
       type: googlecloud
+
+    ---
+
+    # The following Secret is optional. Uncomment the entire block if you need to use it.
+    # apiVersion: v1
+    # data:
+    #   GCP_APPLICATION_CREDENTIALS: <Base64 Application Credentials>
+    # kind: Secret
+    # metadata:
+    #   name: googlecloud-secret
+    #   namespace: odigos-system
+    # type: Opaque
     ```
   </Step>
   <Step>

--- a/docs/backends/googlecloudmonitoring.mdx
+++ b/docs/backends/googlecloudmonitoring.mdx
@@ -42,6 +42,8 @@ When the Application Credentials field is set, the Odigos UI will save the conte
 which is mounted as a volume into the Collector Pod. The location of that volume is then set as the `GOOGLE_APPLICATION_CREDENTIALS`
 environment variable, instructing the Google Cloud Exporter where to look for its credentials.
 
+Currently, only one Google Cloud destination can be configured with Application Credentials.
+
 See the [Google Cloud OpenTelemetry Collector Exporter docs](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/tree/1ea43a4534606df1d91ee1754e6c5bc31ee8664d/exporter/collector#prerequisite-authenticating)
 for more information on authentication.
 

--- a/docs/backends/googlecloudmonitoring.mdx
+++ b/docs/backends/googlecloudmonitoring.mdx
@@ -24,7 +24,26 @@ icon: 'signal-stream'
     !! START CUSTOM EDIT !!
 */}
 
-Odigos currently supports Standard (non-Autopilot) GKE clusters. Exporting into Google Cloud does not require credentials as the Kubernetes nodes are permissioned to access the Google Cloud Monitoring APIs by default.
+Odigos currently supports Standard (non-Autopilot) GKE clusters.
+
+### Authenticating with Google Cloud
+
+When running the Google Cloud Exporter on GKE, by default the OpenTelemetry Collector will attempt to use
+[Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials)
+to authenticate to the Google Cloud Observability backend. This means that for most use cases running on GCP,
+there is not authentication or service account token required as your workloads are automatically authenticated.
+
+However, to authenticate with Cloud Observability when running off-GKE (for example, on a local machine for another
+cloud provider) you must provide a [service account key](https://cloud.google.com/iam/docs/keys-create-delete#iam-service-account-keys-create-console)
+for the OpenTelemetry Collector Exporter. In Odigos, this can be provided in the Application Credentials field of the
+Google Cloud destination.
+
+When the Application Credentials field is set, the Odigos UI will save the contents of that field as a Kubernetes Secret
+which is mounted as a volume into the Collector Pod. The location of that volume is then set as the `GOOGLE_APPLICATION_CREDENTIALS`
+environment variable, instructing the Google Cloud Exporter where to look for its credentials.
+
+See the [Google Cloud OpenTelemetry Collector Exporter docs](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/tree/1ea43a4534606df1d91ee1754e6c5bc31ee8664d/exporter/collector#prerequisite-authenticating)
+for more information on authentication.
 
 {/*
     !! Do not remove this comment, this acts as a key indicator in `docs/sync-dest-doc.py` !!

--- a/docs/backends/googlecloudmonitoring.mdx
+++ b/docs/backends/googlecloudmonitoring.mdx
@@ -39,6 +39,14 @@ Odigos currently supports Standard (non-Autopilot) GKE clusters. Exporting into 
   ✅ Logs
 </Accordion>
 
+- **GCP_TIMEOUT** `string` : Timeout. The request timeout in seconds for the Google Cloud Monitoring API.
+  - This field is optional
+  - Example: `10s`
+- **GCP_PROJECT_ID** `string` : Project ID. The project ID for the Google Cloud Monitoring API.
+  - This field is optional
+- **GCP_BILLING_PROJECT** `string` : Billing Project.
+  - This field is optional
+
 ### Adding Destination to Odigos
 
 There are two primary methods for configuring destinations in Odigos:

--- a/frontend/services/destinations.go
+++ b/frontend/services/destinations.go
@@ -157,9 +157,10 @@ func TransformFieldsToDataAndSecrets(destTypeConfig *destinations.Destination, f
 			if fieldName == fieldConfig.Name {
 				if fieldConfig.Secret {
 					secretFields[fieldName] = fieldValue
-				} else {
-					dataFields[fieldName] = fieldValue
+					// Preserve the fact that the field is set so that we can act on that once it has been processed to a Destination.
+					fieldValue = "redacted"
 				}
+				dataFields[fieldName] = fieldValue
 			}
 		}
 	}

--- a/frontend/services/destinations.go
+++ b/frontend/services/destinations.go
@@ -157,12 +157,9 @@ func TransformFieldsToDataAndSecrets(destTypeConfig *destinations.Destination, f
 			if fieldName == fieldConfig.Name {
 				if fieldConfig.Secret {
 					secretFields[fieldName] = fieldValue
-					// Persist the fact that the field is set so that we can act on that once it has been processed to a Destination.
-					// For example, the GCP exporter applies different config if the "Application Credentials" secret field is set.
-					// But we still do not want to persist the actual credentials in the Destination, so we replace the value with "redacted".
-					fieldValue = "redacted"
+				} else {
+					dataFields[fieldName] = fieldValue
 				}
-				dataFields[fieldName] = fieldValue
 			}
 		}
 	}

--- a/frontend/services/destinations.go
+++ b/frontend/services/destinations.go
@@ -157,7 +157,9 @@ func TransformFieldsToDataAndSecrets(destTypeConfig *destinations.Destination, f
 			if fieldName == fieldConfig.Name {
 				if fieldConfig.Secret {
 					secretFields[fieldName] = fieldValue
-					// Preserve the fact that the field is set so that we can act on that once it has been processed to a Destination.
+					// Persist the fact that the field is set so that we can act on that once it has been processed to a Destination.
+					// For example, the GCP exporter applies different config if the "Application Credentials" secret field is set.
+					// But we still do not want to persist the actual credentials in the Destination, so we replace the value with "redacted".
 					fieldValue = "redacted"
 				}
 				dataFields[fieldName] = fieldValue


### PR DESCRIPTION
## Description

This adds the following options to the GCP exporter:

* `timeout` -- configure timeout for requests to cloud observability API
* `project ID` -- used when sending telemetry to a different GCP project than where the app is currently running (also conditionally required if running off-GKE and sending traces to GCP observability)
* `billing project ID` -- the *billing* project for counting trace quota usage when sending to GCP
* `Google application credentials` -- service account token/info for sending traces to GCP when running off GKE

Application credentials requires something new where a Destination can conditionally configure the Collector Deployment. This is because, when setting custom credentials for GCP, the exporter needs the credentials as a file in the Pod.

This is implemented with a new `K8sConfiger` interface that builds on the common `Configer` to add k8s-specific updates to the deployment without adding k8s dependencies to the common package. `K8sConfiger` objects are linked to their common `Configer` with a `DestinationType()` method.

Replaces https://github.com/odigos-io/odigos/pull/2904 with a more simplified, decoupled approach to `K8sConfiger`.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [x] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
