### PR TITLE
feat: add flag to force hostNetork to false for odiglet

### DIFF
--- a/helm/odigos/templates/odiglet/daemonset.yaml
+++ b/helm/odigos/templates/odiglet/daemonset.yaml
@@ -373,7 +373,8 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 10
 {{- end }}
-      {{- if semverCompare "<1.26.0" $k8sVersion }}
+      # set hostNetwork only for k8s versions prior to v1.26 unless noHostNetwork is true
+      {{- if and (semverCompare "<1.26.0" $k8sVersion) (not .Values.odiglet.noHostNetwork) }}
       hostNetwork: true
       {{- end}}
       {{- if not .Values.odiglet.noHostPid }}

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -415,6 +415,11 @@ odiglet:
         cpu: 100m
         memory: 300Mi
 
+  # noHostNetwork can be set to true to avoid using hostNetwork in the odiglet daemonset.
+  # for k8s versions prior to v1.26, hostNetwork is required for OpAmp to work correctly and for some of the OTel agents.
+  # for k8s v1.26 and later, hostNetwork is not required and this flag is a no-op.
+  noHostNetwork: false
+
   ## Odiglet init container resources, the init container is responsible for copying the instrumentation agents to the host.
   ## There is a tradeoff of using more resources for the init container, and the time it takes to copy the instrumentation agents to the host.
   initContainerResources:


### PR DESCRIPTION
When running in k8s clusters with version lower than 1.26, the `LocalTrafficPolicy` service feature is not availabe.
In these cases any of the ports used by the odiglet containers can cause a conflict failure if one of them is taken in the host by another process.
To help mitigate this, we add a flag to force `hostNetwork: false` in the odiglet - even for k8s versions lower than 1.26, For newer versions, this flag is a no-op.
Using this flag can cause some functionalities to be affected mainly the OpAmp agents which rely on communicating with the local odiglet, or OSS OTel agents that export to the local data collection.

emergency-ticket id: EMR-579
