### PR TITLE
central: persist Keycloak data via PVC

### DIFF
--- a/api/k8sconsts/odigoscentral.go
+++ b/api/k8sconsts/odigoscentral.go
@@ -66,6 +66,8 @@ const (
 	KeycloakSecretName          = "keycloak-admin-credentials"
 	KeycloakAdminUsernameKey    = "admin-username"
 	KeycloakAdminPasswordKey    = "admin-password"
+	KeycloakDataPVCName         = "keycloak-data"
+	KeycloakDataVolumeName      = "keycloak-data"
 )
 
 const (

--- a/helm/odigos-central/templates/keycloak/deployment.yaml
+++ b/helm/odigos-central/templates/keycloak/deployment.yaml
@@ -60,9 +60,20 @@ spec:
                   key: admin-password
             - name: KC_HOSTNAME
               value: "localhost"
+          {{- if .Values.auth.persistence.enabled }}
+          volumeMounts:
+            - name: keycloak-data
+              mountPath: /opt/keycloak/data
+          {{- end }}
           ports:
             - containerPort: {{ .Values.auth.port }}
               name: {{ .Values.auth.portName }}
           resources:
             {{- toYaml .Values.auth.resources | nindent 12 }}
+      {{- if .Values.auth.persistence.enabled }}
+      volumes:
+        - name: keycloak-data
+          persistentVolumeClaim:
+            claimName: {{ default "keycloak-data" .Values.auth.persistence.existingClaim }}
+      {{- end }}
 {{- end }}

--- a/helm/odigos-central/templates/keycloak/pvc.yaml
+++ b/helm/odigos-central/templates/keycloak/pvc.yaml
@@ -1,0 +1,21 @@
+{{- if (include "odigos.secretExists" .) }}
+{{- if not .Values.auth.adminPassword }}{{- fail "Central admin password is required. Please use --set auth.adminPassword=<your-password>" }}{{- end }}
+{{- if and .Values.auth.persistence.enabled (not .Values.auth.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: keycloak-data
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: keycloak
+    odigos.io/system-object: "true"
+spec:
+  accessModes: {{- toYaml .Values.auth.persistence.accessModes | nindent 2 }}
+  resources:
+    requests:
+      storage: {{ .Values.auth.persistence.size | quote }}
+  {{- if .Values.auth.persistence.storageClassName }}
+  storageClassName: {{ .Values.auth.persistence.storageClassName | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/odigos-central/values.yaml
+++ b/helm/odigos-central/values.yaml
@@ -43,6 +43,13 @@ auth:
   adminUsername: admin
   port: 8080
   portName: http
+  persistence:
+    enabled: true
+    size: 1Gi
+    accessModes:
+      - ReadWriteOnce
+    storageClassName: ''
+    existingClaim: ''
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
Persist Keycloak data using a PersistentVolumeClaim (PVC) so admin/configuration data survives pod restarts.

emergency-ticket id: EMR-406
