### PR TITLE
chore: separte exporter per signal in data collection + adjust tests …

### DIFF
--- a/.github/workflows/full-build.yaml
+++ b/.github/workflows/full-build.yaml
@@ -34,7 +34,7 @@ jobs:
             dockerfile_path: frontend
           - service: operator
             dockerfile_path: operator
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     steps:
       - uses: actions/checkout@v5
       - name: Set up Docker Buildx
@@ -53,7 +53,7 @@ jobs:
           build-args: ${{ matrix.build-args }}
 
   build-cli:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     steps:
       - uses: actions/checkout@v5
       - name: Set up Go

--- a/autoscaler/controllers/nodecollector/collectorconfig/logs.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/logs.go
@@ -204,7 +204,7 @@ func LogsConfig(nodeCG *odigosv1.CollectorsGroup, odigosNamespace string, manife
 				logsPipelineName: {
 					Receivers:  []string{filelogReceiverName},
 					Processors: pipelineProcessors,
-					Exporters:  []string{clusterCollectorExporterName},
+					Exporters:  []string{clusterCollectorLogsExporterName},
 				},
 			},
 		},

--- a/autoscaler/controllers/nodecollector/collectorconfig/metrics.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/metrics.go
@@ -96,7 +96,7 @@ func MetricsConfig(nodeCG *odigosv1.CollectorsGroup, odigosNamespace string, man
 				odigosMetricsPipelineName: {
 					Receivers:  pipelineReceiverNames,
 					Processors: metricsPipelineProcessors,
-					Exporters:  []string{clusterCollectorExporterName},
+					Exporters:  []string{clusterCollectorMetricsExporterName},
 				},
 			},
 		},

--- a/autoscaler/controllers/nodecollector/collectorconfig/traces.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/traces.go
@@ -96,7 +96,7 @@ func tracesExporters(nodeCG *odigosv1.CollectorsGroup, odigosNamespace string, t
 			// Use the common cluster collector exporter
 			// Note: The actual exporter merge by commonExporters before this function is called.
 			// Here we just add it to the exporter name
-			exporterNames = append(exporterNames, clusterCollectorTraceExporterName)
+			exporterNames = append(exporterNames, clusterCollectorTracesExporterName)
 		}
 	}
 

--- a/autoscaler/controllers/nodecollector/testdata/logs_included.yaml
+++ b/autoscaler/controllers/nodecollector/testdata/logs_included.yaml
@@ -14,12 +14,20 @@ exporters:
       enabled: false
     tls:
       insecure: true
-  otlp/out-cluster-collector:
+  otlp/out-cluster-collector-logs:
+    balancer_name: round_robin
     compression: none
     endpoint: dns:///odigos-gateway.odigos-system:4317
     tls:
       insecure: true
-  otlp/out-cluster-collector-trace:
+  otlp/out-cluster-collector-metrics:
+    balancer_name: round_robin
+    compression: none
+    endpoint: dns:///odigos-gateway.odigos-system:4317
+    tls:
+      insecure: true
+  otlp/out-cluster-collector-traces:
+    balancer_name: round_robin
     compression: none
     endpoint: dns:///odigos-gateway.odigos-system:4317
     tls:
@@ -137,7 +145,7 @@ service:
   pipelines:
     logs:
       exporters:
-      - otlp/out-cluster-collector
+      - otlp/out-cluster-collector-logs
       processors:
       - memory_limiter
       - resource/node-name
@@ -148,7 +156,7 @@ service:
       - filelog
     metrics:
       exporters:
-      - otlp/out-cluster-collector
+      - otlp/out-cluster-collector-metrics
       processors:
       - batch
       - memory_limiter

--- a/autoscaler/controllers/nodecollector/testdata/traces_only_no_loadbalancing.yaml
+++ b/autoscaler/controllers/nodecollector/testdata/traces_only_no_loadbalancing.yaml
@@ -5,12 +5,20 @@ exporters:
       enabled: false
     tls:
       insecure: true
-  otlp/out-cluster-collector:
+  otlp/out-cluster-collector-logs:
+    balancer_name: round_robin
     compression: none
     endpoint: dns:///odigos-gateway.odigos-system:4317
     tls:
       insecure: true
-  otlp/out-cluster-collector-trace:
+  otlp/out-cluster-collector-metrics:
+    balancer_name: round_robin
+    compression: none
+    endpoint: dns:///odigos-gateway.odigos-system:4317
+    tls:
+      insecure: true
+  otlp/out-cluster-collector-traces:
+    balancer_name: round_robin
     compression: none
     endpoint: dns:///odigos-gateway.odigos-system:4317
     tls:
@@ -89,7 +97,7 @@ service:
       - prometheus/self-metrics
     traces:
       exporters:
-      - otlp/out-cluster-collector-trace
+      - otlp/out-cluster-collector-traces
       processors:
       - batch
       - memory_limiter


### PR DESCRIPTION
…(#3764)

## Description

This pr is Cherry pick the separation of pipeline per signal in data collection to v1.9.x.
To improve flexibility, we create a separate exporter for each signal, allowing us to control configuration and features independently for traces, metrics, and logs.

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

## Description

<!-- Short summary of the changes -->

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-477
