### PR TITLE
fix: disable own metrics in no-op config map

### DIFF
--- a/autoscaler/controllers/nodecollector/configmap.go
+++ b/autoscaler/controllers/nodecollector/configmap.go
@@ -139,6 +139,11 @@ func noopConfigMap() (string, error) {
 					Exporters:  []string{"nop"},
 				},
 			},
+			Telemetry: config.Telemetry{
+				Metrics: config.GenericMap{
+					"level": "none",
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
When the no-op config is used, the collector tries to bind to port 8888 for own metrics by default.
In older k8s versions (older than 1.26) the node collector runs with `hostNetwork: true` - which implies the collector would try to bind to this port when in no-op mode. This can leas to conflicting port error.
Once a source and a destination are added, the config will become an active one, and the metrics port can be configured by the user and is defaulted to a non popular port.

emergency-ticket id: EMR-533
