### PR TITLE
Cherry pick hpa to 1.10

### DIFF
--- a/autoscaler/controllers/clustercollector/hpa.go
+++ b/autoscaler/controllers/clustercollector/hpa.go
@@ -27,24 +27,56 @@ const (
 )
 
 var (
-	defaultMinReplicas         = intPtr(1)
-	defaultMaxReplicas         = int32(10)
-	stabilizationWindowSeconds = intPtr(300) // cooldown period for scaling down
+	defaultMinReplicas                  = intPtr(1)
+	defaultMaxReplicas                  = int32(10)
+	ScaleDownStabilizationWindowSeconds = intPtr(900) // 15 minutes cooldown period for scaling down
+	ScaleUpStabilizationWindowSeconds   = intPtr(0)   // no cooldown period for scaling up
 )
 
+// syncHPA dynamically creates or updates the HorizontalPodAutoscaler (HPA)
+// for the Odigos Gateway deployment based on the running Kubernetes version.
+//
+// Version handling:
+//   - < 1.23  → uses autoscaling/v2beta1 (no behavior support)
+//   - 1.23 <= version < 1.25 → uses autoscaling/v2beta2 (manual "Min"/"Max" scaling policy)
+//   - ≥ 1.25  → uses autoscaling/v2 (stable API, with predefined policy enums)
+//
+// Scaling logic:
+//
+//	The HPA combines Odigos custom "odigos_gateway_rejections" metric with
+//	standard CPU and memory metrics for hybrid scaling. The custom metric is a
+//	binary signal (0 or 1) indicating when ≥50% of gateway pods reject requests
+//	due to memory pressure. This allows the autoscaler to react quickly under
+//	stress — even when CPU or memory metrics are unavailable (e.g., pods in
+//	CrashLoopBackOff and not reporting to the Metrics Server).
+//
+// Behavior rationale:
+//   - ScaleUp → aggressive and fast (add up to +2 pods per 15s if triggered)
+//   - ScaleDown → conservative and gradual (reduce ≤1 pod or ≤25% per 60s,
+//     with a 15-minute stabilization window to prevent oscillation)
+//   - SelectPolicy: Max for scale-up (react to any metric spike),
+//     Min for scale-down (only act when all metrics are low)
+//
+// Metrics summary:
+//  1. Object metric  → odigos_gateway_rejections (Value: 0.5 == 50% threshold)
+//  2. Resource metric → CPU (AverageValue target based on configured limit)
+//  3. Resource metric → Memory (AverageValue target based on configured limit)
+//
+// This hybrid HPA ensures rapid scale-out when gateways reject due to overload,
+// while avoiding aggressive scale-in that could cause instability.
 func syncHPA(gateway *odigosv1.CollectorsGroup, ctx context.Context, c client.Client, scheme *runtime.Scheme) error {
 	kubeVersion := commonconfig.ControllerConfig.K8sVersion
 	logger := log.FromContext(ctx)
 
 	var hpa client.Object
 
-	// Memory metric calculation
+	// Metric thresholds computation
+	// Use percentages of the configured resource limits for the HPA targets.
 	memLimit := gateway.Spec.ResourcesSettings.GomemlimitMiB * memoryLimitPercentageForHPA / 100
-	metricQuantity := resource.MustParse(fmt.Sprintf("%dMi", memLimit))
+	memQuantity := resource.MustParse(fmt.Sprintf("%dMi", memLimit))
 
-	// CPU metric calculation
 	cpuTargetMillicores := gateway.Spec.ResourcesSettings.CpuLimitMillicores * cpuLimitPercentageForHPA / 100
-	metricQuantityCPU := resource.MustParse(fmt.Sprintf("%dm", cpuTargetMillicores))
+	cpuQuantity := resource.MustParse(fmt.Sprintf("%dm", cpuTargetMillicores))
 
 	minReplicas := defaultMinReplicas
 	if gateway.Spec.ResourcesSettings.MinReplicas != nil && *gateway.Spec.ResourcesSettings.MinReplicas > 0 {
@@ -56,7 +88,13 @@ func syncHPA(gateway *odigosv1.CollectorsGroup, ctx context.Context, c client.Cl
 		maxReplicas = int32(*gateway.Spec.ResourcesSettings.MaxReplicas)
 	}
 
+	// ----------------------------------------------------------------------
+	// Version switch for Kubernetes compatibility
+	// ----------------------------------------------------------------------
 	switch {
+	// ------------------------------------------------------------------
+	// For legacy clusters (<1.23): v2beta1 — no Behavior or Object metrics support
+	// ------------------------------------------------------------------
 	case kubeVersion.LessThan(version.MustParse("1.23.0")):
 		hpa = &autoscalingv2beta1.HorizontalPodAutoscaler{
 			TypeMeta: metav1.TypeMeta{
@@ -73,24 +111,33 @@ func syncHPA(gateway *odigosv1.CollectorsGroup, ctx context.Context, c client.Cl
 				MinReplicas: minReplicas,
 				MaxReplicas: maxReplicas,
 				Metrics: []autoscalingv2beta1.MetricSpec{
+					// Memory target
 					{
 						Type: autoscalingv2beta1.ResourceMetricSourceType,
 						Resource: &autoscalingv2beta1.ResourceMetricSource{
 							Name:               "memory",
-							TargetAverageValue: &metricQuantity,
+							TargetAverageValue: &memQuantity,
 						},
 					},
+					// CPU target
 					{
 						Type: autoscalingv2beta1.ResourceMetricSourceType,
 						Resource: &autoscalingv2beta1.ResourceMetricSource{
 							Name:               "cpu",
-							TargetAverageValue: &metricQuantityCPU,
+							TargetAverageValue: &cpuQuantity,
 						},
 					},
 				},
 			},
 		}
+
+	// ------------------------------------------------------------------
+	// For mid-range clusters (1.23 ≤ version < 1.25): v2beta2
+	//      Supports Behavior and Object metrics
+	// ------------------------------------------------------------------
 	case kubeVersion.LessThan(version.MustParse("1.25.0")):
+		minPolicy := autoscalingv2beta2.ScalingPolicySelect("Min")
+		maxPolicy := autoscalingv2beta2.ScalingPolicySelect("Max")
 		hpa = &autoscalingv2beta2.HorizontalPodAutoscaler{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "autoscaling/v2beta2",
@@ -105,36 +152,91 @@ func syncHPA(gateway *odigosv1.CollectorsGroup, ctx context.Context, c client.Cl
 				},
 				MinReplicas: minReplicas,
 				MaxReplicas: maxReplicas,
+
+				// Behavior supported from v2beta2 onward
+				Behavior: &autoscalingv2beta2.HorizontalPodAutoscalerBehavior{
+					// Fast scale-up
+					ScaleUp: &autoscalingv2beta2.HPAScalingRules{
+						StabilizationWindowSeconds: ScaleUpStabilizationWindowSeconds,
+						SelectPolicy:               &maxPolicy,
+						Policies: []autoscalingv2beta2.HPAScalingPolicy{
+							{
+								Type:          autoscalingv2beta2.PodsScalingPolicy,
+								Value:         2, // add up to 2 pods every 15s
+								PeriodSeconds: 15,
+							},
+						},
+					},
+					// Slow scale-down (prevent oscillations)
+					ScaleDown: &autoscalingv2beta2.HPAScalingRules{
+						StabilizationWindowSeconds: ScaleDownStabilizationWindowSeconds, // 15 min
+						SelectPolicy:               &minPolicy,
+						Policies: []autoscalingv2beta2.HPAScalingPolicy{
+							{
+								Type:          autoscalingv2beta2.PodsScalingPolicy,
+								Value:         1,
+								PeriodSeconds: 60,
+							},
+							{
+								Type:          autoscalingv2beta2.PercentScalingPolicy,
+								Value:         25,
+								PeriodSeconds: 60,
+							},
+						},
+					},
+				},
+
 				Metrics: []autoscalingv2beta2.MetricSpec{
+					// Custom Odigos binary metric
+					{
+						Type: autoscalingv2beta2.ObjectMetricSourceType,
+						Object: &autoscalingv2beta2.ObjectMetricSource{
+							DescribedObject: autoscalingv2beta2.CrossVersionObjectReference{
+								APIVersion: "apps/v1",
+								Kind:       "Deployment",
+								Name:       k8sconsts.OdigosClusterCollectorDeploymentName,
+							},
+							Metric: autoscalingv2beta2.MetricIdentifier{
+								Name: "odigos_gateway_rejections",
+							},
+							Target: autoscalingv2beta2.MetricTarget{
+								Type:  autoscalingv2beta2.ValueMetricType,
+								Value: resource.NewMilliQuantity(500, resource.DecimalSI), // "0.5" equivalent
+							},
+						},
+					},
+					// CPU metric
 					{
 						Type: autoscalingv2beta2.ResourceMetricSourceType,
 						Resource: &autoscalingv2beta2.ResourceMetricSource{
 							Name: "memory",
 							Target: autoscalingv2beta2.MetricTarget{
 								Type:         autoscalingv2beta2.AverageValueMetricType,
-								AverageValue: &metricQuantity,
+								AverageValue: &memQuantity,
 							},
 						},
 					},
+					// Memory metric
 					{
 						Type: autoscalingv2beta2.ResourceMetricSourceType,
 						Resource: &autoscalingv2beta2.ResourceMetricSource{
 							Name: "cpu",
 							Target: autoscalingv2beta2.MetricTarget{
 								Type:         autoscalingv2beta2.AverageValueMetricType,
-								AverageValue: &metricQuantityCPU,
+								AverageValue: &cpuQuantity,
 							},
 						},
 					},
 				},
-				Behavior: &autoscalingv2beta2.HorizontalPodAutoscalerBehavior{
-					ScaleDown: &autoscalingv2beta2.HPAScalingRules{
-						StabilizationWindowSeconds: stabilizationWindowSeconds,
-					},
-				},
 			},
 		}
+
+	// ------------------------------------------------------------------
+	// Modern clusters (>=1.25): v2 — fully stable API
+	// ------------------------------------------------------------------
 	default:
+		maxPolicy := autoscalingv2.MaxChangePolicySelect
+		minPolicy := autoscalingv2.MinChangePolicySelect
 		hpa = &autoscalingv2.HorizontalPodAutoscaler{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "autoscaling/v2",
@@ -149,14 +251,61 @@ func syncHPA(gateway *odigosv1.CollectorsGroup, ctx context.Context, c client.Cl
 				},
 				MinReplicas: minReplicas,
 				MaxReplicas: maxReplicas,
+				Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{
+					ScaleUp: &autoscalingv2.HPAScalingRules{
+						StabilizationWindowSeconds: ScaleUpStabilizationWindowSeconds,
+						SelectPolicy:               &maxPolicy,
+						Policies: []autoscalingv2.HPAScalingPolicy{
+							{
+								Type:          autoscalingv2.PodsScalingPolicy,
+								Value:         2, // add up to 2 pods every 15s
+								PeriodSeconds: 15,
+							},
+						},
+					},
+					ScaleDown: &autoscalingv2.HPAScalingRules{
+						StabilizationWindowSeconds: ScaleDownStabilizationWindowSeconds,
+						SelectPolicy:               &minPolicy,
+						Policies: []autoscalingv2.HPAScalingPolicy{
+							// remove 1 pod or 25% of the pods every 60s whichever is smaller
+							{
+								Type:          autoscalingv2.PodsScalingPolicy,
+								Value:         1,
+								PeriodSeconds: 60,
+							},
+							{
+								Type:          autoscalingv2.PercentScalingPolicy,
+								Value:         25,
+								PeriodSeconds: 60,
+							},
+						},
+					},
+				},
 				Metrics: []autoscalingv2.MetricSpec{
+					{
+						Type: autoscalingv2.ObjectMetricSourceType,
+						Object: &autoscalingv2.ObjectMetricSource{
+							DescribedObject: autoscalingv2.CrossVersionObjectReference{
+								APIVersion: "apps/v1",
+								Kind:       "Deployment",
+								Name:       k8sconsts.OdigosClusterCollectorDeploymentName,
+							},
+							Metric: autoscalingv2.MetricIdentifier{
+								Name: "odigos_gateway_rejections",
+							},
+							Target: autoscalingv2.MetricTarget{
+								Type:  autoscalingv2.ValueMetricType,
+								Value: resource.NewMilliQuantity(500, resource.DecimalSI),
+							},
+						},
+					},
 					{
 						Type: autoscalingv2.ResourceMetricSourceType,
 						Resource: &autoscalingv2.ResourceMetricSource{
 							Name: "memory",
 							Target: autoscalingv2.MetricTarget{
 								Type:         autoscalingv2.AverageValueMetricType,
-								AverageValue: &metricQuantity,
+								AverageValue: &memQuantity,
 							},
 						},
 					},
@@ -166,14 +315,9 @@ func syncHPA(gateway *odigosv1.CollectorsGroup, ctx context.Context, c client.Cl
 							Name: "cpu",
 							Target: autoscalingv2.MetricTarget{
 								Type:         autoscalingv2.AverageValueMetricType,
-								AverageValue: &metricQuantityCPU,
+								AverageValue: &cpuQuantity,
 							},
 						},
-					},
-				},
-				Behavior: &autoscalingv2.HorizontalPodAutoscalerBehavior{
-					ScaleDown: &autoscalingv2.HPAScalingRules{
-						StabilizationWindowSeconds: stabilizationWindowSeconds,
 					},
 				},
 			},

--- a/autoscaler/controllers/metricshandler/cacync_controller.go
+++ b/autoscaler/controllers/metricshandler/cacync_controller.go
@@ -1,0 +1,66 @@
+package metricshandler
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/odigos-io/odigos/api/k8sconsts"
+)
+
+// CAUpdaterReconciler watches the webhook cert secret and updates the APIService CABundle.
+type CAUpdaterReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// Reconcile ensures the APIService CA bundle stays synced with the Secret's ca.crt.
+func (r *CAUpdaterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	// Only care about the autoscaler cert Secret
+	if req.Name != k8sconsts.AutoscalerWebhookSecretName {
+		return ctrl.Result{}, nil
+	}
+
+	secret := &corev1.Secret{}
+	if err := r.Client.Get(ctx, client.ObjectKey{
+		Name:      req.Name,
+		Namespace: req.Namespace,
+	}, secret); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	ca, ok := secret.Data["ca.crt"]
+	if !ok || len(ca) == 0 {
+		logger.Info("Secret found but missing ca.crt, skipping")
+		return ctrl.Result{}, nil
+	}
+
+	apiSvc := &apiregv1.APIService{}
+	if err := r.Client.Get(ctx, client.ObjectKey{
+		Name: "v1beta1.custom.metrics.k8s.io",
+	}, apiSvc); err != nil {
+		logger.Error(err, "Failed to get APIService")
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if string(apiSvc.Spec.CABundle) == string(ca) {
+		logger.V(1).Info("CA bundle already up-to-date")
+		return ctrl.Result{}, nil
+	}
+
+	apiSvc.Spec.CABundle = ca
+	if err := r.Client.Update(ctx, apiSvc); err != nil {
+		logger.Error(err, "Failed to update APIService CABundle")
+		return ctrl.Result{}, err
+	}
+
+	logger.Info("Updated APIService CABundle successfully")
+	return ctrl.Result{}, nil
+}

--- a/autoscaler/controllers/metricshandler/custom_metrics_handler.go
+++ b/autoscaler/controllers/metricshandler/custom_metrics_handler.go
@@ -1,0 +1,316 @@
+package metricshandler
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/odigos-io/odigos/api/k8sconsts"
+	"github.com/odigos-io/odigos/k8sutils/pkg/env"
+	"github.com/prometheus/common/expfmt"
+)
+
+const (
+	gatewayRejectionMetricName = "odigos_gateway_memory_limiter_rejections_total"
+)
+
+type MetricValueList struct {
+	APIVersion string        `json:"apiVersion"`
+	Kind       string        `json:"kind"`
+	Items      []MetricValue `json:"items"`
+}
+
+type MetricValue struct {
+	DescribedObject map[string]string `json:"describedObject"`
+	MetricName      string            `json:"metricName"`
+	Timestamp       time.Time         `json:"timestamp"`
+	Value           string            `json:"value"`
+}
+
+var lastSample sync.Map
+
+// MetricHandler aggregates gateway rejection metrics across all pods
+func MetricHandler(ctx context.Context, k8sClient client.Client, namespace string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		log := ctrl.Log.WithName("gateway-metric-handler")
+
+		var podList corev1.PodList
+		err := k8sClient.List(ctx, &podList,
+			client.InNamespace(namespace),
+			client.MatchingLabels{
+				k8sconsts.OdigosCollectorRoleLabel: string(k8sconsts.CollectorsRoleClusterGateway),
+			})
+		if err != nil {
+			log.Error(err, "Failed to list gateway pods")
+			http.Error(w, fmt.Sprintf("failed to list gateway pods: %v", err), http.StatusInternalServerError)
+			return
+		}
+
+		totalPods := len(podList.Items)
+		if totalPods == 0 {
+			http.Error(w, "no gateway pods found", http.StatusNotFound)
+			return
+		}
+
+		now := time.Now()
+		rejectingPods := 0
+
+		for _, pod := range podList.Items {
+			// Check if pod is OOMKilled (CrashLoopBackOff due to OOM)
+			// if so, we consider it as rejecting requests due to memory pressure
+			if isPodOOMKilled(&pod) {
+				rejectingPods++
+				continue
+			}
+
+			value, err := scrapeGatewayMetric(pod.Status.PodIP)
+			if err != nil {
+				log.V(1).Info("Failed to scrape gateway pod metrics",
+					"pod", pod.Name,
+					"podIP", pod.Status.PodIP,
+					"error", err,
+				)
+				continue // skip unreachable pods
+			}
+
+			key := pod.Name
+			prevVal, loaded := lastSample.LoadOrStore(key, value)
+
+			var delta float64
+			if loaded {
+				delta = value - prevVal.(float64)
+				if delta < 0 {
+					delta = 0 // counter reset
+				}
+			} else {
+				delta = 0 // First sample, no delta
+			}
+
+			if delta > 0 {
+				rejectingPods++
+			}
+
+			lastSample.Store(key, value)
+		}
+
+		// Calculate rejection ratio
+		rejectRatio := float64(rejectingPods) / float64(totalPods)
+
+		// Binary metric: 1 if ≥50% pods reject, else 0
+		var metricVal float64
+		if rejectRatio >= 0.5 {
+			metricVal = 1
+		} else {
+			metricVal = 0
+		}
+
+		// Only log if there are actually rejections
+		if rejectingPods > 0 {
+			log.Info("Observed gateway pods that rejecting data",
+				"totalGatewayPodsRejectingData", rejectingPods,
+				"totalGatewayPods", totalPods,
+			)
+		}
+
+		resp := MetricValueList{
+			APIVersion: "custom.metrics.k8s.io/v1beta1",
+			Kind:       "MetricValueList",
+			Items: []MetricValue{
+				{
+					MetricName: "odigos_gateway_rejections",
+					Timestamp:  now,
+					Value:      fmt.Sprintf("%.2f", metricVal),
+					DescribedObject: map[string]string{
+						"kind":      "Deployment",
+						"namespace": namespace,
+						"name":      "odigos-gateway",
+					},
+				},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			log.Error(err, "Failed to encode JSON response")
+		}
+	}
+}
+
+// DiscoveryHandler responds with the APIResourceList so the API server knows what metrics you offer
+func DiscoveryHandler(w http.ResponseWriter, r *http.Request) {
+	response := map[string]interface{}{
+		"kind":         "APIResourceList",
+		"apiVersion":   "v1",
+		"groupVersion": "custom.metrics.k8s.io/v1beta1",
+		"resources": []map[string]interface{}{
+			{
+				"name":         "deployments.apps/odigos_gateway_rejections",
+				"singularName": "",
+				"namespaced":   true,
+				"kind":         "MetricValueList",
+				"verbs":        []string{"get"},
+			},
+		},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+// RegisterCustomMetricsAPI sets up both the APIService and HTTP routes
+func RegisterCustomMetricsAPI(mgr ctrl.Manager) error {
+	ctx := context.Background()
+
+	namespace := env.GetCurrentNamespace()
+	// Load CA from Secret created by the rotator
+	secret := &corev1.Secret{}
+	if err := mgr.GetClient().Get(ctx, client.ObjectKey{
+		Namespace: namespace,
+		Name:      k8sconsts.AutoscalerWebhookSecretName,
+	}, secret); err != nil {
+		return fmt.Errorf("failed to get cert secret: %w", err)
+	}
+
+	caData, ok := secret.Data["ca.crt"]
+	if !ok {
+		return fmt.Errorf("ca.crt not found in secret %s", secret.Name)
+	}
+
+	// Create or update APIService for custom.metrics.k8s.io
+	apiSvcName := "v1beta1.custom.metrics.k8s.io"
+	existing := &apiregv1.APIService{}
+	err := mgr.GetClient().Get(ctx, client.ObjectKey{Name: apiSvcName}, existing)
+	if client.IgnoreNotFound(err) != nil {
+		return err
+	}
+
+	if err != nil {
+		// NotFound error -> create the APIService
+		port := int32(9443)
+		apiSvc := &apiregv1.APIService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: apiSvcName,
+			},
+			Spec: apiregv1.APIServiceSpec{
+				Service: &apiregv1.ServiceReference{
+					Name:      "odigos-autoscaler",
+					Namespace: namespace,
+					Port:      &port,
+				},
+				Group:                 "custom.metrics.k8s.io",
+				Version:               "v1beta1",
+				InsecureSkipTLSVerify: false,
+				CABundle:              caData,
+				GroupPriorityMinimum:  100,
+				VersionPriority:       100,
+			},
+		}
+		if err := mgr.GetClient().Create(ctx, apiSvc); err != nil {
+			return fmt.Errorf("failed to create APIService: %w", err)
+		}
+	} else {
+		// Found -> update if CA changed
+		if base64.StdEncoding.EncodeToString(existing.Spec.CABundle) !=
+			base64.StdEncoding.EncodeToString(caData) {
+			existing.Spec.CABundle = caData
+			if err := mgr.GetClient().Update(ctx, existing); err != nil {
+				return fmt.Errorf("failed to update APIService: %w", err)
+			}
+		}
+	}
+
+	// Register HTTP handlers on the webhook server
+	webhookServer := mgr.GetWebhookServer()
+
+	discoveryPath := "/apis/custom.metrics.k8s.io/v1beta1"
+	webhookServer.Register(discoveryPath, http.HandlerFunc(DiscoveryHandler))
+
+	deploymentMetricPath := fmt.Sprintf(
+		"/apis/custom.metrics.k8s.io/v1beta1/namespaces/%s/deployments.apps/odigos-gateway/odigos_gateway_rejections",
+		namespace,
+	)
+	webhookServer.Register(deploymentMetricPath, MetricHandler(ctx, mgr.GetClient(), namespace))
+
+	ctrl.Log.Info("Custom Metrics API registered successfully")
+	return nil
+}
+
+func scrapeGatewayMetric(podIP string) (float64, error) {
+	url := fmt.Sprintf("http://%s:%d/metrics", podIP, k8sconsts.OdigosClusterCollectorOwnTelemetryPortDefault)
+
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+	}
+
+	resp, err := client.Get(url)
+	if err != nil {
+		return 0, fmt.Errorf("failed to reach pod: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	parser := expfmt.TextParser{}
+	metricFamilies, err := parser.TextToMetricFamilies(bytes.NewReader(body))
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse metrics: %w", err)
+	}
+
+	mf, ok := metricFamilies[gatewayRejectionMetricName]
+	if !ok {
+		// metric not found → treat as 0 rejections
+		// This can happen if the gateway is not running or the metric is not available yet.
+		return 0, nil
+	}
+
+	var total float64
+	for _, m := range mf.Metric {
+		if m.Counter != nil && m.Counter.Value != nil {
+			total += *m.Counter.Value
+		}
+	}
+
+	return total, nil
+}
+
+// isPodOOMKilled checks if the pod is in CrashLoopBackOff due to OOM or currently OOMKilled
+func isPodOOMKilled(pod *corev1.Pod) bool {
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		// Scenario 1: Container is waiting in CrashLoopBackOff after being OOMKilled
+		if containerStatus.State.Waiting != nil &&
+			containerStatus.State.Waiting.Reason == "CrashLoopBackOff" {
+			// Check if last termination was due to OOM
+			if containerStatus.LastTerminationState.Terminated != nil &&
+				containerStatus.LastTerminationState.Terminated.Reason == "OOMKilled" {
+				return true
+			}
+		}
+
+		// Scenario 2: Container is currently terminated due to OOM
+		if containerStatus.State.Terminated != nil &&
+			containerStatus.State.Terminated.Reason == "OOMKilled" {
+			return true
+		}
+	}
+
+	return false
+}

--- a/autoscaler/controllers/metricshandler/manager.go
+++ b/autoscaler/controllers/metricshandler/manager.go
@@ -1,0 +1,26 @@
+package metricshandler
+
+import (
+	"github.com/odigos-io/odigos/api/k8sconsts"
+	odigospredicate "github.com/odigos-io/odigos/k8sutils/pkg/predicate"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+)
+
+// SetupWithManager registers the CAUpdaterReconciler
+// similar to how clustercollector sets up its controllers.
+func SetupWithManager(mgr ctrl.Manager) error {
+
+	return builder.
+		ControllerManagedBy(mgr).
+		Named("metricshandler-ca-sync").
+		For(&corev1.Secret{}).
+		WithEventFilter(&odigospredicate.ObjectNamePredicate{
+			AllowedObjectName: k8sconsts.AutoscalerWebhookSecretName,
+		}).
+		Complete(&CAUpdaterReconciler{
+			Client: mgr.GetClient(),
+			Scheme: mgr.GetScheme(),
+		})
+}

--- a/autoscaler/go.mod
+++ b/autoscaler/go.mod
@@ -14,12 +14,14 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.38.2
 	github.com/open-policy-agent/cert-controller v0.14.0
+	github.com/prometheus/common v0.65.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.37.0
 	golang.org/x/sync v0.17.0
 	k8s.io/api v0.34.1
 	k8s.io/apimachinery v0.34.1
 	k8s.io/client-go v0.34.1
+	k8s.io/kube-aggregator v0.33.4
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 	sigs.k8s.io/controller-runtime v0.22.1
 )
@@ -58,7 +60,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/common v0.65.0 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/cli/cmd/resources/autoscaler.go
+++ b/cli/cmd/resources/autoscaler.go
@@ -131,6 +131,11 @@ func NewAutoscalerRole(ns string, openshiftEnabled bool) *rbacv1.Role {
 			Resources: []string{"actions/status"},
 			Verbs:     []string{"get", "patch", "update"},
 		},
+		{ // Needed to watch and manage the pods of the gateway-collector
+			APIGroups: []string{""},
+			Resources: []string{"pods"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
 	}
 
 	// This is needed for OpenShift to update the finalizers of the deployments
@@ -234,6 +239,11 @@ func NewAutoscalerClusterRole(ownerPermissionEnforcement bool) *rbacv1.ClusterRo
 					"list",
 					"watch",
 				},
+			},
+			{
+				APIGroups: []string{"apiregistration.k8s.io"},
+				Resources: []string{"apiservices"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
 			},
 		}, finalizersUpdate...),
 	}

--- a/helm/odigos/templates/autoscaler/clusterrole.yaml
+++ b/helm/odigos/templates/autoscaler/clusterrole.yaml
@@ -47,3 +47,14 @@ rules:
       - odigos-action-validating-webhook-configuration
     verbs:
       - update
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch

--- a/helm/odigos/templates/autoscaler/role.yaml
+++ b/helm/odigos/templates/autoscaler/role.yaml
@@ -7,6 +7,14 @@ metadata:
     odigos.io/system-object: "true"
 rules:
   - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - ''
     resources:
       - configmaps

--- a/operator/bundle.Dockerfile
+++ b/operator/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=odigos-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.41.1
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.39.1
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 

--- a/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
@@ -19,9 +19,10 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Logging & Tracing
-    containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:24013320dc3fbb9c929c7b720c1ed7a1cd07ff7000c2adbf478ec90c9305367a
-    createdAt: "2025-11-03T21:14:33Z"
-    description: Odigos enables automatic distributed tracing with OpenTelemetry and eBPF.
+    containerImage: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9:v1.8.7
+    createdAt: "2025-11-10T13:38:22Z"
+    description: Odigos enables automatic distributed tracing with OpenTelemetry and
+      eBPF.
     features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "false"
@@ -29,8 +30,9 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    operators.openshift.io/valid-subscription: Odigos Enterprise subscription (for enterprise features)
-    operators.operatorframework.io/builder: operator-sdk-v1.41.1
+    operators.openshift.io/valid-subscription: Odigos Enterprise subscription (for
+      enterprise features)
+    operators.operatorframework.io/builder: operator-sdk-v1.39.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     support: Odigos
   name: odigos-operator.v1.8.7
@@ -39,78 +41,81 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-      - description: Odigos is the Schema for the odigos API
-        displayName: Odigos
-        kind: Odigos
-        name: odigos.operator.odigos.io
-        specDescriptors:
-          - description: (Optional) OnPremToken is an enterprise token for Odigos Enterprise.
-            displayName: On-Prem Token
-            path: onPremToken
-          - description: (Optional) IgnoredContainers is a list of container names to exclude from instrumentation (useful for ignoring sidecars).
-            displayName: Ignored Containers
-            path: ignoredContainers
-          - description: (Optional) IgnoredNamespaces is a list of namespaces to not show in the Odigos UI.
-            displayName: Ignored Namespaces
-            path: ignoredNamespaces
-          - description: |-
-              (Optional) TelemetryEnabled records general telemetry regarding Odigos usage.
-              Default=false
-            displayName: Telemetry Enabled
-            path: telemetryEnabled
-          - description: |-
-              (Optional) UIMode sets the UI mode to either "normal" or "readonly".
-              In "normal" mode the UI is fully interactive, allowing users to view and edit
-              Odigos configuration and settings. In "readonly" mode, the UI can only be
-              used to view current Odigos configuration and is not interactive.
-              Default=default
-            displayName: UI Mode
-            path: uiMode
-          - description: |-
-              (Optional) AgentEnvVarsInjectionMethod is the method to inject the Odigos agent env vars into the pod.
-              Default=pod-manifest
-            displayName: Agent Env Vars Injection Method
-            path: agentEnvVarsInjectionMethod
-          - description: |-
-              (Optional) NodeSelector is a map of key-value Kubernetes NodeSelector labels to apply to all Odigos components.
-              Note that Odigos will only be able to instrument applications on the same node.
-            displayName: Node Selector
-            path: nodeSelector
-          - description: (Optional) Profiles is a list of preset profiles with a specific configuration.
-            displayName: Profiles
-            path: profiles
-          - description: |-
-              (Optional) ImagePrefix is a prefix for all container images.
-              This should only be used if you are pulling Odigos images from the non-default registry.
-              Default: registry.odigos.io
-              Default (OpenShift): registry.connect.redhat.com
-            displayName: Image Prefix
-            path: imagePrefix
-          - description: |-
-              (Optional) MountMethod optionally defines the mechanism for mounting Odigos files into instrumented pods.
-              One of "k8s-virtual-device" (default) or "k8s-host-path".
-            displayName: Mount Method
-            path: mountMethod
-          - description: |-
-              (Optional) OpenShiftEnabled configures selinux on OpenShift nodes.
-              DEPRECATED: OpenShift clusters are auto-detected and this API field will be removed in a future release.
-            displayName: OpenShift Enabled
-            path: openshiftEnabled
-          - description: |-
-              (Optional) PodSecurityPolicy allows Odigos pods to use a privileged pod security policy.
-              Default=false
-            displayName: Pod Security Policy
-            path: podSecurityPolicy
-          - description: |-
-              (Optional) SkipWebhookIssuerCreation skips creating the Issuer and Certificate for the Instrumentor pod webhook if cert-manager is installed.
-              Default=false
-            displayName: Skip Webhook Issuer Creation
-            path: skipWebhookIssuerCreation
-        statusDescriptors:
-          - description: Conditions store the status conditions of the Odigos instances
-            displayName: Conditions
-            path: conditions
-        version: v1alpha1
+    - description: Odigos is the Schema for the odigos API
+      displayName: Odigos
+      kind: Odigos
+      name: odigos.operator.odigos.io
+      specDescriptors:
+      - description: (Optional) OnPremToken is an enterprise token for Odigos Enterprise.
+        displayName: On-Prem Token
+        path: onPremToken
+      - description: (Optional) IgnoredContainers is a list of container names to
+          exclude from instrumentation (useful for ignoring sidecars).
+        displayName: Ignored Containers
+        path: ignoredContainers
+      - description: (Optional) IgnoredNamespaces is a list of namespaces to not show
+          in the Odigos UI.
+        displayName: Ignored Namespaces
+        path: ignoredNamespaces
+      - description: |-
+          (Optional) TelemetryEnabled records general telemetry regarding Odigos usage.
+          Default=false
+        displayName: Telemetry Enabled
+        path: telemetryEnabled
+      - description: |-
+          (Optional) UIMode sets the UI mode to either "normal" or "readonly".
+          In "normal" mode the UI is fully interactive, allowing users to view and edit
+          Odigos configuration and settings. In "readonly" mode, the UI can only be
+          used to view current Odigos configuration and is not interactive.
+          Default=default
+        displayName: UI Mode
+        path: uiMode
+      - description: |-
+          (Optional) AgentEnvVarsInjectionMethod is the method to inject the Odigos agent env vars into the pod.
+          Default=pod-manifest
+        displayName: Agent Env Vars Injection Method
+        path: agentEnvVarsInjectionMethod
+      - description: |-
+          (Optional) NodeSelector is a map of key-value Kubernetes NodeSelector labels to apply to all Odigos components.
+          Note that Odigos will only be able to instrument applications on the same node.
+        displayName: Node Selector
+        path: nodeSelector
+      - description: (Optional) Profiles is a list of preset profiles with a specific
+          configuration.
+        displayName: Profiles
+        path: profiles
+      - description: |-
+          (Optional) ImagePrefix is a prefix for all container images.
+          This should only be used if you are pulling Odigos images from the non-default registry.
+          Default: registry.odigos.io
+          Default (OpenShift): registry.connect.redhat.com
+        displayName: Image Prefix
+        path: imagePrefix
+      - description: |-
+          (Optional) MountMethod optionally defines the mechanism for mounting Odigos files into instrumented pods.
+          One of "k8s-virtual-device" (default) or "k8s-host-path".
+        displayName: Mount Method
+        path: mountMethod
+      - description: |-
+          (Optional) OpenShiftEnabled configures selinux on OpenShift nodes.
+          DEPRECATED: OpenShift clusters are auto-detected and this API field will be removed in a future release.
+        displayName: OpenShift Enabled
+        path: openshiftEnabled
+      - description: |-
+          (Optional) PodSecurityPolicy allows Odigos pods to use a privileged pod security policy.
+          Default=false
+        displayName: Pod Security Policy
+        path: podSecurityPolicy
+      - description: |-
+          (Optional) SkipWebhookIssuerCreation skips creating the Issuer and Certificate for the Instrumentor pod webhook if cert-manager is installed.
+          Default=false
+        displayName: Skip Webhook Issuer Creation
+        path: skipWebhookIssuerCreation
+      statusDescriptors:
+      - description: Conditions store the status conditions of the Odigos instances
+        displayName: Conditions
+        path: conditions
+      version: v1alpha1
   description: |-
     The Odigos Operator provides options for installing and configuring Odigos.
 
@@ -125,500 +130,503 @@ spec:
     With Odigos installed, follow the Odigos docs at docs.odigos.io for instructions on instrumenting applications and configuring destinations.
   displayName: Odigos Operator
   icon:
-    - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgdmlld0JveD0iMCAtMiAxNiAxNiIgZmlsbD0iIzE1MTUxNSI+CiAgPHBhdGgKICAgIGQ9Ik01LjE3MjE1IDkuMDE4ODRMMi4xODM3NyA3LjY5ODEzQzEuNDgxNTkgNy4zODczMiAxLjA0NDggNi43MzY3NyAxLjA0NDggNS45OTk0OEMxLjA0NDggNS4yNjIyIDEuNDgwNTYgNC42MTE2NSAyLjE4Mzc3IDQuMzAwODNMNi4zNjE3MiAyLjQ1MzQ5TDYuNDUxNTYgMi40MTQyNVYwSDEuNjYxMjdDMS4wNDE3IDAgMC41Mzg4MTggMC40NzgxIDAuNTM4ODE4IDEuMDY3NzJWMTAuOTMxMkMwLjUzODgxOCAxMS41MjA5IDEuMDQxNyAxMS45OTkgMS42NjEyNyAxMS45OTlINS44MzMwM0g2LjQ1MjU5VjkuNTY4Mkw1LjE3MzE5IDkuMDE3ODFINS4xNzIxNVY5LjAxODg0WiIgLz4KICA8cGF0aAogICAgZD0iTTE0LjMzOTcgMEg5LjU0ODRWMi40NDExTDEwLjgwNDEgMi45ODExNUwxMC44MDEgMi45Njk4TDEzLjgxNjIgNC4zMDI5QzE0LjUxODQgNC42MTM3MiAxNC45NTUyIDUuMjY0MjYgMTQuOTU1MiA2LjAwMTU1QzE0Ljk1NTIgNi43Mzg4MyAxNC41MTk0IDcuMzg5MzggMTMuODE2MiA3LjcwMDJMMTAuMTY0OSA5LjMxNDE3TDkuNTQ3MzYgOS41NzY0NlYxMkgxNC4zMzg3QzE0Ljk1ODMgMTIgMTUuNDYxMSAxMS41MjE5IDE1LjQ2MTEgMTAuOTMyM1YxLjA2NzcyQzE1LjQ2MTEgMC40NzgxIDE0Ljk1ODMgMCAxNC4zMzg3IDBIMTQuMzM5N1oiIC8+CiAgPHBhdGgKICAgIGQ9Ik04LjAwMDQ4IDguNDc5NzJDOS4zNjk3MiA4LjQ3OTcyIDEwLjQ4MDggNy4zNjk2NiAxMC40ODA4IDUuOTk5MzhDMTAuNDgwOCA0LjYyOTEgOS4zNzA3NiAzLjUxOTA0IDguMDAwNDggMy41MTkwNEM2LjYzMDIgMy41MTkwNCA1LjUyMDE0IDQuNjI5MSA1LjUyMDE0IDUuOTk5MzhDNS41MjAxNCA3LjM2OTY2IDYuNjMwMiA4LjQ3OTcyIDguMDAwNDggOC40Nzk3MloiIC8+Cjwvc3ZnPg==
-      mediatype: image/svg+xml
+  - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgdmlld0JveD0iMCAtMiAxNiAxNiIgZmlsbD0iIzE1MTUxNSI+CiAgPHBhdGgKICAgIGQ9Ik01LjE3MjE1IDkuMDE4ODRMMi4xODM3NyA3LjY5ODEzQzEuNDgxNTkgNy4zODczMiAxLjA0NDggNi43MzY3NyAxLjA0NDggNS45OTk0OEMxLjA0NDggNS4yNjIyIDEuNDgwNTYgNC42MTE2NSAyLjE4Mzc3IDQuMzAwODNMNi4zNjE3MiAyLjQ1MzQ5TDYuNDUxNTYgMi40MTQyNVYwSDEuNjYxMjdDMS4wNDE3IDAgMC41Mzg4MTggMC40NzgxIDAuNTM4ODE4IDEuMDY3NzJWMTAuOTMxMkMwLjUzODgxOCAxMS41MjA5IDEuMDQxNyAxMS45OTkgMS42NjEyNyAxMS45OTlINS44MzMwM0g2LjQ1MjU5VjkuNTY4Mkw1LjE3MzE5IDkuMDE3ODFINS4xNzIxNVY5LjAxODg0WiIgLz4KICA8cGF0aAogICAgZD0iTTE0LjMzOTcgMEg5LjU0ODRWMi40NDExTDEwLjgwNDEgMi45ODExNUwxMC44MDEgMi45Njk4TDEzLjgxNjIgNC4zMDI5QzE0LjUxODQgNC42MTM3MiAxNC45NTUyIDUuMjY0MjYgMTQuOTU1MiA2LjAwMTU1QzE0Ljk1NTIgNi43Mzg4MyAxNC41MTk0IDcuMzg5MzggMTMuODE2MiA3LjcwMDJMMTAuMTY0OSA5LjMxNDE3TDkuNTQ3MzYgOS41NzY0NlYxMkgxNC4zMzg3QzE0Ljk1ODMgMTIgMTUuNDYxMSAxMS41MjE5IDE1LjQ2MTEgMTAuOTMyM1YxLjA2NzcyQzE1LjQ2MTEgMC40NzgxIDE0Ljk1ODMgMCAxNC4zMzg3IDBIMTQuMzM5N1oiIC8+CiAgPHBhdGgKICAgIGQ9Ik04LjAwMDQ4IDguNDc5NzJDOS4zNjk3MiA4LjQ3OTcyIDEwLjQ4MDggNy4zNjk2NiAxMC40ODA4IDUuOTk5MzhDMTAuNDgwOCA0LjYyOTEgOS4zNzA3NiAzLjUxOTA0IDguMDAwNDggMy41MTkwNEM2LjYzMDIgMy41MTkwNCA1LjUyMDE0IDQuNjI5MSA1LjUyMDE0IDUuOTk5MzhDNS41MjAxNCA3LjM2OTY2IDYuNjMwMiA4LjQ3OTcyIDguMDAwNDggOC40Nzk3MloiIC8+Cjwvc3ZnPg==
+    mediatype: image/svg+xml
   install:
     spec:
       clusterPermissions:
-        - rules:
-            - apiGroups:
-                - ""
-              resources:
-                - configmaps
-                - endpoints
-                - secrets
-                - services
-              verbs:
-                - create
-                - delete
-                - deletecollection
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - ""
-              resources:
-                - configmaps/finalizers
-                - pods/finalizers
-              verbs:
-                - update
-            - apiGroups:
-                - ""
-              resources:
-                - events
-              verbs:
-                - create
-                - patch
-            - apiGroups:
-                - ""
-              resources:
-                - namespaces
-              verbs:
-                - get
-                - list
-                - patch
-                - watch
-            - apiGroups:
-                - ""
-              resources:
-                - nodes
-              verbs:
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - ""
-              resources:
-                - nodes/proxy
-                - nodes/stats
-              verbs:
-                - get
-                - list
-            - apiGroups:
-                - ""
-              resources:
-                - pods
-              verbs:
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - ""
-              resources:
-                - pods/status
-              verbs:
-                - get
-            - apiGroups:
-                - ""
-              resources:
-                - serviceaccounts
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - watch
-            - apiGroups:
-                - actions.odigos.io
-              resources:
-                - '*'
-              verbs:
-                - create
-                - delete
-                - deletecollection
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - actions.odigos.io
-              resources:
-                - '*/status'
-              verbs:
-                - get
-                - patch
-                - update
-            - apiGroups:
-                - admissionregistration.k8s.io
-              resources:
-                - mutatingwebhookconfigurations
-                - validatingwebhookconfigurations
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - apiextensions.k8s.io
-              resources:
-                - customresourcedefinitions
-              verbs:
-                - create
-                - delete
-                - deletecollection
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - apps
-              resources:
-                - daemonsets
-                - deployments
-                - replicasets
-                - statefulsets
-              verbs:
-                - create
-                - delete
-                - deletecollection
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - apps
-              resources:
-                - daemonsets/finalizers
-                - deployments/finalizers
-                - replicasets/finalizers
-                - statefulsets/finalizers
-              verbs:
-                - update
-            - apiGroups:
-                - apps
-              resources:
-                - daemonsets/status
-                - deployments/status
-                - statefulsets/status
-              verbs:
-                - get
-            - apiGroups:
-                - apps.openshift.io
-              resources:
-                - deploymentconfigs
-                - deploymentconfigs/finalizers
-              verbs:
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - autoscaling
-              resources:
-                - horizontalpodautoscalers
-              verbs:
-                - create
-                - delete
-                - patch
-                - update
-            - apiGroups:
-                - batch
-              resources:
-                - cronjobs
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - batch
-              resources:
-                - jobs
-              verbs:
-                - create
-            - apiGroups:
-                - coordination.k8s.io
-              resources:
-                - leases
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - odigos.io
-              resources:
-                - '*'
-              verbs:
-                - '*'
-            - apiGroups:
-                - odigos.io
-              resources:
-                - collectorsgroups/finalizers
-                - sources/finalizers
-              verbs:
-                - update
-            - apiGroups:
-                - odigos.io
-              resources:
-                - collectorsgroups/status
-                - destinations/status
-                - instrumentationconfigs/status
-                - instrumentationinstances/status
-              verbs:
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - odigos.io
-              resources:
-                - instrumentationrules/status
-              verbs:
-                - get
-                - patch
-                - update
-            - apiGroups:
-                - operator.odigos.io
-              resources:
-                - odigos
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - operator.odigos.io
-              resources:
-                - odigos/finalizers
-              verbs:
-                - update
-            - apiGroups:
-                - operator.odigos.io
-              resources:
-                - odigos/status
-              verbs:
-                - get
-                - patch
-                - update
-            - apiGroups:
-                - policy
-              resourceNames:
-                - privileged
-              resources:
-                - podsecuritypolicies
-              verbs:
-                - use
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resources:
-                - clusterrolebindings
-                - clusterroles
-                - rolebindings
-                - roles
-              verbs:
-                - create
-                - delete
-                - deletecollection
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - security.openshift.io
-              resources:
-                - securitycontextconstraints
-              verbs:
-                - use
-            - apiGroups:
-                - authentication.k8s.io
-              resources:
-                - tokenreviews
-              verbs:
-                - create
-            - apiGroups:
-                - authorization.k8s.io
-              resources:
-                - subjectaccessreviews
-              verbs:
-                - create
-          serviceAccountName: odigos-operator-controller-manager
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - endpoints
+          - secrets
+          - services
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps/finalizers
+          - pods/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes/proxy
+          - nodes/stats
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/status
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - actions.odigos.io
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - actions.odigos.io
+          resources:
+          - '*/status'
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          - validatingwebhookconfigurations
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets/finalizers
+          - deployments/finalizers
+          - replicasets/finalizers
+          - statefulsets/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets/status
+          - deployments/status
+          - statefulsets/status
+          verbs:
+          - get
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          - deploymentconfigs/finalizers
+          verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - create
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - odigos.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - odigos.io
+          resources:
+          - collectorsgroups/finalizers
+          - sources/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - odigos.io
+          resources:
+          - collectorsgroups/status
+          - destinations/status
+          - instrumentationconfigs/status
+          - instrumentationinstances/status
+          verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - odigos.io
+          resources:
+          - instrumentationrules/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - operator.odigos.io
+          resources:
+          - odigos
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - operator.odigos.io
+          resources:
+          - odigos/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - operator.odigos.io
+          resources:
+          - odigos/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - policy
+          resourceNames:
+          - privileged
+          resources:
+          - podsecuritypolicies
+          verbs:
+          - use
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: odigos-operator-controller-manager
       deployments:
-        - label:
-            app.kubernetes.io/managed-by: kustomize
-            app.kubernetes.io/name: odigos-operator
-            control-plane: controller-manager
-          name: odigos-operator-controller-manager
-          spec:
-            replicas: 1
-            selector:
-              matchLabels:
+      - label:
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/name: odigos-operator
+          control-plane: controller-manager
+        name: odigos-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
                 control-plane: controller-manager
-            strategy: {}
-            template:
-              metadata:
-                annotations:
-                  kubectl.kubernetes.io/default-container: manager
-                labels:
-                  control-plane: controller-manager
-              spec:
-                containers:
-                  - args:
-                      - --metrics-bind-address=:8443
-                      - --leader-elect
-                      - --health-probe-bind-address=:8081
-                    command:
-                      - /manager
-                    env:
-                      - name: CURRENT_NS
-                        valueFrom:
-                          fieldRef:
-                            apiVersion: v1
-                            fieldPath: metadata.namespace
-                      - name: ODIGOS_VERSION
-                        valueFrom:
-                          configMapKeyRef:
-                            key: ODIGOS_VERSION
-                            name: odigos-operator-odigos-version-mgk5m6d4f5
-                      - name: RELATED_IMAGE_AUTOSCALER
-                        value: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:c78969b5bcf2cbfd5bcbe0dd956e7c9dc7915ed09dc6291cb110a3cf81d209ae
-                      - name: RELATED_IMAGE_COLLECTOR
-                        value: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:068db5052186faa8c254cc3ff8a9d9b45721d232ba8d951efb51e0297d86764e
-                      - name: RELATED_IMAGE_FRONTEND
-                        value: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:2ecf2da14f3ed8ed94f6c54cadfe2d0db43899322f8b820969365b3ebb7338e6
-                      - name: RELATED_IMAGE_INSTRUMENTOR
-                        value: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:72cd54d3de007975c54a6c75f0fc26dbc32010dd0d7b3eaa859f66d8be376c6a
-                      - name: RELATED_IMAGE_ENTERPRISE_INSTRUMENTOR
-                        value: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:b8ff40cb22a90145ff42bd6430d92582fe4fedb6782054871a10c54432a43e4d
-                      - name: RELATED_IMAGE_ODIGLET
-                        value: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:329af65d8edb56a3b185d73a5c929e19f8433cf8d06bbd8f337b4a8b53d5a777
-                      - name: RELATED_IMAGE_ENTERPRISE_ODIGLET
-                        value: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:4e376d781632ac45c0d607df33065bb84e720e5e0cce882e994ab8728a276c7d
-                      - name: RELATED_IMAGE_SCHEDULER
-                        value: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:85b3054fbaef8a1192340a033f01ea797ab88a6b4542b68407c4fadd9bf161de
-                    image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:24013320dc3fbb9c929c7b720c1ed7a1cd07ff7000c2adbf478ec90c9305367a
-                    livenessProbe:
-                      httpGet:
-                        path: /healthz
-                        port: 8081
-                      initialDelaySeconds: 15
-                      periodSeconds: 20
-                    name: manager
-                    readinessProbe:
-                      httpGet:
-                        path: /readyz
-                        port: 8081
-                      initialDelaySeconds: 5
-                      periodSeconds: 10
-                    resources:
-                      limits:
-                        cpu: 500m
-                        memory: 128Mi
-                      requests:
-                        cpu: 10m
-                        memory: 64Mi
-                    securityContext:
-                      allowPrivilegeEscalation: false
-                      capabilities:
-                        drop:
-                          - ALL
+            spec:
+              containers:
+              - args:
+                - --metrics-bind-address=:8443
+                - --leader-elect
+                - --health-probe-bind-address=:8081
+                command:
+                - /manager
+                env:
+                - name: CURRENT_NS
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                - name: ODIGOS_VERSION
+                  valueFrom:
+                    configMapKeyRef:
+                      key: ODIGOS_VERSION
+                      name: odigos-operator-odigos-version-mgk5m6d4f5
+                - name: RELATED_IMAGE_AUTOSCALER
+                  value: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9:v1.8.7
+                - name: RELATED_IMAGE_COLLECTOR
+                  value: registry.connect.redhat.com/odigos/odigos-collector-ubi9:v1.8.7
+                - name: RELATED_IMAGE_FRONTEND
+                  value: registry.connect.redhat.com/odigos/odigos-ui-ubi9:v1.8.7
+                - name: RELATED_IMAGE_INSTRUMENTOR
+                  value: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9:v1.8.7
+                - name: RELATED_IMAGE_ENTERPRISE_INSTRUMENTOR
+                  value: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9:v1.8.7
+                - name: RELATED_IMAGE_ODIGLET
+                  value: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9:v1.8.7
+                - name: RELATED_IMAGE_ENTERPRISE_ODIGLET
+                  value: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9:v1.8.7
+                - name: RELATED_IMAGE_SCHEDULER
+                  value: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9:v1.8.7
+                image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9:v1.8.7
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 10m
+                    memory: 64Mi
                 securityContext:
-                  runAsNonRoot: true
-                serviceAccountName: odigos-operator-controller-manager
-                terminationGracePeriodSeconds: 10
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: odigos-operator-controller-manager
+              terminationGracePeriodSeconds: 10
       permissions:
-        - rules:
-            - apiGroups:
-                - ""
-              resources:
-                - configmaps
-              verbs:
-                - get
-                - list
-                - watch
-                - create
-                - update
-                - patch
-                - delete
-            - apiGroups:
-                - coordination.k8s.io
-              resources:
-                - leases
-              verbs:
-                - get
-                - list
-                - watch
-                - create
-                - update
-                - patch
-                - delete
-            - apiGroups:
-                - ""
-              resources:
-                - events
-              verbs:
-                - create
-                - patch
-          serviceAccountName: odigos-operator-controller-manager
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: odigos-operator-controller-manager
     strategy: deployment
   installModes:
-    - supported: true
-      type: OwnNamespace
-    - supported: false
-      type: SingleNamespace
-    - supported: false
-      type: MultiNamespace
-    - supported: false
-      type: AllNamespaces
+  - supported: true
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
   keywords:
-    - OpenTelemetry
-    - eBPF
-    - tracing
-    - observability
-    - distributed tracing
-    - otel
-    - monitoring
+  - OpenTelemetry
+  - eBPF
+  - tracing
+  - observability
+  - distributed tracing
+  - otel
+  - monitoring
   links:
-    - name: Odigos
-      url: https://odigos.io
-    - name: Odigos Documentation
-      url: https://docs.odigos.io
-    - name: Odigos on Github
-      url: https://github.com/odigos-io/odigos
+  - name: Odigos
+    url: https://odigos.io
+  - name: Odigos Documentation
+    url: https://docs.odigos.io
+  - name: Odigos on Github
+    url: https://github.com/odigos-io/odigos
   maintainers:
-    - email: mike@odigos.io
-      name: Mike Dame
+  - email: mike@odigos.io
+    name: Mike Dame
   maturity: alpha
   minKubeVersion: 1.20.15
   provider:
     name: Odigos
     url: https://odigos.io
   relatedImages:
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:b8ff40cb22a90145ff42bd6430d92582fe4fedb6782054871a10c54432a43e4d
-      name: enterprise-instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:4e376d781632ac45c0d607df33065bb84e720e5e0cce882e994ab8728a276c7d
-      name: enterprise-odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:24013320dc3fbb9c929c7b720c1ed7a1cd07ff7000c2adbf478ec90c9305367a
-      name: manager
-    - image: registry.connect.redhat.com/odigos/odigos-certified-operator-ubi9@sha256:24013320dc3fbb9c929c7b720c1ed7a1cd07ff7000c2adbf478ec90c9305367a
-      name: odigos-certified-operator-ubi9-24013320dc3fbb9c929c7b720c1ed7a1cd07ff7000c2adbf478ec90c9305367a-annotation
-    - image: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9@sha256:c78969b5bcf2cbfd5bcbe0dd956e7c9dc7915ed09dc6291cb110a3cf81d209ae
-      name: autoscaler
-    - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9@sha256:72cd54d3de007975c54a6c75f0fc26dbc32010dd0d7b3eaa859f66d8be376c6a
-      name: instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9@sha256:329af65d8edb56a3b185d73a5c929e19f8433cf8d06bbd8f337b4a8b53d5a777
-      name: odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9@sha256:85b3054fbaef8a1192340a033f01ea797ab88a6b4542b68407c4fadd9bf161de
-      name: scheduler
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9@sha256:b8ff40cb22a90145ff42bd6430d92582fe4fedb6782054871a10c54432a43e4d
-      name: enterprise_instrumentor
-    - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9@sha256:4e376d781632ac45c0d607df33065bb84e720e5e0cce882e994ab8728a276c7d
-      name: enterprise_odiglet
-    - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9@sha256:068db5052186faa8c254cc3ff8a9d9b45721d232ba8d951efb51e0297d86764e
-      name: collector
-    - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9@sha256:2ecf2da14f3ed8ed94f6c54cadfe2d0db43899322f8b820969365b3ebb7338e6
-      name: frontend
+  - image: registry.connect.redhat.com/odigos/odigos-autoscaler-ubi9:v1.8.7
+    name: autoscaler
+  - image: registry.connect.redhat.com/odigos/odigos-collector-ubi9:v1.8.7
+    name: collector
+  - image: registry.connect.redhat.com/odigos/odigos-ui-ubi9:v1.8.7
+    name: frontend
+  - image: registry.connect.redhat.com/odigos/odigos-instrumentor-ubi9:v1.8.7
+    name: instrumentor
+  - image: registry.connect.redhat.com/odigos/odigos-enterprise-instrumentor-ubi9:v1.8.7
+    name: enterprise-instrumentor
+  - image: registry.connect.redhat.com/odigos/odigos-odiglet-ubi9:v1.8.7
+    name: odiglet
+  - image: registry.connect.redhat.com/odigos/odigos-enterprise-odiglet-ubi9:v1.8.7
+    name: enterprise-odiglet
+  - image: registry.connect.redhat.com/odigos/odigos-scheduler-ubi9:v1.8.7
+    name: scheduler
   version: 1.8.7

--- a/operator/bundle/metadata/annotations.yaml
+++ b/operator/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: odigos-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.41.1
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.39.1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
 

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -134,6 +134,17 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiregistration.k8s.io
+  resources:
+  - apiservices
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - apps
   resources:
   - daemonsets

--- a/operator/internal/controller/odigos_controller.go
+++ b/operator/internal/controller/odigos_controller.go
@@ -124,6 +124,7 @@ var relatedImageEnvVars = map[string]string{
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=create;patch;update;delete
 // +kubebuilder:rbac:groups=policy,resources=podsecuritypolicies,resourceNames=privileged,verbs=use
 // +kubebuilder:rbac:groups=apps.openshift.io,resources=deploymentconfigs;deploymentconfigs/finalizers,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=apiregistration.k8s.io,resources=apiservices,verbs=get;list;watch;create;update;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
## Description

<!-- Short summary of the changes -->

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-470
