### PR TITLE
chore: fix datastreams flake

### DIFF
--- a/tests/e2e/data-streams/chainsaw-test.yaml
+++ b/tests/e2e/data-streams/chainsaw-test.yaml
@@ -116,6 +116,9 @@ spec:
               diff /tmp/current-datastreams-connector-config.yaml expected-datastreams-config.yaml >/dev/null
               echo "✅ Diff matched expected datastreams config"
 
+              ## This sleep here to ensure configuration is updated in the collector because of the debounce mechanism
+              sleep 5
+
     - name: '[2 - Workload Instrumentation] Generate Traffic'
       try:
         - apply:

--- a/tests/e2e/data-streams/chainsaw-test.yaml
+++ b/tests/e2e/data-streams/chainsaw-test.yaml
@@ -97,6 +97,12 @@ spec:
         - script:
             timeout: 2m
             content: ../../common/wait_for_rollout.sh
+        - script:
+            timeout: 30s
+            content: |
+              kubectl get cm odigos-gateway -n odigos-test -o jsonpath='{.data.collector-conf}' > /tmp/current.yaml
+              yq '.connectors."odigosrouterconnector/traces"' /tmp/current.yaml > /tmp/current-datastreams-connector-config.yaml
+              diff /tmp/current-datastreams-connector-config.yaml expected-datastreams-config.yaml
 
     - name: '[2 - Workload Instrumentation] Generate Traffic'
       try:

--- a/tests/e2e/data-streams/chainsaw-test.yaml
+++ b/tests/e2e/data-streams/chainsaw-test.yaml
@@ -98,11 +98,23 @@ spec:
             timeout: 2m
             content: ../../common/wait_for_rollout.sh
         - script:
-            timeout: 30s
+            timeout: 60s
             content: |
-              kubectl get cm odigos-gateway -n odigos-test -o jsonpath='{.data.collector-conf}' > /tmp/current.yaml
-              yq '.connectors."odigosrouterconnector/traces"' /tmp/current.yaml > /tmp/current-datastreams-connector-config.yaml
-              diff /tmp/current-datastreams-connector-config.yaml expected-datastreams-config.yaml
+              echo "===== FETCHING ACTUAL CONNECTOR CONFIG ====="
+              kubectl get cm odigos-gateway -n odigos-test -o jsonpath='{.data.collector-conf}' \
+                > /tmp/raw-collector-conf.yaml
+
+              echo "===== PARSING CONNECTOR CONFIG ====="
+              yq '.connectors."odigosrouterconnector/traces"' /tmp/raw-collector-conf.yaml \
+                > /tmp/current-datastreams-connector-config.yaml
+
+              echo "===== ACTUAL CONNECTOR CONFIG ====="
+              cat /tmp/current-datastreams-connector-config.yaml
+              echo "===== END ACTUAL CONNECTOR CONFIG ====="
+
+              echo "===== DIFF EXPECTED vs ACTUAL ====="
+              diff /tmp/current-datastreams-connector-config.yaml expected-datastreams-config.yaml >/dev/null
+              echo "✅ Diff matched expected datastreams config"
 
     - name: '[2 - Workload Instrumentation] Generate Traffic'
       try:

--- a/tests/e2e/data-streams/expected-datastreams-config.yaml
+++ b/tests/e2e/data-streams/expected-datastreams-config.yaml
@@ -1,18 +1,9 @@
 datastreams:
-  - name: default
+  - name: stream-1
     sources:
       - namespace: default
         kind: Deployment
-        name: pricing
-      - namespace: default
-        kind: Deployment
         name: frontend
-      - namespace: default
-        kind: Deployment
-        name: membership
-      - namespace: default
-        kind: Deployment
-        name: currency
       - namespace: default
         kind: Deployment
         name: coupon
@@ -20,12 +11,24 @@ datastreams:
         kind: Deployment
         name: inventory
       - namespace: default
-        kind: CronJob
-        name: load-generator
+        kind: Deployment
+        name: pricing
+    destinations:
+      - destinationname: odigos.io.dest.simple-trace-db-stream-1
+        configuredsignals:
+          - TRACES
+  - name: stream-2
+    sources:
+      - namespace: default
+        kind: Deployment
+        name: currency
       - namespace: default
         kind: Deployment
         name: geolocation
+      - namespace: default
+        kind: Deployment
+        name: frontend
     destinations:
-      - destinationname: odigos.io.dest.jaeger-lj2vx
+      - destinationname: odigos.io.dest.simple-trace-db-stream-2
         configuredsignals:
           - TRACES

--- a/tests/e2e/data-streams/expected-datastreams-config.yaml
+++ b/tests/e2e/data-streams/expected-datastreams-config.yaml
@@ -1,0 +1,31 @@
+datastreams:
+  - name: default
+    sources:
+      - namespace: default
+        kind: Deployment
+        name: pricing
+      - namespace: default
+        kind: Deployment
+        name: frontend
+      - namespace: default
+        kind: Deployment
+        name: membership
+      - namespace: default
+        kind: Deployment
+        name: currency
+      - namespace: default
+        kind: Deployment
+        name: coupon
+      - namespace: default
+        kind: Deployment
+        name: inventory
+      - namespace: default
+        kind: CronJob
+        name: load-generator
+      - namespace: default
+        kind: Deployment
+        name: geolocation
+    destinations:
+      - destinationname: odigos.io.dest.jaeger-lj2vx
+        configuredsignals:
+          - TRACES


### PR DESCRIPTION
## Description

The flake in data streams happen because of the configuration not yet updated once generating the traffic.
Adding this assertion will make sure config in place before generating the traffic.
and also adding sleep for 5s before generating the traffic to make waiting for debouncing the config changes.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [x] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-307
