### PR TITLE
Add Service Graph metrics when sending to Prometheus

### DIFF
--- a/common/config/prometheus.go
+++ b/common/config/prometheus.go
@@ -38,6 +38,12 @@ func (p *Prometheus) ModifyConfig(dest ExporterConfigurer, currentConfig *Config
 
 	currentConfig.Exporters[rwExporterName] = GenericMap{
 		"endpoint": fmt.Sprintf("%s/api/v1/write", url),
+		"resource_to_telemetry_conversion": GenericMap{
+			"enabled": true,
+		},
+		"external_labels": map[string]string{
+			"job": "odigos-remote-write",
+		},
 	}
 
 	resourceAttributesLabels, exists := config[prometheusResourceAttributesLabelsKey]

--- a/common/pipelinegen/config_builder.go
+++ b/common/pipelinegen/config_builder.go
@@ -257,6 +257,14 @@ func insertServiceGraphPipeline(currentConfig *config.Config) {
 	}
 	pipeline.Exporters = append(pipeline.Exporters, consts.ServiceGraphConnectorName)
 	currentConfig.Service.Pipelines[rootPipelineName] = pipeline
+
+	// Add ServiceGraphConnectorName receiver to every prometheus pipeline starts with metrics/prometheus-
+	for pipelineName, pipeline := range currentConfig.Service.Pipelines {
+		if strings.HasPrefix(pipelineName, "metrics/prometheus-") {
+			pipeline.Receivers = append(pipeline.Receivers, consts.ServiceGraphConnectorName)
+			currentConfig.Service.Pipelines[pipelineName] = pipeline
+		}
+	}
 }
 
 func GetBasicConfig() *config.Config {


### PR DESCRIPTION
## Description

<!-- Short summary of the changes -->

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [X] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
