### PR TITLE
feat: config options to control span metrics resource attributes to exclude

### DIFF
--- a/api/config/crd/bases/odigos.io_collectorsgroups.yaml
+++ b/api/config/crd/bases/odigos.io_collectorsgroups.yaml
@@ -155,6 +155,16 @@ spec:
                           - true - span metrics will never be collected, even if destinations require it.
                           - false / nil - span metrics will be collected if destinations require it (can be opt-in and out in destination level).
                         type: boolean
+                      excludedResourceAttributes:
+                        description: |-
+                          exclude resource attributes from being added to span metrics.
+                          for example - if you don't care about the process granularity,
+                          and prefer the metrics to be aggregated for all processes in a pod container,
+                          you can list all "process.*" attributes here to exclude them from being added to span metrics.
+                          any other resource attribute can be set, either for senetation or to reduce dimenssions for generate metrics.
+                        items:
+                          type: string
+                        type: array
                       histogramBuckets:
                         description: "explicit buckets list for the histogram metrics.\nformat
                           is duration string (`1us`, `2ms`, `3s`, `4m`, `5h`, `6d`
@@ -171,6 +181,15 @@ spec:
                         type: array
                       histogramDisabled:
                         description: if true, histogram metrics will not be collected.
+                        type: boolean
+                      includedProcessInDimensions:
+                        description: |-
+                          by default, odigos will aggregate base on pod container.
+                          if you have multiple processes in the same container,
+                          you will get each metrics aggregatint all processes measurements.
+                          to have more granularity, you can set this to true.
+                          this will create more dimensions for metrics, including process info,
+                          but with cost of more metrics series and costs.
                         type: boolean
                       interval:
                         description: 'time interval for flusing metrics (format: 15s,

--- a/autoscaler/controllers/nodecollector/collectorconfig/spanmetrics.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/spanmetrics.go
@@ -1,0 +1,159 @@
+package collectorconfig
+
+import (
+	"slices"
+
+	"github.com/odigos-io/odigos/common"
+	"github.com/odigos-io/odigos/common/config"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+)
+
+var (
+	spanMetricsConnectorName                         = "spanmetrics"
+	spanMetricsTracesInConnectorName                 = "forward/trace/spanmetrics"
+	spanMetricsPipelineName                          = "traces/spanmetrics"
+	spanMetricsResourceRemoveDimensionsProcessorName = "resource/spanmetrics/remove-dimensions"
+)
+
+func getSpanMetricsConnectorConfig(spanMetricsConfig common.MetricsSourceSpanMetricsConfiguration) config.GenericMap {
+	histogramConfig := config.GenericMap{}
+
+	if spanMetricsConfig.HistogramDisabled {
+		histogramConfig["disabled"] = true
+	} else {
+		if spanMetricsConfig.ExplicitHistogramBuckets != nil {
+			histogramConfig["explicit"] = config.GenericMap{
+				"buckets": spanMetricsConfig.ExplicitHistogramBuckets,
+			}
+		}
+	}
+
+	dimensionsAttributeNames := []string{
+		"http.method",
+		"http.request.method",
+		"http.status_code",
+		"http.response.status_code",
+		"http.route",
+	}
+	if spanMetricsConfig.AdditionalDimensions != nil {
+		dimensionsAttributeNames = append(dimensionsAttributeNames, spanMetricsConfig.AdditionalDimensions...)
+	}
+
+	dimensions := make([]config.GenericMap, len(dimensionsAttributeNames))
+	for i, dimensionAttributeName := range dimensionsAttributeNames {
+		dimensions[i] = config.GenericMap{
+			"name": dimensionAttributeName,
+		}
+	}
+
+	return config.GenericMap{
+		"histogram": histogramConfig,
+		// Taking into account changes in the semantic conventions, to support a range of instrumentation libraries
+		"dimensions": dimensions,
+		"exemplars": config.GenericMap{
+			"enabled": true,
+		},
+		"exclude_dimensions":              []string{"status.code"},
+		"dimensions_cache_size":           1000,
+		"aggregation_temporality":         "AGGREGATION_TEMPORALITY_CUMULATIVE",
+		"metrics_flush_interval":          spanMetricsConfig.Interval,
+		"metrics_expiration":              spanMetricsConfig.MetricsExpiration,
+		"resource_metrics_key_attributes": []string{"service.name", "telemetry.sdk.language", "telemetry.sdk.name"},
+		"events": config.GenericMap{
+			"enabled": true,
+			"dimensions": []config.GenericMap{
+				{
+					"name": "exception.type",
+				},
+				{
+					"name": "exception.message",
+				},
+			},
+		},
+	}
+}
+
+func getSpanMetricsConnectors(spanMetricsConfig common.MetricsSourceSpanMetricsConfiguration) config.GenericMap {
+	return config.GenericMap{
+		spanMetricsConnectorName:         getSpanMetricsConnectorConfig(spanMetricsConfig),
+		spanMetricsTracesInConnectorName: &config.GenericMap{},
+	}
+}
+
+func getSpanMetricsPipelineProcessors(spanMetricsConfig common.MetricsSourceSpanMetricsConfiguration) (config.GenericMap, []string) {
+
+	processors := config.GenericMap{}
+	processorNames := []string{}
+	resourceAttrToExclude := []string{
+		// always delete these two attributes, as they are just noise in span metrics
+		// TODO: consider making it an opt-in configuration option one day
+		string(semconv.TelemetrySDKNameKey),
+		string(semconv.TelemetrySDKVersionKey),
+	}
+
+	if spanMetricsConfig.IncludedProcessInDimensions == nil || !*spanMetricsConfig.IncludedProcessInDimensions {
+		// if include process is not specifically set,
+		// we want by default to remove all "process.*" attributes from the resource,
+		// so the span metrics dimensions will be aggregated without it.
+		resourceAttrToExclude = append(resourceAttrToExclude, []string{
+			string(semconv.ProcessCommandKey),
+			string(semconv.ProcessCommandArgsKey),
+			string(semconv.ProcessExecutableNameKey),
+			string(semconv.ProcessExecutablePathKey),
+			string(semconv.ProcessPIDKey),
+			string(semconv.ProcessVpidKey),
+			string(semconv.ProcessParentPIDKey),
+		}...)
+	}
+
+	if spanMetricsConfig.ExcludedResourceAttributes != nil {
+		resourceAttrToExclude = append(resourceAttrToExclude, spanMetricsConfig.ExcludedResourceAttributes...)
+	}
+
+	// remove duplicates. doing sort and compact, which might not be most efficient
+	// but the list is expected to be small anyway.
+	slices.Sort(resourceAttrToExclude)
+	resourceAttrToExclude = slices.Compact(resourceAttrToExclude)
+
+	attributes := []config.GenericMap{}
+	for _, attributeName := range resourceAttrToExclude {
+		attributes = append(attributes, config.GenericMap{
+			"key":    attributeName,
+			"action": "delete",
+		})
+	}
+
+	processors[spanMetricsResourceRemoveDimensionsProcessorName] = config.GenericMap{
+		"attributes": attributes,
+	}
+	processorNames = append(processorNames, spanMetricsResourceRemoveDimensionsProcessorName)
+
+	return processors, processorNames
+}
+
+func GetSpanMetricsConfig(spanMetricsConfig common.MetricsSourceSpanMetricsConfiguration) (config.Config, []string, []string) {
+	connectors := getSpanMetricsConnectors(spanMetricsConfig)
+	processors, processorNames := getSpanMetricsPipelineProcessors(spanMetricsConfig)
+
+	// this config domain api to the outside world.
+	// when set, the caller also needs to:
+	// - add the returned exporters to the trace pipeline
+	// - add the returned recivers to the metrics pipeline
+	additionalTraceExporters := []string{spanMetricsTracesInConnectorName}
+	additionalMetricsRecivers := []string{spanMetricsConnectorName}
+	configDomain := config.Config{
+		Connectors: connectors,
+		Processors: processors,
+		Service: config.Service{
+			Pipelines: map[string]config.Pipeline{
+				spanMetricsPipelineName: {
+					Receivers:  []string{spanMetricsTracesInConnectorName},
+					Processors: processorNames,
+					Exporters:  []string{spanMetricsConnectorName},
+				},
+			},
+		},
+	}
+
+	return configDomain, additionalTraceExporters, additionalMetricsRecivers
+}

--- a/common/odigos_config.go
+++ b/common/odigos_config.go
@@ -189,6 +189,21 @@ type MetricsSourceSpanMetricsConfiguration struct {
 	// 		["2ms", "4ms", "6ms", "8ms", "10ms", "50ms", "100ms", "200ms", "400ms", "800ms", "1s", "1400ms", "2s", "5s", "10s", "15s"]
 	// notice that more granular buckets are recommended for better precision but costs more since more metric series are produced.
 	ExplicitHistogramBuckets []string `json:"histogramBuckets,omitempty"`
+
+	// by default, odigos will aggregate base on pod container.
+	// if you have multiple processes in the same container,
+	// you will get each metrics aggregatint all processes measurements.
+	// to have more granularity, you can set this to true.
+	// this will create more dimensions for metrics, including process info,
+	// but with cost of more metrics series and costs.
+	IncludedProcessInDimensions *bool `json:"includedProcessInDimensions,omitempty"`
+
+	// exclude resource attributes from being added to span metrics.
+	// for example - if you don't care about the process granularity,
+	// and prefer the metrics to be aggregated for all processes in a pod container,
+	// you can list all "process.*" attributes here to exclude them from being added to span metrics.
+	// any other resource attribute can be set, either for senetation or to reduce dimenssions for generate metrics.
+	ExcludedResourceAttributes []string `json:"excludedResourceAttributes,omitempty"`
 }
 
 // +kubebuilder:object:generate=true

--- a/helm/odigos/templates/crds/odigos.io_collectorsgroups.yaml
+++ b/helm/odigos/templates/crds/odigos.io_collectorsgroups.yaml
@@ -155,6 +155,16 @@ spec:
                           - true - span metrics will never be collected, even if destinations require it.
                           - false / nil - span metrics will be collected if destinations require it (can be opt-in and out in destination level).
                         type: boolean
+                      excludedResourceAttributes:
+                        description: |-
+                          exclude resource attributes from being added to span metrics.
+                          for example - if you don't care about the process granularity,
+                          and prefer the metrics to be aggregated for all processes in a pod container,
+                          you can list all "process.*" attributes here to exclude them from being added to span metrics.
+                          any other resource attribute can be set, either for senetation or to reduce dimenssions for generate metrics.
+                        items:
+                          type: string
+                        type: array
                       histogramBuckets:
                         description: "explicit buckets list for the histogram metrics.\nformat
                           is duration string (`1us`, `2ms`, `3s`, `4m`, `5h`, `6d`
@@ -171,6 +181,15 @@ spec:
                         type: array
                       histogramDisabled:
                         description: if true, histogram metrics will not be collected.
+                        type: boolean
+                      includedProcessInDimensions:
+                        description: |-
+                          by default, odigos will aggregate base on pod container.
+                          if you have multiple processes in the same container,
+                          you will get each metrics aggregatint all processes measurements.
+                          to have more granularity, you can set this to true.
+                          this will create more dimensions for metrics, including process info,
+                          but with cost of more metrics series and costs.
                         type: boolean
                       interval:
                         description: 'time interval for flusing metrics (format: 15s,

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -539,6 +539,15 @@ metricsSources:
     ## format is duration string (1us, 2ms, 3s, 4m, 5h, 6d, etc)
     # explicitHistogramBuckets: ['2ms', '4ms', '6ms', '8ms', '10ms', '50ms', '100ms', '200ms', '400ms', '800ms', '1s', '1400ms', '2s', '5s', '10s', '15s']
 
+    ## set if process level dimenssions will be included in span metrics
+    ## by default, process level metrics are not included
+    ## when set to true - timeseries will be created for each process in a container
+    ## when unset or set to false - timeseries will aggregate all processes into a single value per series
+    # includedProcessInDimensions: true
+
+    ## set resource attributes to exclude from the span metrics
+    # excludedResourceAttributes: ['process.runtime.name', 'process.runtime.version']
+
 
 # Enable automatic Go library offsets updates.
 # See https://docs.odigos.io/pipeline/golang/ebpf#go-auto-offsets for more details.


### PR DESCRIPTION
Fixes: CORE-271

this PR adds a pipeline in node collector which mutate spans before they are sent into the spanmetrics connector.

it will add a `resource` processor that will delete some resource attributes, effectively removing them as dimensions from the auto generate metrics.

also removed 2 `telemetery.sdk` attributes which looks useless, and removed few `process.*` attributes by default, with an opt-in config option to enable them