### PR TITLE
Allow exposing central UI on any interface

### DIFF
--- a/cli/cmd/pro.go
+++ b/cli/cmd/pro.go
@@ -528,15 +528,6 @@ var portForwardCentralCmd = &cobra.Command{
 		}
 		startPortForward(&wg, ctx, uiPod, client, k8sconsts.CentralUIPort, "UI", localAddress)
 
-		keycloakPod, err := findPodWithAppLabel(ctx, client, proNamespaceFlag, k8sconsts.KeycloakAppName)
-		if err != nil {
-			fmt.Printf("\033[31mERROR\033[0m Cannot find Keycloak pod: %v\n", err)
-			cancel()
-			wg.Wait()
-			os.Exit(1)
-		}
-		startPortForward(&wg, ctx, keycloakPod, client, fmt.Sprintf("%d", k8sconsts.KeycloakPort), "Keycloak", localAddress)
-
 		fmt.Printf("Odigos Tower UI is available at: http://%s:%s\n", localAddress, k8sconsts.CentralUIPort)
 		fmt.Printf("Odigos Tower Backend is available at: http://%s:%s\n", localAddress, k8sconsts.CentralBackendPort)
 		fmt.Printf("Press Ctrl+C to stop\n")

--- a/docs/cli/odigos_pro.mdx
+++ b/docs/cli/odigos_pro.mdx
@@ -17,7 +17,7 @@ odigos pro [flags]
 ### Examples
 
 ```
-  
+
 # Renew the on-premises token for Odigos,
 odigos pro --onprem-token <token>
 

--- a/docs/cli/odigos_pro_central.mdx
+++ b/docs/cli/odigos_pro_central.mdx
@@ -30,4 +30,4 @@ Manage Odigos Tower backend and UI components used in enterprise deployments.
 * [odigos pro](/cli/odigos_pro)	 - Manage Odigos onprem tier for enterprise users
 * [odigos pro central install](/cli/odigos_pro_central_install)	 - Install Odigos Tower backend and UI components
 * [odigos pro central ui](/cli/odigos_pro_central_ui)	 - Port-forward Odigos Tower UI and Backend to localhost
-* [odigos pro central uninstall](/cli/odigos_pro_central_uninstall)	 - Uninstall Odigos Tower backend and UI components
+* [odigos pro central upgrade](/cli/odigos_pro_central_upgrade)	 - Upgrade Odigos Tower UI in the central namespace

--- a/docs/cli/odigos_pro_central_ui.mdx
+++ b/docs/cli/odigos_pro_central_ui.mdx
@@ -8,7 +8,7 @@ Port-forward Odigos Tower UI and Backend to localhost
 
 ### Synopsis
 
-Port-forward the Tower UI (port 3000) and Tower Backend (port 8081) to localhost to enable local access to Odigos UI.
+Port-forward the Tower UI (port 3000) and Tower Backend (port 8081) to enable local access to Odigos UI. Use --address to bind to specific interfaces.
 
 ```
 odigos pro central ui [flags]
@@ -17,7 +17,8 @@ odigos pro central ui [flags]
 ### Options
 
 ```
-  -h, --help   help for ui
+      --address string   Address to serve the UI on (default "localhost")
+  -h, --help             help for ui
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/odigos_pro_central_upgrade.mdx
+++ b/docs/cli/odigos_pro_central_upgrade.mdx
@@ -1,21 +1,22 @@
 ---
-title: "odigos pro central uninstall"
-sidebarTitle: "odigos pro central uninstall"
+title: "odigos pro central upgrade"
+sidebarTitle: "odigos pro central upgrade"
 ---
-## odigos pro central uninstall
+## odigos pro central upgrade
 
-Uninstall Odigos Tower backend and UI components
+Upgrade Odigos Tower UI in the central namespace
 
 ```
-odigos pro central uninstall [flags]
+odigos pro central upgrade [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help               help for uninstall
-  -n, --namespace string   Target namespace for Odigos Tower uninstallation (default "odigos-central")
-      --yes                skip the confirmation prompt
+  -h, --help               help for upgrade
+  -n, --namespace string   Target namespace for Odigos Tower upgrade (default "odigos-central")
+      --version string     Specify version to upgrade to
+      --yes                Confirm the upgrade without prompting
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
## Description

<!-- Short summary of the changes -->

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [x] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-290
