### PR TITLE
refactor: use processor crd as config

### DIFF
--- a/autoscaler/controllers/nodecollector/collectorconfig/metrics.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/metrics.go
@@ -159,6 +159,9 @@ func MetricsConfig(nodeCG *odigosv1.CollectorsGroup, odigosNamespace string, man
 	connectors, connectorNames := metricsConnectors(metricsConfigSettings)
 	pipelineReceiverNames = append(pipelineReceiverNames, connectorNames...)
 
+	// currently used for spanmetrics - which is needed to be added as a trace exporter in trace pipeline
+	additionalTraceExporters := connectorNames
+
 	return config.Config{
 		Receivers:  receivers,
 		Connectors: connectors,
@@ -171,5 +174,5 @@ func MetricsConfig(nodeCG *odigosv1.CollectorsGroup, odigosNamespace string, man
 				},
 			},
 		},
-	}, connectorNames
+	}, additionalTraceExporters
 }

--- a/autoscaler/controllers/nodecollector/sync.go
+++ b/autoscaler/controllers/nodecollector/sync.go
@@ -85,6 +85,10 @@ func (b *nodeCollectorBaseReconciler) syncDataCollection(ctx context.Context, so
 		return err
 	}
 
+	// enabled signals also takes into account spanmetrics connector
+	// e.g - cluster collector can accept only metrics,
+	// while node collector collects both metrics and traces, which it converts to metrics and does not forward downstream.
+	// the enabled signals represents what's actually collected from agents in node collector.
 	enabledSignals := clusterCollectorSignals
 	spanMetricsEnabled := dataCollection.Spec.Metrics != nil && dataCollection.Spec.Metrics.SpanMetrics != nil
 	if spanMetricsEnabled {

--- a/common/config/processor.go
+++ b/common/config/processor.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 )
 
-func GetCrdProcessorsConfigMap(processors []ProcessorConfigurer) (cfg GenericMap,
+func CrdProcessorToConfig(processors []ProcessorConfigurer) (cfg Config,
 	tracesProcessors []string, metricsProcessors []string, logsProcessors []string, errs map[string]error) {
 	errs = make(map[string]error)
-	cfg = GenericMap{}
+	processorsMap := GenericMap{}
 	for _, processor := range processors {
 		processorKey := fmt.Sprintf("%s/%s", processor.GetType(), processor.GetID())
 		processorsConfig, err := processor.GetConfig()
@@ -20,7 +20,7 @@ func GetCrdProcessorsConfigMap(processors []ProcessorConfigurer) (cfg GenericMap
 		if processorKey == "" || processorsConfig == nil {
 			continue
 		}
-		cfg[processorKey] = processorsConfig
+		processorsMap[processorKey] = processorsConfig
 
 		if isTracingEnabled(processor) {
 			tracesProcessors = append(tracesProcessors, processorKey)
@@ -32,8 +32,12 @@ func GetCrdProcessorsConfigMap(processors []ProcessorConfigurer) (cfg GenericMap
 			logsProcessors = append(logsProcessors, processorKey)
 		}
 	}
-	if len(errs) == 0 {
-		return cfg, tracesProcessors, metricsProcessors, logsProcessors, nil
+	cfg = Config{
+		Processors: processorsMap,
 	}
+	if len(errs) != 0 {
+		return cfg, tracesProcessors, metricsProcessors, logsProcessors, errs
+	}
+
 	return cfg, tracesProcessors, metricsProcessors, logsProcessors, errs
 }

--- a/common/pipelinegen/config_builder.go
+++ b/common/pipelinegen/config_builder.go
@@ -63,11 +63,11 @@ func CalculateGatewayConfig(
 	logsEnabled := false
 
 	// Configure processors
-	processorsCfg, tracesProcessors, metricsProcessors, logsProcessors, errs := config.GetCrdProcessorsConfigMap(processors)
+	processorsCfg, tracesProcessors, metricsProcessors, logsProcessors, errs := config.CrdProcessorToConfig(processors)
 	if errs != nil {
 		status.Processor = errs
 	}
-	for processorKey, processorCfg := range processorsCfg {
+	for processorKey, processorCfg := range processorsCfg.Processors {
 		currentConfig.Processors[processorKey] = processorCfg
 	}
 


### PR DESCRIPTION
Fixes: CORE-271

Small refactor just to have the processor CRDs as collector config (with just processors) so we can merge it easily with other config domains and cleanup some code in configmap.go

also addressing review comments by @RonFed  from #3556 