### PR TITLE
Cherry pick #3823 to 1.9

### DIFF
--- a/opampserver/pkg/agent/agenthealthstatus.go
+++ b/opampserver/pkg/agent/agenthealthstatus.go
@@ -1,0 +1,31 @@
+package agent
+
+type AgentHealthStatus string
+
+const (
+	HealthStatusHealthy                   AgentHealthStatus = "Healthy"
+	HealthStatusUnknown                   AgentHealthStatus = "Unknown"
+	HealthStatusStarting                  AgentHealthStatus = "Starting"
+	HealthStatusUnsupportedRuntime        AgentHealthStatus = "UnsupportedRuntimeVersion"
+	HealthStatusTerminated                AgentHealthStatus = "ProcessTerminated"
+	HealthStatusAgentFailure              AgentHealthStatus = "AgentFailure"
+	HealthStatusNoConnectionToOpAMPServer AgentHealthStatus = "NoConnectionToOpAMPServer"
+)
+
+func GetAgentHealthStatus(status string) AgentHealthStatus {
+	switch status {
+	case string(HealthStatusHealthy):
+		return HealthStatusHealthy
+	case string(HealthStatusStarting):
+		return HealthStatusStarting
+	case string(HealthStatusUnsupportedRuntime):
+		return HealthStatusUnsupportedRuntime
+	case string(HealthStatusNoConnectionToOpAMPServer):
+		return HealthStatusNoConnectionToOpAMPServer
+	case string(HealthStatusTerminated):
+		return HealthStatusTerminated
+	case string(HealthStatusAgentFailure):
+		return HealthStatusAgentFailure
+	}
+	return HealthStatusUnknown
+}

--- a/opampserver/pkg/connection/types.go
+++ b/opampserver/pkg/connection/types.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/odigos-io/odigos/api/k8sconsts"
+	"github.com/odigos-io/odigos/opampserver/pkg/agent"
 	"github.com/odigos-io/odigos/opampserver/pkg/sdkconfig/configresolvers"
 	"github.com/odigos-io/odigos/opampserver/protobufs"
 	corev1 "k8s.io/api/core/v1"
@@ -17,6 +18,8 @@ type ConnectionInfo struct {
 	InstrumentedAppName string
 	LastMessageTime     time.Time
 	ProgrammingLanguage string
+
+	Status agent.AgentHealthStatus
 
 	// config related fields
 	// AgentRemoteConfig is the full remote config opamp message to send to the agent when needed

--- a/opampserver/pkg/server/handlers.go
+++ b/opampserver/pkg/server/handlers.go
@@ -128,7 +128,8 @@ func (c *ConnectionHandlers) OnAgentToServerMessage(ctx context.Context, request
 	// If the remote config changed, send the new config to the agent on the response
 	if request.RemoteConfigStatus == nil {
 		// this is to support older agents which do not send remote config status
-		c.logger.Info("missing remote config status in agent to server message", "workload", connectionInfo.Workload)
+		c.logger.Info("missing remote config status in agent to server message, sending full remote config", "workload", connectionInfo.Workload)
+		response.RemoteConfig = connectionInfo.AgentRemoteConfig
 	} else {
 		if !bytes.Equal(request.RemoteConfigStatus.LastRemoteConfigHash, connectionInfo.AgentRemoteConfig.ConfigHash) {
 			c.logger.Info("Remote config changed, sending new config to agent", "workload", connectionInfo.Workload)


### PR DESCRIPTION
## Description

Cheery pick #3823

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

## Description

<!-- Short summary of the changes -->

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-528
