### PR TITLE
chore: change the runner to be deput-ubuntu

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -103,7 +103,7 @@ jobs:
     strategy:
       matrix:
         dockerfile: ['collector/Dockerfile', 'collector/Dockerfile.rhel']
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     steps:
       - uses: actions/checkout@v5
       - name: Set up Docker Buildx

--- a/.github/workflows/full-build.yaml
+++ b/.github/workflows/full-build.yaml
@@ -34,7 +34,7 @@ jobs:
             dockerfile_path: frontend
           - service: operator
             dockerfile_path: operator
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     steps:
       - uses: actions/checkout@v5
       - name: Set up Docker Buildx
@@ -53,7 +53,7 @@ jobs:
           build-args: ${{ matrix.build-args }}
 
   build-cli:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     steps:
       - uses: actions/checkout@v5
       - name: Set up Go


### PR DESCRIPTION
## Description

Due to 
```
689.4 compile: writing output: write $WORK/b3573/_pkg_.a: no space left on device
```
Trying to change the ubuntu-latest to depot-ubuntu-24.04-8

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-491
