### PR TITLE
CORE-269 adding create role for service account

### DIFF
--- a/cli/cmd/resources/autoscaler.go
+++ b/cli/cmd/resources/autoscaler.go
@@ -110,10 +110,10 @@ func NewAutoscalerRole(ns string) *rbacv1.Role {
 				Resources: []string{"processors"},
 				Verbs:     []string{"get", "list", "watch", "create", "patch", "update"},
 			},
-			{ // Needed to read actions transform them to processors
+			{ // Needed to read actions transform them to processors and to update to generic CRDS
 				APIGroups: []string{"actions.odigos.io"},
 				Resources: []string{"*"},
-				Verbs:     []string{"get", "list", "watch"},
+				Verbs:     []string{"get", "list", "watch", "update"},
 			},
 			{ // Needed to updated the status of the actions (confirms the user-made-changes)
 				APIGroups: []string{"actions.odigos.io"},

--- a/helm/odigos/templates/autoscaler/role.yaml
+++ b/helm/odigos/templates/autoscaler/role.yaml
@@ -138,6 +138,7 @@ rules:
       - get
       - list
       - watch
+      - update
   - apiGroups:
       - actions.odigos.io
     resources:


### PR DESCRIPTION
## Description

Adding permissions for the autoscaler to update actions to the generic CRD

## How Has This Been Tested?
Deployed locally with helm, made sure we don't get the permissions error anymore and that the actions are visible in the UI again

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [x] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [x] Modifies Odigos manifests (addressed in both CLI and Helm)
- [x] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [x] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
