### PR TITLE
Handle orphaned SGs on VPC destroy

### DIFF
--- a/.github/actions/cross-cloud-tests/action.yml
+++ b/.github/actions/cross-cloud-tests/action.yml
@@ -190,7 +190,6 @@ runs:
         export TF_VAR_run_id="${GITHUB_RUN_ID}"
         export TF_VAR_resource_group_name="${{ inputs.test_scenario }}-${{ inputs.platform }}-${GITHUB_RUN_ID}"
         tofu -chdir="$TF_DIR" destroy -auto-approve
-      continue-on-error: true
 
     # 18) Extract Tag (optional)
     - name: Extract Tag

--- a/tests-infrastructure/terraform/eks/main.tf
+++ b/tests-infrastructure/terraform/eks/main.tf
@@ -1,9 +1,14 @@
 terraform {
   required_version = ">= 1.0.0"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 5.88"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
     }
   }
 }
@@ -59,8 +64,9 @@ module "eks" {
 
   cluster_name    = var.cluster_name
   cluster_version = "1.32"
-  vpc_id          = module.vpc.vpc_id
-  subnet_ids      = module.vpc.private_subnets  # Ensures at least 2 AZs
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets  # Ensures at least 2 AZs
 
   cluster_endpoint_public_access  = true
   cluster_endpoint_private_access = true
@@ -83,11 +89,10 @@ module "eks" {
   }
 }
 
-
 # VPC Endpoint for EKS API communication
 resource "aws_vpc_endpoint" "eks_api" {
-  vpc_id          = module.vpc.vpc_id
-  service_name    = "com.amazonaws.${var.region}.eks"
+  vpc_id            = module.vpc.vpc_id
+  service_name      = "com.amazonaws.${var.region}.eks"
   vpc_endpoint_type = "Interface"
 
   subnet_ids          = module.vpc.private_subnets
@@ -114,7 +119,6 @@ resource "aws_security_group" "eks_api_sg" {
   }
 }
 
-
 # Allow Kubernetes API to communicate with private services
 resource "aws_security_group_rule" "allow_api_private" {
   type              = "ingress"
@@ -125,7 +129,6 @@ resource "aws_security_group_rule" "allow_api_private" {
   security_group_id = module.eks.cluster_security_group_id
 }
 
-
 # Allow port 4318 for internal communication to simple-trace-db service
 resource "aws_security_group_rule" "allow_4318_internal" {
   type              = "ingress"
@@ -135,4 +138,77 @@ resource "aws_security_group_rule" "allow_4318_internal" {
   cidr_blocks       = ["10.0.0.0/16"] # Your VPC CIDR
   security_group_id = module.eks.node_security_group_id
   description       = "Allow 4318 for e2e-tests-tempo"
+}
+
+# ---------------------------------------------------------------------------
+# Destroy-time cleanup for orphaned k8s ELB security groups in this VPC
+# (like: k8s-elb-a367a23ca7fae41879cf70630c16845b)
+#
+# NOTE:
+# - We can only reference self.* in a destroy-time provisioner.
+# - So we pass VPC ID + region via triggers and read them via self.triggers.*
+# ---------------------------------------------------------------------------
+resource "null_resource" "cleanup_non_default_sgs" {
+  # Triggers capture the VPC and region so they are available as self.triggers.*
+  triggers = {
+    vpc_id = module.vpc.vpc_id
+    region = var.region
+  }
+
+  # Important: this resource depends on the VPC so its *destroy* runs
+  # before the VPC is destroyed (which is what we want).
+  # The dependency is implied by triggers, so no explicit depends_on needed.
+
+  provisioner "local-exec" {
+    when = destroy
+
+    command = <<-EOT
+      set -euo pipefail
+
+      VPC_ID="${self.triggers.vpc_id}"
+      REGION="${self.triggers.region}"
+
+      echo "Scanning for orphan k8s-elb-* security groups in VPC $VPC_ID (region: $REGION)..."
+
+      # Only pick SGs created by Kubernetes ELB controller (k8s-elb-*)
+      SG_IDS=$(aws ec2 describe-security-groups \
+        --region "$REGION" \
+        --filters "Name=vpc-id,Values=$${VPC_ID}" \
+        --query "SecurityGroups[?starts_with(GroupName, 'k8s-elb-')].GroupId" \
+        --output text || true)
+
+      if [ -z "$${SG_IDS:-}" ]; then
+        echo "No k8s-elb-* security groups found in VPC $VPC_ID"
+        exit 0
+      fi
+
+      echo "Found Kubernetes ELB security groups to delete: $SG_IDS"
+
+      for SG in $SG_IDS; do
+        echo "Attempting to delete security group $SG..."
+
+        # Clear ingress/egress rules defensively (sometimes helps)
+        aws ec2 revoke-security-group-ingress \
+          --region "$REGION" \
+          --group-id "$SG" \
+          --ip-permissions '[]' \
+          >/dev/null 2>&1 || true
+
+        aws ec2 revoke-security-group-egress \
+          --region "$REGION" \
+          --group-id "$SG" \
+          --ip-permissions '[]' \
+          >/dev/null 2>&1 || true
+
+        aws ec2 delete-security-group \
+          --region "$REGION" \
+          --group-id "$SG" \
+          >/dev/null 2>&1 || true
+      done
+
+      echo "Finished k8s-elb SG cleanup for VPC $VPC_ID"
+    EOT
+
+    interpreter = ["/bin/bash", "-c"]
+  }
 }

--- a/tests-infrastructure/terraform/eks/variables.tf
+++ b/tests-infrastructure/terraform/eks/variables.tf
@@ -23,9 +23,9 @@ variable "platform" {
   description = "Target CPU architecture for worker nodes"
   type        = string
   default     = "amd" # allowed: amd | arm
+
   validation {
     condition     = contains(["amd", "arm"], var.platform)
     error_message = "platform must be either \"amd\" or \"arm\"."
   }
 }
-


### PR DESCRIPTION
Handle orphan k8s ELB security groups on EKS VPC destroy

* Add null provider and destroy-time cleanup via local-exec
* Delete k8s-elb-* security groups to prevent VPC DependencyViolation

emergency-ticket id: EMR-588
