### PR TITLE
CORE279: add StartupProbe to gateway

### DIFF
--- a/autoscaler/controllers/clustercollector/deployment.go
+++ b/autoscaler/controllers/clustercollector/deployment.go
@@ -236,6 +236,16 @@ func getDesiredDeployment(ctx context.Context, c client.Client, enabledDests *od
 								SuccessThreshold: 1,
 								TimeoutSeconds:   5,
 							},
+							StartupProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/",
+										Port: intstr.FromInt(13133),
+									},
+								},
+								FailureThreshold: 30,
+								PeriodSeconds:    10,
+							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceMemory: requestMemoryQuantity,

--- a/tests/common/assert/pipeline-ready.yaml
+++ b/tests/common/assert/pipeline-ready.yaml
@@ -69,6 +69,13 @@ spec:
             limits:
               (memory != null): true
               (cpu != null): true
+          # startupProbe addition is checked by the existing availableReplicas test below
+          startupProbe:
+            httpGet:
+              path: /
+              port: 13133
+            failureThreshold: 30
+            periodSeconds: 10
 status:
   availableReplicas: 2
   readyReplicas: 2


### PR DESCRIPTION
Adds a StartupProbe to gateway, which allows up to 5 minutes of delay in startup using a health check endpoint.

Tests done:
Manually delayed startup for 1 minute with a sleep command:
```sh
kubectl patch deployment odigos-gateway -n odigos-system --type='json' -p='[
  {
    "op": "add",
    "path": "/spec/template/spec/initContainers",
    "value": [
      {
        "name": "slow-startup-simulator",
        "image": "busybox",
        "command": ["sh", "-c", "echo Starting slow init... && sleep 60 && echo Init complete"]
      }
    ]
  }
]'
```

Watching the deployment showed that gateway did not restart (startup probe delayed the liveness probe from acting)

I didn't add more e2e tests or unit tests since those will just check that k8s startup probes work as expected, and it is redundant to test the functionaility of an external lib

emergency-ticket id: EMR-800
