### PR TITLE
chore: adding a metric for total ebpf read and reuse protomarshler

### DIFF
--- a/collector/receivers/odigosebpfreceiver/documentation.md
+++ b/collector/receivers/odigosebpfreceiver/documentation.md
@@ -24,7 +24,7 @@ Total time spent waiting due to memory pressure. Can be compared with otelcol_pr
 
 ### otelcol_ebpf_total_bytes_read
 
-Total number of bytes read from the eBPF ring buffer.
+Total number of bytes read from the eBPF buffer (perf or ring).
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |

--- a/collector/receivers/odigosebpfreceiver/documentation.md
+++ b/collector/receivers/odigosebpfreceiver/documentation.md
@@ -21,3 +21,11 @@ Total time spent waiting due to memory pressure. Can be compared with otelcol_pr
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
 | ms | Sum | Int | true |
+
+### otelcol_ebpf_total_bytes_read
+
+Total number of bytes read from the eBPF ring buffer.
+
+| Unit | Metric Type | Value Type | Monotonic |
+| ---- | ----------- | ---------- | --------- |
+| bytes | Sum | Int | true |

--- a/collector/receivers/odigosebpfreceiver/internal/metadata/generated_telemetry.go
+++ b/collector/receivers/odigosebpfreceiver/internal/metadata/generated_telemetry.go
@@ -74,7 +74,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	errs = errors.Join(errs, err)
 	builder.EbpfTotalBytesRead, err = builder.meter.Int64Counter(
 		"otelcol_ebpf_total_bytes_read",
-		metric.WithDescription("Total number of bytes read from the eBPF ring buffer."),
+		metric.WithDescription("Total number of bytes read from the eBPF buffer (perf or ring)."),
 		metric.WithUnit("bytes"),
 	)
 	errs = errors.Join(errs, err)

--- a/collector/receivers/odigosebpfreceiver/internal/metadata/generated_telemetry.go
+++ b/collector/receivers/odigosebpfreceiver/internal/metadata/generated_telemetry.go
@@ -28,6 +28,7 @@ type TelemetryBuilder struct {
 	registrations                   []metric.Registration
 	EbpfLostSamples                 metric.Int64Counter
 	EbpfMemoryPressureWaitTimeTotal metric.Int64Counter
+	EbpfTotalBytesRead              metric.Int64Counter
 }
 
 // TelemetryBuilderOption applies changes to default builder.
@@ -69,6 +70,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		"otelcol_ebpf_memory_pressure_wait_time_total",
 		metric.WithDescription("Total time spent waiting due to memory pressure. Can be compared with otelcol_process_uptime_seconds_total to calculate the percentage of time spent in memory pressure: (ebpf_memory_pressure_wait_time_total_milliseconds / (otelcol_process_uptime_seconds_total * 1000)) * 100"),
 		metric.WithUnit("ms"),
+	)
+	errs = errors.Join(errs, err)
+	builder.EbpfTotalBytesRead, err = builder.meter.Int64Counter(
+		"otelcol_ebpf_total_bytes_read",
+		metric.WithDescription("Total number of bytes read from the eBPF ring buffer."),
+		metric.WithUnit("bytes"),
 	)
 	errs = errors.Join(errs, err)
 	return &builder, errs

--- a/collector/receivers/odigosebpfreceiver/internal/metadatatest/generated_telemetrytest.go
+++ b/collector/receivers/odigosebpfreceiver/internal/metadatatest/generated_telemetrytest.go
@@ -56,7 +56,7 @@ func AssertEqualEbpfMemoryPressureWaitTimeTotal(t *testing.T, tt *componenttest.
 func AssertEqualEbpfTotalBytesRead(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_ebpf_total_bytes_read",
-		Description: "Total number of bytes read from the eBPF ring buffer.",
+		Description: "Total number of bytes read from the eBPF buffer (perf or ring).",
 		Unit:        "bytes",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,

--- a/collector/receivers/odigosebpfreceiver/internal/metadatatest/generated_telemetrytest.go
+++ b/collector/receivers/odigosebpfreceiver/internal/metadatatest/generated_telemetrytest.go
@@ -52,3 +52,19 @@ func AssertEqualEbpfMemoryPressureWaitTimeTotal(t *testing.T, tt *componenttest.
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
+
+func AssertEqualEbpfTotalBytesRead(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_ebpf_total_bytes_read",
+		Description: "Total number of bytes read from the eBPF ring buffer.",
+		Unit:        "bytes",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_ebpf_total_bytes_read")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}

--- a/collector/receivers/odigosebpfreceiver/internal/metadatatest/generated_telemetrytest_test.go
+++ b/collector/receivers/odigosebpfreceiver/internal/metadatatest/generated_telemetrytest_test.go
@@ -22,10 +22,14 @@ func TestSetupTelemetry(t *testing.T) {
 	defer tb.Shutdown()
 	tb.EbpfLostSamples.Add(context.Background(), 1)
 	tb.EbpfMemoryPressureWaitTimeTotal.Add(context.Background(), 1)
+	tb.EbpfTotalBytesRead.Add(context.Background(), 1)
 	AssertEqualEbpfLostSamples(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualEbpfMemoryPressureWaitTimeTotal(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualEbpfTotalBytesRead(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 

--- a/collector/receivers/odigosebpfreceiver/metadata.yaml
+++ b/collector/receivers/odigosebpfreceiver/metadata.yaml
@@ -27,7 +27,7 @@ telemetry:
 
     ebpf_total_bytes_read:
       enabled: true
-      description: "Total number of bytes read from the eBPF ring buffer."
+      description: "Total number of bytes read from the eBPF buffer (perf or ring)."
       unit: "bytes"
       sum:
         value_type: int

--- a/collector/receivers/odigosebpfreceiver/metadata.yaml
+++ b/collector/receivers/odigosebpfreceiver/metadata.yaml
@@ -24,3 +24,11 @@ telemetry:
       sum:
         value_type: int
         monotonic: true
+
+    ebpf_total_bytes_read:
+      enabled: true
+      description: "Total number of bytes read from the eBPF ring buffer."
+      unit: "bytes"
+      sum:
+        value_type: int
+        monotonic: true


### PR DESCRIPTION
## Description

Add a new metric calls `ebpf_total_bytes_read` to track the amount of data in bytes we read from the ebpf map.
also, reuse `protoUnmarshaler` and not create it in every read operation.
## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-592
