### PR TITLE
fix: add semconv profile on metrics and add http status code

### DIFF
--- a/profiles/manifests/semconv.yaml
+++ b/profiles/manifests/semconv.yaml
@@ -58,10 +58,14 @@ spec:
         action: upsert
       - key: db.statement
         action: delete
-
-
+      - key: http.response.status_code
+        from_attribute: http.status_code
+        action: upsert
+      - key: http.status_code
+        action: delete
 
   signals:
   - TRACES
+  - METRICS
   collectorRoles:
   - CLUSTER_GATEWAY


### PR DESCRIPTION
Fixes: CORE-271

Since few instrumentations emit deprecated semconv `http.status_code` and others emit `http.response.status_code` - this PR adds this fix to the semconv profile and also apply it on metrics so the labels are consistent between agents.