### PR TITLE
chore: Bump operator to v1.8.0

### DIFF
--- a/autoscaler/controllers/nodecollector/configmap.go
+++ b/autoscaler/controllers/nodecollector/configmap.go
@@ -48,7 +48,7 @@ func (b *nodeCollectorBaseReconciler) SyncConfigMap(ctx context.Context, sources
 	}
 
 	existing := &v1.ConfigMap{}
-	if err := b.Client.Get(ctx, client.ObjectKey{Namespace: env.GetCurrentNamespace(), Name: k8sconsts.OdigosNodeCollectorCollectorGroupName}, existing); err != nil {
+	if err := b.Client.Get(ctx, client.ObjectKey{Namespace: env.GetCurrentNamespace(), Name: k8sconsts.OdigosNodeCollectorConfigMapName}, existing); err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.V(0).Info("creating config map")
 			_, err := b.createConfigMap(desired, ctx)

--- a/cli/cmd/resources/autoscaler.go
+++ b/cli/cmd/resources/autoscaler.go
@@ -171,16 +171,23 @@ func NewAutoscalerRoleBinding(ns string) *rbacv1.RoleBinding {
 func NewAutoscalerClusterRole(ownerPermissionEnforcement bool) *rbacv1.ClusterRole {
 	finalizersUpdate := []rbacv1.PolicyRule{}
 	if ownerPermissionEnforcement {
-		finalizersUpdate = append(finalizersUpdate, rbacv1.PolicyRule{
-			// Required for OwnerReferencesPermissionEnforcement (on by default in OpenShift)
-			// When we create a collector COnfigMap, we set the OwnerReference to the collectorsgroups.
-			// Controller-runtime sets BlockDeletion: true. So with this Admission Plugin we need permission to
-			// update finalizers on the collectorsgroup so that they can block deletion.
-			// seehttps://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
-			APIGroups: []string{"odigos.io"},
-			Resources: []string{"collectorsgroups/finalizers"},
-			Verbs:     []string{"update"},
-		})
+		finalizersUpdate = append(finalizersUpdate,
+			rbacv1.PolicyRule{
+				// Required for OwnerReferencesPermissionEnforcement (on by default in OpenShift)
+				// When we create a collector COnfigMap, we set the OwnerReference to the collectorsgroups.
+				// Controller-runtime sets BlockDeletion: true. So with this Admission Plugin we need permission to
+				// update finalizers on the collectorsgroup so that they can block deletion.
+				// seehttps://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+				APIGroups: []string{"odigos.io"},
+				Resources: []string{"collectorsgroups/finalizers"},
+				Verbs:     []string{"update"},
+			},
+			rbacv1.PolicyRule{
+				APIGroups: []string{"apps"},
+				Resources: []string{"deployments/finalizers"},
+				Verbs:     []string{"update"},
+			},
+		)
 	}
 
 	return &rbacv1.ClusterRole{

--- a/cli/cmd/resources/autoscaler.go
+++ b/cli/cmd/resources/autoscaler.go
@@ -133,6 +133,11 @@ func NewAutoscalerRole(ns string, openshiftEnabled bool) *rbacv1.Role {
 		},
 	}
 
+	// This is needed for OpenShift to update the finalizers of the deployments
+	// Used when setting the OwnerReference of the CollectorsGroup to the scheduler deployment
+	// Controller-runtime sets BlockDeletion: true. So with this Admission Plugin we need permission to
+	// update finalizers on the autoscaler deployment so that they can block deletion.
+	// seehttps://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
 	if openshiftEnabled {
 		rules = append(rules, rbacv1.PolicyRule{
 			APIGroups: []string{"apps"},

--- a/cli/cmd/resources/autoscaler.go
+++ b/cli/cmd/resources/autoscaler.go
@@ -32,7 +32,115 @@ func NewAutoscalerServiceAccount(ns string) *corev1.ServiceAccount {
 	}
 }
 
-func NewAutoscalerRole(ns string) *rbacv1.Role {
+func NewAutoscalerRole(ns string, openshiftEnabled bool) *rbacv1.Role {
+	rules := []rbacv1.PolicyRule{
+		{ // Needed to manage the configmaps of the data-collector and gateway-collector
+			APIGroups: []string{""},
+			Resources: []string{"configmaps"},
+			Verbs:     []string{"get", "list", "watch", "create", "patch", "update", "delete"},
+		},
+		{ // Needed to manage the k8s-service of gateway-collector
+			APIGroups: []string{""},
+			Resources: []string{"services"},
+			Verbs:     []string{"get", "list", "watch", "create", "patch", "update", "delete", "deletecollection"},
+		},
+		{ // Needed to manage the daemonsets for data-collector
+			APIGroups: []string{"apps"},
+			Resources: []string{"daemonsets"},
+			Verbs:     []string{"get", "list", "watch", "create", "patch", "update", "delete", "deletecollection"},
+		},
+		{ // Needed to read the "readiness" status of the collectorsgroup
+			APIGroups: []string{"apps"},
+			Resources: []string{"daemonsets/status"},
+			Verbs:     []string{"get"},
+		},
+		{ // Needed to manage the deployments for data-collector
+			APIGroups: []string{"apps"},
+			Resources: []string{"deployments"},
+			Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+		},
+		{ // Needed to read the "readiness" status of the collectorsgroup
+			APIGroups: []string{"apps"},
+			Resources: []string{"deployments/status"},
+			Verbs:     []string{"get"},
+		},
+		{ // Needed to apply autoscaling to the gateway-collector
+			APIGroups: []string{"autoscaling"},
+			Resources: []string{"horizontalpodautoscalers"},
+			Verbs:     []string{"create", "patch", "update", "delete"},
+		},
+		{ // Needed to track changes and restart gateway-collector
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{ // Needed to update the webhook certificates and manage rotation
+			APIGroups:     []string{""},
+			Resources:     []string{"secrets"},
+			ResourceNames: []string{k8sconsts.AutoscalerWebhookSecretName},
+			Verbs:         []string{"update"},
+		},
+		{ // Needed to migrate away from the old secret
+			APIGroups:     []string{""},
+			Resources:     []string{"secrets"},
+			ResourceNames: []string{k8sconsts.DeprecatedAutoscalerWebhookSecretName},
+			Verbs:         []string{"delete"},
+		},
+		{ // Needed to sync the gateway-collector configuration
+			APIGroups: []string{"odigos.io"},
+			Resources: []string{"destinations"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{ // Needed to track destination-config changes and update the status accordingly
+			APIGroups: []string{"odigos.io"},
+			Resources: []string{"destinations/status"},
+			Verbs:     []string{"get", "patch", "update"},
+		},
+		{ // Needed to identify changes to pipeline-actions and update the data & gateway collectors configmap
+			APIGroups: []string{"odigos.io"},
+			Resources: []string{"processors"},
+			Verbs:     []string{"get", "list", "watch", "create", "patch", "update"},
+		},
+		{ // Needed to read actions transform them to processors and to update to generic CRDS
+			APIGroups: []string{"actions.odigos.io"},
+			Resources: []string{"*"},
+			Verbs:     []string{"get", "list", "watch", "update"},
+		},
+		{ // Needed to updated the status of the actions (confirms the user-made-changes)
+			APIGroups: []string{"actions.odigos.io"},
+			Resources: []string{"*/status"},
+			Verbs:     []string{"get", "patch", "update"},
+		},
+		{ // Needed to watch for changes made in the the collectorgroups and apply them to the cluster
+			APIGroups: []string{"odigos.io"},
+			Resources: []string{"collectorsgroups"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{ // After applying the collectorgroups tot he cluster, we need to update the status of the operation
+			APIGroups: []string{"odigos.io"},
+			Resources: []string{"collectorsgroups/status"},
+			Verbs:     []string{"get", "patch", "update"},
+		},
+		{ // Needed to watch and manage actions in order to transform them to processors
+			APIGroups: []string{"odigos.io"},
+			Resources: []string{"actions"},
+			Verbs:     []string{"get", "list", "watch", "create", "patch", "update"},
+		},
+		{ // Update conditions of the action after transforming it to a processor
+			APIGroups: []string{"odigos.io"},
+			Resources: []string{"actions/status"},
+			Verbs:     []string{"get", "patch", "update"},
+		},
+	}
+
+	if openshiftEnabled {
+		rules = append(rules, rbacv1.PolicyRule{
+			APIGroups: []string{"apps"},
+			Resources: []string{"deployments/finalizers"},
+			Verbs:     []string{"update"},
+		})
+	}
+
 	return &rbacv1.Role{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Role",
@@ -42,105 +150,7 @@ func NewAutoscalerRole(ns string) *rbacv1.Role {
 			Name:      k8sconsts.AutoScalerRoleName,
 			Namespace: ns,
 		},
-		Rules: []rbacv1.PolicyRule{
-			{ // Needed to manage the configmaps of the data-collector and gateway-collector
-				APIGroups: []string{""},
-				Resources: []string{"configmaps"},
-				Verbs:     []string{"get", "list", "watch", "create", "patch", "update", "delete"},
-			},
-			{ // Needed to manage the k8s-service of gateway-collector
-				APIGroups: []string{""},
-				Resources: []string{"services"},
-				Verbs:     []string{"get", "list", "watch", "create", "patch", "update", "delete", "deletecollection"},
-			},
-			{ // Needed to manage the daemonsets for data-collector
-				APIGroups: []string{"apps"},
-				Resources: []string{"daemonsets"},
-				Verbs:     []string{"get", "list", "watch", "create", "patch", "update", "delete", "deletecollection"},
-			},
-			{ // Needed to read the "readiness" status of the collectorsgroup
-				APIGroups: []string{"apps"},
-				Resources: []string{"daemonsets/status"},
-				Verbs:     []string{"get"},
-			},
-			{ // Needed to manage the deployments for data-collector
-				APIGroups: []string{"apps"},
-				Resources: []string{"deployments"},
-				Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
-			},
-			{ // Needed to read the "readiness" status of the collectorsgroup
-				APIGroups: []string{"apps"},
-				Resources: []string{"deployments/status"},
-				Verbs:     []string{"get"},
-			},
-			{ // Needed to apply autoscaling to the gateway-collector
-				APIGroups: []string{"autoscaling"},
-				Resources: []string{"horizontalpodautoscalers"},
-				Verbs:     []string{"create", "patch", "update", "delete"},
-			},
-			{ // Needed to track changes and restart gateway-collector
-				APIGroups: []string{""},
-				Resources: []string{"secrets"},
-				Verbs:     []string{"get", "list", "watch"},
-			},
-			{ // Needed to update the webhook certificates and manage rotation
-				APIGroups:     []string{""},
-				Resources:     []string{"secrets"},
-				ResourceNames: []string{k8sconsts.AutoscalerWebhookSecretName},
-				Verbs:         []string{"update"},
-			},
-			{ // Needed to migrate away from the old secret
-				APIGroups:     []string{""},
-				Resources:     []string{"secrets"},
-				ResourceNames: []string{k8sconsts.DeprecatedAutoscalerWebhookSecretName},
-				Verbs:         []string{"delete"},
-			},
-			{ // Needed to sync the gateway-collector configuration
-				APIGroups: []string{"odigos.io"},
-				Resources: []string{"destinations"},
-				Verbs:     []string{"get", "list", "watch"},
-			},
-			{ // Needed to track destination-config changes and update the status accordingly
-				APIGroups: []string{"odigos.io"},
-				Resources: []string{"destinations/status"},
-				Verbs:     []string{"get", "patch", "update"},
-			},
-			{ // Needed to identify changes to pipeline-actions and update the data & gateway collectors configmap
-				APIGroups: []string{"odigos.io"},
-				Resources: []string{"processors"},
-				Verbs:     []string{"get", "list", "watch", "create", "patch", "update"},
-			},
-			{ // Needed to read actions transform them to processors and to update to generic CRDS
-				APIGroups: []string{"actions.odigos.io"},
-				Resources: []string{"*"},
-				Verbs:     []string{"get", "list", "watch", "update"},
-			},
-			{ // Needed to updated the status of the actions (confirms the user-made-changes)
-				APIGroups: []string{"actions.odigos.io"},
-				Resources: []string{"*/status"},
-				Verbs:     []string{"get", "patch", "update"},
-			},
-			{ // Needed to watch for changes made in the the collectorgroups and apply them to the cluster
-				APIGroups: []string{"odigos.io"},
-				Resources: []string{"collectorsgroups"},
-				Verbs:     []string{"get", "list", "watch"},
-			},
-			{ // After applying the collectorgroups tot he cluster, we need to update the status of the operation
-				APIGroups: []string{"odigos.io"},
-				Resources: []string{"collectorsgroups/status"},
-				Verbs:     []string{"get", "patch", "update"},
-			},
-			{ // Needed to watch and manage actions in order to transform them to processors
-				APIGroups: []string{"odigos.io"},
-				Resources: []string{"actions"},
-				Verbs:     []string{"get", "list", "watch", "create", "patch", "update"},
-			},
-			{ // Update conditions of the action after transforming it to a processor
-				APIGroups: []string{"odigos.io"},
-				Resources: []string{"actions/status"},
-				Verbs:     []string{"get", "patch", "update"},
-			},
-		},
+		Rules: rules,
 	}
 }
 
@@ -180,11 +190,6 @@ func NewAutoscalerClusterRole(ownerPermissionEnforcement bool) *rbacv1.ClusterRo
 				// seehttps://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
 				APIGroups: []string{"odigos.io"},
 				Resources: []string{"collectorsgroups/finalizers"},
-				Verbs:     []string{"update"},
-			},
-			rbacv1.PolicyRule{
-				APIGroups: []string{"apps"},
-				Resources: []string{"deployments/finalizers"},
 				Verbs:     []string{"update"},
 			},
 		)
@@ -570,7 +575,7 @@ func (a *autoScalerResourceManager) Name() string { return "AutoScaler" }
 func (a *autoScalerResourceManager) InstallFromScratch(ctx context.Context) error {
 	resources := []kube.Object{
 		NewAutoscalerServiceAccount(a.ns),
-		NewAutoscalerRole(a.ns),
+		NewAutoscalerRole(a.ns, a.config.OpenshiftEnabled),
 		NewAutoscalerRoleBinding(a.ns),
 		NewAutoscalerClusterRole(a.config.OpenshiftEnabled),
 		NewAutoscalerClusterRoleBinding(a.ns),

--- a/cli/cmd/resources/datacollection.go
+++ b/cli/cmd/resources/datacollection.go
@@ -66,7 +66,7 @@ func NewDataCollectionRoleBinding(ns string) *rbacv1.RoleBinding {
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "Role",
-			Name:     k8sconsts.OdigosNodeCollectorRoleName,
+			Name:     k8sconsts.OdigletRoleName,
 		},
 	}
 }

--- a/cli/cmd/resources/scheduler.go
+++ b/cli/cmd/resources/scheduler.go
@@ -113,6 +113,11 @@ func NewSchedulerRole(ns string, openshiftEnabled bool) *rbacv1.Role {
 		},
 	}
 
+	// This is needed for OpenShift to update the finalizers of the deployments
+	// Used when setting the OwnerReference of the Collector Configmap to the autoscaler deployment
+	// Controller-runtime sets BlockDeletion: true. So with this Admission Plugin we need permission to
+	// update finalizers on the scheduler deployment so that they can block deletion.
+	// seehttps://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
 	if openshiftEnabled {
 		rules = append(rules, rbacv1.PolicyRule{
 			APIGroups: []string{"apps"},

--- a/cli/cmd/resources/scheduler.go
+++ b/cli/cmd/resources/scheduler.go
@@ -168,11 +168,18 @@ func NewSchedulerClusterRole(openshiftEnabled bool) *rbacv1.ClusterRole {
 	}
 
 	if openshiftEnabled {
-		rules = append(rules, rbacv1.PolicyRule{
-			APIGroups: []string{""},
-			Resources: []string{"configmaps/finalizers"},
-			Verbs:     []string{"update"},
-		})
+		rules = append(rules,
+			rbacv1.PolicyRule{
+				APIGroups: []string{""},
+				Resources: []string{"configmaps/finalizers"},
+				Verbs:     []string{"update"},
+			},
+			rbacv1.PolicyRule{
+				APIGroups: []string{"apps"},
+				Resources: []string{"deployments/finalizers"},
+				Verbs:     []string{"update"},
+			},
+		)
 	}
 
 	return &rbacv1.ClusterRole{

--- a/helm/odigos/templates/autoscaler/clusterrole.yaml
+++ b/helm/odigos/templates/autoscaler/clusterrole.yaml
@@ -30,12 +30,6 @@ rules:
       - get
       - patch
       - update
-  - apiGroups:
-      - 'apps'
-    resources:
-      - deployments/finalizers
-    verbs:
-      - update
 {{- end }}
   - apiGroups:
       - admissionregistration.k8s.io

--- a/helm/odigos/templates/autoscaler/clusterrole.yaml
+++ b/helm/odigos/templates/autoscaler/clusterrole.yaml
@@ -30,6 +30,12 @@ rules:
       - get
       - patch
       - update
+  - apiGroups:
+      - 'apps'
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
 {{- end }}
   - apiGroups:
       - admissionregistration.k8s.io

--- a/helm/odigos/templates/autoscaler/role.yaml
+++ b/helm/odigos/templates/autoscaler/role.yaml
@@ -182,3 +182,11 @@ rules:
       - get
       - patch
       - update
+{{- if .Values.openshift.enabled }}
+  - apiGroups:
+      - 'apps'
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+{{- end }}

--- a/helm/odigos/templates/scheduler/clusterrole.yaml
+++ b/helm/odigos/templates/scheduler/clusterrole.yaml
@@ -20,12 +20,6 @@ rules:
       - configmaps/finalizers
     verbs:
       - update
-  - apiGroups:
-      - 'apps'
-    resources:
-      - deployments/finalizers
-    verbs:
-      - update
 {{- end }}
   - apiGroups:
       - 'batch'

--- a/helm/odigos/templates/scheduler/clusterrole.yaml
+++ b/helm/odigos/templates/scheduler/clusterrole.yaml
@@ -20,6 +20,12 @@ rules:
       - configmaps/finalizers
     verbs:
       - update
+  - apiGroups:
+      - 'apps'
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
 {{- end }}
   - apiGroups:
       - 'batch'

--- a/helm/odigos/templates/scheduler/role.yaml
+++ b/helm/odigos/templates/scheduler/role.yaml
@@ -120,3 +120,11 @@ rules:
       - 'get'
       - 'list'
       - 'watch'
+{{- if .Values.openshift.enabled }}
+  - apiGroups:
+      - 'apps'
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+{{- end }}

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.0.212
+VERSION ?= 1.8.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/operator/api/v1alpha1/odigos_types.go
+++ b/operator/api/v1alpha1/odigos_types.go
@@ -56,7 +56,6 @@ type OdigosSpec struct {
 	// (Optional) AgentEnvVarsInjectionMethod is the method to inject the Odigos agent env vars into the pod.
 	// Default=pod-manifest
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=3
-	// +kubebuilder:default=pod-manifest
 	AgentEnvVarsInjectionMethod common.EnvInjectionMethod `json:"agentEnvVarsInjectionMethod,omitempty"`
 
 	// (Optional) NodeSelector is a map of key-value Kubernetes NodeSelector labels to apply to all Odigos components.

--- a/operator/bundle.Dockerfile
+++ b/operator/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=odigos-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.40.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.41.1
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 

--- a/operator/bundle/manifests/odigos-operator-odigos-version-2b69t4d487_v1_configmap.yaml
+++ b/operator/bundle/manifests/odigos-operator-odigos-version-2b69t4d487_v1_configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+data:
+  ODIGOS_VERSION: 1.8.0
+kind: ConfigMap
+metadata:
+  name: odigos-operator-odigos-version-2b69t4d487

--- a/operator/bundle/manifests/odigos-operator-odigos-version-5472996t4d_v1_configmap.yaml
+++ b/operator/bundle/manifests/odigos-operator-odigos-version-5472996t4d_v1_configmap.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-data:
-  ODIGOS_VERSION: 1.0.212
-kind: ConfigMap
-metadata:
-  name: odigos-operator-odigos-version-5472996t4d

--- a/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.39.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     support: Odigos
-  name: odigos-operator.v1.0.212
+  name: odigos-operator.v1.8.0
   namespace: odigos-operator-system
 spec:
   apiservicedefinitions: {}
@@ -460,62 +460,74 @@ spec:
                 kubectl.kubernetes.io/default-container: manager
               labels:
                 control-plane: controller-manager
-            spec:
-              containers:
-              - args:
-                - --metrics-bind-address=:8443
-                - --leader-elect
-                - --health-probe-bind-address=:8081
-                command:
-                - /manager
-                env:
-                - name: CURRENT_NS
-                  valueFrom:
-                    fieldRef:
-                      apiVersion: v1
-                      fieldPath: metadata.namespace
-                - name: ODIGOS_VERSION
-                  valueFrom:
-                    configMapKeyRef:
-                      key: ODIGOS_VERSION
-                      name: odigos-operator-odigos-version-5472996t4d
-                - name: RELATED_IMAGE_AUTOSCALER
-                  value: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9:v1.0.212
-                - name: RELATED_IMAGE_COLLECTOR
-                  value: registry.connect.redhat.com/odigos/odigos-collector-ubi9:v1.0.212
-                - name: RELATED_IMAGE_FRONTEND
-                  value: registry.connect.redhat.com/odigos/odigos-ui-ubi9:v1.0.212
-                - name: RELATED_IMAGE_INSTRUMENTOR
-                  value: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9:v1.0.212
-                - name: RELATED_IMAGE_ENTERPRISE_INSTRUMENTOR
-                  value: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9:v1.0.212
-                - name: RELATED_IMAGE_ODIGLET
-                  value: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9:v1.0.212
-                - name: RELATED_IMAGE_ENTERPRISE_ODIGLET
-                  value: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9:v1.0.212
-                - name: RELATED_IMAGE_SCHEDULER
-                  value: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9:v1.0.212
-                image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9:v1.0.212
-                livenessProbe:
-                  httpGet:
-                    path: /healthz
-                    port: 8081
-                  initialDelaySeconds: 15
-                  periodSeconds: 20
-                name: manager
-                readinessProbe:
-                  httpGet:
-                    path: /readyz
-                    port: 8081
-                  initialDelaySeconds: 5
-                  periodSeconds: 10
-                resources:
-                  limits:
-                    cpu: 500m
-                    memory: 128Mi
-                  requests:
-                    cpu: 10m
-                    memory: 64Mi
+            strategy: {}
+            template:
+              metadata:
+                annotations:
+                  kubectl.kubernetes.io/default-container: manager
+                labels:
+                  control-plane: controller-manager
+              spec:
+                containers:
+                  - args:
+                      - --metrics-bind-address=:8443
+                      - --leader-elect
+                      - --health-probe-bind-address=:8081
+                    command:
+                      - /manager
+                    env:
+                      - name: CURRENT_NS
+                        valueFrom:
+                          fieldRef:
+                            apiVersion: v1
+                            fieldPath: metadata.namespace
+                      - name: ODIGOS_VERSION
+                        valueFrom:
+                          configMapKeyRef:
+                            key: ODIGOS_VERSION
+                            name: odigos-operator-odigos-version-2b69t4d487
+                      - name: RELATED_IMAGE_AUTOSCALER
+                        value: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:4da3ace23a9ae7a97f6b3fd0e271c4b853312aa8add6fd76d2d50224dcf5b52d
+                      - name: RELATED_IMAGE_COLLECTOR
+                        value: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:a3f35268de797ee326f08584ca25b76464a3a612500d2f95a2686c0e8b6fcf67
+                      - name: RELATED_IMAGE_FRONTEND
+                        value: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:f11f1ef06e7efcf89d1e9906f5a289a12864e519da8a3de10df96ead20672098
+                      - name: RELATED_IMAGE_INSTRUMENTOR
+                        value: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:d96d9bd1d0ac4c9acaf1e56fe46372217f79d888f9743b931a5c815745957b8b
+                      - name: RELATED_IMAGE_ENTERPRISE_INSTRUMENTOR
+                        value: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:63f5ec3c3b1aa7190c558e4cafe5563dfcfec6c0a8b166856e2bdfc6952df94e
+                      - name: RELATED_IMAGE_ODIGLET
+                        value: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:1a1f7ab783285a76204f4e2a5470fef7446beb32d2a65bb8cc3e5dbe1e00bc08
+                      - name: RELATED_IMAGE_ENTERPRISE_ODIGLET
+                        value: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:3b04ff5d65c80fcae7be799a85d3417e3f36b182d9af5067367a0dae7014cb7e
+                      - name: RELATED_IMAGE_SCHEDULER
+                        value: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:9bd5a96b45aab7d9b2a52cbd28587f34e823369186a4180400c0e02ef5fe6a05
+                    image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    name: manager
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 128Mi
+                      requests:
+                        cpu: 10m
+                        memory: 64Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
                 securityContext:
                   allowPrivilegeEscalation: false
                   capabilities:
@@ -610,3 +622,4 @@ spec:
   - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9:v1.0.212
     name: scheduler
   version: 1.0.212
+  

--- a/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
@@ -142,9 +142,11 @@ spec:
                 - configmaps
                 - endpoints
                 - secrets
+                - services
               verbs:
                 - create
                 - delete
+                - deletecollection
                 - get
                 - list
                 - patch
@@ -217,25 +219,13 @@ spec:
                 - patch
                 - watch
             - apiGroups:
-                - ""
-              resources:
-                - services
-              verbs:
-                - create
-                - delete
-                - deletecollection
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
                 - actions.odigos.io
               resources:
                 - '*'
               verbs:
                 - create
                 - delete
+                - deletecollection
                 - get
                 - list
                 - patch
@@ -411,6 +401,7 @@ spec:
               verbs:
                 - create
                 - delete
+                - deletecollection
                 - get
                 - list
                 - patch

--- a/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
     capabilities: Basic Install
     categories: Logging & Tracing
     containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a
-    createdAt: "2025-10-23T12:51:10Z"
+    createdAt: "2025-10-23T13:37:14Z"
     description: Odigos enables automatic distributed tracing with OpenTelemetry and eBPF.
     features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "true"
@@ -586,28 +586,28 @@ spec:
     name: Odigos
     url: https://odigos.io
   relatedImages:
-    - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:d96d9bd1d0ac4c9acaf1e56fe46372217f79d888f9743b931a5c815745957b8b
-      name: instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:63f5ec3c3b1aa7190c558e4cafe5563dfcfec6c0a8b166856e2bdfc6952df94e
-      name: enterprise-instrumentor
     - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:1a1f7ab783285a76204f4e2a5470fef7446beb32d2a65bb8cc3e5dbe1e00bc08
       name: odiglet
     - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:9bd5a96b45aab7d9b2a52cbd28587f34e823369186a4180400c0e02ef5fe6a05
       name: scheduler
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:63f5ec3c3b1aa7190c558e4cafe5563dfcfec6c0a8b166856e2bdfc6952df94e
+      name: enterprise_instrumentor
     - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:3b04ff5d65c80fcae7be799a85d3417e3f36b182d9af5067367a0dae7014cb7e
       name: enterprise_odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a
-      name: odigos-certified-operator-ubi9-ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a-annotation
-    - image: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:4da3ace23a9ae7a97f6b3fd0e271c4b853312aa8add6fd76d2d50224dcf5b52d
-      name: autoscaler
-    - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:a3f35268de797ee326f08584ca25b76464a3a612500d2f95a2686c0e8b6fcf67
-      name: collector
     - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:f11f1ef06e7efcf89d1e9906f5a289a12864e519da8a3de10df96ead20672098
       name: frontend
     - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:3b04ff5d65c80fcae7be799a85d3417e3f36b182d9af5067367a0dae7014cb7e
       name: enterprise-odiglet
     - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a
       name: manager
+    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a
+      name: odigos-certified-operator-ubi9-ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a-annotation
+    - image: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:4da3ace23a9ae7a97f6b3fd0e271c4b853312aa8add6fd76d2d50224dcf5b52d
+      name: autoscaler
+    - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:a3f35268de797ee326f08584ca25b76464a3a612500d2f95a2686c0e8b6fcf67
+      name: collector
+    - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:d96d9bd1d0ac4c9acaf1e56fe46372217f79d888f9743b931a5c815745957b8b
+      name: instrumentor
     - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:63f5ec3c3b1aa7190c558e4cafe5563dfcfec6c0a8b166856e2bdfc6952df94e
-      name: enterprise_instrumentor
+      name: enterprise-instrumentor
   version: 1.8.0

--- a/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
@@ -589,21 +589,29 @@ spec:
     name: Odigos
     url: https://odigos.io
   relatedImages:
-  - image: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9:v1.0.212
-    name: autoscaler
-  - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9:v1.0.212
-    name: collector
-  - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9:v1.0.212
-    name: frontend
-  - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9:v1.0.212
-    name: instrumentor
-  - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9:v1.0.212
-    name: enterprise-instrumentor
-  - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9:v1.0.212
-    name: odiglet
-  - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9:v1.0.212
-    name: enterprise-odiglet
-  - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9:v1.0.212
-    name: scheduler
-  version: 1.0.212
+    - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:f11f1ef06e7efcf89d1e9906f5a289a12864e519da8a3de10df96ead20672098
+      name: frontend
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:63f5ec3c3b1aa7190c558e4cafe5563dfcfec6c0a8b166856e2bdfc6952df94e
+      name: enterprise-instrumentor
+    - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:1a1f7ab783285a76204f4e2a5470fef7446beb32d2a65bb8cc3e5dbe1e00bc08
+      name: odiglet
+    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a
+      name: manager
+    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a
+      name: odigos-certified-operator-ubi9-ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a-annotation
+    - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:a3f35268de797ee326f08584ca25b76464a3a612500d2f95a2686c0e8b6fcf67
+      name: collector
+    - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:d96d9bd1d0ac4c9acaf1e56fe46372217f79d888f9743b931a5c815745957b8b
+      name: instrumentor
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:3b04ff5d65c80fcae7be799a85d3417e3f36b182d9af5067367a0dae7014cb7e
+      name: enterprise-odiglet
+    - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:9bd5a96b45aab7d9b2a52cbd28587f34e823369186a4180400c0e02ef5fe6a05
+      name: scheduler
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:63f5ec3c3b1aa7190c558e4cafe5563dfcfec6c0a8b166856e2bdfc6952df94e
+      name: enterprise_instrumentor
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:3b04ff5d65c80fcae7be799a85d3417e3f36b182d9af5067367a0dae7014cb7e
+      name: enterprise_odiglet
+    - image: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:4da3ace23a9ae7a97f6b3fd0e271c4b853312aa8add6fd76d2d50224dcf5b52d
+      name: autoscaler
+  version: 1.8.0
 

--- a/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
@@ -19,10 +19,9 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Logging & Tracing
-    containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9:v1.0.212
-    createdAt: "2025-10-15T14:43:10Z"
-    description: Odigos enables automatic distributed tracing with OpenTelemetry and
-      eBPF.
+    containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a
+    createdAt: "2025-10-23T12:51:10Z"
+    description: Odigos enables automatic distributed tracing with OpenTelemetry and eBPF.
     features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "false"
@@ -30,9 +29,8 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    operators.openshift.io/valid-subscription: Odigos Enterprise subscription (for
-      enterprise features)
-    operators.operatorframework.io/builder: operator-sdk-v1.39.1
+    operators.openshift.io/valid-subscription: Odigos Enterprise subscription (for enterprise features)
+    operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     support: Odigos
   name: odigos-operator.v1.8.0
@@ -41,81 +39,78 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: Odigos is the Schema for the odigos API
-      displayName: Odigos
-      kind: Odigos
-      name: odigos.operator.odigos.io
-      specDescriptors:
-      - description: (Optional) OnPremToken is an enterprise token for Odigos Enterprise.
-        displayName: On-Prem Token
-        path: onPremToken
-      - description: (Optional) IgnoredContainers is a list of container names to
-          exclude from instrumentation (useful for ignoring sidecars).
-        displayName: Ignored Containers
-        path: ignoredContainers
-      - description: (Optional) IgnoredNamespaces is a list of namespaces to not show
-          in the Odigos UI.
-        displayName: Ignored Namespaces
-        path: ignoredNamespaces
-      - description: |-
-          (Optional) TelemetryEnabled records general telemetry regarding Odigos usage.
-          Default=false
-        displayName: Telemetry Enabled
-        path: telemetryEnabled
-      - description: |-
-          (Optional) UIMode sets the UI mode to either "normal" or "readonly".
-          In "normal" mode the UI is fully interactive, allowing users to view and edit
-          Odigos configuration and settings. In "readonly" mode, the UI can only be
-          used to view current Odigos configuration and is not interactive.
-          Default=default
-        displayName: UI Mode
-        path: uiMode
-      - description: |-
-          (Optional) AgentEnvVarsInjectionMethod is the method to inject the Odigos agent env vars into the pod.
-          Default=pod-manifest
-        displayName: Agent Env Vars Injection Method
-        path: agentEnvVarsInjectionMethod
-      - description: |-
-          (Optional) NodeSelector is a map of key-value Kubernetes NodeSelector labels to apply to all Odigos components.
-          Note that Odigos will only be able to instrument applications on the same node.
-        displayName: Node Selector
-        path: nodeSelector
-      - description: (Optional) Profiles is a list of preset profiles with a specific
-          configuration.
-        displayName: Profiles
-        path: profiles
-      - description: |-
-          (Optional) ImagePrefix is a prefix for all container images.
-          This should only be used if you are pulling Odigos images from the non-default registry.
-          Default: registry.odigos.io
-          Default (OpenShift): registry.connect.redhat.com
-        displayName: Image Prefix
-        path: imagePrefix
-      - description: |-
-          (Optional) MountMethod optionally defines the mechanism for mounting Odigos files into instrumented pods.
-          One of "k8s-virtual-device" (default) or "k8s-host-path".
-        displayName: Mount Method
-        path: mountMethod
-      - description: |-
-          (Optional) OpenShiftEnabled configures selinux on OpenShift nodes.
-          DEPRECATED: OpenShift clusters are auto-detected and this API field will be removed in a future release.
-        displayName: OpenShift Enabled
-        path: openshiftEnabled
-      - description: |-
-          (Optional) PodSecurityPolicy allows Odigos pods to use a privileged pod security policy.
-          Default=false
-        displayName: Pod Security Policy
-        path: podSecurityPolicy
-      - description: |-
-          (Optional) SkipWebhookIssuerCreation skips creating the Issuer and Certificate for the Instrumentor pod webhook if cert-manager is installed.
-          Default=false
-        displayName: Skip Webhook Issuer Creation
-        path: skipWebhookIssuerCreation
-      statusDescriptors:
-      - description: Conditions store the status conditions of the Odigos instances
-        displayName: Conditions
-        path: conditions
-      version: v1alpha1
+      - description: Odigos is the Schema for the odigos API
+        displayName: Odigos
+        kind: Odigos
+        name: odigos.operator.odigos.io
+        specDescriptors:
+          - description: (Optional) OnPremToken is an enterprise token for Odigos Enterprise.
+            displayName: On-Prem Token
+            path: onPremToken
+          - description: (Optional) IgnoredContainers is a list of container names to exclude from instrumentation (useful for ignoring sidecars).
+            displayName: Ignored Containers
+            path: ignoredContainers
+          - description: (Optional) IgnoredNamespaces is a list of namespaces to not show in the Odigos UI.
+            displayName: Ignored Namespaces
+            path: ignoredNamespaces
+          - description: |-
+              (Optional) TelemetryEnabled records general telemetry regarding Odigos usage.
+              Default=false
+            displayName: Telemetry Enabled
+            path: telemetryEnabled
+          - description: |-
+              (Optional) UIMode sets the UI mode to either "normal" or "readonly".
+              In "normal" mode the UI is fully interactive, allowing users to view and edit
+              Odigos configuration and settings. In "readonly" mode, the UI can only be
+              used to view current Odigos configuration and is not interactive.
+              Default=default
+            displayName: UI Mode
+            path: uiMode
+          - description: |-
+              (Optional) AgentEnvVarsInjectionMethod is the method to inject the Odigos agent env vars into the pod.
+              Default=pod-manifest
+            displayName: Agent Env Vars Injection Method
+            path: agentEnvVarsInjectionMethod
+          - description: |-
+              (Optional) NodeSelector is a map of key-value Kubernetes NodeSelector labels to apply to all Odigos components.
+              Note that Odigos will only be able to instrument applications on the same node.
+            displayName: Node Selector
+            path: nodeSelector
+          - description: (Optional) Profiles is a list of preset profiles with a specific configuration.
+            displayName: Profiles
+            path: profiles
+          - description: |-
+              (Optional) ImagePrefix is a prefix for all container images.
+              This should only be used if you are pulling Odigos images from the non-default registry.
+              Default: registry.odigos.io
+              Default (OpenShift): registry.connect.redhat.com
+            displayName: Image Prefix
+            path: imagePrefix
+          - description: |-
+              (Optional) MountMethod optionally defines the mechanism for mounting Odigos files into instrumented pods.
+              One of "k8s-virtual-device" (default) or "k8s-host-path".
+            displayName: Mount Method
+            path: mountMethod
+          - description: |-
+              (Optional) OpenShiftEnabled configures selinux on OpenShift nodes.
+              DEPRECATED: OpenShift clusters are auto-detected and this API field will be removed in a future release.
+            displayName: OpenShift Enabled
+            path: openshiftEnabled
+          - description: |-
+              (Optional) PodSecurityPolicy allows Odigos pods to use a privileged pod security policy.
+              Default=false
+            displayName: Pod Security Policy
+            path: podSecurityPolicy
+          - description: |-
+              (Optional) SkipWebhookIssuerCreation skips creating the Issuer and Certificate for the Instrumentor pod webhook if cert-manager is installed.
+              Default=false
+            displayName: Skip Webhook Issuer Creation
+            path: skipWebhookIssuerCreation
+        statusDescriptors:
+          - description: Conditions store the status conditions of the Odigos instances
+            displayName: Conditions
+            path: conditions
+        version: v1alpha1
   description: |-
     The Odigos Operator provides options for installing and configuring Odigos.
 
@@ -130,8 +125,8 @@ spec:
     With Odigos installed, follow the Odigos docs at docs.odigos.io for instructions on instrumenting applications and configuring destinations.
   displayName: Odigos Operator
   icon:
-  - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgdmlld0JveD0iMCAtMiAxNiAxNiIgZmlsbD0iIzE1MTUxNSI+CiAgPHBhdGgKICAgIGQ9Ik01LjE3MjE1IDkuMDE4ODRMMi4xODM3NyA3LjY5ODEzQzEuNDgxNTkgNy4zODczMiAxLjA0NDggNi43MzY3NyAxLjA0NDggNS45OTk0OEMxLjA0NDggNS4yNjIyIDEuNDgwNTYgNC42MTE2NSAyLjE4Mzc3IDQuMzAwODNMNi4zNjE3MiAyLjQ1MzQ5TDYuNDUxNTYgMi40MTQyNVYwSDEuNjYxMjdDMS4wNDE3IDAgMC41Mzg4MTggMC40NzgxIDAuNTM4ODE4IDEuMDY3NzJWMTAuOTMxMkMwLjUzODgxOCAxMS41MjA5IDEuMDQxNyAxMS45OTkgMS42NjEyNyAxMS45OTlINS44MzMwM0g2LjQ1MjU5VjkuNTY4Mkw1LjE3MzE5IDkuMDE3ODFINS4xNzIxNVY5LjAxODg0WiIgLz4KICA8cGF0aAogICAgZD0iTTE0LjMzOTcgMEg5LjU0ODRWMi40NDExTDEwLjgwNDEgMi45ODExNUwxMC44MDEgMi45Njk4TDEzLjgxNjIgNC4zMDI5QzE0LjUxODQgNC42MTM3MiAxNC45NTUyIDUuMjY0MjYgMTQuOTU1MiA2LjAwMTU1QzE0Ljk1NTIgNi43Mzg4MyAxNC41MTk0IDcuMzg5MzggMTMuODE2MiA3LjcwMDJMMTAuMTY0OSA5LjMxNDE3TDkuNTQ3MzYgOS41NzY0NlYxMkgxNC4zMzg3QzE0Ljk1ODMgMTIgMTUuNDYxMSAxMS41MjE5IDE1LjQ2MTEgMTAuOTMyM1YxLjA2NzcyQzE1LjQ2MTEgMC40NzgxIDE0Ljk1ODMgMCAxNC4zMzg3IDBIMTQuMzM5N1oiIC8+CiAgPHBhdGgKICAgIGQ9Ik04LjAwMDQ4IDguNDc5NzJDOS4zNjk3MiA4LjQ3OTcyIDEwLjQ4MDggNy4zNjk2NiAxMC40ODA4IDUuOTk5MzhDMTAuNDgwOCA0LjYyOTEgOS4zNzA3NiAzLjUxOTA0IDguMDAwNDggMy41MTkwNEM2LjYzMDIgMy41MTkwNCA1LjUyMDE0IDQuNjI5MSA1LjUyMDE0IDUuOTk5MzhDNS41MjAxNCA3LjM2OTY2IDYuNjMwMiA4LjQ3OTcyIDguMDAwNDggOC40Nzk3MloiIC8+Cjwvc3ZnPg==
-    mediatype: image/svg+xml
+    - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgdmlld0JveD0iMCAtMiAxNiAxNiIgZmlsbD0iIzE1MTUxNSI+CiAgPHBhdGgKICAgIGQ9Ik01LjE3MjE1IDkuMDE4ODRMMi4xODM3NyA3LjY5ODEzQzEuNDgxNTkgNy4zODczMiAxLjA0NDggNi43MzY3NyAxLjA0NDggNS45OTk0OEMxLjA0NDggNS4yNjIyIDEuNDgwNTYgNC42MTE2NSAyLjE4Mzc3IDQuMzAwODNMNi4zNjE3MiAyLjQ1MzQ5TDYuNDUxNTYgMi40MTQyNVYwSDEuNjYxMjdDMS4wNDE3IDAgMC41Mzg4MTggMC40NzgxIDAuNTM4ODE4IDEuMDY3NzJWMTAuOTMxMkMwLjUzODgxOCAxMS41MjA5IDEuMDQxNyAxMS45OTkgMS42NjEyNyAxMS45OTlINS44MzMwM0g2LjQ1MjU5VjkuNTY4Mkw1LjE3MzE5IDkuMDE3ODFINS4xNzIxNVY5LjAxODg0WiIgLz4KICA8cGF0aAogICAgZD0iTTE0LjMzOTcgMEg5LjU0ODRWMi40NDExTDEwLjgwNDEgMi45ODExNUwxMC44MDEgMi45Njk4TDEzLjgxNjIgNC4zMDI5QzE0LjUxODQgNC42MTM3MiAxNC45NTUyIDUuMjY0MjYgMTQuOTU1MiA2LjAwMTU1QzE0Ljk1NTIgNi43Mzg4MyAxNC41MTk0IDcuMzg5MzggMTMuODE2MiA3LjcwMDJMMTAuMTY0OSA5LjMxNDE3TDkuNTQ3MzYgOS41NzY0NlYxMkgxNC4zMzg3QzE0Ljk1ODMgMTIgMTUuNDYxMSAxMS41MjE5IDE1LjQ2MTEgMTAuOTMyM1YxLjA2NzcyQzE1LjQ2MTEgMC40NzgxIDE0Ljk1ODMgMCAxNC4zMzg3IDBIMTQuMzM5N1oiIC8+CiAgPHBhdGgKICAgIGQ9Ik04LjAwMDQ4IDguNDc5NzJDOS4zNjk3MiA4LjQ3OTcyIDEwLjQ4MDggNy4zNjk2NiAxMC40ODA4IDUuOTk5MzhDMTAuNDgwOCA0LjYyOTEgOS4zNzA3NiAzLjUxOTA0IDguMDAwNDggMy41MTkwNEM2LjYzMDIgMy41MTkwNCA1LjUyMDE0IDQuNjI5MSA1LjUyMDE0IDUuOTk5MzhDNS41MjAxNCA3LjM2OTY2IDYuNjMwMiA4LjQ3OTcyIDguMDAwNDggOC40Nzk3MloiIC8+Cjwvc3ZnPg==
+      mediatype: image/svg+xml
   install:
     spec:
       clusterPermissions:
@@ -320,6 +315,12 @@ spec:
                 - update
                 - watch
             - apiGroups:
+                - batch
+              resources:
+                - jobs
+              verbs:
+                - create
+            - apiGroups:
                 - coordination.k8s.io
               resources:
                 - leases
@@ -357,6 +358,14 @@ spec:
                 - patch
                 - update
                 - watch
+            - apiGroups:
+                - odigos.io
+              resources:
+                - instrumentationrules/status
+              verbs:
+                - get
+                - patch
+                - update
             - apiGroups:
                 - operator.odigos.io
               resources:
@@ -427,22 +436,15 @@ spec:
                 - create
           serviceAccountName: odigos-operator-controller-manager
       deployments:
-      - label:
-          app.kubernetes.io/managed-by: kustomize
-          app.kubernetes.io/name: odigos-operator
-          control-plane: controller-manager
-        name: odigos-operator-controller-manager
-        spec:
-          replicas: 1
-          selector:
-            matchLabels:
-              control-plane: controller-manager
-          strategy: {}
-          template:
-            metadata:
-              annotations:
-                kubectl.kubernetes.io/default-container: manager
-              labels:
+        - label:
+            app.kubernetes.io/managed-by: kustomize
+            app.kubernetes.io/name: odigos-operator
+            control-plane: controller-manager
+          name: odigos-operator-controller-manager
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
                 control-plane: controller-manager
             strategy: {}
             template:
@@ -513,105 +515,99 @@ spec:
                         drop:
                           - ALL
                 securityContext:
-                  allowPrivilegeEscalation: false
-                  capabilities:
-                    drop:
-                    - ALL
-              securityContext:
-                runAsNonRoot: true
-              serviceAccountName: odigos-operator-controller-manager
-              terminationGracePeriodSeconds: 10
+                  runAsNonRoot: true
+                serviceAccountName: odigos-operator-controller-manager
+                terminationGracePeriodSeconds: 10
       permissions:
-      - rules:
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          verbs:
-          - get
-          - list
-          - watch
-          - create
-          - update
-          - patch
-          - delete
-        - apiGroups:
-          - coordination.k8s.io
-          resources:
-          - leases
-          verbs:
-          - get
-          - list
-          - watch
-          - create
-          - update
-          - patch
-          - delete
-        - apiGroups:
-          - ""
-          resources:
-          - events
-          verbs:
-          - create
-          - patch
-        serviceAccountName: odigos-operator-controller-manager
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+          serviceAccountName: odigos-operator-controller-manager
     strategy: deployment
   installModes:
-  - supported: true
-    type: OwnNamespace
-  - supported: false
-    type: SingleNamespace
-  - supported: false
-    type: MultiNamespace
-  - supported: false
-    type: AllNamespaces
+    - supported: true
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: false
+      type: AllNamespaces
   keywords:
-  - OpenTelemetry
-  - eBPF
-  - tracing
-  - observability
-  - distributed tracing
-  - otel
-  - monitoring
+    - OpenTelemetry
+    - eBPF
+    - tracing
+    - observability
+    - distributed tracing
+    - otel
+    - monitoring
   links:
-  - name: Odigos
-    url: https://odigos.io
-  - name: Odigos Documentation
-    url: https://docs.odigos.io
-  - name: Odigos on Github
-    url: https://github.com/odigos-io/odigos
+    - name: Odigos
+      url: https://odigos.io
+    - name: Odigos Documentation
+      url: https://docs.odigos.io
+    - name: Odigos on Github
+      url: https://github.com/odigos-io/odigos
   maintainers:
-  - email: mike@odigos.io
-    name: Mike Dame
+    - email: mike@odigos.io
+      name: Mike Dame
   maturity: alpha
   minKubeVersion: 1.20.15
   provider:
     name: Odigos
     url: https://odigos.io
   relatedImages:
-    - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:f11f1ef06e7efcf89d1e9906f5a289a12864e519da8a3de10df96ead20672098
-      name: frontend
+    - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:d96d9bd1d0ac4c9acaf1e56fe46372217f79d888f9743b931a5c815745957b8b
+      name: instrumentor
     - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:63f5ec3c3b1aa7190c558e4cafe5563dfcfec6c0a8b166856e2bdfc6952df94e
       name: enterprise-instrumentor
     - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:1a1f7ab783285a76204f4e2a5470fef7446beb32d2a65bb8cc3e5dbe1e00bc08
       name: odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a
-      name: manager
-    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a
-      name: odigos-certified-operator-ubi9-ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a-annotation
-    - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:a3f35268de797ee326f08584ca25b76464a3a612500d2f95a2686c0e8b6fcf67
-      name: collector
-    - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:d96d9bd1d0ac4c9acaf1e56fe46372217f79d888f9743b931a5c815745957b8b
-      name: instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:3b04ff5d65c80fcae7be799a85d3417e3f36b182d9af5067367a0dae7014cb7e
-      name: enterprise-odiglet
     - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:9bd5a96b45aab7d9b2a52cbd28587f34e823369186a4180400c0e02ef5fe6a05
       name: scheduler
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:63f5ec3c3b1aa7190c558e4cafe5563dfcfec6c0a8b166856e2bdfc6952df94e
-      name: enterprise_instrumentor
     - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:3b04ff5d65c80fcae7be799a85d3417e3f36b182d9af5067367a0dae7014cb7e
       name: enterprise_odiglet
+    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a
+      name: odigos-certified-operator-ubi9-ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a-annotation
     - image: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:4da3ace23a9ae7a97f6b3fd0e271c4b853312aa8add6fd76d2d50224dcf5b52d
       name: autoscaler
+    - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:a3f35268de797ee326f08584ca25b76464a3a612500d2f95a2686c0e8b6fcf67
+      name: collector
+    - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:f11f1ef06e7efcf89d1e9906f5a289a12864e519da8a3de10df96ead20672098
+      name: frontend
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:3b04ff5d65c80fcae7be799a85d3417e3f36b182d9af5067367a0dae7014cb7e
+      name: enterprise-odiglet
+    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a
+      name: manager
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:63f5ec3c3b1aa7190c558e4cafe5563dfcfec6c0a8b166856e2bdfc6952df94e
+      name: enterprise_instrumentor
   version: 1.8.0
-

--- a/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
@@ -135,313 +135,306 @@ spec:
   install:
     spec:
       clusterPermissions:
-      - rules:
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          - endpoints
-          - secrets
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps/finalizers
-          - pods/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - ""
-          resources:
-          - events
-          verbs:
-          - create
-          - patch
-        - apiGroups:
-          - ""
-          resources:
-          - namespaces
-          verbs:
-          - get
-          - list
-          - patch
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - nodes
-          verbs:
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - nodes/proxy
-          - nodes/stats
-          verbs:
-          - get
-          - list
-        - apiGroups:
-          - ""
-          resources:
-          - pods
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - pods/status
-          verbs:
-          - get
-        - apiGroups:
-          - ""
-          resources:
-          - serviceaccounts
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - services
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - actions.odigos.io
-          resources:
-          - '*'
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - actions.odigos.io
-          resources:
-          - '*/status'
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - admissionregistration.k8s.io
-          resources:
-          - mutatingwebhookconfigurations
-          - validatingwebhookconfigurations
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - apiextensions.k8s.io
-          resources:
-          - customresourcedefinitions
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - apps
-          resources:
-          - daemonsets
-          - deployments
-          - replicasets
-          - statefulsets
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - apps
-          resources:
-          - daemonsets/finalizers
-          - deployments/finalizers
-          - replicasets/finalizers
-          - statefulsets/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - apps
-          resources:
-          - daemonsets/status
-          - deployments/status
-          - statefulsets/status
-          verbs:
-          - get
-        - apiGroups:
-          - autoscaling
-          resources:
-          - horizontalpodautoscalers
-          verbs:
-          - create
-          - delete
-          - patch
-          - update
-        - apiGroups:
-          - batch
-          resources:
-          - cronjobs
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - coordination.k8s.io
-          resources:
-          - leases
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - odigos.io
-          resources:
-          - '*'
-          verbs:
-          - '*'
-        - apiGroups:
-          - odigos.io
-          resources:
-          - collectorsgroups/finalizers
-          - sources/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - odigos.io
-          resources:
-          - collectorsgroups/status
-          - destinations/status
-          - instrumentationconfigs/status
-          - instrumentationinstances/status
-          verbs:
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - odigos.io
-          resources:
-          - instrumentationrules/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - operator.odigos.io
-          resources:
-          - odigos
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - operator.odigos.io
-          resources:
-          - odigos/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - operator.odigos.io
-          resources:
-          - odigos/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - policy
-          resourceNames:
-          - privileged
-          resources:
-          - podsecuritypolicies
-          verbs:
-          - use
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
-          - clusterrolebindings
-          - clusterroles
-          - rolebindings
-          - roles
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - security.openshift.io
-          resources:
-          - securitycontextconstraints
-          verbs:
-          - use
-        - apiGroups:
-          - authentication.k8s.io
-          resources:
-          - tokenreviews
-          verbs:
-          - create
-        - apiGroups:
-          - authorization.k8s.io
-          resources:
-          - subjectaccessreviews
-          verbs:
-          - create
-        serviceAccountName: odigos-operator-controller-manager
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+                - endpoints
+                - secrets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps/finalizers
+                - pods/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+              verbs:
+                - get
+                - list
+                - patch
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - nodes
+              verbs:
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - nodes/proxy
+                - nodes/stats
+              verbs:
+                - get
+                - list
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - pods/status
+              verbs:
+                - get
+            - apiGroups:
+                - ""
+              resources:
+                - serviceaccounts
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - services
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - actions.odigos.io
+              resources:
+                - '*'
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - actions.odigos.io
+              resources:
+                - '*/status'
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - admissionregistration.k8s.io
+              resources:
+                - mutatingwebhookconfigurations
+                - validatingwebhookconfigurations
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - daemonsets
+                - deployments
+                - replicasets
+                - statefulsets
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - daemonsets/finalizers
+                - deployments/finalizers
+                - replicasets/finalizers
+                - statefulsets/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - apps
+              resources:
+                - daemonsets/status
+                - deployments/status
+                - statefulsets/status
+              verbs:
+                - get
+            - apiGroups:
+                - autoscaling
+              resources:
+                - horizontalpodautoscalers
+              verbs:
+                - create
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - batch
+              resources:
+                - cronjobs
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - odigos.io
+              resources:
+                - '*'
+              verbs:
+                - '*'
+            - apiGroups:
+                - odigos.io
+              resources:
+                - collectorsgroups/finalizers
+                - sources/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - odigos.io
+              resources:
+                - collectorsgroups/status
+                - destinations/status
+                - instrumentationconfigs/status
+                - instrumentationinstances/status
+              verbs:
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - operator.odigos.io
+              resources:
+                - odigos
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - operator.odigos.io
+              resources:
+                - odigos/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - operator.odigos.io
+              resources:
+                - odigos/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - policy
+              resourceNames:
+                - privileged
+              resources:
+                - podsecuritypolicies
+              verbs:
+                - use
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterrolebindings
+                - clusterroles
+                - rolebindings
+                - roles
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - security.openshift.io
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - use
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - subjectaccessreviews
+              verbs:
+                - create
+          serviceAccountName: odigos-operator-controller-manager
       deployments:
       - label:
           app.kubernetes.io/managed-by: kustomize
@@ -622,4 +615,4 @@ spec:
   - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9:v1.0.212
     name: scheduler
   version: 1.0.212
-  
+

--- a/operator/bundle/manifests/operator.odigos.io_odigos.yaml
+++ b/operator/bundle/manifests/operator.odigos.io_odigos.yaml
@@ -40,7 +40,6 @@ spec:
             description: OdigosSpec defines the desired state of Odigos
             properties:
               agentEnvVarsInjectionMethod:
-                default: pod-manifest
                 description: |-
                   (Optional) AgentEnvVarsInjectionMethod is the method to inject the Odigos agent env vars into the pod.
                   Default=pod-manifest

--- a/operator/bundle/manifests/operator.odigos.io_odigos.yaml
+++ b/operator/bundle/manifests/operator.odigos.io_odigos.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   creationTimestamp: null
   name: odigos.operator.odigos.io
 spec:

--- a/operator/bundle/metadata/annotations.yaml
+++ b/operator/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: odigos-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.40.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.41.1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
 

--- a/operator/config/crd/bases/operator.odigos.io_odigos.yaml
+++ b/operator/config/crd/bases/operator.odigos.io_odigos.yaml
@@ -40,7 +40,6 @@ spec:
             description: OdigosSpec defines the desired state of Odigos
             properties:
               agentEnvVarsInjectionMethod:
-                default: pod-manifest
                 description: |-
                   (Optional) AgentEnvVarsInjectionMethod is the method to inject the Odigos agent env vars into the pod.
                   Default=pod-manifest

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -5,32 +5,32 @@ kind: Kustomization
 images:
 - name: autoscaler
   newName: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9
-  newTag: v1.0.212
+  newTag: v1.8.0
 - name: collector
   newName: registry.connect.redhat.com/odigos/odigos-collector-ubi9
-  newTag: v1.0.212
+  newTag: v1.8.0
 - name: controller
   newName: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9
-  newTag: v1.0.212
+  newTag: v1.8.0
 - name: enterprise-instrumentor
   newName: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9
-  newTag: v1.0.212
+  newTag: v1.8.0
 - name: enterprise-odiglet
   newName: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9
-  newTag: v1.0.212
+  newTag: v1.8.0
 - name: frontend
   newName: registry.connect.redhat.com/odigos/odigos-ui-ubi9
-  newTag: v1.0.212
+  newTag: v1.8.0
 - name: instrumentor
   newName: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9
-  newTag: v1.0.212
+  newTag: v1.8.0
 - name: odiglet
   newName: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9
-  newTag: v1.0.212
+  newTag: v1.8.0
 - name: scheduler
   newName: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9
-  newTag: v1.0.212
+  newTag: v1.8.0
 configMapGenerator:
 - literals:
-  - ODIGOS_VERSION=1.0.212
+  - ODIGOS_VERSION=1.8.0
   name: odigos-version

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -78,21 +78,21 @@ spec:
               name: odigos-version
               key: ODIGOS_VERSION
         - name: RELATED_IMAGE_AUTOSCALER
-          value: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9:v1.0.212
+          value: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9:v1.8.0
         - name: RELATED_IMAGE_COLLECTOR
-          value: registry.connect.redhat.com/odigos/odigos-collector-ubi9:v1.0.212
+          value: registry.connect.redhat.com/odigos/odigos-collector-ubi9:v1.8.0
         - name: RELATED_IMAGE_FRONTEND
-          value: registry.connect.redhat.com/odigos/odigos-ui-ubi9:v1.0.212
+          value: registry.connect.redhat.com/odigos/odigos-ui-ubi9:v1.8.0
         - name: RELATED_IMAGE_INSTRUMENTOR
-          value: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9:v1.0.212
+          value: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9:v1.8.0
         - name: RELATED_IMAGE_ENTERPRISE_INSTRUMENTOR
-          value: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9:v1.0.212
+          value: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9:v1.8.0
         - name: RELATED_IMAGE_ODIGLET
-          value: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9:v1.0.212
+          value: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9:v1.8.0
         - name: RELATED_IMAGE_ENTERPRISE_ODIGLET
-          value: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9:v1.0.212
+          value: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9:v1.8.0
         - name: RELATED_IMAGE_SCHEDULER
-          value: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9:v1.0.212
+          value: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9:v1.8.0
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/operator/config/manifests/bases/odigos-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/odigos-operator.clusterserviceversion.yaml
@@ -3,10 +3,10 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     alm-examples: '[{"apiVersion":"operator.odigos.io/v1alpha1", "kind":"Odigos",
-      "metadata":{"name":"odigos","namespace":"odigos-operator-system"}, "spec":{"version":"v1.0.212"}}]'
+      "metadata":{"name":"odigos","namespace":"odigos-operator-system"}, "spec":{"version":"v1.8.0"}}]'
     capabilities: Basic Install
     categories: Logging & Tracing
-    containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9:v1.0.212
+    containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9:v1.8.0
     description: Odigos enables automatic distributed tracing with OpenTelemetry and
       eBPF.
     features.operators.openshift.io/disconnected: "false"
@@ -19,7 +19,7 @@ metadata:
     operators.openshift.io/valid-subscription: Odigos Enterprise subscription (for
       enterprise features)
     support: Odigos
-  name: odigos-operator.v1.0.212
+  name: odigos-operator.v1.8.0
   namespace: odigos-operator-system
 spec:
   apiservicedefinitions: {}
@@ -152,4 +152,4 @@ spec:
   provider:
     name: Odigos
     url: https://odigos.io
-  version: 1.0.212
+  version: 1.8.0

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -137,6 +137,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -10,9 +10,11 @@ rules:
   - configmaps
   - endpoints
   - secrets
+  - services
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -85,25 +87,13 @@ rules:
   - patch
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - actions.odigos.io
   resources:
   - '*'
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -293,6 +283,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch

--- a/operator/internal/controller/odigos_controller.go
+++ b/operator/internal/controller/odigos_controller.go
@@ -346,7 +346,11 @@ func (r *OdigosReconciler) install(ctx context.Context, kubeClient *kube.Client,
 		odigosConfiguration.UiMode = common.UiMode(odigos.Spec.UIMode)
 	}
 	odigosConfiguration.NodeSelector = nodeSelector
-	odigosConfiguration.AgentEnvVarsInjectionMethod = &odigos.Spec.AgentEnvVarsInjectionMethod
+	agentEnvVarsInjectionMethod := odigos.Spec.AgentEnvVarsInjectionMethod
+	if agentEnvVarsInjectionMethod == "" {
+		agentEnvVarsInjectionMethod = common.PodManifestEnvInjectionMethod
+	}
+	odigosConfiguration.AgentEnvVarsInjectionMethod = &agentEnvVarsInjectionMethod
 
 	ownerReference := metav1.OwnerReference{
 		APIVersion: odigos.APIVersion,

--- a/operator/internal/controller/odigos_controller.go
+++ b/operator/internal/controller/odigos_controller.go
@@ -92,7 +92,7 @@ var relatedImageEnvVars = map[string]string{
 // +kubebuilder:rbac:groups=operator.odigos.io,resources=odigos,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=operator.odigos.io,resources=odigos/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=operator.odigos.io,resources=odigos/finalizers,verbs=update
-// +kubebuilder:rbac:groups=actions.odigos.io,resources=*,verbs=get;list;watch;create;patch;update;delete
+// +kubebuilder:rbac:groups=actions.odigos.io,resources=*,verbs=get;list;watch;create;patch;update;delete;deletecollection
 // +kubebuilder:rbac:groups=actions.odigos.io,resources=*/status,verbs=get;patch;update
 // +kubebuilder:rbac:groups=odigos.io,resources=instrumentationrules/status,verbs=get;patch;update
 // +kubebuilder:rbac:groups=odigos.io,resources=*,verbs=*
@@ -100,7 +100,7 @@ var relatedImageEnvVars = map[string]string{
 // +kubebuilder:rbac:groups=odigos.io,resources=sources/finalizers,verbs=update
 // +kubebuilder:rbac:groups=odigos.io,resources=collectorsgroups/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete;deletecollection
-// +kubebuilder:rbac:groups="",resources=configmaps;endpoints;secrets,verbs=get;list;watch;create;update;delete;patch
+// +kubebuilder:rbac:groups="",resources=configmaps;endpoints;secrets,verbs=get;list;watch;create;update;delete;patch;deletecollection
 // +kubebuilder:rbac:groups="",resources=configmaps/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=create;get;list;watch;patch;delete
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;patch
@@ -116,7 +116,7 @@ var relatedImageEnvVars = map[string]string{
 // +kubebuilder:rbac:groups=apps,resources=deployments/status;daemonsets/status;statefulsets/status,verbs=get
 // +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;create;update;patch;watch;delete
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=create
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings;roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings;roles;rolebindings,verbs=get;list;watch;create;update;patch;delete;deletecollection
 // +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;update;patch;delete;deletecollection

--- a/operator/internal/controller/odigos_controller.go
+++ b/operator/internal/controller/odigos_controller.go
@@ -119,7 +119,7 @@ var relatedImageEnvVars = map[string]string{
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings;roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;update;patch;delete;deletecollection
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=create;patch;update;delete
 // +kubebuilder:rbac:groups=policy,resources=podsecuritypolicies,resourceNames=privileged,verbs=use


### PR DESCRIPTION
## Description

This updates the operator along with some changes for compatibility since this last operator release:

* Add permission to DeleteCollection for uninstall calls https://github.com/odigos-io/odigos/pull/3651/commits/f230431d3fad4321b2cddf5382dbc106e69d4f28 https://github.com/odigos-io/odigos/pull/3651/commits/24516fef126a2b7df8882ba4af6da5ca63638c9e#diff-bf75d41206005954349fa60826c9cc3bd1a976c9e5c8884de0cb59ee68a13fa8 (used in [uninstall](https://github.com/odigos-io/odigos/blob/cbb90d34081062e12ca65d909eb07a9d1cb0b60e/cli/pkg/kube/client.go#L158)
* Update the DataCollection rolebinding to use the Odiglet role https://github.com/odigos-io/odigos/pull/3651/commits/ba445e4cf368fd7df4e240cebceee67b147e096f (data collection role no longer exists now that it's bundled into the odiglet)
* Update the autoscaler deployment controller to use the node collector *configmap* name instead of *collectorgroup* https://github.com/odigos-io/odigos/pull/3651/commits/174718a8dd2bc7d7703452545be70469d998ee72 (this is effectively a no-op since they're the same but makes it clearer since this controller actually reconciles the configmap)
* Removes the agentenvinjection kubebuilder default https://github.com/odigos-io/odigos/pull/3651/commits/fd0c69c5c938ba891c80e9c65cebc58dceb1f612 (this was updating the operator CR and causing a no-op sync loop -- moved defaulting logic to controller)
* Don't overwrite operator CR values (similar to above reason) and also uses `Patch()` instead of `Update()` to set finalizers, because `Update()` triggers a reconcile that bypasses the `GenerationChangedPredicate` https://github.com/odigos-io/odigos/pull/3651/commits/b3b45f1ee4e77eb30b05787a20d6ce60d377ae79
* Add finalizers permissions to scheduler and autoscaler https://github.com/odigos-io/odigos/pull/3651/commits/176f7bb0a1c381a871dad8ccd4d3c2370feb636c (similar to introduced in https://github.com/odigos-io/odigos/pull/2996, this is an openshift requirement for setting finalizers and is due to the changes around how data collection configmap is created by autoscaler instead of at install)

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-361
