### PR TITLE
chore: check nil pointer in kratos.go for disabling java runtime metrics

### DIFF
--- a/profiles/aggregators/kratos.go
+++ b/profiles/aggregators/kratos.go
@@ -28,6 +28,20 @@ var KratosProfile = profile.Profile{
 	ModifyConfigFunc: func(config *common.OdigosConfiguration) {
 		disabled := true
 		config.RollbackDisabled = &disabled
+
+		// Ensure each level exists, creating only if nil
+		if config.MetricsSources == nil {
+			config.MetricsSources = &common.MetricsSourceConfiguration{}
+		}
+		if config.MetricsSources.AgentMetrics == nil {
+			config.MetricsSources.AgentMetrics = &common.MetricsSourceAgentMetricsConfiguration{}
+		}
+		if config.MetricsSources.AgentMetrics.RuntimeMetrics == nil {
+			config.MetricsSources.AgentMetrics.RuntimeMetrics = &common.MetricsSourceAgentRuntimeMetricsConfiguration{}
+		}
+		if config.MetricsSources.AgentMetrics.RuntimeMetrics.Java == nil {
+			config.MetricsSources.AgentMetrics.RuntimeMetrics.Java = &common.MetricsSourceAgentJavaRuntimeMetricsConfiguration{}
+		}
 		config.MetricsSources.AgentMetrics.RuntimeMetrics.Java.Disabled = &disabled
 	},
 }


### PR DESCRIPTION
In kratos, need to verify that java runtime metrics eventually disabled.

emergency-ticket id: EMR-899
