### PR TITLE
fix: handle sources deletion if exists multiple sources for workload

### DIFF
--- a/instrumentor/controllers/sources_webhooks.go
+++ b/instrumentor/controllers/sources_webhooks.go
@@ -228,14 +228,17 @@ func (s *SourcesValidator) validateSourceFields(ctx context.Context, source *v1a
 			fmt.Sprintf("Source must have at least one %s* label to indicate a data stream group", k8sconsts.SourceDataStreamLabelPrefix),
 		))
 	}
-
-	err := s.validateSourceUniqueness(ctx, source)
-	if err != nil {
-		allErrs = append(allErrs, field.Invalid(
-			field.NewPath("spec").Child("workload"),
-			source.Spec.Workload,
-			err.Error(),
-		))
+	
+	// Skip uniqueness validation if source is being deleted
+	if source.DeletionTimestamp == nil || source.DeletionTimestamp.IsZero() {
+		err := s.validateSourceUniqueness(ctx, source)
+		if err != nil {
+			allErrs = append(allErrs, field.Invalid(
+				field.NewPath("spec").Child("workload"),
+				source.Spec.Workload,
+				err.Error(),
+			))
+		}
 	}
 
 	if source.Spec.Workload.Kind == k8sconsts.WorkloadKindNamespace &&


### PR DESCRIPTION
## Description
This PR introduces the first-phase bug fix for a race condition in the source validation webhook cache during source creation. Due to this race condition, multiple sources could be created for the same workload, which then could not be deleted.

When attempting to delete such sources, they became stuck in the "Terminating" state.
This issue occurred because the uniqueness validation in the GetSources function was designed to only allow a single source per workload.

To fix this, I updated the code so that the uniqueness constraints in the source validation webhook do not run on deletion events, while still maintaining deterministic behavior in cases where multiple sources exist.

<!-- Short summary of the changes -->
I updated the code so that the uniqueness constraints in the sources validation webhook do not run on deletion events. This ensures that deletion works correctly and maintains deterministic behavior even in cases where multiple sources exist.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly
