### PR TITLE
chore: restart proxy when config change

### DIFF
--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -171,6 +171,15 @@ var setConfigCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		// central proxy depends on central-backend-url / cluster-name, ensure it restarts when those change
+		if (property == consts.CentralBackendURLProperty || property == consts.ClusterNameProperty) &&
+			currentTier == common.OnPremOdigosTier &&
+			config.CentralBackendURL != "" && config.ClusterName != "" {
+			if err := kube.RestartDeployment(ctx, client, ns, k8sconsts.CentralProxyDeploymentName); err != nil {
+				fmt.Printf("Warning: failed to restart central-proxy: %v\n", err)
+			}
+		}
+
 		l.Success()
 
 	},

--- a/cli/cmd/pro.go
+++ b/cli/cmd/pro.go
@@ -11,7 +11,6 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
-	"time"
 
 	"github.com/odigos-io/odigos/api/k8sconsts"
 	"github.com/odigos-io/odigos/cli/cmd/resources"
@@ -29,7 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 var (
@@ -469,19 +467,7 @@ func findPodWithAppLabel(ctx context.Context, client *kube.Client, ns, appLabel 
 }
 
 func restartOdiglet(ctx context.Context, client *kube.Client, ns string) error {
-	// Create patch to add/update the restartedAt annotation
-	patch := fmt.Sprintf(`{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"%s"}}}}}`,
-		time.Now().Format(time.RFC3339))
-
-	// Patch the Odiglet daemonset
-	_, err := client.AppsV1().DaemonSets(ns).Patch(
-		ctx,
-		k8sconsts.OdigletDaemonSetName,
-		types.StrategicMergePatchType,
-		[]byte(patch),
-		metav1.PatchOptions{},
-	)
-	return err
+	return kube.RestartDaemonSet(ctx, client, ns, k8sconsts.OdigletDaemonSetName)
 }
 
 func init() {


### PR DESCRIPTION
Ensure central proxy picks up updated central-backend-url and cluster-name set via odigos config set by triggering a rolling restart of the central-proxy Deployment (On-Prem tier only, when both values are non-empty).

Extract generic restart helpers to cli/pkg/kube/restart.go:
1. RestartDeployment(...)
2. RestartDaemonSet(...)

Refactor:
1. cli/cmd/config.go to use RestartDeployment for central-proxy.
2. cli/cmd/pro.go to use RestartDaemonSet for Odiglet.