### PR TITLE
chore: remove comma

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,7 +209,7 @@ jobs:
           --image-label version=${{ env.TAG }} \
           --image-label release=${{ env.TAG }} \
           --image-label summary="Odigos CLI" \
-          --image-label description="Odigos CLI installs, manages, and uninstalls Odigos in your Kubernetes cluster." \
+          --image-label description="Odigos CLI to install and manage Odigos in your Kubernetes cluster." \
           --platform=all .
 
       - name: Install crane


### PR DESCRIPTION
## Description

`publish cli UBI9 image to GCR registry` fail because of this comma with the error
```
Error: error creating builder: error setting up builder options: invalid label flag:  manages
```

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-422
