### PR TITLE
fix: remove wasp-enabled command line argument in instrumentor

### DIFF
--- a/helm/odigos/templates/instrumentor/deployment.yaml
+++ b/helm/odigos/templates/instrumentor/deployment.yaml
@@ -52,9 +52,6 @@ spec:
           - --health-probe-bind-address=:8081
           - --metrics-bind-address=0.0.0.0:8080
           - --leader-elect
-        {{- if .Values.wasp.enabled }}
-          - --wasp-enabled
-        {{- end }}
         command:
           - /app
         {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}


### PR DESCRIPTION


emergency-ticket id: EMR-620
