### PR TITLE
chore: Bump operator to v1.8.0 (#3651) (release-1.8)

### DIFF
--- a/autoscaler/controllers/nodecollector/configmap.go
+++ b/autoscaler/controllers/nodecollector/configmap.go
@@ -48,7 +48,7 @@ func (b *nodeCollectorBaseReconciler) SyncConfigMap(ctx context.Context, sources
 	}
 
 	existing := &v1.ConfigMap{}
-	if err := b.Client.Get(ctx, client.ObjectKey{Namespace: env.GetCurrentNamespace(), Name: k8sconsts.OdigosNodeCollectorCollectorGroupName}, existing); err != nil {
+	if err := b.Client.Get(ctx, client.ObjectKey{Namespace: env.GetCurrentNamespace(), Name: k8sconsts.OdigosNodeCollectorConfigMapName}, existing); err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.V(0).Info("creating config map")
 			_, err := b.createConfigMap(desired, ctx)

--- a/cli/cmd/resources/datacollection.go
+++ b/cli/cmd/resources/datacollection.go
@@ -66,7 +66,7 @@ func NewDataCollectionRoleBinding(ns string) *rbacv1.RoleBinding {
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "Role",
-			Name:     k8sconsts.OdigosNodeCollectorRoleName,
+			Name:     k8sconsts.OdigletRoleName,
 		},
 	}
 }

--- a/cli/cmd/resources/scheduler.go
+++ b/cli/cmd/resources/scheduler.go
@@ -55,7 +55,77 @@ func NewSchedulerLeaderElectionRoleBinding(ns string) *rbacv1.RoleBinding {
 	}
 }
 
-func NewSchedulerRole(ns string) *rbacv1.Role {
+func NewSchedulerRole(ns string, openshiftEnabled bool) *rbacv1.Role {
+	rules := []rbacv1.PolicyRule{
+		{ // Needed to react and reconcile odigos-configuration changes to effective config
+			APIGroups: []string{""},
+			Resources: []string{"configmaps"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{ // Needed to apply effective config after reconciling (defaulting and profile applying) and react to it
+			APIGroups:     []string{""},
+			Resources:     []string{"configmaps"},
+			ResourceNames: []string{consts.OdigosEffectiveConfigName, k8sconsts.OdigosDeploymentConfigMapName, k8sconsts.GoOffsetsConfigMap},
+			Verbs:         []string{"patch", "create", "update"},
+		},
+		{ // Needed because the scheduler is managing the collectorsgroups
+			APIGroups: []string{"odigos.io"},
+			Resources: []string{"collectorsgroups"},
+			Verbs:     []string{"get", "list", "create", "patch", "update", "watch", "delete"},
+		},
+		{ // Needed to read the status of the gateway collector, to wake the data collector
+			APIGroups: []string{"odigos.io"},
+			Resources: []string{"collectorsgroups/status"},
+			Verbs:     []string{"get"},
+		},
+		{ // apply profiles
+			APIGroups: []string{"odigos.io"},
+			Resources: []string{"processors", "instrumentationrules", "actions"},
+			Verbs:     []string{"get", "list", "watch", "patch", "delete", "create"},
+		},
+		{ // read odigos pro token
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{ // manage go offsets CronJob
+			APIGroups:     []string{"batch"},
+			Resources:     []string{"cronjobs"},
+			ResourceNames: []string{k8sconsts.OffsetCronJobName},
+			Verbs:         []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+		},
+		{ // restart odiglet daemonset after updating go offsets
+			APIGroups:     []string{"apps"},
+			Resources:     []string{"daemonsets"},
+			ResourceNames: []string{k8sconsts.OdigletDaemonSetName},
+			Verbs:         []string{"patch"},
+		},
+		{
+			APIGroups:     []string{"apps"},
+			Resources:     []string{"deployments"},
+			ResourceNames: []string{k8sconsts.SchedulerDeploymentName},
+			Verbs:         []string{"get", "list", "watch"},
+		},
+		{ // for calculating collectors group config based on the active destinations
+			APIGroups: []string{"odigos.io"},
+			Resources: []string{"destinations"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+	}
+
+	// This is needed for OpenShift to update the finalizers of the deployments
+	// Used when setting the OwnerReference of the Collector Configmap to the autoscaler deployment
+	// Controller-runtime sets BlockDeletion: true. So with this Admission Plugin we need permission to
+	// update finalizers on the scheduler deployment so that they can block deletion.
+	// seehttps://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+	if openshiftEnabled {
+		rules = append(rules, rbacv1.PolicyRule{
+			APIGroups: []string{"apps"},
+			Resources: []string{"deployments/finalizers"},
+			Verbs:     []string{"update"},
+		})
+	}
+
 	return &rbacv1.Role{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Role",
@@ -65,62 +135,7 @@ func NewSchedulerRole(ns string) *rbacv1.Role {
 			Name:      k8sconsts.SchedulerRoleName,
 			Namespace: ns,
 		},
-		Rules: []rbacv1.PolicyRule{
-			{ // Needed to react and reconcile odigos-configuration changes to effective config
-				APIGroups: []string{""},
-				Resources: []string{"configmaps"},
-				Verbs:     []string{"get", "list", "watch"},
-			},
-			{ // Needed to apply effective config after reconciling (defaulting and profile applying) and react to it
-				APIGroups:     []string{""},
-				Resources:     []string{"configmaps"},
-				ResourceNames: []string{consts.OdigosEffectiveConfigName, k8sconsts.OdigosDeploymentConfigMapName, k8sconsts.GoOffsetsConfigMap},
-				Verbs:         []string{"patch", "create", "update"},
-			},
-			{ // Needed because the scheduler is managing the collectorsgroups
-				APIGroups: []string{"odigos.io"},
-				Resources: []string{"collectorsgroups"},
-				Verbs:     []string{"get", "list", "create", "patch", "update", "watch", "delete"},
-			},
-			{ // Needed to read the status of the gateway collector, to wake the data collector
-				APIGroups: []string{"odigos.io"},
-				Resources: []string{"collectorsgroups/status"},
-				Verbs:     []string{"get"},
-			},
-			{ // apply profiles
-				APIGroups: []string{"odigos.io"},
-				Resources: []string{"processors", "instrumentationrules", "actions"},
-				Verbs:     []string{"get", "list", "watch", "patch", "delete", "create"},
-			},
-			{ // read odigos pro token
-				APIGroups: []string{""},
-				Resources: []string{"secrets"},
-				Verbs:     []string{"get", "list", "watch"},
-			},
-			{ // manage go offsets CronJob
-				APIGroups:     []string{"batch"},
-				Resources:     []string{"cronjobs"},
-				ResourceNames: []string{k8sconsts.OffsetCronJobName},
-				Verbs:         []string{"get", "list", "watch", "create", "update", "patch", "delete"},
-			},
-			{ // restart odiglet daemonset after updating go offsets
-				APIGroups:     []string{"apps"},
-				Resources:     []string{"daemonsets"},
-				ResourceNames: []string{k8sconsts.OdigletDaemonSetName},
-				Verbs:         []string{"patch"},
-			},
-			{
-				APIGroups:     []string{"apps"},
-				Resources:     []string{"deployments"},
-				ResourceNames: []string{k8sconsts.SchedulerDeploymentName},
-				Verbs:         []string{"get", "list", "watch"},
-			},
-			{ // for calculating collectors group config based on the active destinations
-				APIGroups: []string{"odigos.io"},
-				Resources: []string{"destinations"},
-				Verbs:     []string{"get", "list", "watch"},
-			},
-		},
+		Rules: rules,
 	}
 }
 
@@ -168,11 +183,13 @@ func NewSchedulerClusterRole(openshiftEnabled bool) *rbacv1.ClusterRole {
 	}
 
 	if openshiftEnabled {
-		rules = append(rules, rbacv1.PolicyRule{
-			APIGroups: []string{""},
-			Resources: []string{"configmaps/finalizers"},
-			Verbs:     []string{"update"},
-		})
+		rules = append(rules,
+			rbacv1.PolicyRule{
+				APIGroups: []string{""},
+				Resources: []string{"configmaps/finalizers"},
+				Verbs:     []string{"update"},
+			},
+		)
 	}
 
 	return &rbacv1.ClusterRole{
@@ -407,7 +424,7 @@ func (a *schedulerResourceManager) InstallFromScratch(ctx context.Context) error
 	resources := []kube.Object{
 		NewSchedulerServiceAccount(a.ns),
 		NewSchedulerLeaderElectionRoleBinding(a.ns),
-		NewSchedulerRole(a.ns),
+		NewSchedulerRole(a.ns, a.config.OpenshiftEnabled),
 		NewSchedulerRoleBinding(a.ns),
 		NewSchedulerClusterRole(a.config.OpenshiftEnabled),
 		NewSchedulerClusterRoleBinding(a.ns),

--- a/helm/odigos/templates/autoscaler/role.yaml
+++ b/helm/odigos/templates/autoscaler/role.yaml
@@ -182,3 +182,11 @@ rules:
       - get
       - patch
       - update
+{{- if .Values.openshift.enabled }}
+  - apiGroups:
+      - 'apps'
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+{{- end }}

--- a/helm/odigos/templates/scheduler/role.yaml
+++ b/helm/odigos/templates/scheduler/role.yaml
@@ -120,3 +120,11 @@ rules:
       - 'get'
       - 'list'
       - 'watch'
+{{- if .Values.openshift.enabled }}
+  - apiGroups:
+      - 'apps'
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+{{- end }}

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.0.212
+VERSION ?= 1.8.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/operator/api/v1alpha1/odigos_types.go
+++ b/operator/api/v1alpha1/odigos_types.go
@@ -56,7 +56,6 @@ type OdigosSpec struct {
 	// (Optional) AgentEnvVarsInjectionMethod is the method to inject the Odigos agent env vars into the pod.
 	// Default=pod-manifest
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=3
-	// +kubebuilder:default=pod-manifest
 	AgentEnvVarsInjectionMethod common.EnvInjectionMethod `json:"agentEnvVarsInjectionMethod,omitempty"`
 
 	// (Optional) NodeSelector is a map of key-value Kubernetes NodeSelector labels to apply to all Odigos components.

--- a/operator/bundle.Dockerfile
+++ b/operator/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=odigos-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.40.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.41.1
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 

--- a/operator/bundle/manifests/odigos-operator-odigos-version-2b69t4d487_v1_configmap.yaml
+++ b/operator/bundle/manifests/odigos-operator-odigos-version-2b69t4d487_v1_configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+data:
+  ODIGOS_VERSION: 1.8.0
+kind: ConfigMap
+metadata:
+  name: odigos-operator-odigos-version-2b69t4d487

--- a/operator/bundle/manifests/odigos-operator-odigos-version-5472996t4d_v1_configmap.yaml
+++ b/operator/bundle/manifests/odigos-operator-odigos-version-5472996t4d_v1_configmap.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-data:
-  ODIGOS_VERSION: 1.0.212
-kind: ConfigMap
-metadata:
-  name: odigos-operator-odigos-version-5472996t4d

--- a/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
@@ -19,8 +19,8 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Logging & Tracing
-    containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:c221eb2be22c2fcabcee728429bbca1255e0e31642c572e4dc40096d1d35e0d1
-    createdAt: "2025-07-18T13:23:10Z"
+    containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a
+    createdAt: "2025-10-23T16:13:36Z"
     description: Odigos enables automatic distributed tracing with OpenTelemetry and eBPF.
     features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "true"
@@ -30,10 +30,10 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     operators.openshift.io/valid-subscription: Odigos Enterprise subscription (for enterprise features)
-    operators.operatorframework.io/builder: operator-sdk-v1.40.0
+    operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     support: Odigos
-  name: odigos-operator.v1.0.212
+  name: odigos-operator.v1.8.0
   namespace: odigos-operator-system
 spec:
   apiservicedefinitions: {}
@@ -137,9 +137,11 @@ spec:
                 - configmaps
                 - endpoints
                 - secrets
+                - services
               verbs:
                 - create
                 - delete
+                - deletecollection
                 - get
                 - list
                 - patch
@@ -212,25 +214,13 @@ spec:
                 - patch
                 - watch
             - apiGroups:
-                - ""
-              resources:
-                - services
-              verbs:
-                - create
-                - delete
-                - deletecollection
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
                 - actions.odigos.io
               resources:
                 - '*'
               verbs:
                 - create
                 - delete
+                - deletecollection
                 - get
                 - list
                 - patch
@@ -264,6 +254,7 @@ spec:
               verbs:
                 - create
                 - delete
+                - deletecollection
                 - get
                 - list
                 - patch
@@ -323,6 +314,12 @@ spec:
                 - patch
                 - update
                 - watch
+            - apiGroups:
+                - batch
+              resources:
+                - jobs
+              verbs:
+                - create
             - apiGroups:
                 - coordination.k8s.io
               resources:
@@ -405,6 +402,7 @@ spec:
               verbs:
                 - create
                 - delete
+                - deletecollection
                 - get
                 - list
                 - patch
@@ -465,24 +463,24 @@ spec:
                         valueFrom:
                           configMapKeyRef:
                             key: ODIGOS_VERSION
-                            name: odigos-operator-odigos-version-5472996t4d
+                            name: odigos-operator-odigos-version-2b69t4d487
                       - name: RELATED_IMAGE_AUTOSCALER
-                        value: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:692193851b40f72ca79f7c82903136686d721c7fed77ef599037269ac6e55fdb
+                        value: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:4da3ace23a9ae7a97f6b3fd0e271c4b853312aa8add6fd76d2d50224dcf5b52d
                       - name: RELATED_IMAGE_COLLECTOR
-                        value: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:b67138d3ffd9e721602c5bf83f0c03ae1dcee230eca5e15335dcb9abced281ba
+                        value: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:a3f35268de797ee326f08584ca25b76464a3a612500d2f95a2686c0e8b6fcf67
                       - name: RELATED_IMAGE_FRONTEND
-                        value: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:b2a27cdfc94f1968a06ae18de1977127bb7d4e7d553e875d09a212693302f9c6
+                        value: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:f11f1ef06e7efcf89d1e9906f5a289a12864e519da8a3de10df96ead20672098
                       - name: RELATED_IMAGE_INSTRUMENTOR
-                        value: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:16712373c8e927b7208e43e9fe6e21180289975dbf3a81df60578e8550cf7150
+                        value: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:d96d9bd1d0ac4c9acaf1e56fe46372217f79d888f9743b931a5c815745957b8b
                       - name: RELATED_IMAGE_ENTERPRISE_INSTRUMENTOR
-                        value: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:647e526cdbe38023bb221a802b180f0b95cb25734a0b39fa11cbbe22a07482a3
+                        value: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:63f5ec3c3b1aa7190c558e4cafe5563dfcfec6c0a8b166856e2bdfc6952df94e
                       - name: RELATED_IMAGE_ODIGLET
-                        value: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:770193901b4e5abcec59833f56f1530b43d4ec9514f3b5a5cb0bbb4356e06c67
+                        value: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:1a1f7ab783285a76204f4e2a5470fef7446beb32d2a65bb8cc3e5dbe1e00bc08
                       - name: RELATED_IMAGE_ENTERPRISE_ODIGLET
-                        value: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:aec9b66461375994dc9aa92e5b2cc7d4151cf0332150726840cec049a7cbe7d9
+                        value: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:3b04ff5d65c80fcae7be799a85d3417e3f36b182d9af5067367a0dae7014cb7e
                       - name: RELATED_IMAGE_SCHEDULER
-                        value: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:9e613c9b22d2fbfa3d21cc24f3b1e2dbc2e7287790e1f4286f1817c92565c865
-                    image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:c221eb2be22c2fcabcee728429bbca1255e0e31642c572e4dc40096d1d35e0d1
+                        value: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:9bd5a96b45aab7d9b2a52cbd28587f34e823369186a4180400c0e02ef5fe6a05
+                    image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a
                     livenessProbe:
                       httpGet:
                         path: /healthz
@@ -580,28 +578,28 @@ spec:
     name: Odigos
     url: https://odigos.io
   relatedImages:
-    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:c221eb2be22c2fcabcee728429bbca1255e0e31642c572e4dc40096d1d35e0d1
-      name: odigos-certified-operator-ubi9-c221eb2be22c2fcabcee728429bbca1255e0e31642c572e4dc40096d1d35e0d1-annotation
-    - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:b2a27cdfc94f1968a06ae18de1977127bb7d4e7d553e875d09a212693302f9c6
-      name: frontend
-    - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:770193901b4e5abcec59833f56f1530b43d4ec9514f3b5a5cb0bbb4356e06c67
-      name: odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:aec9b66461375994dc9aa92e5b2cc7d4151cf0332150726840cec049a7cbe7d9
-      name: enterprise-odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:647e526cdbe38023bb221a802b180f0b95cb25734a0b39fa11cbbe22a07482a3
-      name: enterprise_instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:aec9b66461375994dc9aa92e5b2cc7d4151cf0332150726840cec049a7cbe7d9
-      name: enterprise_odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:692193851b40f72ca79f7c82903136686d721c7fed77ef599037269ac6e55fdb
-      name: autoscaler
-    - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:b67138d3ffd9e721602c5bf83f0c03ae1dcee230eca5e15335dcb9abced281ba
+    - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:a3f35268de797ee326f08584ca25b76464a3a612500d2f95a2686c0e8b6fcf67
       name: collector
-    - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:16712373c8e927b7208e43e9fe6e21180289975dbf3a81df60578e8550cf7150
-      name: instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:647e526cdbe38023bb221a802b180f0b95cb25734a0b39fa11cbbe22a07482a3
+    - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:f11f1ef06e7efcf89d1e9906f5a289a12864e519da8a3de10df96ead20672098
+      name: frontend
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:63f5ec3c3b1aa7190c558e4cafe5563dfcfec6c0a8b166856e2bdfc6952df94e
       name: enterprise-instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:9e613c9b22d2fbfa3d21cc24f3b1e2dbc2e7287790e1f4286f1817c92565c865
+    - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:1a1f7ab783285a76204f4e2a5470fef7446beb32d2a65bb8cc3e5dbe1e00bc08
+      name: odiglet
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:3b04ff5d65c80fcae7be799a85d3417e3f36b182d9af5067367a0dae7014cb7e
+      name: enterprise-odiglet
+    - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:9bd5a96b45aab7d9b2a52cbd28587f34e823369186a4180400c0e02ef5fe6a05
       name: scheduler
-    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:c221eb2be22c2fcabcee728429bbca1255e0e31642c572e4dc40096d1d35e0d1
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:63f5ec3c3b1aa7190c558e4cafe5563dfcfec6c0a8b166856e2bdfc6952df94e
+      name: enterprise_instrumentor
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:3b04ff5d65c80fcae7be799a85d3417e3f36b182d9af5067367a0dae7014cb7e
+      name: enterprise_odiglet
+    - image: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:4da3ace23a9ae7a97f6b3fd0e271c4b853312aa8add6fd76d2d50224dcf5b52d
+      name: autoscaler
+    - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:d96d9bd1d0ac4c9acaf1e56fe46372217f79d888f9743b931a5c815745957b8b
+      name: instrumentor
+    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a
       name: manager
-  version: 1.0.212
+    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a
+      name: odigos-certified-operator-ubi9-ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a-annotation
+  version: 1.8.0

--- a/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
     capabilities: Basic Install
     categories: Logging & Tracing
     containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a
-    createdAt: "2025-10-23T16:13:36Z"
+    createdAt: "2025-10-23T16:30:08Z"
     description: Odigos enables automatic distributed tracing with OpenTelemetry and eBPF.
     features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "true"
@@ -578,28 +578,28 @@ spec:
     name: Odigos
     url: https://odigos.io
   relatedImages:
+    - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:1a1f7ab783285a76204f4e2a5470fef7446beb32d2a65bb8cc3e5dbe1e00bc08
+      name: odiglet
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:3b04ff5d65c80fcae7be799a85d3417e3f36b182d9af5067367a0dae7014cb7e
+      name: enterprise-odiglet
+    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a
+      name: manager
+    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:63f5ec3c3b1aa7190c558e4cafe5563dfcfec6c0a8b166856e2bdfc6952df94e
+      name: enterprise_instrumentor
+    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a
+      name: odigos-certified-operator-ubi9-ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a-annotation
     - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:a3f35268de797ee326f08584ca25b76464a3a612500d2f95a2686c0e8b6fcf67
       name: collector
     - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:f11f1ef06e7efcf89d1e9906f5a289a12864e519da8a3de10df96ead20672098
       name: frontend
     - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:63f5ec3c3b1aa7190c558e4cafe5563dfcfec6c0a8b166856e2bdfc6952df94e
       name: enterprise-instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:1a1f7ab783285a76204f4e2a5470fef7446beb32d2a65bb8cc3e5dbe1e00bc08
-      name: odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:3b04ff5d65c80fcae7be799a85d3417e3f36b182d9af5067367a0dae7014cb7e
-      name: enterprise-odiglet
     - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:9bd5a96b45aab7d9b2a52cbd28587f34e823369186a4180400c0e02ef5fe6a05
       name: scheduler
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:63f5ec3c3b1aa7190c558e4cafe5563dfcfec6c0a8b166856e2bdfc6952df94e
-      name: enterprise_instrumentor
     - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:3b04ff5d65c80fcae7be799a85d3417e3f36b182d9af5067367a0dae7014cb7e
       name: enterprise_odiglet
     - image: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:4da3ace23a9ae7a97f6b3fd0e271c4b853312aa8add6fd76d2d50224dcf5b52d
       name: autoscaler
     - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:d96d9bd1d0ac4c9acaf1e56fe46372217f79d888f9743b931a5c815745957b8b
       name: instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a
-      name: manager
-    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a
-      name: odigos-certified-operator-ubi9-ef45b967043beb8efddc5e2fb2b3071329ca03c1038a48bc25b827e7c8da988a-annotation
   version: 1.8.0

--- a/operator/bundle/manifests/operator.odigos.io_odigos.yaml
+++ b/operator/bundle/manifests/operator.odigos.io_odigos.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   creationTimestamp: null
   name: odigos.operator.odigos.io
 spec:
@@ -40,7 +40,6 @@ spec:
             description: OdigosSpec defines the desired state of Odigos
             properties:
               agentEnvVarsInjectionMethod:
-                default: pod-manifest
                 description: |-
                   (Optional) AgentEnvVarsInjectionMethod is the method to inject the Odigos agent env vars into the pod.
                   Default=pod-manifest
@@ -75,6 +74,7 @@ spec:
                 enum:
                 - k8s-virtual-device
                 - k8s-host-path
+                - k8s-init-container
                 type: string
               nodeSelector:
                 additionalProperties:

--- a/operator/bundle/metadata/annotations.yaml
+++ b/operator/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: odigos-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.40.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.41.1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
 

--- a/operator/config/crd/bases/operator.odigos.io_odigos.yaml
+++ b/operator/config/crd/bases/operator.odigos.io_odigos.yaml
@@ -40,7 +40,6 @@ spec:
             description: OdigosSpec defines the desired state of Odigos
             properties:
               agentEnvVarsInjectionMethod:
-                default: pod-manifest
                 description: |-
                   (Optional) AgentEnvVarsInjectionMethod is the method to inject the Odigos agent env vars into the pod.
                   Default=pod-manifest

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -5,32 +5,32 @@ kind: Kustomization
 images:
 - name: autoscaler
   newName: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9
-  newTag: v1.0.212
+  newTag: v1.8.0
 - name: collector
   newName: registry.connect.redhat.com/odigos/odigos-collector-ubi9
-  newTag: v1.0.212
+  newTag: v1.8.0
 - name: controller
   newName: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9
-  newTag: v1.0.212
+  newTag: v1.8.0
 - name: enterprise-instrumentor
   newName: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9
-  newTag: v1.0.212
+  newTag: v1.8.0
 - name: enterprise-odiglet
   newName: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9
-  newTag: v1.0.212
+  newTag: v1.8.0
 - name: frontend
   newName: registry.connect.redhat.com/odigos/odigos-ui-ubi9
-  newTag: v1.0.212
+  newTag: v1.8.0
 - name: instrumentor
   newName: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9
-  newTag: v1.0.212
+  newTag: v1.8.0
 - name: odiglet
   newName: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9
-  newTag: v1.0.212
+  newTag: v1.8.0
 - name: scheduler
   newName: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9
-  newTag: v1.0.212
+  newTag: v1.8.0
 configMapGenerator:
 - literals:
-  - ODIGOS_VERSION=1.0.212
+  - ODIGOS_VERSION=1.8.0
   name: odigos-version

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -78,21 +78,21 @@ spec:
               name: odigos-version
               key: ODIGOS_VERSION
         - name: RELATED_IMAGE_AUTOSCALER
-          value: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9:v1.0.212
+          value: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9:v1.8.0
         - name: RELATED_IMAGE_COLLECTOR
-          value: registry.connect.redhat.com/odigos/odigos-collector-ubi9:v1.0.212
+          value: registry.connect.redhat.com/odigos/odigos-collector-ubi9:v1.8.0
         - name: RELATED_IMAGE_FRONTEND
-          value: registry.connect.redhat.com/odigos/odigos-ui-ubi9:v1.0.212
+          value: registry.connect.redhat.com/odigos/odigos-ui-ubi9:v1.8.0
         - name: RELATED_IMAGE_INSTRUMENTOR
-          value: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9:v1.0.212
+          value: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9:v1.8.0
         - name: RELATED_IMAGE_ENTERPRISE_INSTRUMENTOR
-          value: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9:v1.0.212
+          value: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9:v1.8.0
         - name: RELATED_IMAGE_ODIGLET
-          value: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9:v1.0.212
+          value: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9:v1.8.0
         - name: RELATED_IMAGE_ENTERPRISE_ODIGLET
-          value: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9:v1.0.212
+          value: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9:v1.8.0
         - name: RELATED_IMAGE_SCHEDULER
-          value: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9:v1.0.212
+          value: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9:v1.8.0
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/operator/config/manifests/bases/odigos-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/odigos-operator.clusterserviceversion.yaml
@@ -3,10 +3,10 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     alm-examples: '[{"apiVersion":"operator.odigos.io/v1alpha1", "kind":"Odigos",
-      "metadata":{"name":"odigos","namespace":"odigos-operator-system"}, "spec":{"version":"v1.0.212"}}]'
+      "metadata":{"name":"odigos","namespace":"odigos-operator-system"}, "spec":{"version":"v1.8.0"}}]'
     capabilities: Basic Install
     categories: Logging & Tracing
-    containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9:v1.0.212
+    containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9:v1.8.0
     description: Odigos enables automatic distributed tracing with OpenTelemetry and
       eBPF.
     features.operators.openshift.io/disconnected: "false"
@@ -19,7 +19,7 @@ metadata:
     operators.openshift.io/valid-subscription: Odigos Enterprise subscription (for
       enterprise features)
     support: Odigos
-  name: odigos-operator.v1.0.212
+  name: odigos-operator.v1.8.0
   namespace: odigos-operator-system
 spec:
   apiservicedefinitions: {}
@@ -152,4 +152,4 @@ spec:
   provider:
     name: Odigos
     url: https://odigos.io
-  version: 1.0.212
+  version: 1.8.0

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -10,9 +10,11 @@ rules:
   - configmaps
   - endpoints
   - secrets
+  - services
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -85,25 +87,13 @@ rules:
   - patch
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - actions.odigos.io
   resources:
   - '*'
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -137,6 +127,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -284,6 +275,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch

--- a/operator/internal/controller/odigos_controller.go
+++ b/operator/internal/controller/odigos_controller.go
@@ -92,14 +92,14 @@ var relatedImageEnvVars = map[string]string{
 // +kubebuilder:rbac:groups=operator.odigos.io,resources=odigos,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=operator.odigos.io,resources=odigos/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=operator.odigos.io,resources=odigos/finalizers,verbs=update
-// +kubebuilder:rbac:groups=actions.odigos.io,resources=*,verbs=get;list;watch;create;patch;update;delete
+// +kubebuilder:rbac:groups=actions.odigos.io,resources=*,verbs=get;list;watch;create;patch;update;delete;deletecollection
 // +kubebuilder:rbac:groups=actions.odigos.io,resources=*/status,verbs=get;patch;update
 // +kubebuilder:rbac:groups=odigos.io,resources=*,verbs=*
 // +kubebuilder:rbac:groups=odigos.io,resources=destinations/status;instrumentationinstances/status;instrumentationconfigs/status;collectorsgroups/status,verbs=get;list;watch;patch;update
 // +kubebuilder:rbac:groups=odigos.io,resources=sources/finalizers,verbs=update
 // +kubebuilder:rbac:groups=odigos.io,resources=collectorsgroups/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete;deletecollection
-// +kubebuilder:rbac:groups="",resources=configmaps;endpoints;secrets,verbs=get;list;watch;create;update;delete;patch
+// +kubebuilder:rbac:groups="",resources=configmaps;endpoints;secrets,verbs=get;list;watch;create;update;delete;patch;deletecollection
 // +kubebuilder:rbac:groups="",resources=configmaps/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=create;get;list;watch;patch;delete
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;patch
@@ -115,10 +115,10 @@ var relatedImageEnvVars = map[string]string{
 // +kubebuilder:rbac:groups=apps,resources=deployments/status;daemonsets/status;statefulsets/status,verbs=get
 // +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;create;update;patch;watch;delete
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=create
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings;roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings;roles;rolebindings,verbs=get;list;watch;create;update;patch;delete;deletecollection
 // +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;update;patch;delete;deletecollection
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=create;patch;update;delete
 // +kubebuilder:rbac:groups=policy,resources=podsecuritypolicies,resourceNames=privileged,verbs=use
@@ -168,10 +168,13 @@ func (r *OdigosReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		Config:        k8sConfig,
 	}
 
+	// Store original object for patch operations
+	originalOdigos := odigos.DeepCopy()
+
 	if odigos.ObjectMeta.DeletionTimestamp.IsZero() {
-		return r.install(ctx, kubeClient, odigos)
+		return r.install(ctx, kubeClient, odigos, originalOdigos)
 	} else {
-		return r.uninstall(ctx, kubeClient, odigos)
+		return r.uninstall(ctx, kubeClient, odigos, originalOdigos)
 	}
 }
 
@@ -183,7 +186,7 @@ func (r *OdigosReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (r *OdigosReconciler) uninstall(ctx context.Context, kubeClient *kube.Client, odigos *operatorv1alpha1.Odigos) (ctrl.Result, error) {
+func (r *OdigosReconciler) uninstall(ctx context.Context, kubeClient *kube.Client, odigos *operatorv1alpha1.Odigos, originalOdigos *operatorv1alpha1.Odigos) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
 	ns := odigos.GetNamespace()
@@ -192,7 +195,7 @@ func (r *OdigosReconciler) uninstall(ctx context.Context, kubeClient *kube.Clien
 
 	if controllerutil.ContainsFinalizer(odigos, operatorFinalizer) {
 		controllerutil.RemoveFinalizer(odigos, operatorFinalizer)
-		if err := r.Update(ctx, odigos); err != nil {
+		if err := r.Patch(ctx, odigos, client.MergeFrom(originalOdigos)); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -202,12 +205,12 @@ func (r *OdigosReconciler) uninstall(ctx context.Context, kubeClient *kube.Clien
 }
 
 // install Odigos based on the config passed in odigos
-func (r *OdigosReconciler) install(ctx context.Context, kubeClient *kube.Client, odigos *operatorv1alpha1.Odigos) (ctrl.Result, error) {
+func (r *OdigosReconciler) install(ctx context.Context, kubeClient *kube.Client, odigos *operatorv1alpha1.Odigos, originalOdigos *operatorv1alpha1.Odigos) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
 	if !controllerutil.ContainsFinalizer(odigos, operatorFinalizer) {
 		controllerutil.AddFinalizer(odigos, operatorFinalizer)
-		if err := r.Update(ctx, odigos); err != nil {
+		if err := r.Patch(ctx, odigos, client.MergeFrom(originalOdigos)); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -250,10 +253,11 @@ func (r *OdigosReconciler) install(ctx context.Context, kubeClient *kube.Client,
 		return ctrl.Result{}, r.Status().Update(ctx, odigos)
 	}
 
+	openshiftEnabled := false
 	details := autodetect.GetK8SClusterDetails(ctx, "", "", kubeClient)
 	if details.Kind == autodetect.KindOpenShift {
 		logger.Info("Detected OpenShift cluster, enabling required configuration")
-		odigos.Spec.OpenShiftEnabled = true
+		openshiftEnabled = true
 	}
 	ctx = cmdcontext.ContextWithClusterDetails(ctx, details)
 
@@ -330,7 +334,7 @@ func (r *OdigosReconciler) install(ctx context.Context, kubeClient *kube.Client,
 	}
 
 	odigosConfiguration.TelemetryEnabled = odigos.Spec.TelemetryEnabled
-	odigosConfiguration.OpenshiftEnabled = odigos.Spec.OpenShiftEnabled
+	odigosConfiguration.OpenshiftEnabled = openshiftEnabled
 	odigosConfiguration.IgnoredNamespaces = odigos.Spec.IgnoredNamespaces
 	odigosConfiguration.IgnoredContainers = odigos.Spec.IgnoredContainers
 	odigosConfiguration.SkipWebhookIssuerCreation = odigos.Spec.SkipWebhookIssuerCreation
@@ -345,7 +349,11 @@ func (r *OdigosReconciler) install(ctx context.Context, kubeClient *kube.Client,
 		odigosConfiguration.UiMode = common.UiMode(odigos.Spec.UIMode)
 	}
 	odigosConfiguration.NodeSelector = nodeSelector
-	odigosConfiguration.AgentEnvVarsInjectionMethod = &odigos.Spec.AgentEnvVarsInjectionMethod
+	agentEnvVarsInjectionMethod := odigos.Spec.AgentEnvVarsInjectionMethod
+	if agentEnvVarsInjectionMethod == "" {
+		agentEnvVarsInjectionMethod = common.PodManifestEnvInjectionMethod
+	}
+	odigosConfiguration.AgentEnvVarsInjectionMethod = &agentEnvVarsInjectionMethod
 
 	ownerReference := metav1.OwnerReference{
 		APIVersion: odigos.APIVersion,
@@ -356,8 +364,8 @@ func (r *OdigosReconciler) install(ctx context.Context, kubeClient *kube.Client,
 	managerOpts := resourcemanager.ManagerOpts{
 		OwnerReferences: []metav1.OwnerReference{ownerReference},
 	}
-	imageReferences := cmd.GetImageReferences(odigosTier, odigos.Spec.OpenShiftEnabled)
-	if odigos.Spec.OpenShiftEnabled {
+	imageReferences := cmd.GetImageReferences(odigosTier, openshiftEnabled)
+	if openshiftEnabled {
 		imageReferences.AutoscalerImage = os.Getenv(relatedImageEnvVars[imageReferences.AutoscalerImage])
 		imageReferences.CollectorImage = os.Getenv(relatedImageEnvVars[imageReferences.CollectorImage])
 		imageReferences.UIImage = os.Getenv(relatedImageEnvVars[imageReferences.UIImage])
@@ -388,7 +396,7 @@ func (r *OdigosReconciler) install(ctx context.Context, kubeClient *kube.Client,
 		odigosConfiguration.MountMethod = &odigos.Spec.MountMethod
 	}
 
-	if !odigos.Spec.OpenShiftEnabled {
+	if !openshiftEnabled {
 		if odigos.Spec.ImagePrefix == "" {
 			odigosConfiguration.ImagePrefix = k8sconsts.OdigosImagePrefix
 		}


### PR DESCRIPTION
## Description

Cherry pick of https://github.com/odigos-io/odigos/pull/3651 to release-1.8. Will publish a 1.8.3 patch after this to get a release for openshift this week.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [x] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-376
