### PR TITLE
chore: remove small batches from kratos profile

### DIFF
--- a/profiles/aggregators/kratos.go
+++ b/profiles/aggregators/kratos.go
@@ -18,7 +18,7 @@ var KratosProfile = profile.Profile{
 		"hostname-as-podname",
 		"code-attributes",
 		"query-operation-detector",
-		"small-batches",
+		// "small-batches", - issue is fixed in receiver. can now handle 85MB
 		"allow_concurrent_agents",
 		"mount-method-k8s-host-path",
 		"reduce-span-name-cardinality",


### PR DESCRIPTION
Fixes: CORE-271

since the upstream grpc max payload size in increased long ago, the small batches are no longer needed and will improve cpu and memory consumption.

The profile itself is not removed and can be introduced via the profiles 