### PR TITLE
feat: allow to configure metrics expiration for span metrics

### DIFF
--- a/api/config/crd/bases/odigos.io_collectorsgroups.yaml
+++ b/api/config/crd/bases/odigos.io_collectorsgroups.yaml
@@ -176,6 +176,14 @@ spec:
                         description: 'time interval for flusing metrics (format: 15s,
                           1m etc). defaults: 60s (one minute).'
                         type: string
+                      metricsExpiration:
+                        description: |-
+                          used to remove metrics after time that they are not reporting.
+                          if an app only generates metrics once in a while, this parameter can tune
+                          how much gap is allowed.
+                          format: duration string (15s, 1m, etc).
+                          default is 5m (five minutes).
+                        type: string
                     type: object
                 type: object
               resourcesSettings:

--- a/autoscaler/controllers/nodecollector/collectorconfig/metrics.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/metrics.go
@@ -122,7 +122,7 @@ func metricsConnectors(metricsConfigSettings *odigosv1.CollectorsGroupMetricsCol
 			"dimensions_cache_size":           1000,
 			"aggregation_temporality":         "AGGREGATION_TEMPORALITY_CUMULATIVE",
 			"metrics_flush_interval":          metricsConfigSettings.SpanMetrics.Interval,
-			"metrics_expiration":              "5m",
+			"metrics_expiration":              metricsConfigSettings.SpanMetrics.MetricsExpiration,
 			"resource_metrics_key_attributes": []string{"service.name", "telemetry.sdk.language", "telemetry.sdk.name"},
 			"events": config.GenericMap{
 				"enabled": true,

--- a/common/odigos_config.go
+++ b/common/odigos_config.go
@@ -163,6 +163,13 @@ type MetricsSourceSpanMetricsConfiguration struct {
 	// time interval for flusing metrics (format: 15s, 1m etc). defaults: 60s (one minute).
 	Interval string `json:"interval,omitempty"`
 
+	// used to remove metrics after time that they are not reporting.
+	// if an app only generates metrics once in a while, this parameter can tune
+	// how much gap is allowed.
+	// format: duration string (15s, 1m, etc).
+	// default is 5m (five minutes).
+	MetricsExpiration string `json:"metricsExpiration,omitempty"`
+
 	// additional dimensions to add to the span metrics.
 	// these are span attributes that you want to convert to metrics attributes during collection.
 	// the values of the attributes must have low cardinality.

--- a/helm/odigos/templates/crds/odigos.io_collectorsgroups.yaml
+++ b/helm/odigos/templates/crds/odigos.io_collectorsgroups.yaml
@@ -176,6 +176,14 @@ spec:
                         description: 'time interval for flusing metrics (format: 15s,
                           1m etc). defaults: 60s (one minute).'
                         type: string
+                      metricsExpiration:
+                        description: |-
+                          used to remove metrics after time that they are not reporting.
+                          if an app only generates metrics once in a while, this parameter can tune
+                          how much gap is allowed.
+                          format: duration string (15s, 1m, etc).
+                          default is 5m (five minutes).
+                        type: string
                     type: object
                 type: object
               resourcesSettings:

--- a/scheduler/controllers/nodecollectorsgroup/common.go
+++ b/scheduler/controllers/nodecollectorsgroup/common.go
@@ -167,6 +167,9 @@ func getSpanMetricsConfiguration(odigosConfiguration *common.OdigosConfiguration
 	if spanMetricsCopy.Interval == "" {
 		spanMetricsCopy.Interval = "60s"
 	}
+	if spanMetricsCopy.MetricsExpiration == "" {
+		spanMetricsCopy.MetricsExpiration = "5m"
+	}
 	if len(spanMetricsCopy.ExplicitHistogramBuckets) == 0 {
 		spanMetricsCopy.ExplicitHistogramBuckets = []string{"2ms", "4ms", "6ms", "8ms", "10ms", "50ms", "100ms", "200ms", "400ms", "800ms", "1s", "1400ms", "2s", "5s", "10s", "15s"}
 	}


### PR DESCRIPTION
Fixes: CORE-271

Per user request. Currently we are populating `5m` in this field. now user can set it via odigos-configuration. if not set, defaults to `5m`