### PR TITLE
refactor: extract trace related config to it's own file

### DIFF
--- a/autoscaler/controllers/nodecollector/collectorconfig/traces.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/traces.go
@@ -1,0 +1,85 @@
+package collectorconfig
+
+import (
+	"fmt"
+
+	"github.com/odigos-io/odigos/api/k8sconsts"
+	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	"github.com/odigos-io/odigos/common/config"
+)
+
+const (
+	odigosEbpfReceiverName                = "odigosebpf"
+	odigosTracesLoadbalancingExporterName = "loadbalancing/traces"
+	odigosTracesPipelineName              = "traces"
+)
+
+var staticTracesReceivers config.GenericMap
+
+func init() {
+	staticTracesReceivers = config.GenericMap{
+		odigosEbpfReceiverName: config.GenericMap{},
+	}
+}
+
+func tracesExporters(nodeCG *odigosv1.CollectorsGroup, odigosNamespace string) config.GenericMap {
+	compression := "none"
+	dataCompressionEnabled := nodeCG.Spec.EnableDataCompression
+	if dataCompressionEnabled != nil && *dataCompressionEnabled {
+		compression = "gzip"
+	}
+
+	service := fmt.Sprintf("%s.%s", k8sconsts.OdigosClusterCollectorServiceName, odigosNamespace)
+
+	// Add loadbalancing exporter for traces to ensure consistent gateway routing.
+	// This allows the servicegraph connector to properly aggregate trace data
+	// by sending all traces from a node collector to the same gateway instance.
+	return config.GenericMap{
+		odigosTracesLoadbalancingExporterName: config.GenericMap{
+			"protocol": config.GenericMap{
+				"otlp": config.GenericMap{
+					"compression": compression,
+					"tls": config.GenericMap{
+						"insecure": true,
+					},
+				},
+			},
+			"resolver": config.GenericMap{
+				"k8s": config.GenericMap{
+					"service": service,
+				},
+			},
+		},
+	}
+}
+
+func TracesConfig(nodeCG *odigosv1.CollectorsGroup, odigosNamespace string, manifestProcessorNames []string) config.Config {
+
+	tracePipelineProcessors := append([]string{
+		BatchProcessorName,         // always start with batch
+		MemoryLimiterProcessorName, // memory limiter is temporary, until we migrate all inputs to rtml based memory protection
+		NodeNameProcessorName,
+		ResourceDetectionProcessorName,
+	}, manifestProcessorNames...)
+	tracePipelineProcessors = append(tracePipelineProcessors, OdigosTrafficMetricsProcessorName) // keep traffic metrics last for most accurate tracking
+
+	return config.Config{
+		Receivers: staticTracesReceivers,
+		Exporters: tracesExporters(nodeCG, odigosNamespace),
+		Service: config.Service{
+			Pipelines: map[string]config.Pipeline{
+				odigosTracesPipelineName: {
+					Receivers:  []string{OTLPInReceiverName, odigosEbpfReceiverName},
+					Processors: tracePipelineProcessors,
+					Exporters:  []string{odigosTracesLoadbalancingExporterName},
+				},
+			},
+		},
+	}
+}
+
+// cfg.Service.Pipelines["traces"] = config.Pipeline{
+// 	Receivers:  []string{collectorconfig.OTLPInReceiverName, "odigosebpf"},
+// 	Processors: append(getAgentPipelineCommonProcessors(), tracesProcessors...),
+// 	Exporters:  tracesPipelineExporter,
+// }

--- a/autoscaler/controllers/nodecollector/configmap_test.go
+++ b/autoscaler/controllers/nodecollector/configmap_test.go
@@ -158,7 +158,9 @@ func TestCalculateConfigMapData(t *testing.T) {
 					},
 				},
 			},
-		})
+		},
+		false, /* onGKE */
+	)
 
 	assert.Equal(t, err, nil)
 	assert.Equal(t, want, got)

--- a/autoscaler/controllers/nodecollector/testdata/logs_included.yaml
+++ b/autoscaler/controllers/nodecollector/testdata/logs_included.yaml
@@ -1,5 +1,5 @@
 exporters:
-  loadbalancing:
+  loadbalancing/traces:
     protocol:
       otlp:
         compression: none
@@ -161,14 +161,14 @@ service:
       - prometheus/self-metrics
     traces:
       exporters:
-      - loadbalancing
+      - loadbalancing/traces
       processors:
       - batch
       - memory_limiter
       - resource/node-name
       - resourcedetection
-      - odigostrafficmetrics
       - test_type/test_processor
+      - odigostrafficmetrics
       receivers:
       - otlp/in
       - odigosebpf


### PR DESCRIPTION
Fixes: CORE-271

extract the "traces" related config to it's own file and use it generically from the autoscaler nodecollector configmap calculation 