### PR TITLE
chore: refactor distro params handling

### DIFF
--- a/instrumentor/controllers/agentenabled/distroparams.go
+++ b/instrumentor/controllers/agentenabled/distroparams.go
@@ -1,0 +1,140 @@
+package agentenabled
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-version"
+	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	"github.com/odigos-io/odigos/common"
+	distroTypes "github.com/odigos-io/odigos/distros/distro"
+)
+
+// DistroParams is a map of string keys to string values,
+// Which allows the reconcile to pass parameters to the distro,
+// used in webhook to make the injection as a parameterized operation.
+//
+// They capture info from runtime detection, verify it's validation and existence
+// and then populate it in the container agent config.
+// It allows the webhook to be simpler, only relying on processed, transactional data,
+// that can be directly used in the injection logic.
+
+type DistroParam = map[string]string
+
+func AddLibcDistroParamFromRuntimeDetails(params DistroParam, distroName string, runtimeDetails *odigosv1.RuntimeDetailsByContainer) (err *odigosv1.ContainerAgentConfig) {
+	if runtimeDetails.LibCType == nil {
+		return &odigosv1.ContainerAgentConfig{
+			ContainerName:       runtimeDetails.ContainerName,
+			AgentEnabled:        false,
+			AgentEnabledReason:  odigosv1.AgentEnabledReasonMissingDistroParameter,
+			AgentEnabledMessage: fmt.Sprintf("failed to detect libc type for opentelemetry distribution '%s' which is required for instrumentation", distroName),
+		}
+	}
+	params[common.LibcTypeDistroParameterName] = string(*runtimeDetails.LibCType)
+
+	return nil
+}
+
+func AddRuntimeVersionMajorMinorDistroParamFromRuntimeDetails(params DistroParam, distroName string, runtimeDetails *odigosv1.RuntimeDetailsByContainer) *odigosv1.ContainerAgentConfig {
+	if runtimeDetails.RuntimeVersion == "" {
+		return &odigosv1.ContainerAgentConfig{
+			ContainerName:       runtimeDetails.ContainerName,
+			AgentEnabled:        false,
+			AgentEnabledReason:  odigosv1.AgentEnabledReasonMissingDistroParameter,
+			AgentEnabledMessage: fmt.Sprintf("failed to detect runtime version for opentelemetry distribution '%s' which is required for instrumentation", distroName),
+		}
+	}
+	version, err := version.NewVersion(runtimeDetails.RuntimeVersion)
+	if err != nil {
+		return &odigosv1.ContainerAgentConfig{
+			ContainerName:       runtimeDetails.ContainerName,
+			AgentEnabled:        false,
+			AgentEnabledReason:  odigosv1.AgentEnabledReasonMissingDistroParameter,
+			AgentEnabledMessage: fmt.Sprintf("failed to parse runtime version from detection: %s", runtimeDetails.RuntimeVersion),
+		}
+	}
+	versionAsMajorMinor, err := common.MajorMinorStringOnly(version)
+	if err != nil {
+		return &odigosv1.ContainerAgentConfig{
+			ContainerName:       runtimeDetails.ContainerName,
+			AgentEnabled:        false,
+			AgentEnabledReason:  odigosv1.AgentEnabledReasonMissingDistroParameter,
+			AgentEnabledMessage: fmt.Sprintf("failed to parse runtime version as major.minor: %s", runtimeDetails.RuntimeVersion),
+		}
+	}
+	params[distroTypes.RuntimeVersionMajorMinorDistroParameterName] = versionAsMajorMinor
+
+	return nil
+}
+
+func CalculateRequiredParametersFromRuntimeDetails(distro *distroTypes.OtelDistro, runtimeDetails *odigosv1.RuntimeDetailsByContainer) (requiredParams DistroParam, err *odigosv1.ContainerAgentConfig) {
+	requiredParams = DistroParam{}
+	for _, parameterName := range distro.RequireParameters {
+		switch parameterName {
+		case common.LibcTypeDistroParameterName:
+			err := AddLibcDistroParamFromRuntimeDetails(requiredParams, distro.Name, runtimeDetails)
+			if err != nil {
+				return requiredParams, err
+			}
+		case distroTypes.RuntimeVersionMajorMinorDistroParameterName:
+			err := AddRuntimeVersionMajorMinorDistroParamFromRuntimeDetails(requiredParams, distro.Name, runtimeDetails)
+			if err != nil {
+				return requiredParams, err
+			}
+		default:
+			return requiredParams, &odigosv1.ContainerAgentConfig{
+				ContainerName:       runtimeDetails.ContainerName,
+				AgentEnabled:        false,
+				AgentEnabledReason:  odigosv1.AgentEnabledReasonMissingDistroParameter,
+				AgentEnabledMessage: fmt.Sprintf("unsupported parameter '%s' for distro '%s'", parameterName, distro.Name),
+			}
+		}
+	}
+	return requiredParams, nil
+}
+
+func CalculateAppendEnvParametersFromRuntimeDetails(distro *distroTypes.OtelDistro, runtimeDetails *odigosv1.RuntimeDetailsByContainer) (appendEnvParams DistroParam, err *odigosv1.ContainerAgentConfig) {
+
+	// at this point we should have already checked for CRI errors and not execute this code,
+	// but let's check to be more robust and avoid using invalid data
+	if runtimeDetails.CriErrorMessage != nil {
+		return appendEnvParams, &odigosv1.ContainerAgentConfig{
+			ContainerName:       runtimeDetails.ContainerName,
+			AgentEnabled:        false,
+			AgentEnabledReason:  odigosv1.AgentEnabledReasonMissingDistroParameter,
+			AgentEnabledMessage: fmt.Sprintf("failed to get env var from runtime details: %s", *runtimeDetails.CriErrorMessage),
+		}
+	}
+
+	// any "append env var" from distro manifest that is found in the runtime details,
+	// is added here as a distro parameter with the same name and the value from the container runtime env vars
+	appendEnvParams = DistroParam{}
+	for _, envVar := range distro.EnvironmentVariables.AppendOdigosVariables {
+		envName := envVar.EnvName
+		criValue, ok := getEnvVarFromList(runtimeDetails.EnvFromContainerRuntime, envName)
+		if ok && criValue != "" {
+			appendEnvParams[envName] = criValue
+		}
+	}
+	return appendEnvParams, nil
+}
+
+func CalculateDistroParams(distro *distroTypes.OtelDistro, runtimeDetails *odigosv1.RuntimeDetailsByContainer) (distroParams DistroParam, err *odigosv1.ContainerAgentConfig) {
+	distroParams = DistroParam{}
+
+	if len(distro.RequireParameters) > 0 {
+		distroParams, err = CalculateRequiredParametersFromRuntimeDetails(distro, runtimeDetails)
+		if err != nil {
+			return distroParams, err
+		}
+	}
+
+	if len(distro.EnvironmentVariables.AppendOdigosVariables) > 0 {
+		appendEnvParams, err := CalculateAppendEnvParametersFromRuntimeDetails(distro, runtimeDetails)
+		if err != nil {
+			return distroParams, err
+		}
+		distroParams = mergeMaps(distroParams, appendEnvParams)
+	}
+
+	return distroParams, nil
+}

--- a/instrumentor/controllers/agentenabled/distroparams.go
+++ b/instrumentor/controllers/agentenabled/distroparams.go
@@ -94,18 +94,6 @@ func calculateRequiredParametersFromRuntimeDetails(distro *distroTypes.OtelDistr
 }
 
 func calculateAppendEnvParametersFromRuntimeDetails(distro *distroTypes.OtelDistro, runtimeDetails *odigosv1.RuntimeDetailsByContainer) (appendEnvParams DistroParam, err *odigosv1.ContainerAgentConfig) {
-	appendEnvParams = DistroParam{}
-	for _, envVar := range distro.EnvironmentVariables.AppendOdigosVariables {
-		envName := envVar.EnvName
-		criValue, ok := getEnvVarFromList(runtimeDetails.EnvFromContainerRuntime, envName)
-		if ok && criValue != "" {
-			appendEnvParams[envName] = criValue
-		}
-	}
-	return appendEnvParams, nil
-}
-
-func calculateAppendEnvParametersFromRuntimeDetails(distro *distroTypes.OtelDistro, runtimeDetails *odigosv1.RuntimeDetailsByContainer) (appendEnvParams DistroParam, err *odigosv1.ContainerAgentConfig) {
 
 	// at this point we should have already checked for CRI errors and not execute this code,
 	// but let's check to be more robust and avoid using invalid data

--- a/instrumentor/controllers/agentenabled/pods_webhook.go
+++ b/instrumentor/controllers/agentenabled/pods_webhook.go
@@ -243,9 +243,9 @@ func (p *PodsWebhook) injectOdigos(ctx context.Context, pod *corev1.Pod, req adm
 	return nil
 }
 
-func mergeMaps(a, b map[string]struct{}) map[string]struct{} {
-	for k := range b {
-		a[k] = struct{}{}
+func mergeMaps[T any](a, b map[string]T) map[string]T {
+	for k, v := range b {
+		a[k] = v
 	}
 	return a
 }

--- a/instrumentor/controllers/agentenabled/sync.go
+++ b/instrumentor/controllers/agentenabled/sync.go
@@ -328,19 +328,6 @@ func isLoaderInjectionSupportedByRuntimeDetails(containerName string, runtimeDet
 	return nil
 }
 
-func isPodManifestInjectionSupportedByRuntimeDetails(containerName string, runtimeDetails *odigosv1.RuntimeDetailsByContainer) *odigosv1.ContainerAgentConfig {
-	if runtimeDetails.CriErrorMessage != nil {
-		return &odigosv1.ContainerAgentConfig{
-			ContainerName:       containerName,
-			AgentEnabled:        false,
-			AgentEnabledReason:  odigosv1.AgentEnabledReasonInjectionConflict,
-			AgentEnabledMessage: "failed to inspect container runtime environment variables, cannot use pod manifest env injection method",
-		}
-	}
-
-	return nil
-}
-
 // Will calculate the env injection method for the container based on the relevant parameters.
 // returned paramters are:
 // - the env injection method to use for this container (may be nil if no injection should take place)
@@ -388,7 +375,7 @@ func getEnvInjectionDecision(
 
 	// at this point, we know that either:
 	// - user configured to use pod manifest injection, or
-	// - usser requested loader fallback to pod manifest, and we are at the fallback stage.
+	// - user requested loader fallback to pod manifest, and we are at the fallback stage.
 	distroHasAppendEnvVar := len(distro.EnvironmentVariables.AppendOdigosVariables) > 0
 	if !distroHasAppendEnvVar {
 		// this is a common case, where a distro doesn't support nor loader or append env var injection.
@@ -396,11 +383,6 @@ func getEnvInjectionDecision(
 		// for those we mark env injection as nil to denote "no injection"
 		// and return err as nil to denote "no error".
 		return nil, nil
-	}
-
-	err := isPodManifestInjectionSupportedByRuntimeDetails(containerName, runtimeDetails)
-	if err != nil {
-		return nil, err
 	}
 
 	envInjectionDecision := common.EnvInjectionDecisionPodManifest
@@ -539,7 +521,7 @@ func calculateContainerInstrumentationConfig(containerName string,
 		}
 	}
 
-	distroParameters, err := CalculateDistroParams(distro, runtimeDetails)
+	distroParameters, err := calculateDistroParams(distro, runtimeDetails, envInjectionDecision)
 	if err != nil {
 		return *err
 	}

--- a/instrumentor/controllers/agentenabled/sync.go
+++ b/instrumentor/controllers/agentenabled/sync.go
@@ -15,7 +15,6 @@ import (
 	commonconsts "github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/distros"
 	"github.com/odigos-io/odigos/distros/distro"
-	distroTypes "github.com/odigos-io/odigos/distros/distro"
 	"github.com/odigos-io/odigos/instrumentor/controllers/agentenabled/rollout"
 	"github.com/odigos-io/odigos/k8sutils/pkg/utils"
 	k8sutils "github.com/odigos-io/odigos/k8sutils/pkg/utils"
@@ -284,11 +283,11 @@ func getEnabledSignalsForContainer(nodeCollectorsGroup *odigosv1.CollectorsGroup
 	return tracesEnabled, metricsEnabled, logsEnabled
 }
 
-func getEnvVarFromRuntimeDetails(runtimeDetails *odigosv1.RuntimeDetailsByContainer, envVarName string) (string, bool) {
+func getEnvVarFromList(envVars []odigosv1.EnvVar, envVarName string) (string, bool) {
 	// here we check for the value of LD_PRELOAD in the EnvVars list,
 	// which returns the env as read from /proc to make sure if there is any value set,
 	// via any mechanism (manifest, device, script, other agent, etc.) then we are aware.
-	for _, envVar := range runtimeDetails.EnvVars {
+	for _, envVar := range envVars {
 		if envVar.Name == envVarName {
 			return envVar.Value, true
 		}
@@ -315,7 +314,7 @@ func isLoaderInjectionSupportedByRuntimeDetails(containerName string, runtimeDet
 	}
 
 	odigosLoaderPath := filepath.Join(k8sconsts.OdigosAgentsDirectory, commonconsts.OdigosLoaderDirName, commonconsts.OdigosLoaderName)
-	ldPreloadVal, ldPreloadFoundInInspection := getEnvVarFromRuntimeDetails(runtimeDetails, commonconsts.LdPreloadEnvVarName)
+	ldPreloadVal, ldPreloadFoundInInspection := getEnvVarFromList(runtimeDetails.EnvVars, commonconsts.LdPreloadEnvVarName)
 	ldPreloadUnsetOrExpected := !ldPreloadFoundInInspection || strings.Contains(ldPreloadVal, odigosLoaderPath)
 	if !ldPreloadUnsetOrExpected {
 		return &odigosv1.ContainerAgentConfig{
@@ -540,57 +539,9 @@ func calculateContainerInstrumentationConfig(containerName string,
 		}
 	}
 
-	distroParameters := map[string]string{}
-	for _, parameterName := range distro.RequireParameters {
-		switch parameterName {
-		case common.LibcTypeDistroParameterName:
-			if runtimeDetails.LibCType == nil {
-				return odigosv1.ContainerAgentConfig{
-					ContainerName:       containerName,
-					AgentEnabled:        false,
-					AgentEnabledReason:  odigosv1.AgentEnabledReasonMissingDistroParameter,
-					AgentEnabledMessage: fmt.Sprintf("missing required parameter '%s' for distro '%s'", common.LibcTypeDistroParameterName, distroName),
-				}
-			}
-			distroParameters[common.LibcTypeDistroParameterName] = string(*runtimeDetails.LibCType)
-
-		case distroTypes.RuntimeVersionMajorMinorDistroParameterName:
-			if runtimeDetails.RuntimeVersion == "" {
-				return odigosv1.ContainerAgentConfig{
-					ContainerName:       containerName,
-					AgentEnabled:        false,
-					AgentEnabledReason:  odigosv1.AgentEnabledReasonMissingDistroParameter,
-					AgentEnabledMessage: fmt.Sprintf("missing required parameter '%s' for distro '%s'", distroTypes.RuntimeVersionMajorMinorDistroParameterName, distroName),
-				}
-			}
-			version, err := version.NewVersion(runtimeDetails.RuntimeVersion)
-			if err != nil {
-				return odigosv1.ContainerAgentConfig{
-					ContainerName:       containerName,
-					AgentEnabled:        false,
-					AgentEnabledReason:  odigosv1.AgentEnabledReasonMissingDistroParameter,
-					AgentEnabledMessage: fmt.Sprintf("failed to parse runtime version: %s", runtimeDetails.RuntimeVersion),
-				}
-			}
-			versionAsMajorMinor, err := common.MajorMinorStringOnly(version)
-			if err != nil {
-				return odigosv1.ContainerAgentConfig{
-					ContainerName:       containerName,
-					AgentEnabled:        false,
-					AgentEnabledReason:  odigosv1.AgentEnabledReasonMissingDistroParameter,
-					AgentEnabledMessage: fmt.Sprintf("failed to parse runtime version as major.minor: %s", runtimeDetails.RuntimeVersion),
-				}
-			}
-			distroParameters[distroTypes.RuntimeVersionMajorMinorDistroParameterName] = versionAsMajorMinor
-
-		default:
-			return odigosv1.ContainerAgentConfig{
-				ContainerName:       containerName,
-				AgentEnabled:        false,
-				AgentEnabledReason:  odigosv1.AgentEnabledReasonMissingDistroParameter,
-				AgentEnabledMessage: fmt.Sprintf("unsupported parameter '%s' for distro '%s'", parameterName, distroName),
-			}
-		}
+	distroParameters, err := CalculateDistroParams(distro, runtimeDetails)
+	if err != nil {
+		return *err
 	}
 
 	if crashDetected {


### PR DESCRIPTION
Fixes: CORE-160

Distro params are a way to propagate parameters from the runtime detection into the webhook, to be used during the injection of the distro in the webhook.

It allows use to:
- verify the value from runtime detection is available when required
- the value is in the right format (for example - a version number)
- process the value to make it useful for the webhook (for example, calculate MAJOR.MINOR for ruby/php)
- simplify the code in webhook (get processed values without needing to validate or compute anything)
- transaction - the values are all coming from the reconcile, so if the runtime details are updated, there will be no race with the new result of the reconcile and the webhook that also access these values.

This PR extract the functions to handle the distro params to a dedicated file since the original function in the `sync` is quite long already.
It also introduces the "append env variables" found in CRI detection into the params. They will later be used to refactor the pod manifest env injection which currently uses otelsdk.

This is the error in UI when we have criError and env injection is set to pod manifest:

<img width="738" height="218" alt="image" src="https://github.com/user-attachments/assets/c3130a2f-30d0-4fc0-8c80-f55e9012aeb9" />
