### PR TITLE
fix: order datastreams and sources to avoid multiple reloads

### DIFF
--- a/autoscaler/controllers/clustercollector/configmap.go
+++ b/autoscaler/controllers/clustercollector/configmap.go
@@ -342,6 +342,11 @@ func calculateDataStreams(
 		dataStreamDetailsList = append(dataStreamDetailsList, *ds)
 	}
 
+	// Sort by Name to ensure consistent ordering
+	slices.SortFunc(dataStreamDetailsList, func(a, b pipelinegen.DataStreams) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
 	return dataStreamDetailsList, nil
 }
 
@@ -385,6 +390,17 @@ func getSourcesForDataStream(
 			Name:      pw.Name,
 		})
 	}
+
+	// Sort by Namespace, then Kind, then Name to ensure consistent ordering
+	slices.SortFunc(sourcesFilters, func(a, b pipelinegen.SourceFilter) int {
+		if a.Namespace != b.Namespace {
+			return strings.Compare(a.Namespace, b.Namespace)
+		}
+		if a.Kind != b.Kind {
+			return strings.Compare(a.Kind, b.Kind)
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
 
 	return sourcesFilters, nil
 }

--- a/autoscaler/controllers/nodecollector/testdata/logs_included.yaml
+++ b/autoscaler/controllers/nodecollector/testdata/logs_included.yaml
@@ -15,7 +15,7 @@ exporters:
     tls:
       insecure: true
   otlp/out-cluster-collector:
-    balancer_name: round_robin
+    compression: none
     endpoint: dns:///odigos-gateway.odigos-system:4317
     tls:
       insecure: true

--- a/autoscaler/controllers/nodecollector/testdata/logs_included.yaml
+++ b/autoscaler/controllers/nodecollector/testdata/logs_included.yaml
@@ -15,7 +15,7 @@ exporters:
     tls:
       insecure: true
   otlp/out-cluster-collector:
-    compression: none
+    balancer_name: round_robin
     endpoint: dns:///odigos-gateway.odigos-system:4317
     tls:
       insecure: true


### PR DESCRIPTION
## Description

In case sources change order in the datastream configuration, the collector will reload per change without need.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [X] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-400
