### PR TITLE
fix: if not using embeeded chart do not rely on existing repositories.yaml file

### DIFF
--- a/cli/pkg/helm/helpers.go
+++ b/cli/pkg/helm/helpers.go
@@ -2,6 +2,7 @@ package helm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -136,10 +137,11 @@ func PrepareChartAndValues(settings *cli.EnvSettings) (*chart.Chart, map[string]
 func ensureHelmRepo(settings *cli.EnvSettings, name, url string) error {
 	repoFile := settings.RepositoryConfig
 	f, err := repo.LoadFile(repoFile)
-	if err != nil && !os.IsNotExist(err) {
+	// Use errors.Is to properly handle wrapped errors from Helm
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
-	// check if exists
+	// check if repo already exists
 	if f != nil {
 		for _, r := range f.Repositories {
 			if r.Name == name {


### PR DESCRIPTION
## Description

In the new CLI installation approach with embedded charts, we added an option to install the chart directly from the Odigos Helm repository when the user has internet access.
Previously, we checked for the existence of repositories.yaml using:

```
if err != nil && !os.IsNotExist(err) {
```


However, since the Helm SDK likely wraps this error, the condition didn’t work as expected.
We’ve now updated the check to:
```
if err != nil && !errors.Is(err, os.ErrNotExist) {
```

This change resolves the issue.
Before this fix, users occasionally encountered the following error if no helm installation exists:
```
Error: couldn't load repositories file (/home/runner/.config/helm/repositories.yaml): open /home/runner/.config/helm/repositories.yaml: no such file or directory
Usage:

```
## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [X] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-387
