### PR TITLE
Add VM defaulter for now

### DIFF
--- a/distros/oteldistributions.go
+++ b/distros/oteldistributions.go
@@ -16,6 +16,7 @@ import (
 
 type Defaulter interface {
 	GetDefaultDistroNames() map[common.ProgrammingLanguage]string
+	GetDefaultVmDistroNames() map[common.ProgrammingLanguage]string
 }
 
 type communityDefaulter struct{}
@@ -53,6 +54,10 @@ func (c *communityDefaulter) GetDefaultDistroNames() map[common.ProgrammingLangu
 		common.PhpProgrammingLanguage:        "php-community",
 		common.RubyProgrammingLanguage:       "ruby-community",
 	}
+}
+
+func (c *communityDefaulter) GetDefaultVmDistroNames() map[common.ProgrammingLanguage]string {
+	return c.GetDefaultDistroNames()
 }
 
 type Getter struct {


### PR DESCRIPTION
## Description

<!-- Short summary of the changes -->

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-454
