### PR TITLE
fix: inaccurate Java runtime version (#3747)

### DIFF
--- a/procdiscovery/pkg/inspectors/java/java.go
+++ b/procdiscovery/pkg/inspectors/java/java.go
@@ -19,7 +19,7 @@ var (
 	binaries = []string{
 		"/libjvm.so", // Ensures "libjvm.so" appears within a path (because of the "/" prefix)
 	}
-	versionRegex = regexp.MustCompile(`\d+\.\d+\.\d+\+\d+`)
+	versionRegex = regexp.MustCompile(`\d+\.\d+\.\d+(?:\.\d+)?\+\d+`)
 )
 
 func (j *JavaInspector) QuickScan(pcx *process.ProcessContext) (common.ProgrammingLanguage, bool) {


### PR DESCRIPTION
Cherry picked: https://github.com/odigos-io/odigos/pull/3747

emergency-ticket id: EMR-448
