### PR TITLE
Update prerelease PR checks to not depend on each other

### DIFF
--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -55,7 +55,7 @@ jobs:
 
   verify-dependencies-sync:
     if: ${{ needs.decide.outputs.skip != 'true' }}
-    needs: verify-offsets
+    needs: decide
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -88,7 +88,7 @@ jobs:
 
   verify-release-blockers:
     if: ${{ needs.decide.outputs.skip != 'true' }}
-    needs: verify-dependencies-sync
+    needs: decide
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
In the prerelease PRs, we check for offsets, dependency-syncs, and release blockers. These should all only depend on the initial check job ("decide"), not each other.

When these depend on each other, and 1 fails, the others will be skipped. This can be annoying if the other checks fail too once we get them to run. So, run them all at once so we know all failures to save time.

emergency-ticket id: EMR-740
