### PR TITLE
Update cli-upgrade to use latest tag on current branch

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -171,7 +171,30 @@ jobs:
       - name: Move CLI binary & set permissions
         run: chmod +x cli/odigos
 
+      - name: Get latest release tag for branch from Helm
+        id: get-latest-tag
+        run: |
+          echo "📦 Updating Helm repositories..."
+          helm repo add odigos https://odigos-io.github.io/odigos/ || true
+          helm repo update
+
+          BRANCH="${{ github.base_ref || github.ref_name }}"
+          # If on a release branch (e.g., releases/v1.14.0), get latest Helm version for that version line
+          # Otherwise (main), get the latest overall Helm chart version
+          if [[ "$BRANCH" == releases/* ]]; then
+            VERSION_PREFIX=$(echo "$BRANCH" | sed -E 's|releases/v([0-9]+\.[0-9]+)\..*|\1|')
+            echo "Release branch detected, looking for v${VERSION_PREFIX}.* in Helm"
+            LATEST_RELEASE_TAG=$(helm search repo odigos/odigos --versions | awk -v prefix="^v${VERSION_PREFIX}\\\\." '$1 == "odigos/odigos" && $3 ~ prefix {print $3; exit}')
+          else
+            echo "Non-release branch, using latest Helm chart version"
+            LATEST_RELEASE_TAG=$(helm search repo odigos/odigos | awk '$1 == "odigos/odigos" {print $3}')
+          fi
+          echo "LATEST_RELEASE_TAG=$LATEST_RELEASE_TAG" >> $GITHUB_OUTPUT
+          echo "Latest release tag for branch $BRANCH: $LATEST_RELEASE_TAG"
+
       - name: Run E2E Tests
+        env:
+          LATEST_RELEASE_TAG: ${{ steps.get-latest-tag.outputs.LATEST_RELEASE_TAG }}
         run: |
           MINOR_VERSION=$(echo ${{ matrix.kube-version }} | sed -E 's/^1\.([0-9]+).*$/\1/')
           chainsaw test tests/e2e/${{ matrix.test-scenario }} --values - <<EOF

--- a/tests/e2e/cli-upgrade/chainsaw-test.yaml
+++ b/tests/e2e/cli-upgrade/chainsaw-test.yaml
@@ -26,17 +26,33 @@ spec:
               echo "🧼 Cleaning up any existing installation that might be left over from previous runs..."
               ./odigos uninstall || true
 
-              echo "📦 Updating Helm repositories..."
-              helm repo add odigos https://odigos-io.github.io/odigos/
-              helm repo update
+              # If LATEST_RELEASE_TAG is not set (running locally), compute it from Helm
+              if [[ -z "$LATEST_RELEASE_TAG" ]]; then
+                echo "🔍 LATEST_RELEASE_TAG not set, fetching from Helm..."
 
-              echo "🔍 Fetching latest Odigos release from Helm Chart..."
-              IMAGE_TAG=$(helm search repo odigos | awk '$1 == "odigos/odigos" {print $3}')
-              if [[ -z "$IMAGE_TAG" ]]; then
-                echo "❌ ERROR: Failed to fetch latest release, aborting..."
-              else
-                echo "✅ Successfully fetched latest Odigos release from Helm Chart: $IMAGE_TAG"
+                echo "📦 Updating Helm repositories..."
+                helm repo add odigos https://odigos-io.github.io/odigos/ || true
+                helm repo update
+
+                # Determine the branch to get version prefix
+                BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+                if [[ "$BRANCH" == releases/* ]]; then
+                  # Extract version prefix (e.g., "1.14" from "releases/v1.14.0")
+                  VERSION_PREFIX=$(echo "$BRANCH" | sed -E 's|releases/v([0-9]+\.[0-9]+)\..*|\1|')
+                  echo "Release branch detected, looking for v${VERSION_PREFIX}.* in Helm"
+                  LATEST_RELEASE_TAG=$(helm search repo odigos/odigos --versions | awk -v prefix="^v${VERSION_PREFIX}\\\\." '$1 == "odigos/odigos" && $3 ~ prefix {print $3; exit}')
+                else
+                  echo "Non-release branch, using latest Helm chart version"
+                  LATEST_RELEASE_TAG=$(helm search repo odigos/odigos | awk '$1 == "odigos/odigos" {print $3}')
+                fi
               fi
+
+              if [[ -z "$LATEST_RELEASE_TAG" ]]; then
+                echo "❌ ERROR: Failed to determine LATEST_RELEASE_TAG, aborting..."
+                exit 1
+              fi
+              echo "✅ Using latest Odigos release tag: $LATEST_RELEASE_TAG"
 
               OS=$(uname | tr '[:upper:]' '[:lower:]') # Get the OS name in lowercase
               ARCH=$(uname -m) # Get the system architecture, then convert match GitHub naming conventions
@@ -46,15 +62,15 @@ spec:
                   ARCH="arm64"
               fi
 
-              DOWNLOAD_URL="https://github.com/odigos-io/odigos/releases/download/${IMAGE_TAG}/cli_${IMAGE_TAG#v}_${OS}_${ARCH}.tar.gz"
-              echo "⬇️ Downloading Odigos $IMAGE_TAG from: $DOWNLOAD_URL"
+              DOWNLOAD_URL="https://github.com/odigos-io/odigos/releases/download/${LATEST_RELEASE_TAG}/cli_${LATEST_RELEASE_TAG#v}_${OS}_${ARCH}.tar.gz"
+              echo "⬇️ Downloading Odigos $LATEST_RELEASE_TAG from: $DOWNLOAD_URL"
               # --retry X: retry up to X times
               # --retry-delay X: wait X second between retries
               # --retry-max-time X: maximum time to spend retrying (X seconds for download)
               curl -L -o odigos-latest-cli.tar.gz --retry 5 --retry-delay 1 --retry-max-time 60 "$DOWNLOAD_URL"
               tar -xvzf odigos-latest-cli.tar.gz
 
-              echo "🚀 Installing Odigos $IMAGE_TAG from CLI Binary..."
+              echo "🚀 Installing Odigos $LATEST_RELEASE_TAG from CLI Binary..."
               ./odigos install --ns odigos-test || true
               kubectl label namespace odigos-test odigos.io/system-object="true"
         - assert:


### PR DESCRIPTION
Same as https://github.com/odigos-io/odigos-enterprise/pull/2023

In #4087, cli-upgrade was fixed to use the latest release. But in backport/release branch situations, we actually want to use the latest release from that branch. Otherwise, the test can break because it's actually installing a newer version first, possibly missing changes from that release branch (and effectively trying to do a downgrade)

For example:

* latest release is 1.15.0
* open patch on 1.14 branch (where latest release is 1.14.3)
* cli-upgrade currently grabs latest version (1.15.0) and builds the 1.14 branch then tries to "upgrade" 1.15.0->1.14.4*

This modifies the helm approach to extract the latest tag that matches the current branch

emergency-ticket id: EMR-879
