### PR TITLE
changing rbac docs to match change in autoscaler

### DIFF
--- a/docs/permissions.mdx
+++ b/docs/permissions.mdx
@@ -113,11 +113,11 @@ Below are the Roles used by Odigos components. These Roles are only scoped to th
 | odigos.io | destinations | \* | get<br />list<br />watch |
 | odigos.io | destinations/status | \* | get<br />patch<br />update |
 | odigos.io | processors | \* | get<br />list<br />watch<br />create<br />patch<br />update |
-| actions.odigos.io | \* | \* | get<br />list<br />watch |
+| actions.odigos.io | \* | \* | get<br />list<br />watch<br />update |
 | actions.odigos.io | */status | \* | get<br />patch<br />update |
 | odigos.io | collectorsgroups | \* | get<br />list<br />watch |
 | odigos.io | collectorsgroups/status | \* | get<br />patch<br />update |
-| odigos.io | actions | \* | get<br />list<br />watch |
+| odigos.io | actions | \* | get<br />list<br />watch<br />create<br />patch<br />update |
 | odigos.io | actions/status | \* | get<br />patch<br />update |
 
 ### cleanup-role


### PR DESCRIPTION
## Description

<!-- Short summary of the changes -->

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
