### PR TITLE
feat: replace promethues with victoriametrics

### DIFF
--- a/autoscaler/controllers/nodecollector/collectorconfig/ownmetrics.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/ownmetrics.go
@@ -22,12 +22,13 @@ const (
 	odigosOwnTelemetryOtlpHttpReceiverName = "otlp/odigos-own-metrics-in"
 	ownMetricsUiPipelineName               = "metrics/own-metrics-ui"
 	ownMetricsPrometheusPipelineName       = "metrics/own-metrics-prometheus"
-	odigosPrometheusExporterName           = "otlphttp/odigos-prometheus"
+	odigosVictoriametricsExporterName      = "otlphttp/odigos-victoriametrics"
 )
 
 var staticOwnMetricsProcessors config.GenericMap
 var uiOtlpEndpoint string
 var odigosPrometheusOtlpHttpEndpoint string
+var odigosVictoriametricsOtlpHttpEndpoint string
 
 func init() {
 
@@ -58,7 +59,7 @@ func init() {
 	}
 
 	uiOtlpEndpoint = fmt.Sprintf("ui.%s:%d", odigosNamespace, consts.OTLPPort)
-	odigosPrometheusOtlpHttpEndpoint = fmt.Sprintf("http://odigos-prometheus.%s:9090/api/v1/otlp", odigosNamespace)
+	odigosVictoriametricsOtlpHttpEndpoint = fmt.Sprintf("http://odigos-victoriametrics.%s:8428/opentelemetry", odigosNamespace)
 }
 
 func receiversConfigForOwnMetrics(ownMetricsPort int32, odigosPrometheusEnabled bool) config.GenericMap {
@@ -173,8 +174,8 @@ func ownMetricsExporters(odigosPrometheusEnabled bool) config.GenericMap {
 		},
 	}
 	if odigosPrometheusEnabled {
-		exporters[odigosPrometheusExporterName] = config.GenericMap{
-			"endpoint": odigosPrometheusOtlpHttpEndpoint,
+		exporters[odigosVictoriametricsExporterName] = config.GenericMap{
+			"endpoint": odigosVictoriametricsOtlpHttpEndpoint,
 			"retry_on_failure": config.GenericMap{
 				"enabled": false,
 			},
@@ -197,7 +198,7 @@ func ownMetricsPipelines(odigosPrometheusEnabled bool) map[string]config.Pipelin
 	if odigosPrometheusEnabled {
 		pipelines[ownMetricsPrometheusPipelineName] = config.Pipeline{
 			Receivers: []string{odigosOwnTelemetryOtlpHttpReceiverName},
-			Exporters: []string{odigosPrometheusExporterName},
+			Exporters: []string{odigosVictoriametricsExporterName},
 		}
 	}
 	return pipelines

--- a/helm/odigos/templates/odigospromethues/configmap.yaml
+++ b/helm/odigos/templates/odigospromethues/configmap.yaml
@@ -2,30 +2,15 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: odigos-prometheus-config
+  name: odigos-victoriametrics-config
 data:
-  prometheus.yml: |
-    global:
-      scrape_interval: 1m
-      evaluation_interval: 1m
-
-    # No rules, no alertmanagers, no scrapes
-    rule_files: []
-
+  scrape.yml: |
     scrape_configs:
-    - job_name: prometheus
+    - job_name: self
       static_configs:
-      - targets: ['localhost:9090']
+      - targets: ['localhost:8428']
       metric_relabel_configs:
-        # Keep only tsdb (disk usage) metrics, to avoid scraping too much prometheus data.
         - source_labels: [__name__]
           regex: '(.*tsdb.*)'
           action: keep
-
-    otlp:
-      promote_resource_attributes:
-      - service.name
-      - service.instance.id
-      - k8s.pod.name
-      - k8s.node.name
 {{- end }}

--- a/helm/odigos/templates/odigospromethues/deployment.yaml
+++ b/helm/odigos/templates/odigospromethues/deployment.yaml
@@ -2,40 +2,43 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: odigos-prometheus
-  labels:
-    app.kubernetes.io/name: odigos-prometheus
+  name: odigos-victoriametrics
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: odigos-prometheus
+      app.kubernetes.io/name: odigos-victoriametrics
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: odigos-prometheus
+        app.kubernetes.io/name: odigos-victoriametrics
     spec:
       containers:
-      - name: prometheus
-        image: prom/prometheus:v3.7.3
+      - name: vm
+        image: victoriametrics/victoria-metrics:v1.103.0
         args:
-          - "--config.file=/etc/prometheus/prometheus.yml"
-          - "--web.enable-otlp-receiver"
-          - "--web.external-url=http://odigos-prometheus:9090"
-          - "--web.route-prefix=/"
-          - "--enable-feature=remote-write-receiver"
-          - "--storage.tsdb.path=/tmp/prom-tsdb"
-          - "--storage.tsdb.retention.time=24h"
-          - "--storage.tsdb.retention.size=2GB"
-          - "--web.enable-lifecycle"
+          - "-httpListenAddr=0.0.0.0:8428"
+          - "-storageDataPath=/vm-data"
+          - "-retentionPeriod=1d"
+
         ports:
         - name: http
-          containerPort: 9090
-          protocol: TCP
+          containerPort: 8428
         volumeMounts:
-        - name: config
-          mountPath: /etc/prometheus
-          readOnly: true
+        - name: data
+          mountPath: /vm-data
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 5
+          periodSeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 5
+          periodSeconds: 15
         resources:
           requests:
             cpu: 100m
@@ -43,27 +46,7 @@ spec:
           limits:
             cpu: 500m
             memory: 2Gi
-        livenessProbe:
-          httpGet:
-            path: /-/healthy
-            port: http
-          initialDelaySeconds: 30
-          periodSeconds: 10
-          timeoutSeconds: 5
-        readinessProbe:
-          httpGet:
-            path: /-/ready
-            port: http
-          initialDelaySeconds: 15
-          periodSeconds: 5
-          timeoutSeconds: 3
-        securityContext:
-          runAsNonRoot: true
-          runAsUser: 65534
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: false
       volumes:
-      - name: config
-        configMap:
-          name: odigos-prometheus-config
+      - name: data
+        emptyDir: {}
 {{- end }}

--- a/helm/odigos/templates/odigospromethues/service.yaml
+++ b/helm/odigos/templates/odigospromethues/service.yaml
@@ -2,16 +2,17 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: odigos-prometheus
+  name: odigos-victoriametrics
   labels:
-    app.kubernetes.io/name: odigos-prometheus
+    app.kubernetes.io/name: odigos-victoriametrics
 spec:
   type: ClusterIP
   ports:
   - name: http
-    port: 9090
+    port: 8428
     targetPort: http
     protocol: TCP
   selector:
-    app.kubernetes.io/name: odigos-prometheus
+    app.kubernetes.io/name: odigos-victoriametrics
+
 {{- end }}


### PR DESCRIPTION
## Description

<!-- Short summary of the changes -->

## How Has This Been Tested?

<!-- Describe the tests you ran and how you verified your changes. -->

- [ ] Added Unit Tests
- [ ] Updated e2e Tests
- [ ] Manual Testing
- [ ] Manual Load Test

## Kubernetes Checklist

<!-- If this PR affects how Odigos interacts with Kubernetes, check the relevant boxes below and provide more details -->

- [ ] Changes how Odigos interacts with Kubernetes
- [ ] Introduces additional calls to the API Server (potential performance impact)
- [ ] New Query/feature supported in all the k8s versions supported by Odigos
- [ ] Modifies Odigos manifests (addressed in both CLI and Helm)
- [ ] Changes RBAC permissions

## User Facing Changes

<!-- Any changes that users will notice or need to be aware of -->

- [ ] Users need to take action before upgrading
- [ ] Automatic migration will modify existing objects (backward compatible)
- [ ] Changes UI, CLI, or K8s Manifests aspects in a way that users need to be aware of
- [ ] Documentation updated accordingly

emergency-ticket id: EMR-590
