### PR TITLE
frontend: add pauseOdigos GraphQL mutation 

### DIFF
--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -575,6 +575,7 @@ type ComplexityRoot struct {
 		DeleteDataStream             func(childComplexity int, id string) int
 		DeleteDestination            func(childComplexity int, id string, currentStreamName string) int
 		DeleteInstrumentationRule    func(childComplexity int, ruleID string) int
+		PauseOdigos                  func(childComplexity int) int
 		PersistK8sNamespaces         func(childComplexity int, namespaces []*model.PersistNamespaceItemInput) int
 		PersistK8sSources            func(childComplexity int, sources []*model.PersistNamespaceSourceInput) int
 		RestartWorkloads             func(childComplexity int, sourceIds []*model.K8sSourceID) int
@@ -859,6 +860,7 @@ type MutationResolver interface {
 	UpdateAPIToken(ctx context.Context, token string) (bool, error)
 	UpdateOdigosConfig(ctx context.Context, odigosConfig model.OdigosConfigurationInput) (bool, error)
 	UninstrumentCluster(ctx context.Context) (bool, error)
+	PauseOdigos(ctx context.Context) (bool, error)
 	PersistK8sNamespaces(ctx context.Context, namespaces []*model.PersistNamespaceItemInput) (bool, error)
 	PersistK8sSources(ctx context.Context, sources []*model.PersistNamespaceSourceInput) (bool, error)
 	UpdateK8sActualSource(ctx context.Context, sourceID model.K8sSourceID, patchSourceRequest model.PatchSourceRequestInput) (bool, error)
@@ -3194,6 +3196,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.DeleteInstrumentationRule(childComplexity, args["ruleId"].(string)), true
+
+	case "Mutation.pauseOdigos":
+		if e.complexity.Mutation.PauseOdigos == nil {
+			break
+		}
+
+		return e.complexity.Mutation.PauseOdigos(childComplexity), true
 
 	case "Mutation.persistK8sNamespaces":
 		if e.complexity.Mutation.PersistK8sNamespaces == nil {
@@ -20267,6 +20276,50 @@ func (ec *executionContext) fieldContext_Mutation_uninstrumentCluster(_ context.
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_pauseOdigos(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_pauseOdigos(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().PauseOdigos(rctx)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_pauseOdigos(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation_persistK8sNamespaces(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation_persistK8sNamespaces(ctx, field)
 	if err != nil {
@@ -36453,6 +36506,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "uninstrumentCluster":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_uninstrumentCluster(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "pauseOdigos":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_pauseOdigos(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++

--- a/frontend/graph/schema.graphqls
+++ b/frontend/graph/schema.graphqls
@@ -1002,6 +1002,7 @@ type Mutation {
   updateApiToken(token: String!): Boolean!
   updateOdigosConfig(odigosConfig: OdigosConfigurationInput!): Boolean!
   uninstrumentCluster: Boolean!
+  pauseOdigos: Boolean!
   persistK8sNamespaces(namespaces: [PersistNamespaceItemInput!]!): Boolean!
   persistK8sSources(sources: [PersistNamespaceSourceInput!]!): Boolean!
   updateK8sActualSource(

--- a/frontend/graph/schema.resolvers.go
+++ b/frontend/graph/schema.resolvers.go
@@ -474,6 +474,14 @@ func (r *mutationResolver) UninstrumentCluster(ctx context.Context) (bool, error
 	return true, nil
 }
 
+// PauseOdigos is the resolver for the pauseOdigos field.
+func (r *mutationResolver) PauseOdigos(ctx context.Context) (bool, error) {
+	if err := services.PauseOdigos(ctx); err != nil {
+		return false, fmt.Errorf("failed to pause odigos: %v", err)
+	}
+	return true, nil
+}
+
 // PersistK8sNamespaces is the resolver for the persistK8sNamespaces field.
 func (r *mutationResolver) PersistK8sNamespaces(ctx context.Context, namespaces []*model.PersistNamespaceItemInput) (bool, error) {
 	persistObjects := []*model.PersistNamespaceSourceInput{}

--- a/frontend/services/pause.go
+++ b/frontend/services/pause.go
@@ -1,0 +1,80 @@
+package services
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/odigos-io/odigos/api/k8sconsts"
+	"github.com/odigos-io/odigos/frontend/kube"
+	"github.com/odigos-io/odigos/k8sutils/pkg/env"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// PauseOdigos scales down instrumentor and effectively drains odiglet
+// without restarting user workloads.
+func PauseOdigos(ctx context.Context) error {
+	ns := env.GetCurrentNamespace()
+
+	if err := scaleDeploymentToZero(ctx, ns, k8sconsts.InstrumentorDeploymentName); err != nil {
+		return fmt.Errorf("scale instrumentor to 0: %w", err)
+	}
+
+	if err := disableOdiglet(ctx, ns, k8sconsts.OdigletDaemonSetName); err != nil {
+		return fmt.Errorf("disable odiglet: %w", err)
+	}
+
+	return nil
+}
+
+func scaleDeploymentToZero(ctx context.Context, ns string, name string) error {
+
+	scale, err := kube.DefaultClient.AppsV1().Deployments(ns).GetScale(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	var zero int32 = 0
+	scale.Spec.Replicas = zero
+	_, err = kube.DefaultClient.AppsV1().Deployments(ns).UpdateScale(ctx, name, scale, metav1.UpdateOptions{})
+	return err
+}
+
+func disableOdiglet(ctx context.Context, ns string, name string) error {
+	// Patch DaemonSet template with an impossible nodeSelector and bump annotation to force rollout
+	// Also set maxUnavailable to 100% for faster drain
+	patch := []byte(`{
+      "spec": {
+        "updateStrategy": {
+          "type": "RollingUpdate",
+          "rollingUpdate": {"maxUnavailable": "100%"}
+        },
+        "template": {
+          "metadata": {
+            "annotations": {"odigos.io/pause-revision": "` + "1" + `"}
+          },
+          "spec": {
+            "nodeSelector": {"odigos.io/disabled": "true"}
+          }
+        }
+      }
+    }`)
+
+	if _, err := kube.DefaultClient.AppsV1().DaemonSets(ns).Patch(ctx, name, types.StrategicMergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		return err
+	}
+
+	// Delete existing odiglet pods to stop data flow immediately
+	// match by label used in chart
+	selector := fmt.Sprintf("app.kubernetes.io/name=%s", k8sconsts.OdigletDaemonSetName)
+	podList, err := kube.DefaultClient.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return err
+	}
+
+	policy := metav1.DeletePropagationBackground
+	for _, pod := range podList.Items {
+		_ = kube.DefaultClient.CoreV1().Pods(ns).Delete(ctx, pod.Name, metav1.DeleteOptions{PropagationPolicy: &policy})
+	}
+
+	return nil
+}

--- a/helm/odigos/templates/ui/role.yaml
+++ b/helm/odigos/templates/ui/role.yaml
@@ -75,14 +75,14 @@ rules:
     resources:
       - deployments/scale
     resourceNames:
-      - {{ .Values.instrumentor.name | default "odigos-instrumentor" }}
+      - odigos-instrumentor
     verbs: ["get", "update", "patch"]
   - apiGroups:
       - apps
     resources:
       - daemonsets
     resourceNames:
-      - {{ .Values.odiglet.name | default "odiglet" }}
+      - odiglet
     verbs: ["get", "update", "patch"]
   - apiGroups:
       - ''

--- a/helm/odigos/templates/ui/role.yaml
+++ b/helm/odigos/templates/ui/role.yaml
@@ -68,3 +68,25 @@ rules:
       - update
       - delete
       {{- end }}
+  # Permissions for pauseOdigos mutation
+  {{- if ne .Values.ui.uiMode "readonly" }}
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/scale
+    resourceNames:
+      - {{ .Values.instrumentor.name | default "odigos-instrumentor" }}
+    verbs: ["get", "update", "patch"]
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+    resourceNames:
+      - {{ .Values.odiglet.name | default "odiglet" }}
+    verbs: ["get", "update", "patch"]
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs: ["list", "delete"]
+  {{- end }}


### PR DESCRIPTION
- Add GraphQL mutation pauseOdigos to scale instrumentor to 0 and disable odiglet (no app restarts; new pods not instrumented; telemetry stops).
- Extend Helm UI RBAC to allow scaling deployments, patching daemonsets, and deleting odiglet pods.

emergency-ticket id: EMR-392
