### PR TITLE
fix: odiglet base ci missing permission

### DIFF
--- a/.github/workflows/publish-odiglet-base-builder.yaml
+++ b/.github/workflows/publish-odiglet-base-builder.yaml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: 'write'
 
 env:
   DOCKERHUB_ORG: "keyval"


### PR DESCRIPTION
Adding missing permission for GCP auth similar to other actions.

emergency-ticket id: EMR-325
