### PR TITLE
fix: apply real time memory limit in otlp grpc receiver

### DIFF
--- a/autoscaler/controllers/nodecollector/configmap.go
+++ b/autoscaler/controllers/nodecollector/configmap.go
@@ -295,6 +295,9 @@ func calculateConfigMapData(
 				"protocols": config.GenericMap{
 					"grpc": config.GenericMap{
 						"endpoint": "0.0.0.0:4317",
+						// data collection collectors will drop data instead of backpressuring the senders (odiglet or agents),
+						// we don't want the applications to build up memory in the runtime if the pipeline is overloaded.
+						"drop_on_overload": true,
 					},
 					"http": config.GenericMap{
 						"endpoint": "0.0.0.0:4318",


### PR DESCRIPTION
This PR is a followup to an effort done for the gateway collector to have better memory protections from OOM.

It utilizes the [go-rtml](https://github.com/odigos-io/go-rtml) library by odigos, to check the memory limits before accepting an otlp grpc request, to drop it before it enters the pipeline and consume allocations.

There is a new otlp grpc flag, which is being set for the data collection (but not the gateway). It instructs the sender on wether to retry the request or not, which is honored by opentelemetry collector, nodejs exporter, and I hope all other language specific exporters as well.

So:
- Gateway under memory pressure -> return `grpc Unavailable` to indicate the data-collection to retry.
- Datacollection under memory pressure -> return `grpc FailedPrecondition` to indicate the sender should not retry.

These values are chosen based on [this guideline](https://github.com/grpc/grpc-go/blob/ebaf486eab0fdf28996baf269064f83224538150/codes/codes.go#L111) and the [collector implementation](https://github.com/open-telemetry/opentelemetry-collector/blob/67147711bfd4a457a7e0f068f6a9fc298122f908/exporter/otlpexporter/otlp.go#L190).

Tested before and after. before it crashed in few seconds under high load. After applying this fixed it did not crash even once. tested with 500MB limit, 360MB GOMEMLIMIT, cpu (3 tests - 100, 500, 1500), and 15 senders each sending a batch of 2048 spans every second where each span is 10KB in size (> 20 MB * 15 per second). Did not crash even once. memory was at most 40MB above the GOMEMLIMIT but mostly few MB above. tested for 1 hour and did not restart even once