### PR TITLE
Remove load balancer if not needed (#3677)

### DIFF
--- a/autoscaler/controllers/actions/sampling/errorsampler.go
+++ b/autoscaler/controllers/actions/sampling/errorsampler.go
@@ -53,7 +53,7 @@ func (h *ErrorSamplerHandler) List(ctx context.Context, c client.Client, namespa
 	}
 	items := make([]metav1.Object, 0)
 	for i, item := range list.Items {
-		if item.Spec.Samplers.ErrorSampler != nil {
+		if item.Spec.Samplers != nil && item.Spec.Samplers.ErrorSampler != nil {
 			items = append(items, &list.Items[i])
 		}
 	}
@@ -85,6 +85,10 @@ func (h *ErrorSamplerHandler) GetRuleConfig(action metav1.Object) []Rule {
 	}
 	if a, ok := action.(*odigosv1.Action); ok {
 		errorSampler = a
+	}
+
+	if errorSampler.Spec.Samplers == nil || errorSampler.Spec.Samplers.ErrorSampler == nil {
+		return []Rule{}
 	}
 
 	errorDetails := &ErrorConfig{

--- a/autoscaler/controllers/actions/sampling/latencysampler.go
+++ b/autoscaler/controllers/actions/sampling/latencysampler.go
@@ -58,7 +58,7 @@ func (h *LatencySamplerHandler) List(ctx context.Context, c client.Client, names
 	}
 	items := make([]metav1.Object, 0)
 	for i, item := range list.Items {
-		if item.Spec.Samplers.LatencySampler != nil {
+		if item.Spec.Samplers != nil && item.Spec.Samplers.LatencySampler != nil {
 			items = append(items, &list.Items[i])
 		}
 	}
@@ -90,6 +90,10 @@ func (h *LatencySamplerHandler) GetRuleConfig(action metav1.Object) []Rule {
 	}
 	if a, ok := action.(*odigosv1.Action); ok {
 		latencysampler = a
+	}
+
+	if latencysampler.Spec.Samplers == nil || latencysampler.Spec.Samplers.LatencySampler == nil {
+		return []Rule{}
 	}
 
 	actionRules := []Rule{}

--- a/autoscaler/controllers/actions/sampling/servicenamesampler.go
+++ b/autoscaler/controllers/actions/sampling/servicenamesampler.go
@@ -56,7 +56,7 @@ func (h *ServiceNameSamplerHandler) List(ctx context.Context, c client.Client, n
 	}
 	items := make([]metav1.Object, 0)
 	for i, item := range list.Items {
-		if item.Spec.Samplers.ServiceNameSampler != nil {
+		if item.Spec.Samplers != nil && item.Spec.Samplers.ServiceNameSampler != nil {
 			items = append(items, &list.Items[i])
 		}
 	}
@@ -88,6 +88,10 @@ func (h *ServiceNameSamplerHandler) GetRuleConfig(action metav1.Object) []Rule {
 	}
 	if a, ok := action.(*odigosv1.Action); ok {
 		serviceNameSampler = a
+	}
+
+	if serviceNameSampler.Spec.Samplers == nil || serviceNameSampler.Spec.Samplers.ServiceNameSampler == nil {
+		return []Rule{}
 	}
 
 	rules := make([]Rule, 0, len(serviceNameSampler.Spec.Samplers.ServiceNameSampler.ServicesNameFilters))

--- a/autoscaler/controllers/actions/sampling/spanattributesampler.go
+++ b/autoscaler/controllers/actions/sampling/spanattributesampler.go
@@ -61,7 +61,7 @@ func (h *SpanAttributeSamplerHandler) List(ctx context.Context, c client.Client,
 	}
 	items := make([]metav1.Object, 0)
 	for i, item := range list.Items {
-		if item.Spec.Samplers.SpanAttributeSampler != nil {
+		if item.Spec.Samplers != nil && item.Spec.Samplers.SpanAttributeSampler != nil {
 			items = append(items, &list.Items[i])
 		}
 	}
@@ -93,6 +93,10 @@ func (h *SpanAttributeSamplerHandler) GetRuleConfig(action metav1.Object) []Rule
 	}
 	if a, ok := action.(*odigosv1.Action); ok {
 		spanAttributeSampler = a
+	}
+
+	if spanAttributeSampler.Spec.Samplers == nil || spanAttributeSampler.Spec.Samplers.SpanAttributeSampler == nil {
+		return []Rule{}
 	}
 
 	rules := make([]Rule, 0, len(spanAttributeSampler.Spec.Samplers.SpanAttributeSampler.AttributeFilters))

--- a/autoscaler/controllers/nodecollector/configmap.go
+++ b/autoscaler/controllers/nodecollector/configmap.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-func (b *nodeCollectorBaseReconciler) SyncConfigMap(ctx context.Context, sources *odigosv1.InstrumentationConfigList, clusterCollectorSignals []odigoscommon.ObservabilitySignal, allProcessors *odigosv1.ProcessorList,
+func (b *nodeCollectorBaseReconciler) SyncConfigMap(ctx context.Context, sources *odigosv1.InstrumentationConfigList, clusterCollectorGroup odigosv1.CollectorsGroup, allProcessors *odigosv1.ProcessorList,
 	datacollection *odigosv1.CollectorsGroup) error {
 	logger := log.FromContext(ctx)
 
@@ -41,7 +41,7 @@ func (b *nodeCollectorBaseReconciler) SyncConfigMap(ctx context.Context, sources
 		b.autoscalerDeployment = autoscalerDeployment
 	}
 
-	desired, err := b.getDesiredConfigMap(sources, clusterCollectorSignals, processors, datacollection)
+	desired, err := b.getDesiredConfigMap(ctx, sources, clusterCollectorGroup, processors, datacollection)
 	if err != nil {
 		logger.Error(err, "failed to get desired config map")
 		return err
@@ -150,7 +150,7 @@ func noopConfigMap() (string, error) {
 	return string(yamlData), nil
 }
 
-func (b *nodeCollectorBaseReconciler) getDesiredConfigMap(sources *odigosv1.InstrumentationConfigList, clusterCollectorSignals []odigoscommon.ObservabilitySignal, processors []*odigosv1.Processor,
+func (b *nodeCollectorBaseReconciler) getDesiredConfigMap(ctx context.Context, sources *odigosv1.InstrumentationConfigList, clusterCollectorGroup odigosv1.CollectorsGroup, processors []*odigosv1.Processor,
 	cg *odigosv1.CollectorsGroup) (*v1.ConfigMap, error) {
 	if b.autoscalerDeployment == nil {
 		return nil, errors.New("autoscaler deployment is not set in the reconciler, cannot set owner reference")
@@ -158,12 +158,17 @@ func (b *nodeCollectorBaseReconciler) getDesiredConfigMap(sources *odigosv1.Inst
 	var err error
 	var cmData string
 
-	if cg == nil || len(clusterCollectorSignals) == 0 {
+	tracingLoadBalancingNeeded, err := isTracingLoadBalancingNeeded(ctx, b.Client, clusterCollectorGroup)
+	if err != nil {
+		return nil, err
+	}
+
+	if cg == nil || len(clusterCollectorGroup.Status.ReceiverSignals) == 0 {
 		// if collectors group is not created yet, or there are no signals to collect, return a no-op configmap
 		// this can happen if no sources are instrumented yet or no destinations are added.
 		cmData, err = noopConfigMap()
 	} else {
-		cmData, err = calculateConfigMapData(cg, sources, clusterCollectorSignals, processors, commonconf.ControllerConfig.OnGKE)
+		cmData, err = calculateConfigMapData(cg, sources, clusterCollectorGroup.Status.ReceiverSignals, processors, commonconf.ControllerConfig.OnGKE, tracingLoadBalancingNeeded)
 	}
 
 	if err != nil {
@@ -195,7 +200,8 @@ func calculateConfigMapData(
 	sources *odigosv1.InstrumentationConfigList,
 	clusterCollectorSignals []odigoscommon.ObservabilitySignal,
 	processors []*odigosv1.Processor,
-	onGKE bool) (string, error) {
+	onGKE bool,
+	loadBalancingNeeded bool) (string, error) {
 
 	ownMetricsPort := nodeCG.Spec.CollectorOwnMetricsPort
 	odigosNamespace := env.GetCurrentNamespace()
@@ -238,7 +244,7 @@ func calculateConfigMapData(
 	// - cluster collector has traces enabled (trace destination is enabled)
 	// - there are additional trace exporters (e.g. spanmetrics connector)
 	if tracesEnabledInClusterCollector || len(additionalTraceExporters) > 0 {
-		tracesConfig := collectorconfig.TracesConfig(nodeCG, odigosNamespace, additionalTraceProcessors, additionalTraceExporters, tracesEnabledInClusterCollector)
+		tracesConfig := collectorconfig.TracesConfig(nodeCG, odigosNamespace, additionalTraceProcessors, additionalTraceExporters, tracesEnabledInClusterCollector, loadBalancingNeeded)
 		activeConfigDomains = append(activeConfigDomains, tracesConfig)
 	}
 
@@ -309,4 +315,37 @@ func getSignalsFromOtelcolConfig(otelcolConfigContent string) ([]odigoscommon.Ob
 	}
 
 	return signals, nil
+}
+
+func isSamplingActionsEnabled(actions *odigosv1.ActionList) bool {
+	for _, action := range actions.Items {
+		// If the action is disabled, skip it
+		if action.Spec.Disabled {
+			continue
+		}
+		// Only sampling actions that are not disabled should be considered
+		if action.Spec.Samplers != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func isTracingLoadBalancingNeeded(ctx context.Context, client client.Client, clusterCollectorGroup odigosv1.CollectorsGroup) (bool, error) {
+	// We're enabling load balancing for traces only if one of the following conditions is met:
+	// 1. Sampling actions are enabled
+	// 2. Service graph is enabled
+	serviceGraphEnabled := clusterCollectorGroup.Spec.ServiceGraphDisabled == nil || !*clusterCollectorGroup.Spec.ServiceGraphDisabled
+
+	if serviceGraphEnabled {
+		return true, nil
+	}
+
+	actions := odigosv1.ActionList{}
+	if err := client.List(ctx, &actions); err != nil {
+		return false, err
+	}
+	samplingActionsEnabled := isSamplingActionsEnabled(&actions)
+
+	return samplingActionsEnabled, nil
 }

--- a/autoscaler/controllers/nodecollector/configmap_test.go
+++ b/autoscaler/controllers/nodecollector/configmap_test.go
@@ -169,6 +169,60 @@ func TestCalculateConfigMapData(t *testing.T) {
 			},
 		},
 		false, /* onGKE */
+		true,  /* loadBalancingNeeded */
+	)
+
+	assert.Equal(t, err, nil)
+	assert.Equal(t, want, got)
+}
+
+func TestCalculateConfigMapDataTracesOnlyNoLoadBalancing(t *testing.T) {
+	want := openTestData(t, "testdata/traces_only_no_loadbalancing.yaml")
+
+	ns := NewMockNamespace("default")
+	ns2 := NewMockNamespace("other-namespace")
+
+	items := []v1alpha1.InstrumentationConfig{
+		*NewMockInstrumentationConfig(NewMockTestDeployment(ns)),
+		*NewMockInstrumentationConfig(NewMockTestDaemonSet(ns)),
+		*NewMockInstrumentationConfig(NewMockTestStatefulSet(ns2)),
+		*NewMockInstrumentationConfigWoOwner(NewMockTestDeployment(ns2)),
+	}
+
+	got, err := calculateConfigMapData(
+		&odigosv1.CollectorsGroup{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-collector-group"},
+			Spec: odigosv1.CollectorsGroupSpec{
+				CollectorOwnMetricsPort: 4317,
+				// No metrics configuration - only traces
+			},
+		},
+		&odigosv1.InstrumentationConfigList{
+			Items: items,
+		},
+		[]common.ObservabilitySignal{
+			// Only traces enabled, no logs or metrics
+			common.TracesObservabilitySignal,
+		},
+		[]*v1alpha1.Processor{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "test_processor"},
+				Spec: v1alpha1.ProcessorSpec{
+					OrderHint:      1,
+					Type:           "test_type",
+					CollectorRoles: []odigosv1.CollectorsGroupRole{odigosv1.CollectorsGroupRoleNodeCollector},
+					Disabled:       false,
+					ProcessorConfig: runtime.RawExtension{
+						Raw: []byte(`{"key":"val"}`),
+					},
+					Signals: []common.ObservabilitySignal{
+						common.TracesObservabilitySignal,
+					},
+				},
+			},
+		},
+		false, /* onGKE */
+		false, /* loadBalancingNeeded */
 	)
 
 	assert.Equal(t, err, nil)

--- a/autoscaler/controllers/nodecollector/sync.go
+++ b/autoscaler/controllers/nodecollector/sync.go
@@ -60,7 +60,7 @@ func (b *nodeCollectorBaseReconciler) reconcileNodeCollector(ctx context.Context
 		return ctrl.Result{}, err
 	}
 
-	err = b.syncDataCollection(ctx, &ics, clusterCollectorCollectorGroup.Status.ReceiverSignals, &processors, dataCollectionCollectorGroup)
+	err = b.syncDataCollection(ctx, &ics, clusterCollectorCollectorGroup, &processors, dataCollectionCollectorGroup)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -68,7 +68,7 @@ func (b *nodeCollectorBaseReconciler) reconcileNodeCollector(ctx context.Context
 	return ctrl.Result{}, nil
 }
 
-func (b *nodeCollectorBaseReconciler) syncDataCollection(ctx context.Context, sources *odigosv1.InstrumentationConfigList, clusterCollectorSignals []common.ObservabilitySignal, processors *odigosv1.ProcessorList,
+func (b *nodeCollectorBaseReconciler) syncDataCollection(ctx context.Context, sources *odigosv1.InstrumentationConfigList, clusterCollectorGroup odigosv1.CollectorsGroup, processors *odigosv1.ProcessorList,
 	dataCollection *odigosv1.CollectorsGroup) error {
 	logger := log.FromContext(ctx)
 	logger.V(0).Info("Syncing data collection")
@@ -79,7 +79,7 @@ func (b *nodeCollectorBaseReconciler) syncDataCollection(ctx context.Context, so
 		return err
 	}
 
-	err = b.SyncConfigMap(ctx, sources, clusterCollectorSignals, processors, dataCollection)
+	err = b.SyncConfigMap(ctx, sources, clusterCollectorGroup, processors, dataCollection)
 	if err != nil {
 		logger.Error(err, "Failed to sync config map")
 		return err
@@ -89,7 +89,7 @@ func (b *nodeCollectorBaseReconciler) syncDataCollection(ctx context.Context, so
 	// e.g - cluster collector can accept only metrics,
 	// while node collector collects both metrics and traces, which it converts to metrics and does not forward downstream.
 	// the enabled signals represents what's actually collected from agents in node collector.
-	enabledSignals := clusterCollectorSignals
+	enabledSignals := clusterCollectorGroup.Status.ReceiverSignals
 	spanMetricsEnabled := dataCollection != nil && dataCollection.Spec.Metrics != nil && dataCollection.Spec.Metrics.SpanMetrics != nil
 	if spanMetricsEnabled {
 		if !slices.Contains(enabledSignals, common.TracesObservabilitySignal) {

--- a/autoscaler/controllers/nodecollector/testdata/traces_only_no_loadbalancing.yaml
+++ b/autoscaler/controllers/nodecollector/testdata/traces_only_no_loadbalancing.yaml
@@ -1,13 +1,4 @@
 exporters:
-  loadbalancing/traces:
-    protocol:
-      otlp:
-        compression: none
-        tls:
-          insecure: true
-    resolver:
-      k8s:
-        service: odigos-gateway.odigos-system
   otlp/odigos-own-telemetry-ui:
     endpoint: ui.odigos-system:4317
     retry_on_failure:
@@ -56,52 +47,6 @@ processors:
   test_type/test_processor:
     key: val
 receivers:
-  filelog:
-    exclude:
-    - /var/log/pods/kube-system_*/**/*
-    - /var/log/pods/odigos-system_*/**/*
-    include:
-    - /var/log/pods/default_test-deployment-*_*/*/*.log
-    - /var/log/pods/default_test-daemonset-*_*/*/*.log
-    - /var/log/pods/other-namespace_test-statefulset-*_*/*/*.log
-    include_file_name: false
-    include_file_path: true
-    operators:
-    - id: container-parser
-      type: container
-    retry_on_failure:
-      enabled: true
-    start_at: end
-  hostmetrics:
-    collection_interval: 33s
-    root_path: /hostfs
-    scrapers:
-      cpu:
-        metrics:
-          system.cpu.utilization:
-            enabled: true
-      disk: {}
-      filesystem:
-        exclude_mount_points:
-          match_type: regexp
-          mount_points:
-          - /var/lib/kubelet/*
-        metrics:
-          system.filesystem.utilization:
-            enabled: true
-      load: {}
-      memory: {}
-      network: {}
-      paging:
-        metrics:
-          system.paging.utilization:
-            enabled: true
-      processes: {}
-  kubeletstats:
-    auth_type: serviceAccount
-    collection_interval: 44s
-    endpoint: https://${env:NODE_IP}:10250
-    insecure_skip_verify: true
   odigosebpf: {}
   otlp/in:
     protocols:
@@ -128,31 +73,6 @@ service:
   - health_check
   - pprof
   pipelines:
-    logs:
-      exporters:
-      - otlp/out-cluster-collector
-      processors:
-      - memory_limiter
-      - resource/node-name
-      - resourcedetection
-      - test_type/test_processor
-      - odigostrafficmetrics
-      receivers:
-      - filelog
-    metrics:
-      exporters:
-      - otlp/out-cluster-collector
-      processors:
-      - batch
-      - memory_limiter
-      - resource/node-name
-      - resourcedetection
-      - test_type/test_processor
-      - odigostrafficmetrics
-      receivers:
-      - otlp/in
-      - kubeletstats
-      - hostmetrics
     metrics/own-metrics:
       exporters:
       - otlp/odigos-own-telemetry-ui
@@ -162,7 +82,7 @@ service:
       - prometheus/self-metrics
     traces:
       exporters:
-      - loadbalancing/traces
+      - otlp/out-cluster-collector
       processors:
       - batch
       - memory_limiter

--- a/scheduler/controllers/odigosconfiguration/odigosconfiguration_controller.go
+++ b/scheduler/controllers/odigosconfiguration/odigosconfiguration_controller.go
@@ -85,9 +85,9 @@ func (r *odigosConfigurationController) Reconcile(ctx context.Context, _ ctrl.Re
 	modifyConfigWithEffectiveProfiles(effectiveProfiles, &odigosConfiguration)
 	odigosConfiguration.Profiles = effectiveProfiles
 
-	effectiveSizing := sizing.ComputeResourceSizePreset(&odigosConfiguration)
-	odigosConfiguration.CollectorGateway = &effectiveSizing.CollectorGatewayConfig
-	odigosConfiguration.CollectorNode = &effectiveSizing.CollectorNodeConfig
+	// compute effective collector configurations that merge sizing presets with existing configurations
+	// preserving all non-sizing attributes (ServiceGraphDisabled, CollectorOwnMetricsPort, etc.)
+	odigosConfiguration.CollectorGateway, odigosConfiguration.CollectorNode = sizing.ComputeEffectiveCollectorConfig(&odigosConfiguration)
 
 	// TODO: revisit doing this here, might be nicer to maintain in a more generic way
 	// and have it on the config object itself.


### PR DESCRIPTION
## Description

In case servicegraph is disabled and user not set any sampler, we dont need load balancing exporter in the data collection which can potentially consume lots of resources due to connection matrix each gateway manages.
in case we dont need it, uses common otlp exporter.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

## Description

<!-- Short summary of the changes -->

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-398
