### PR TITLE
test k3d cluster instead of kind

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -85,11 +85,11 @@ jobs:
           - "mount-method"
         include:
           - kube-version: "1.20.15"
-            kind-image: "kindest/node:v1.20.15@sha256:a32bf55309294120616886b5338f95dd98a2f7231519c7dedcec32ba29699394"
+            k3d-image: "rancher/k3s:v1.20.15-k3s1"
           - kube-version: "1.23"
-            kind-image: "kindest/node:v1.23.17@sha256:14d0a9a892b943866d7e6be119a06871291c517d279aedb816a4b4bc0ec0a5b3"
+            k3d-image: "rancher/k3s:v1.23.17-k3s1"
           - kube-version: "1.32"
-            kind-image: "kindest/node:v1.32.0@sha256:2458b423d635d7b01637cac2d6de7e1c1dca1148a2ba2e90975e214ca849e7cb"
+            k3d-image: "rancher/k3s:v1.32.0-k3s1"
 
     steps:
       - name: Checkout
@@ -103,13 +103,14 @@ jobs:
       - name: Install chainsaw
         uses: kyverno/action-install-chainsaw@v0.2.12
 
-      - name: Create Kind Cluster
-        uses: helm/kind-action@v1.12.0
+      - name: Create k3d Cluster
+        uses: AbsaOSS/k3d-action@v2
         with:
-          node_image: ${{ matrix.kind-image }}
-          version: "v0.25.0"
-          cluster_name: kind
-          config: tests/common/apply/kind-config.yaml
+          cluster-name: "odigos-test"
+          args: >-
+            --agents 1
+            --image ${{ matrix.k3d-image }}
+            --config=tests/common/apply/k3d-config.yaml
 
       - name: wait for cluster readiness
         run: |
@@ -134,10 +135,10 @@ jobs:
           echo "Expected cache key: ${{ github.run_id }}-odigos-images"
           exit 1
 
-      - name: Load Odigos Images to Kind Cluster
+      - name: Load Odigos Images to k3d Cluster
         run: |
-          kind load image-archive odigos-images.tar
-          kind load image-archive cli-image.tar
+          k3d image import odigos-images.tar -c odigos-test
+          k3d image import cli-image.tar -c odigos-test
 
       - name: Restore cached CLI binary
         id: restore-cli-cache

--- a/tests/common/apply/k3d-config.yaml
+++ b/tests/common/apply/k3d-config.yaml
@@ -1,4 +1,4 @@
-apiVersion: k3d.io/v1alpha4
+apiVersion: k3d.io/v1alpha5
 kind: Simple
 metadata:
   name: odigos-test
@@ -14,8 +14,6 @@ kubeAPI:
 # - v1.23: rancher/k3s:v1.23.17-k3s1
 # - v1.32: rancher/k3s:v1.32.0-k3s1
 image: rancher/k3s:v1.32.0-k3s1
-network: k3d-odigos-test
-subnet: "172.28.0.0/16"
 token: odigos-test-token
 options:
   k3d:

--- a/tests/common/apply/k3d-config.yaml
+++ b/tests/common/apply/k3d-config.yaml
@@ -4,6 +4,15 @@ metadata:
   name: odigos-test
 servers: 1
 agents: 1
+env:
+  - envVar: K3S_KUBECONFIG_OUTPUT=/output/kubeconfig.yaml
+    nodeFilters:
+      - server:0
+      - agent:*
+  - envVar: K3S_TOKEN=odigos-test-token
+    nodeFilters:
+      - server:0
+      - agent:*
 kubeAPI:
   host: "0.0.0.0"
   hostIP: "127.0.0.1"
@@ -18,7 +27,7 @@ token: odigos-test-token
 options:
   k3d:
     wait: true
-    timeout: "60s"
+    timeout: "300s"
     disableLoadbalancer: false
     disableImageVolume: false
   k3s:
@@ -26,7 +35,9 @@ options:
       - arg: --disable=traefik
         nodeFilters:
           - server:0
-          - agent:*
+      - arg: --disable=servicelb
+        nodeFilters:
+          - server:0
   kubeconfig:
     updateDefaultKubeconfig: true
     switchCurrentContext: true

--- a/tests/common/apply/k3d-config.yaml
+++ b/tests/common/apply/k3d-config.yaml
@@ -1,0 +1,34 @@
+apiVersion: k3d.io/v1alpha4
+kind: Simple
+metadata:
+  name: odigos-test
+servers: 1
+agents: 1
+kubeAPI:
+  host: "0.0.0.0"
+  hostIP: "127.0.0.1"
+  hostPort: "6443"
+# Note: The image will be overridden by the k3d command with the appropriate version
+# Supported versions:
+# - v1.20.15: rancher/k3s:v1.20.15-k3s1
+# - v1.23: rancher/k3s:v1.23.17-k3s1
+# - v1.32: rancher/k3s:v1.32.0-k3s1
+image: rancher/k3s:v1.32.0-k3s1
+network: k3d-odigos-test
+subnet: "172.28.0.0/16"
+token: odigos-test-token
+options:
+  k3d:
+    wait: true
+    timeout: "60s"
+    disableLoadbalancer: false
+    disableImageVolume: false
+  k3s:
+    extraArgs:
+      - arg: --disable=traefik
+        nodeFilters:
+          - server:0
+          - agent:*
+  kubeconfig:
+    updateDefaultKubeconfig: true
+    switchCurrentContext: true


### PR DESCRIPTION
## Description

<!-- Short summary of the changes -->

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-231
