### PR TITLE
feat: enhance GetConfig with `platformType` and `odigosVersion` fields

### DIFF
--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -313,6 +313,8 @@ type ComplexityRoot struct {
 	GetConfigResponse struct {
 		InstallationMethod func(childComplexity int) int
 		InstallationStatus func(childComplexity int) int
+		OdigosVersion      func(childComplexity int) int
+		PlatformType       func(childComplexity int) int
 		Readonly           func(childComplexity int) int
 		Tier               func(childComplexity int) int
 	}
@@ -2158,6 +2160,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.GetConfigResponse.InstallationStatus(childComplexity), true
+
+	case "GetConfigResponse.odigosVersion":
+		if e.complexity.GetConfigResponse.OdigosVersion == nil {
+			break
+		}
+
+		return e.complexity.GetConfigResponse.OdigosVersion(childComplexity), true
+
+	case "GetConfigResponse.platformType":
+		if e.complexity.GetConfigResponse.PlatformType == nil {
+			break
+		}
+
+		return e.complexity.GetConfigResponse.PlatformType(childComplexity), true
 
 	case "GetConfigResponse.readonly":
 		if e.complexity.GetConfigResponse.Readonly == nil {
@@ -13841,6 +13857,50 @@ func (ec *executionContext) fieldContext_GetConfigResponse_readonly(_ context.Co
 	return fc, nil
 }
 
+func (ec *executionContext) _GetConfigResponse_platformType(ctx context.Context, field graphql.CollectedField, obj *model.GetConfigResponse) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GetConfigResponse_platformType(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PlatformType, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.ComputePlatformType)
+	fc.Result = res
+	return ec.marshalNComputePlatformType2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐComputePlatformType(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GetConfigResponse_platformType(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GetConfigResponse",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ComputePlatformType does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _GetConfigResponse_tier(ctx context.Context, field graphql.CollectedField, obj *model.GetConfigResponse) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_GetConfigResponse_tier(ctx, field)
 	if err != nil {
@@ -13880,6 +13940,50 @@ func (ec *executionContext) fieldContext_GetConfigResponse_tier(_ context.Contex
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Tier does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GetConfigResponse_odigosVersion(ctx context.Context, field graphql.CollectedField, obj *model.GetConfigResponse) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GetConfigResponse_odigosVersion(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OdigosVersion, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GetConfigResponse_odigosVersion(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GetConfigResponse",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -26802,8 +26906,12 @@ func (ec *executionContext) fieldContext_Query_config(_ context.Context, field g
 			switch field.Name {
 			case "readonly":
 				return ec.fieldContext_GetConfigResponse_readonly(ctx, field)
+			case "platformType":
+				return ec.fieldContext_GetConfigResponse_platformType(ctx, field)
 			case "tier":
 				return ec.fieldContext_GetConfigResponse_tier(ctx, field)
+			case "odigosVersion":
+				return ec.fieldContext_GetConfigResponse_odigosVersion(ctx, field)
 			case "installationMethod":
 				return ec.fieldContext_GetConfigResponse_installationMethod(ctx, field)
 			case "installationStatus":
@@ -36387,8 +36495,18 @@ func (ec *executionContext) _GetConfigResponse(ctx context.Context, sel ast.Sele
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "platformType":
+			out.Values[i] = ec._GetConfigResponse_platformType(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "tier":
 			out.Values[i] = ec._GetConfigResponse_tier(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "odigosVersion":
+			out.Values[i] = ec._GetConfigResponse_odigosVersion(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -354,10 +354,12 @@ type GatewayDeploymentInfo struct {
 }
 
 type GetConfigResponse struct {
-	Readonly           bool               `json:"readonly"`
-	Tier               Tier               `json:"tier"`
-	InstallationMethod string             `json:"installationMethod"`
-	InstallationStatus InstallationStatus `json:"installationStatus"`
+	Readonly           bool                `json:"readonly"`
+	PlatformType       ComputePlatformType `json:"platformType"`
+	Tier               Tier                `json:"tier"`
+	OdigosVersion      string              `json:"odigosVersion"`
+	InstallationMethod string              `json:"installationMethod"`
+	InstallationStatus InstallationStatus  `json:"installationStatus"`
 }
 
 type GetDestinationCategories struct {

--- a/frontend/graph/schema.graphqls
+++ b/frontend/graph/schema.graphqls
@@ -386,7 +386,9 @@ type Destination {
 
 type GetConfigResponse {
   readonly: Boolean!
+  platformType: ComputePlatformType!
   tier: Tier!
+  odigosVersion: String!
   installationMethod: String!
   installationStatus: InstallationStatus!
 }

--- a/frontend/services/config.go
+++ b/frontend/services/config.go
@@ -44,7 +44,9 @@ func GetConfig(ctx context.Context) model.GetConfigResponse {
 	deploymentData := odigosDeployment.Data
 
 	response.Readonly = IsReadonlyMode(ctx)
+	response.PlatformType = model.ComputePlatformTypeK8s // TODO: add support for VM (or others)
 	response.Tier = model.Tier(deploymentData[k8sconsts.OdigosDeploymentConfigMapTierKey])
+	response.OdigosVersion = deploymentData[k8sconsts.OdigosDeploymentConfigMapVersionKey]
 	response.InstallationMethod = string(deploymentData[k8sconsts.OdigosDeploymentConfigMapInstallationMethodKey])
 
 	isNewInstallation := !isSourceCreated(ctx) && !isDestinationConnected(ctx)

--- a/frontend/webapp/app/(v2)/layout.tsx
+++ b/frontend/webapp/app/(v2)/layout.tsx
@@ -6,7 +6,6 @@ import { ROUTES } from '@/utils';
 import { useTheme } from 'styled-components';
 import { OverviewHeader } from '@/components';
 import { useDarkMode } from '@odigos/ui-kit/store';
-import { PlatformType } from '@odigos/ui-kit/types';
 import { Navbar } from '@odigos/ui-kit/components/v2';
 import { OdigosProvider } from '@odigos/ui-kit/contexts';
 import { useConfig, useSSE, useTokenTracker } from '@/hooks';
@@ -95,8 +94,7 @@ function OverviewLayout({ children }: PropsWithChildren) {
 
   return (
     <ErrorBoundary>
-      {/* TODO: get version and platform type from the config, then remove hard coded values */}
-      <OdigosProvider tier={config?.tier} version='v1.13.0' platformType={PlatformType.K8s}>
+      <OdigosProvider tier={config?.tier} version={config?.odigosVersion} platformType={config?.platformType}>
         <FlexColumn $gap={0}>
           <OverviewHeader v2 />
           <FlexRow $gap={0}>

--- a/frontend/webapp/graphql/queries/config.ts
+++ b/frontend/webapp/graphql/queries/config.ts
@@ -4,7 +4,9 @@ export const GET_CONFIG = gql`
   query GetConfig {
     config {
       readonly
+      platformType
       tier
+      odigosVersion
       installationMethod
       installationStatus
     }

--- a/frontend/webapp/types/config.ts
+++ b/frontend/webapp/types/config.ts
@@ -1,4 +1,4 @@
-import { InstallationMethod, Tier } from '@odigos/ui-kit/types';
+import { InstallationMethod, PlatformType, Tier } from '@odigos/ui-kit/types';
 
 export enum InstallationStatus {
   New = 'NEW',
@@ -8,7 +8,9 @@ export enum InstallationStatus {
 
 export interface FetchedConfig {
   readonly: boolean;
+  platformType: PlatformType;
   tier: Tier;
+  odigosVersion: string;
   installationMethod: InstallationMethod;
   installationStatus: InstallationStatus;
 }


### PR DESCRIPTION
- Added platformType and odigosVersion to the GetConfigResponse type in GraphQL schema.
- Updated the GetConfig function to populate these new fields from deployment data.
- Modified frontend components to utilize the new fields for improved configuration handling.

emergency-ticket id: EMR-729
