### PR TITLE
chore: build embedded helm chart in cli in build cli github action

### DIFF
--- a/.github/actions/build/cli/action.yml
+++ b/.github/actions/build/cli/action.yml
@@ -7,5 +7,9 @@ runs:
       shell: bash
       run: |
         cd cli
-        go build -tags=embed_manifests -o odigos
-        chmod +x odigos
+        TAG=0.0.0-e2e-test
+        sed -i -E 's/0.0.0/'"${TAG#v}"'/' ../helm/odigos/Chart.yaml
+        helm package ../helm/odigos -d pkg/helm/embedded
+        go build -tags=embed_manifests \
+          -ldflags "-X github.com/odigos-io/odigos/cli/pkg/helm.OdigosChartVersion=${TAG#v}" \
+          -o odigos

--- a/tests-infrastructure/terraform/aks/provider.tf
+++ b/tests-infrastructure/terraform/aks/provider.tf
@@ -1,3 +1,7 @@
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }


### PR DESCRIPTION
## Description

Need to build the cli with the embedded chart in it in the github `build cli` action.
This will fix the nightly failures in the `source` test.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [X] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-388
