### PR TITLE
Not use odiglet node selector for gateway (#3804)

### DIFF
--- a/autoscaler/controllers/clustercollector/deployment.go
+++ b/autoscaler/controllers/clustercollector/deployment.go
@@ -38,12 +38,6 @@ func syncDeployment(enabledDests *odigosv1.DestinationList, gateway *odigosv1.Co
 	ctx context.Context, c client.Client, scheme *runtime.Scheme, imagePullSecrets []string, odigosVersion string) (*appsv1.Deployment, error) {
 	logger := log.FromContext(ctx)
 
-	odigletDaemonset := &appsv1.DaemonSet{}
-	if err := c.Get(ctx, client.ObjectKey{Namespace: gateway.Namespace, Name: k8sconsts.OdigletDaemonSetName}, odigletDaemonset); err != nil {
-		return nil, err
-	}
-	odigletNodeSelector := odigletDaemonset.Spec.Template.Spec.NodeSelector
-
 	autoscalerDeployment := &appsv1.Deployment{}
 	if err := c.Get(ctx, client.ObjectKey{Namespace: gateway.Namespace, Name: k8sconsts.AutoScalerDeploymentName}, autoscalerDeployment); err != nil {
 		return nil, err
@@ -57,7 +51,8 @@ func syncDeployment(enabledDests *odigosv1.DestinationList, gateway *odigosv1.Co
 
 	// Use the hash of the secrets  to make sure the gateway will restart when the secrets (mounted as environment variables) changes
 	configDataHash := commonconfig.Sha256Hash(secretsVersionHash)
-	desiredDeployment, err := getDesiredDeployment(ctx, c, enabledDests, configDataHash, gateway, scheme, imagePullSecrets, odigosVersion, odigletNodeSelector, autoScalerTopologySpreadConstraints)
+	desiredDeployment, err := getDesiredDeployment(ctx, c, enabledDests, configDataHash, gateway,
+		scheme, imagePullSecrets, odigosVersion, autoScalerTopologySpreadConstraints)
 	if err != nil {
 		return nil, errors.Join(err, errors.New("failed to get desired deployment"))
 	}
@@ -101,9 +96,11 @@ func patchDeployment(existing *appsv1.Deployment, desired *appsv1.Deployment, ct
 }
 
 func getDesiredDeployment(ctx context.Context, c client.Client, enabledDests *odigosv1.DestinationList, configDataHash string,
-	gateway *odigosv1.CollectorsGroup, scheme *runtime.Scheme, imagePullSecrets []string, odigosVersion string, nodeSelector map[string]string, topologySpreadConstraints []corev1.TopologySpreadConstraint) (*appsv1.Deployment, error) {
+	gateway *odigosv1.CollectorsGroup, scheme *runtime.Scheme, imagePullSecrets []string, odigosVersion string, topologySpreadConstraints []corev1.TopologySpreadConstraint) (*appsv1.Deployment, error) {
+
+	nodeSelector := gateway.Spec.NodeSelector
 	if nodeSelector == nil {
-		nodeSelector = make(map[string]string)
+		nodeSelector = &map[string]string{}
 	}
 
 	// request + limits for memory and cpu

--- a/helm/odigos/templates/odigos-configuration-cm.yaml
+++ b/helm/odigos/templates/odigos-configuration-cm.yaml
@@ -61,6 +61,15 @@ data:
       {{- with .Values.collectorGateway.httpsProxyAddress }}
       httpsProxyAddress: {{ . }}
       {{- end }}
+      {{- if .Values.collectorGateway.nodeSelector }}
+      # Component-specific nodeSelector (overrides global values.yaml nodeSelector)
+      nodeSelector:
+        {{- toYaml .Values.collectorGateway.nodeSelector | nindent 8 }}
+      {{- else if .Values.nodeSelector }}
+      # Global nodeSelector from values.yaml
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
     {{- end }}
     {{- if .Values.collectorNode }}
     {{- $nodeLimiter := include "collector.node.memoryLimiter" . | fromYaml }}

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -138,6 +138,12 @@ collectorGateway:
   # when unset or empty, no proxy will be used.
   # httpsProxyAddress: ''
 
+
+  # Node selector for the cluster gateway collector deployment.
+  # Uncomment to override the global nodeSelector (values.nodeSelector) for this component
+  # nodeSelector:
+  #   kubernetes.io/os: linux
+
 # Settings for Odigos data-collection (node) Collectors
 collectorNode:
   # The port to use for exposing the collector's own metrics as a prometheus endpoint.
@@ -209,8 +215,9 @@ collectorNode:
 
 
 autoscaler:
-  nodeSelector:
-    kubernetes.io/os: linux
+  # Uncomment to override the global nodeSelector (values.nodeSelector) for this component
+  # nodeSelector:
+  #   kubernetes.io/os: linux
   tolerations: []
   affinity: {}
   resources:
@@ -222,8 +229,9 @@ autoscaler:
       memory: 512Mi
 
 scheduler:
-  nodeSelector:
-    kubernetes.io/os: linux
+  # Uncomment to override the global nodeSelector (values.nodeSelector) for this component
+  # nodeSelector:
+  #   kubernetes.io/os: linux
   tolerations: []
   affinity: {}
   resources:
@@ -235,8 +243,9 @@ scheduler:
       memory: 512Mi
 
 ui:
-  nodeSelector:
-    kubernetes.io/os: linux
+  # Uncomment to override the global nodeSelector (values.nodeSelector) for this component
+  # nodeSelector:
+  #   kubernetes.io/os: linux
   tolerations: []
   affinity: {}
   resources:
@@ -286,8 +295,9 @@ instrumentor:
   # this is to avoid adding a device (as resource request on a container)
   # where an odiglet might not be able to provide the device on the node and fail k8s scheduling for instrumented pods on all nodes.
   checkDeviceHealthBeforeInjection: false
-  nodeSelector:
-    kubernetes.io/os: linux
+  # Uncomment to override the global nodeSelector (values.nodeSelector) for this component
+  # nodeSelector:
+  #   kubernetes.io/os: linux
   tolerations: []
   affinity: {}
   resources:
@@ -362,8 +372,9 @@ odiglet:
       - BPF
       - PERFMON
       - IPC_LOCK
-  nodeSelector:
-    kubernetes.io/os: linux
+  # Uncomment to override the global nodeSelector (values.nodeSelector) for this component
+  # nodeSelector:
+  #   kubernetes.io/os: linux
   tolerations:
     ## This toleration with 'Exists' operator and no key/effect specified
     ## will match ALL taints, allowing pods to be scheduled on any node
@@ -436,8 +447,9 @@ centralProxy:
       cpu: 500m
       memory: 256Mi
 
-  nodeSelector:
-    kubernetes.io/os: linux
+  # Uncomment to override the global nodeSelector (values.nodeSelector) for this component
+  # nodeSelector:
+  #   kubernetes.io/os: linux
   tolerations: []
   affinity: {}
 


### PR DESCRIPTION
<!-- Short summary of the changes -->

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

## Description

<!-- Short summary of the changes -->

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-480
