### PR TITLE
chore: we're not publishing enterprise images to github registry

### DIFF
--- a/.github/workflows/promote-rc-to-stable.yml
+++ b/.github/workflows/promote-rc-to-stable.yml
@@ -105,30 +105,45 @@ jobs:
 
       - name: Retag existing images to stable
         run: |
-            ALL_REGISTRIES_IMAGE_NAMES=("odigos-agents" "odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-ui" "odigos-operator")
+            # Define which images go to which registries
+            GCR_IMAGE_NAMES=("odigos-agents" "odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-ui" "odigos-operator" "odigos-enterprise-central-backend" "odigos-enterprise-central-proxy" "odigos-enterprise-central-ui" "odigos-enterprise-agents" "odigos-enterprise-instrumentor" "odigos-enterprise-odiglet")
 
-            ONLY_GCR_IMAGE_NAMES=("odigos-enterprise-central-backend" "odigos-enterprise-central-proxy" "odigos-enterprise-central-ui" "odigos-enterprise-agents" "odigos-enterprise-instrumentor" "odigos-enterprise-odiglet")
+            GHCR_IMAGE_NAMES=("odigos-agents" "odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-ui" "odigos-operator")
 
-            ALL_REGISTRIES=(${GCR_REPO} ${GHCR_REPO} ${DOCKERHUB_REPO})
+            DOCKERHUB_IMAGE_NAMES=("odigos-agents" "odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-ui" "odigos-operator" "odigos-enterprise-agents" "odigos-enterprise-instrumentor" "odigos-enterprise-odiglet")
+
             UBI9_SUFFIXES=("" "-ubi9")
             # Track failed copies for potential rollback
             FAILED_COPIES=()
 
             for SUFFIX in "${UBI9_SUFFIXES[@]}"; do
-              for IMAGE_NAME in "${ALL_REGISTRIES_IMAGE_NAMES[@]}"; do
-                for REPO in "${ALL_REGISTRIES[@]}"; do
-                  echo "Copying ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.RC_TAG }} to ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.STABLE_TAG }}"
-                  if ! crane copy ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.RC_TAG }} ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.STABLE_TAG }}; then
-                    echo "ERROR: Failed to copy ${REPO}/${IMAGE_NAME}${SUFFIX}"
-                    FAILED_COPIES+=("${REPO}/${IMAGE_NAME}${SUFFIX}")
-                  else
-                    echo "Successfully copied ${REPO}/${IMAGE_NAME}${SUFFIX}"
-                  fi
-                done
+              # Process GCR images
+              for IMAGE_NAME in "${GCR_IMAGE_NAMES[@]}"; do
+                REPO=${GCR_REPO}
+                echo "Copying ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.RC_TAG }} to ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.STABLE_TAG }}"
+                if ! crane copy ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.RC_TAG }} ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.STABLE_TAG }}; then
+                  echo "ERROR: Failed to copy ${REPO}/${IMAGE_NAME}${SUFFIX}"
+                  FAILED_COPIES+=("${REPO}/${IMAGE_NAME}${SUFFIX}")
+                else
+                  echo "Successfully copied ${REPO}/${IMAGE_NAME}${SUFFIX}"
+                fi
               done
 
-              for IMAGE_NAME in "${ONLY_GCR_IMAGE_NAMES[@]}"; do
-                REPO=${GCR_REPO}
+              # Process GHCR images
+              for IMAGE_NAME in "${GHCR_IMAGE_NAMES[@]}"; do
+                REPO=${GHCR_REPO}
+                echo "Copying ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.RC_TAG }} to ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.STABLE_TAG }}"
+                if ! crane copy ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.RC_TAG }} ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.STABLE_TAG }}; then
+                  echo "ERROR: Failed to copy ${REPO}/${IMAGE_NAME}${SUFFIX}"
+                  FAILED_COPIES+=("${REPO}/${IMAGE_NAME}${SUFFIX}")
+                else
+                  echo "Successfully copied ${REPO}/${IMAGE_NAME}${SUFFIX}"
+                fi
+              done
+
+              # Process DockerHub images
+              for IMAGE_NAME in "${DOCKERHUB_IMAGE_NAMES[@]}"; do
+                REPO=${DOCKERHUB_REPO}
                 echo "Copying ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.RC_TAG }} to ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.STABLE_TAG }}"
                 if ! crane copy ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.RC_TAG }} ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.STABLE_TAG }}; then
                   echo "ERROR: Failed to copy ${REPO}/${IMAGE_NAME}${SUFFIX}"

--- a/.github/workflows/promote-rc-to-stable.yml
+++ b/.github/workflows/promote-rc-to-stable.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Retag existing images to stable
         run: |
             ALL_REGISTRIES_IMAGE_NAMES=("odigos-agents" "odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-ui" "odigos-operator")
-            # TODO: make sure central images are working well in all registries
+
             ONLY_GCR_IMAGE_NAMES=("odigos-enterprise-central-backend" "odigos-enterprise-central-proxy" "odigos-enterprise-central-ui" "odigos-enterprise-agents" "odigos-enterprise-instrumentor" "odigos-enterprise-odiglet")
 
             ALL_REGISTRIES=(${GCR_REPO} ${GHCR_REPO} ${DOCKERHUB_REPO})

--- a/.github/workflows/promote-rc-to-stable.yml
+++ b/.github/workflows/promote-rc-to-stable.yml
@@ -105,9 +105,9 @@ jobs:
 
       - name: Retag existing images to stable
         run: |
-            ALL_REGISTRIES_IMAGE_NAMES=("odigos-agents" "odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-ui" "odigos-operator" "odigos-enterprise-agents" "odigos-enterprise-instrumentor" "odigos-enterprise-odiglet")
+            ALL_REGISTRIES_IMAGE_NAMES=("odigos-agents" "odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-ui" "odigos-operator")
             # TODO: make sure central images are working well in all registries
-            ONLY_GCR_IMAGE_NAMES=("odigos-enterprise-central-backend" "odigos-enterprise-central-proxy" "odigos-enterprise-central-ui")
+            ONLY_GCR_IMAGE_NAMES=("odigos-enterprise-central-backend" "odigos-enterprise-central-proxy" "odigos-enterprise-central-ui" "odigos-enterprise-agents" "odigos-enterprise-instrumentor" "odigos-enterprise-odiglet")
 
             ALL_REGISTRIES=(${GCR_REPO} ${GHCR_REPO} ${DOCKERHUB_REPO})
             UBI9_SUFFIXES=("" "-ubi9")


### PR DESCRIPTION
## Description

We're not pushing the enterprise images to github registry which cause the promote-rc-to-stable job to fail.


## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-447
