### PR TITLE
Different tag versions push to different repos

### DIFF
--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -273,18 +273,17 @@ jobs:
           fetch-depth: 0
           ref: ${{ steps.extract_tag.outputs.tag }}
 
-      - uses: google-github-actions/setup-gcloud@v2
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-
-      - id: gcp-auth
-        name: Authenticate with Google Cloud
-        uses: google-github-actions/auth@v3
-        with:
-          token_format: 'access_token'
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-          access_token_lifetime: 1200s
+      - name: Determine repository (staging vs prod)
+        id: determine_repo
+        run: |
+          TAG="${{ steps.extract_tag.outputs.tag }}"
+          if [[ "$TAG" =~ -(rc|pre)[0-9]*$ ]]; then
+            echo "repository=staging" >> $GITHUB_OUTPUT
+            echo "Detected pre-release/RC tag: $TAG -> using staging repository"
+          else
+            echo "repository=odigos" >> $GITHUB_OUTPUT
+            echo "Detected release tag: $TAG -> using production repository"
+          fi
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -299,29 +298,14 @@ jobs:
           args: release --clean
           workdir: collector
 
-      # Upload deb packages directly to Artifact Registry
-      - name: Upload deb packages to Artifact Registry (odigos-apt)
-        run: |
-          for deb in collector/dist/*.deb; do
-            if [ -f "$deb" ]; then
-              echo "Uploading $deb to Artifact Registry..."
-              gcloud artifacts apt upload odigos-apt \
-                --location=us-central1 \
-                --source="$deb"
-            fi
-          done
-
-      # Upload rpm packages directly to Artifact Registry
-      - name: Upload rpm packages to Artifact Registry (odigos-rpm)
-        run: |
-          for rpm in collector/dist/*.rpm; do
-            if [ -f "$rpm" ]; then
-              echo "Uploading $rpm to Artifact Registry..."
-              gcloud artifacts yum upload odigos-rpm \
-                --location=us-central1 \
-                --source="$rpm"
-            fi
-          done
+      - name: Upload Linux packages to Artifact Registry
+        uses: odigos-io/ci-core/upload-linux-packages@v1.0.5
+        with:
+          gcp-project-id: ${{ secrets.GCP_PROJECT_ID }}
+          gcp-workload-identity-provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          package-directory: 'collector/dist'
+          repository: ${{ steps.determine_repo.outputs.repository }}
 
       - name: Notify Slack Success
         if: always()


### PR DESCRIPTION
Use the new composite action to upload artifacts to the google registry.
rc and pre versions will be published to an internal staging repo
releases will be pushed to the mainstream release pipeline

emergency-ticket id: EMR-748
