### PR TITLE
fix: do not exclude status code from dimensions

### DIFF
--- a/autoscaler/controllers/nodecollector/collectorconfig/spanmetrics.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/spanmetrics.go
@@ -53,7 +53,6 @@ func getSpanMetricsConnectorConfig(spanMetricsConfig common.MetricsSourceSpanMet
 		"exemplars": config.GenericMap{
 			"enabled": true,
 		},
-		"exclude_dimensions":              []string{"status.code"},
 		"dimensions_cache_size":           1000,
 		"aggregation_temporality":         "AGGREGATION_TEMPORALITY_CUMULATIVE",
 		"metrics_flush_interval":          spanMetricsConfig.Interval,


### PR DESCRIPTION
Fixes: CORE-271

`status.code` is included in `exclude_dimensions` but it is needed.
not sure why it was there to begin with - probably copied from the example from the connector README