### PR TITLE
chore: run release preflight checks on prerelease PRs

### DIFF
--- a/.github/workflows/create-release-candidate.yml
+++ b/.github/workflows/create-release-candidate.yml
@@ -151,6 +151,7 @@ jobs:
                 --base $RELEASE_BRANCH \
                 --head $PR_BRANCH \
                 --title "$PR_TITLE" \
+                --label "prerelease" \
                 --body "This is an automated PR for the release candidate ${{ steps.rc_version.outputs.rc_version }}"
             else
               echo "PR for branch $PR_BRANCH already exists"
@@ -171,6 +172,7 @@ jobs:
               --base $RELEASE_BRANCH \
               --head $PR_BRANCH \
               --title "$PR_TITLE" \
+              --label "prerelease" \
               --body "This is an automated PR for the release candidate ${{ steps.rc_version.outputs.rc_version }}"
           fi
 

--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -45,138 +45,10 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-  verify-offsets:
-    needs: decide
-    if: ${{ needs.decide.outputs.skip != 'true' }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        repo: ['enterprise-go-instrumentation']
-    steps:
-      - name: Verify no open offsets PRs
-        id: verify
-        run: |
-          # Fetch open PRs and filter by "offsets" label
-          result=$(curl -s -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.RELEASE_BOT_TOKEN }}" \
-            "https://api.github.com/repos/odigos-io/${{ matrix.repo }}/pulls?state=open&per_page=100")
-
-          pr_links=$(echo "$result" \
-            | jq -r '[.[] | select(.labels | any(.name == "offsets")) | .html_url] | join(" ")')
-
-          count=$(echo "$pr_links" | wc -w)
-          if [ "$count" -gt 0 ]; then
-            # Format PR links for display
-            pr_links_formatted=$(echo "$pr_links" | tr ' ' '\n' | awk '{print "- " $0}' | tr '\n' '\n')
-
-            # Write outputs to GITHUB_OUTPUT instead of using ::set-output
-            echo "status=failed" >> $GITHUB_OUTPUT
-            echo "links=$pr_links" >> $GITHUB_OUTPUT
-            echo "links_formatted=$pr_links_formatted" >> $GITHUB_OUTPUT
-            echo "❌ Error: Open PRs with label \"offsets\" found!" >&2
-            exit 1
-          else
-            echo "status=success" >> $GITHUB_OUTPUT
-            echo "✅ No open PRs with label \"offsets\"."
-          fi
-
-      - name: Notify Slack
-        if: always()
-        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
-        with:
-          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-          success-description: "No open offset PRs in `${{ matrix.repo }}`"
-          failure-description: "ERROR: Open offset PRs found in `${{ matrix.repo }}`\n\n${{ steps.verify.outputs.links_formatted }}"
-
-  verify-dependencies-sync:
-    if: ${{ needs.decide.outputs.skip != 'true' }}
-    needs: verify-offsets
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        repo: ['odigos-enterprise']
-    steps:
-      - name: Verify no open dependencies-syncer-bot PRs
-        id: verify
-        run: |
-          # Fetch open PRs and filter by "dependencies-syncer-bot" label
-          result=$(curl -s -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.RELEASE_BOT_TOKEN }}" \
-            "https://api.github.com/repos/odigos-io/${{ matrix.repo }}/pulls?state=open&per_page=100")
-
-          pr_links=$(echo "$result" \
-            | jq -r '[.[] | select(.labels | any(.name == "dependencies-syncer-bot")) | .html_url] | join(" ")')
-
-          count=$(echo "$pr_links" | wc -w)
-          if [ "$count" -gt 0 ]; then
-            # Format PR links for display
-            pr_links_formatted=$(echo "$pr_links" | tr ' ' '\n' | awk '{print "- " $0}' | tr '\n' '\n')
-
-            # Write outputs to GITHUB_OUTPUT instead of using ::set-output
-            echo "status=failed" >> $GITHUB_OUTPUT
-            echo "links=$pr_links" >> $GITHUB_OUTPUT
-            echo "pr_links_formatted=$pr_links_formatted" >> $GITHUB_OUTPUT
-            echo "❌ Error: Open PRs with label \"dependencies-syncer-bot\" found!" >&2
-            exit 1
-          else
-            echo "status=success" >> $GITHUB_OUTPUT
-            echo "✅ No open PRs with label \"dependencies-syncer-bot\"."
-          fi
-
-      - name: Notify Slack
-        if: always()
-        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
-        with:
-          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-          success-description: "No open dependencies-syncer-bot PRs in `${{ matrix.repo }}`"
-          failure-description: "ERROR: Open dependencies-syncer-bot PRs found in `${{ matrix.repo }}`\n\n${{ steps.verify.outputs.pr_links_formatted }}"
-
-  verify-release-blockers:
-    if: ${{ needs.decide.outputs.skip != 'true' }}
-    needs: verify-dependencies-sync
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        repo: ['odigos', 'odigos-enterprise']
-    steps:
-      - name: Verify no open release-blocker PRs
-        id: verify
-        run: |
-          # Fetch open PRs and filter by "release-blocker" label
-          result=$(curl -s -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.RELEASE_BOT_TOKEN }}" \
-            "https://api.github.com/repos/odigos-io/${{ matrix.repo }}/pulls?state=open&per_page=100")
-
-          pr_links=$(echo "$result" \
-            | jq -r '[.[] | select(.labels | any(.name == "release-blocker")) | .html_url] | join(" ")')
-
-          count=$(echo "$pr_links" | wc -w)
-          if [ "$count" -gt 0 ]; then
-            # Format PR links for display
-            pr_links_formatted=$(echo "$pr_links" | tr ' ' '\n' | awk '{print "- " $0}' | tr '\n' '\n')
-
-            # Write outputs to GITHUB_OUTPUT instead of using ::set-output
-            echo "status=failed" >> $GITHUB_OUTPUT
-            echo "links=$pr_links" >> $GITHUB_OUTPUT
-            echo "pr_links_formatted=$pr_links_formatted" >> $GITHUB_OUTPUT
-            echo "❌ Error: Open PRs with label \"release-blocker\" found!" >&2
-            exit 1
-          else
-            echo "status=success" >> $GITHUB_OUTPUT
-            echo "✅ No open PRs with label \"release-blocker\"."
-          fi
-
-      - name: Notify Slack
-        if: always()
-        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
-        with:
-          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-          success-description: "No open release-blocker PRs in `${{ matrix.repo }}`"
-          failure-description: "ERROR: Open release-blocker PRs found in `${{ matrix.repo }}`\n\n${{ steps.verify.outputs.pr_links_formatted }}"
 
   print-tag:
     if: ${{ needs.decide.outputs.skip != 'true' }}
-    needs: verify-release-blockers
+    needs: decide
     runs-on: ubuntu-latest
     steps:
       - name: Extract Tag
@@ -193,7 +65,7 @@ jobs:
 
   tag-modules:
     if: ${{ needs.decide.outputs.skip != 'true' }}
-    needs: verify-release-blockers
+    needs: decide
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -238,7 +110,7 @@ jobs:
 
   publish-images:
     if: ${{ needs.decide.outputs.skip != 'true' }}
-    needs: verify-release-blockers
+    needs: decide
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -371,7 +243,7 @@ jobs:
 
   publish-collector-linux-packages:
     if: ${{ needs.decide.outputs.skip != 'true' }}
-    needs: verify-release-blockers
+    needs: decide
     runs-on: depot-ubuntu-24.04-8
     steps:
       - name: Extract Tag

--- a/.github/workflows/test-release-candidate.yml
+++ b/.github/workflows/test-release-candidate.yml
@@ -1,0 +1,121 @@
+name: Test Release Candidate
+
+on:
+  pull_request:
+    branches: ['releases/**']
+
+jobs:
+  decide:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
+    steps:
+      - name: Check if PR has prerelease label
+        id: check
+        run: |
+          if [[ "${{ github.event.pull_request.labels.*.name }}" == *"prerelease"* ]]; then
+            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "✅ PR has prerelease label, running tests"
+          else
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "⏭️ PR does not have prerelease label, skipping tests"
+          fi
+
+  verify-offsets:
+    needs: decide
+    if: ${{ needs.decide.outputs.skip != 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: ['enterprise-go-instrumentation']
+    steps:
+      - name: Verify no open offsets PRs
+        id: verify
+        run: |
+          # Fetch open PRs and filter by "offsets" label
+          result=$(curl -s -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.RELEASE_BOT_TOKEN }}" \
+            "https://api.github.com/repos/odigos-io/${{ matrix.repo }}/pulls?state=open&per_page=100")
+
+          pr_links=$(echo "$result" \
+            | jq -r '[.[] | select(.labels | any(.name == "offsets")) | .html_url] | join(" ")')
+
+          count=$(echo "$pr_links" | wc -w)
+          if [ "$count" -gt 0 ]; then
+            # Format PR links for display
+            pr_links_formatted=$(echo "$pr_links" | tr ' ' '\n' | awk '{print "- " $0}' | tr '\n' '\n')
+
+            echo "❌ Error: Open PRs with label \"offsets\" found!" >&2
+            echo "::error::Open offset PRs found in ${{ matrix.repo }}:"
+            echo "$pr_links_formatted"
+            exit 1
+          else
+            echo "✅ No open PRs with label \"offsets\"."
+            echo "::notice::No open offset PRs in ${{ matrix.repo }}"
+          fi
+
+  verify-dependencies-sync:
+    if: ${{ needs.decide.outputs.skip != 'true' }}
+    needs: verify-offsets
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: ['odigos-enterprise']
+    steps:
+      - name: Verify no open dependencies-syncer-bot PRs
+        id: verify
+        run: |
+          # Fetch open PRs and filter by "dependencies-syncer-bot" label
+          result=$(curl -s -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.RELEASE_BOT_TOKEN }}" \
+            "https://api.github.com/repos/odigos-io/${{ matrix.repo }}/pulls?state=open&per_page=100")
+
+          pr_links=$(echo "$result" \
+            | jq -r '[.[] | select(.labels | any(.name == "dependencies-syncer-bot")) | .html_url] | join(" ")')
+
+          count=$(echo "$pr_links" | wc -w)
+          if [ "$count" -gt 0 ]; then
+            # Format PR links for display
+            pr_links_formatted=$(echo "$pr_links" | tr ' ' '\n' | awk '{print "- " $0}' | tr '\n' '\n')
+
+            echo "❌ Error: Open PRs with label \"dependencies-syncer-bot\" found!" >&2
+            echo "::error::Open dependencies-syncer-bot PRs found in ${{ matrix.repo }}:"
+            echo "$pr_links_formatted"
+            exit 1
+          else
+            echo "✅ No open PRs with label \"dependencies-syncer-bot\"."
+            echo "::notice::No open dependencies-syncer-bot PRs in ${{ matrix.repo }}"
+          fi
+
+  verify-release-blockers:
+    if: ${{ needs.decide.outputs.skip != 'true' }}
+    needs: verify-dependencies-sync
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: ['odigos', 'odigos-enterprise']
+    steps:
+      - name: Verify no open release-blocker PRs
+        id: verify
+        run: |
+          # Fetch open PRs and filter by "release-blocker" label
+          result=$(curl -s -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.RELEASE_BOT_TOKEN }}" \
+            "https://api.github.com/repos/odigos-io/${{ matrix.repo }}/pulls?state=open&per_page=100")
+
+          pr_links=$(echo "$result" \
+            | jq -r '[.[] | select(.labels | any(.name == "release-blocker")) | .html_url] | join(" ")')
+
+          count=$(echo "$pr_links" | wc -w)
+          if [ "$count" -gt 0 ]; then
+            # Format PR links for display
+            pr_links_formatted=$(echo "$pr_links" | tr ' ' '\n' | awk '{print "- " $0}' | tr '\n' '\n')
+
+            echo "❌ Error: Open PRs with label \"release-blocker\" found!" >&2
+            echo "::error::Open release-blocker PRs found in ${{ matrix.repo }}:"
+            echo "$pr_links_formatted"
+            exit 1
+          else
+            echo "✅ No open PRs with label \"release-blocker\"."
+            echo "::notice::No open release-blocker PRs in ${{ matrix.repo }}"
+          fi


### PR DESCRIPTION
## Description

Currently we check for release blockers, open dependency syncers, and open Go offsets PRs after the prerelease PR has merged. This means the tag is already created, even if the release will just fail.

This moves the checks to run as a presubmit on the prerelease PR itself, allowing us to catch this before the release actually starts. It's a simple copy and drag right now but can be expanded later to target specific branches and more repos.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-349
