### PR TITLE
fix: create ruby-community symlink for backward compatibility

### DIFF
--- a/odiglet/pkg/instrumentation/fs/agents.go
+++ b/odiglet/pkg/instrumentation/fs/agents.go
@@ -75,6 +75,19 @@ func CopyAgentsDirectoryToHost() error {
 		}
 	}
 
+	// Create a symlink from /var/odigos/ruby-community to /var/odigos/ruby for compatibility
+	rubyCommunityPath := path.Join(k8sconsts.OdigosAgentsDirectory, "ruby-community")
+	rubyPath := path.Join(k8sconsts.OdigosAgentsDirectory, "ruby")
+
+	// Check if ruby-community directory or symlink exists, if not, create symlink
+	if _, err := os.Stat(rubyCommunityPath); os.IsNotExist(err) {
+		if err := os.Symlink(rubyPath, rubyCommunityPath); err != nil {
+			log.Logger.Error(err, "Failed to create symlink for ruby-community")
+		} else {
+			log.Logger.Info("Successfully created symlink from ruby-community to ruby")
+		}
+	}
+
 	// temporary workaround for dotnet.
 	// dotnet used to have directories containing the arch suffix (linux-glibc-arm64).
 	// this works will with virtual device that knows the arch it is running on.


### PR DESCRIPTION
To resolve the issue of instrumentation failure for the pod: geolocation in the official odigos sample, which indicates that the required ruby-community agent library cannot be found.

The Ruby agent directory was renamed from ruby-community to ruby.
Some existing pods still reference ruby-community. 
This patch adds a compatibility symlink to avoid missing agent errors.


## Description

Fix the issue where the `geolocation` pod fails to be instrumented due to the missing `ruby-community` agent.  
This PR ensures that the correct agent path or configuration is used when testing the Ruby community sample with Odigos.

## How Has This Been Tested?

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [x] Manual Testing
- [ ] Manual Load Test

**Manual Testing Steps:**
1. Deployed the `geolocation` sample pod.
2. Verified that Odigos correctly injected the `ruby-community` agent.
3. Confirmed that the pod starts without errors and traces are collected.

## Kubernetes Checklist

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

*(No changes to Kubernetes manifests or permissions were made; issue was with sample configuration.)*

## User Facing Changes

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

*(This PR fixes an internal sample issue; no user-facing changes.)*

emergency-ticket id: EMR-404
