### PR TITLE
chore: bump odiglet base image to use go1.25

### DIFF
--- a/.github/workflows/publish-odiglet-base-builder.yaml
+++ b/.github/workflows/publish-odiglet-base-builder.yaml
@@ -52,6 +52,22 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - id: gcp-auth
+        name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          access_token_lifetime: 1200s
+
+      - name: Login to Artifact Registry
+        uses: docker/login-action@v3
+        with:
+          registry: us-central1-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Set up QEMU
@@ -66,3 +82,4 @@ jobs:
           tags: |
             ${{ env.DOCKERHUB_ORG }}/odiglet-base:${{ github.event.inputs.image_tag }}
             ${{ env.DOCKERHUB_ORG }}/odiglet-base:latest
+            us-central1-docker.pkg.dev/odigos-cloud/components/odiglet-base:${{ github.event.inputs.image_tag }}

--- a/odiglet/base.Dockerfile
+++ b/odiglet/base.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.3-bookworm AS builder
+FROM golang:1.25.3-trixie AS builder
 
 # fury is our registry for linux packages
 RUN echo "deb [trusted=yes] https://apt.fury.io/cli/ * *" > /etc/apt/sources.list.d/fury-cli.list


### PR DESCRIPTION
Update the base image of odiglet to use go1.25.3.
In addition using the `trixie` variant of the image to update to the latest stable version of Debian.
Updating CI to publish the base image also to GCP.
In a follow-up PR I plan to update the odiglet to use this new image - and update all the CI and go.mod to use go1.25.

emergency-ticket id: EMR-326
