### PR TITLE
Filter for latest

### DIFF
--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -662,7 +662,7 @@ metricsSources:
         metrics:
           # Class loading metrics
           - name: jvm.gc.duration
-            disabled: false
+            disabled: true
           - name: jvm.memory.used
             disabled: true
 

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -662,7 +662,7 @@ metricsSources:
         metrics:
           # Class loading metrics
           - name: jvm.gc.duration
-            disabled: true
+            disabled: false
           - name: jvm.memory.used
             disabled: true
 

--- a/tests/e2e/cli-upgrade/chainsaw-test.yaml
+++ b/tests/e2e/cli-upgrade/chainsaw-test.yaml
@@ -24,7 +24,7 @@ spec:
               #!/bin/bash
 
               # Define variables
-              REPO_URL="https://api.github.com/repos/odigos-io/odigos/releases/latest"
+              REPO_URL="https://api.github.com/repos/odigos-io/odigos/releases"
               ARCH=$(uname -m) # Get the system architecture
               OS=$(uname | tr '[:upper:]' '[:lower:]') # Get the OS name in lowercase
 
@@ -35,20 +35,43 @@ spec:
                   ARCH="arm64"
               fi
 
-              # Fetch the release assets from GitHub API with retry
+              # Fetch all releases from GitHub API with retry
               # --retry 5: retry up to 5 times
               # --retry-delay 1: wait 1 second between retries
               # --retry-max-time 30: maximum time to spend retrying (30 seconds)
-              ASSETS_JSON=$(curl -s --retry 5 --retry-delay 1 --retry-max-time 30 "$REPO_URL")
+              RELEASES_JSON=$(curl -s --retry 5 --retry-delay 1 --retry-max-time 30 "$REPO_URL")
 
-              # Find the download URL that matches the OS and architecture
-              DOWNLOAD_URL=$(echo "$ASSETS_JSON" | grep "browser_download_url" | grep "$OS" | grep "$ARCH" | cut -d '"' -f 4)
+              # Find the latest non-RC release by semantic version
+              # Filter out RC/prerelease/draft releases, then sort by semantic version and take the latest
+              LATEST_RELEASE_JSON=$(echo "$RELEASES_JSON" | jq -r '
+                [.[] | select(.tag_name | test("rc"; "i") | not) | select(.prerelease == false) | select(.draft == false)] |
+                sort_by(.tag_name | sub("^v"; "") | split(".") | map(tonumber)) |
+                reverse |
+                .[0]
+              ')
 
-              # Check if the download URL was found
-              if [ -z "$DOWNLOAD_URL" ]; then
-                  echo "No matching release found for OS: $OS and Architecture: $ARCH"
+              # Check if we found a valid release
+              if [ "$LATEST_RELEASE_JSON" = "null" ] || [ -z "$LATEST_RELEASE_JSON" ]; then
+                  echo "No valid non-RC release found"
                   exit 1
               fi
+
+              # Extract the tag name for logging
+              TAG_NAME=$(echo "$LATEST_RELEASE_JSON" | jq -r '.tag_name')
+              echo "Found latest non-RC release: $TAG_NAME"
+
+              # Find the download URL that matches the OS and architecture
+              DOWNLOAD_URL=$(echo "$LATEST_RELEASE_JSON" | jq -r --arg OS "$OS" --arg ARCH "$ARCH" '.assets[] | select(.name | contains($OS) and contains($ARCH)) | .browser_download_url')
+
+              # Check if the download URL was found
+              if [ -z "$DOWNLOAD_URL" ] || [ "$DOWNLOAD_URL" = "null" ]; then
+                  echo "No matching release found for OS: $OS and Architecture: $ARCH"
+                  echo "Available assets for release $TAG_NAME:"
+                  echo "$LATEST_RELEASE_JSON" | jq -r '.assets[].name'
+                  exit 1
+              fi
+
+              echo "Downloading from: $DOWNLOAD_URL"
 
               # Download the matched asset with retry
               # --retry 5: retry up to 5 times

--- a/tests/e2e/helm-upgrade/chainsaw-test.yaml
+++ b/tests/e2e/helm-upgrade/chainsaw-test.yaml
@@ -24,24 +24,41 @@ spec:
               #!/bin/bash
 
               # Define variables
-              REPO_URL="https://api.github.com/repos/odigos-io/odigos/releases/latest"
+              REPO_URL="https://api.github.com/repos/odigos-io/odigos/releases"
 
-              # Fetch the release assets from GitHub API with retry
+              # Fetch all releases from GitHub API with retry
               # --retry 5: retry up to 5 times
               # --retry-delay 1: wait 1 second between retries
               # --retry-max-time 30: maximum time to spend retrying (30 seconds)
-              ASSETS_JSON=$(curl -s --retry 5 --retry-delay 1 --retry-max-time 30 "$REPO_URL")
+              RELEASES_JSON=$(curl -s --retry 5 --retry-delay 1 --retry-max-time 30 "$REPO_URL")
 
-              # Find the download URL for the BASE odigos helm chart 
-              CHART_DOWNLOAD_URL=$(echo "$ASSETS_JSON" \
-                | grep -E '"browser_download_url"' \
-                | grep -E 'helm-chart-odigos-[0-9]' \
-                | cut -d '"' -f 4 \
-                | head -n 1)
+              # Find the latest non-RC release by semantic version
+              # Filter out RC/prerelease/draft releases, then sort by semantic version and take the latest
+              LATEST_RELEASE_JSON=$(echo "$RELEASES_JSON" | jq -r '
+                [.[] | select(.tag_name | test("rc"; "i") | not) | select(.prerelease == false) | select(.draft == false)] |
+                sort_by(.tag_name | sub("^v"; "") | split(".") | map(tonumber)) |
+                reverse |
+                .[0]
+              ')
+
+              # Check if we found a valid release
+              if [ "$LATEST_RELEASE_JSON" = "null" ] || [ -z "$LATEST_RELEASE_JSON" ]; then
+                  echo "No valid non-RC release found"
+                  exit 1
+              fi
+
+              # Extract the tag name for logging
+              TAG_NAME=$(echo "$LATEST_RELEASE_JSON" | jq -r '.tag_name')
+              echo "Found latest non-RC release: $TAG_NAME"
+
+              # Find the download URL for the BASE odigos helm chart
+              CHART_DOWNLOAD_URL=$(echo "$LATEST_RELEASE_JSON" | jq -r '.assets[] | select(.name | test("helm-chart-odigos-[0-9]")) | .browser_download_url')
 
               # Check if the download URL was found
-              if [ -z "$CHART_DOWNLOAD_URL" ]; then
-                  echo "No matching helm chart found in latest release"
+              if [ -z "$CHART_DOWNLOAD_URL" ] || [ "$CHART_DOWNLOAD_URL" = "null" ]; then
+                  echo "No matching helm chart found in release $TAG_NAME"
+                  echo "Available assets for release $TAG_NAME:"
+                  echo "$LATEST_RELEASE_JSON" | jq -r '.assets[].name'
                   exit 1
               fi
 


### PR DESCRIPTION
Manually filter the latest release for cli upgrade and helm upgrade.
following this change i will change the github to not mark not latest patches as the latest.

emergency-ticket id: EMR-865
