### PR TITLE
Add InstrumentationLibraries to manager Load()

### DIFF
--- a/instrumentation/factory.go
+++ b/instrumentation/factory.go
@@ -49,7 +49,7 @@ type Instrumentation interface {
 	// for the instrumentation to be ready to run.
 	// For eBPF, this will load the probes into the kernel
 	// In case of a failure, an error will be returned and all the resources will be cleaned up.
-	Load(ctx context.Context) ([]InstrumentationLibrary, error)
+	Load(ctx context.Context) (Status, error)
 
 	// Run will start reading events from the probes and export them.
 	// It is a blocking call, and will return only when the instrumentation is stopped.
@@ -65,9 +65,19 @@ type Instrumentation interface {
 	ApplyConfig(ctx context.Context, config Config) error
 }
 
-// InstrumentationLibrary is used to identify a specific instrumentation library.
-type InstrumentationLibrary struct {
-	// Name is the name of the instrumentation library.
-	// For example, "net/http", "@opentelemetry/instrumentation-redis".
-	Name string
+// Status is used to identify the status of an instrumentation and its libraries.
+type Status struct {
+	// Status is the status of the instrumentation.
+	Status string
+
+	// Libraries is a map of library names to their status.
+	Libraries map[string]LibraryStatus
+}
+
+type LibraryStatus struct {
+	// Healthy indicates if the library was successfully loaded.
+	Healthy bool
+
+	// Message is the message of the library, if applicable.
+	Message string
 }

--- a/instrumentation/factory.go
+++ b/instrumentation/factory.go
@@ -49,7 +49,7 @@ type Instrumentation interface {
 	// for the instrumentation to be ready to run.
 	// For eBPF, this will load the probes into the kernel
 	// In case of a failure, an error will be returned and all the resources will be cleaned up.
-	Load(ctx context.Context) error
+	Load(ctx context.Context) ([]InstrumentationLibrary, error)
 
 	// Run will start reading events from the probes and export them.
 	// It is a blocking call, and will return only when the instrumentation is stopped.
@@ -63,4 +63,11 @@ type Instrumentation interface {
 
 	// ApplyConfig will send a configuration update to the instrumentation.
 	ApplyConfig(ctx context.Context, config Config) error
+}
+
+// InstrumentationLibrary is used to identify a specific instrumentation library.
+type InstrumentationLibrary struct {
+	// Name is the name of the instrumentation library.
+	// For example, "net/http", "@opentelemetry/instrumentation-redis".
+	Name string
 }

--- a/instrumentation/factory.go
+++ b/instrumentation/factory.go
@@ -50,6 +50,7 @@ type Instrumentation interface {
 	// For eBPF, this will load the probes into the kernel
 	// In case of a failure, an error will be returned and all the resources will be cleaned up.
 	// Returns the overall status of the instrumentation, or an error if the instrumentation failed to load.
+	// Status is only valid if the error is nil.
 	Load(ctx context.Context) (Status, error)
 
 	// Run will start reading events from the probes and export them.
@@ -68,9 +69,6 @@ type Instrumentation interface {
 
 // Status is used to identify the status of an instrumentation and its libraries.
 type Status struct {
-	// Status is the status of the instrumentation.
-	Status string
-
-	// Libraries is a map of library names to their status.
-	Libraries map[string]error
+	// Components is a map of component names (such as instrumentation library names) to their status.
+	Components map[string]error
 }

--- a/instrumentation/factory.go
+++ b/instrumentation/factory.go
@@ -49,6 +49,7 @@ type Instrumentation interface {
 	// for the instrumentation to be ready to run.
 	// For eBPF, this will load the probes into the kernel
 	// In case of a failure, an error will be returned and all the resources will be cleaned up.
+	// Returns the overall status of the instrumentation, or an error if the instrumentation failed to load.
 	Load(ctx context.Context) (Status, error)
 
 	// Run will start reading events from the probes and export them.
@@ -71,13 +72,5 @@ type Status struct {
 	Status string
 
 	// Libraries is a map of library names to their status.
-	Libraries map[string]LibraryStatus
-}
-
-type LibraryStatus struct {
-	// Healthy indicates if the library was successfully loaded.
-	Healthy bool
-
-	// Message is the message of the library, if applicable.
-	Message string
+	Libraries map[string]error
 }

--- a/instrumentation/manager.go
+++ b/instrumentation/manager.go
@@ -374,8 +374,8 @@ func (m *manager[ProcessDetails, ConfigGroup]) tryInstrument(ctx context.Context
 		return initErr
 	}
 
-	libraries, loadErr := inst.Load(ctx)
-	reporterErr = m.handler.Reporter.OnLoad(ctx, e.PID, loadErr, pd, libraries)
+	status, loadErr := inst.Load(ctx)
+	reporterErr = m.handler.Reporter.OnLoad(ctx, e.PID, loadErr, pd, status)
 	if reporterErr != nil {
 		m.logger.Error(reporterErr, "failed to report instrumentation load", "loaded", loadErr == nil, "pid", e.PID, "process group details", pd)
 	}

--- a/instrumentation/manager.go
+++ b/instrumentation/manager.go
@@ -374,8 +374,8 @@ func (m *manager[ProcessDetails, ConfigGroup]) tryInstrument(ctx context.Context
 		return initErr
 	}
 
-	loadErr := inst.Load(ctx)
-	reporterErr = m.handler.Reporter.OnLoad(ctx, e.PID, loadErr, pd)
+	libraries, loadErr := inst.Load(ctx)
+	reporterErr = m.handler.Reporter.OnLoad(ctx, e.PID, loadErr, pd, libraries)
 	if reporterErr != nil {
 		m.logger.Error(reporterErr, "failed to report instrumentation load", "loaded", loadErr == nil, "pid", e.PID, "process group details", pd)
 	}

--- a/instrumentation/types.go
+++ b/instrumentation/types.go
@@ -56,7 +56,7 @@ type Reporter[processDetails ProcessDetails] interface {
 
 	// OnLoad is called after an instrumentation is loaded successfully or failed to load.
 	// The error parameter will be nil if the instrumentation was loaded successfully.
-	OnLoad(ctx context.Context, pid int, err error, pg processDetails, libraries []InstrumentationLibrary) error
+	OnLoad(ctx context.Context, pid int, err error, pg processDetails, status Status) error
 
 	// OnRun is called after the instrumentation stops running.
 	// An error may report a fatal error during the instrumentation run, or a closing error

--- a/instrumentation/types.go
+++ b/instrumentation/types.go
@@ -56,7 +56,7 @@ type Reporter[processDetails ProcessDetails] interface {
 
 	// OnLoad is called after an instrumentation is loaded successfully or failed to load.
 	// The error parameter will be nil if the instrumentation was loaded successfully.
-	OnLoad(ctx context.Context, pid int, err error, pg processDetails) error
+	OnLoad(ctx context.Context, pid int, err error, pg processDetails, libraries []InstrumentationLibrary) error
 
 	// OnRun is called after the instrumentation stops running.
 	// An error may report a fatal error during the instrumentation run, or a closing error

--- a/odiglet/pkg/ebpf/sdks/go.go
+++ b/odiglet/pkg/ebpf/sdks/go.go
@@ -70,9 +70,9 @@ func (g *GoOtelEbpfSdk) Run(ctx context.Context) error {
 	return g.inst.Run(ctx)
 }
 
-func (g *GoOtelEbpfSdk) Load(ctx context.Context) ([]instrumentation.InstrumentationLibrary, error) {
+func (g *GoOtelEbpfSdk) Load(ctx context.Context) (instrumentation.Status, error) {
 	loadErr := g.inst.Load(ctx)
-	return nil, loadErr
+	return instrumentation.Status{}, loadErr
 }
 
 func (g *GoOtelEbpfSdk) Close(_ context.Context) error {

--- a/odiglet/pkg/ebpf/sdks/go.go
+++ b/odiglet/pkg/ebpf/sdks/go.go
@@ -70,8 +70,9 @@ func (g *GoOtelEbpfSdk) Run(ctx context.Context) error {
 	return g.inst.Run(ctx)
 }
 
-func (g *GoOtelEbpfSdk) Load(ctx context.Context) error {
-	return g.inst.Load(ctx)
+func (g *GoOtelEbpfSdk) Load(ctx context.Context) ([]instrumentation.InstrumentationLibrary, error) {
+	loadErr := g.inst.Load(ctx)
+	return nil, loadErr
 }
 
 func (g *GoOtelEbpfSdk) Close(_ context.Context) error {


### PR DESCRIPTION
## Description

This makes it possible for more eBPF instrumentations to return the libraries they have instrumented, see initial implementation for Go with

https://github.com/odigos-io/enterprise-go-instrumentation/pull/1753
https://github.com/odigos-io/ui-kit/pull/421

This can be expanded to show failed libraries and more information about the libraries

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [x] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-324
