### PR TITLE
feat: register odiglet Otel global MeterProvider

### DIFF
--- a/odiglet/go.mod
+++ b/odiglet/go.mod
@@ -19,7 +19,6 @@ require (
 	go.opentelemetry.io/auto v0.21.0
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.38.0
-	go.opentelemetry.io/otel/metric v1.38.0
 	go.opentelemetry.io/otel/sdk v1.38.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/sync v0.17.0
@@ -85,6 +84,7 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.38.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.38.0 // indirect
 	go.opentelemetry.io/otel/log v0.14.0 // indirect
+	go.opentelemetry.io/otel/metric v1.38.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.14.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.38.0 // indirect
 	go.opentelemetry.io/otel/trace v1.38.0 // indirect

--- a/odiglet/pkg/ebpf/common.go
+++ b/odiglet/pkg/ebpf/common.go
@@ -19,7 +19,6 @@ import (
 
 	cilumebpf "github.com/cilium/ebpf"
 	processdetector "github.com/odigos-io/runtime-detector"
-	"go.opentelemetry.io/otel/metric"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -28,7 +27,6 @@ const numOfPages = 2048
 type InstrumentationManagerOptions struct {
 	Factories                  map[string]instrumentation.Factory
 	DistributionGetter         *distros.Getter
-	MeterProvider              metric.MeterProvider
 	OdigletHealthProbeBindPort int
 }
 
@@ -85,7 +83,6 @@ func NewManager(client client.Client, logger logr.Logger, opts InstrumentationMa
 		Handler:         newHandler(logger, client, opts.DistributionGetter),
 		DetectorOptions: detector.DefaultK8sDetectorOptions(logger, appendEnvVarSlice),
 		ConfigUpdates:   configUpdates,
-		MeterProvider:   opts.MeterProvider,
 		TracesMap:       m,
 	}
 


### PR DESCRIPTION
Follow up to #2931.
Setting an Odiglet OTel MeterProvider as the global one easily allows all the components in the Odiglet to add custom metrics, change the instrumentation manager to also use the global MeterProvider.

emergency-ticket id: EMR-418
