### PR TITLE
CORE-263: Don't submit OpenShift preflight on prereleases

### DIFF
--- a/.github/workflows/openshift-preflight.yml
+++ b/.github/workflows/openshift-preflight.yml
@@ -90,9 +90,28 @@ jobs:
             exit 1
           fi
 
+      - name: Check Release Type
+        run: |
+          TAG="${{ env.TAG }}"
+          
+          # Check if it's a pre-release (has additional suffix after vX.Y.Z)
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+- ]]; then
+            echo "IS_PRERELEASE=true" >> $GITHUB_ENV
+            echo "This is a pre-release: $TAG"
+          else
+            echo "IS_PRERELEASE=false" >> $GITHUB_ENV
+            echo "This is a stable release: $TAG"
+          fi
+
       - name: Run Preflight
         run: |
-          ./preflight-linux-amd64 check container registry.odigos.io/odigos-${{ matrix.service }}-ubi9:${{ env.TAG }} --pyxis-api-token=${{ secrets.OPENSHIFT_PYXIS_TOKEN }} --certification-component-id ${{ matrix.project_id }} --submit
+          if [ "${{ env.IS_PRERELEASE }}" = "false" ]; then
+            echo "Running preflight with --submit flag for stable release"
+            ./preflight-linux-amd64 check container registry.odigos.io/odigos-${{ matrix.service }}-ubi9:${{ env.TAG }} --pyxis-api-token=${{ secrets.OPENSHIFT_PYXIS_TOKEN }} --certification-component-id ${{ matrix.project_id }} --submit
+          else
+            echo "Running preflight without --submit flag for pre-release"
+            ./preflight-linux-amd64 check container registry.odigos.io/odigos-${{ matrix.service }}-ubi9:${{ env.TAG }} --pyxis-api-token=${{ secrets.OPENSHIFT_PYXIS_TOKEN }} --certification-component-id ${{ matrix.project_id }}
+          fi
 
 
       - name: Notify Slack


### PR DESCRIPTION
## Description

To prevent failures like this https://github.com/odigos-io/odigos/actions/runs/17793357643/job/50575290184

```
Error: could not submit to pyxis: could not create rpm manifest: status code: 400: body: {"type": "about:blank", "title": "Bad Request", "detail": "Image '{'manifest_list_digest': 'sha256:a3077fee56f4239816a98338b16b95fee83024a9ad821e87c97fc8afab9f0ed9', 'published': True, 'published_date': datetime.datetime(2025, 9, 16, 15, 25, 29, 812000, tzinfo=FixedOffset(datetime.timedelta(0), 'UTC')), 'push_date': datetime.datetime(2025, 9, 16, 15, 25, 29, 812000, tzinfo=FixedOffset(datetime.timedelta(0), 'UTC')), 'registry': 'registry.connect.redhat.com', 'repository': 'odigos/odigos-ui-ubi9', 'tags': [{'added_date': datetime.datetime(2025, 9, 16, 15, 25, 29, 812000, tzinfo=FixedOffset(datetime.timedelta(0), 'UTC')), 'name': 'v1.4.0-rc2'}], 'tags#': 1}' is published, published image can't be updated.", "status": 400, "trace_id": "0x36213e338aa232fa4a5b72bfc8a1c62a"}
2025/09/17 09:37:13 could not submit to pyxis: could not create rpm manifest: status code: 400: body: {"type": "about:blank", "title": "Bad Request", "detail": "Image '{'manifest_list_digest': 'sha256:a3077fee56f4239816a98338b16b95fee83024a9ad821e87c97fc8afab9f0ed9', 'published': True, 'published_date': datetime.datetime(2025, 9, 16, 15, 25, 29, 812000, tzinfo=FixedOffset(datetime.timedelta(0), 'UTC')), 'push_date': datetime.datetime(2025, 9, 16, 15, 25, 29, 812000, tzinfo=FixedOffset(datetime.timedelta(0), 'UTC')), 'registry': 'registry.connect.redhat.com', 'repository': 'odigos/odigos-ui-ubi9', 'tags': [{'added_date': datetime.datetime(2025, 9, 16, 15, 25, 29, 812000, tzinfo=FixedOffset(datetime.timedelta(0), 'UTC')), 'name': 'v1.4.0-rc2'}], 'tags#': 1}' is published, published image can't be updated.", "status": 400, "trace_id": "0x36213e338aa232fa4a5b72bfc8a1c62a"}
```

Since RC image has the same SHA as the promoted image, red hat is rejecting all rc->stable promotions. We don't need to submit RCs to red hat, we can automatically test them without submitting and still manually test RC on openshift if we need to

Thanks @AvihuHenya for reporting!

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
