### PR TITLE
chore: update PHP agent version to v0.2.5 in Dockerfiles

### DIFF
--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -58,7 +58,7 @@ COPY --from=public.ecr.aws/odigos/agents/nodejs-community:v0.0.8 /instrumentatio
 COPY --from=dotnet-builder /dotnet-instrumentation /instrumentations/dotnet
 
 # PHP
-COPY --from=public.ecr.aws/odigos/agents/php-community:v0.2.4 /instrumentations/php /instrumentations/php
+COPY --from=public.ecr.aws/odigos/agents/php-community:v0.2.5 /instrumentations/php /instrumentations/php
 
 # Ruby
 COPY --from=public.ecr.aws/odigos/agents/ruby-community:v0.0.7 /instrumentations/ruby /instrumentations/ruby

--- a/odiglet/debug.Dockerfile
+++ b/odiglet/debug.Dockerfile
@@ -79,7 +79,7 @@ COPY --from=public.ecr.aws/odigos/agents/nodejs-community:v0.0.8 /instrumentatio
 COPY --from=dotnet-builder /dotnet-instrumentation /instrumentations/dotnet
 
 # PHP
-COPY --from=public.ecr.aws/odigos/agents/php-community:v0.2.4 /instrumentations/php /instrumentations/php
+COPY --from=public.ecr.aws/odigos/agents/php-community:v0.2.5 /instrumentations/php /instrumentations/php
 
 # Ruby
 COPY --from=public.ecr.aws/odigos/agents/ruby-community:v0.0.7 /instrumentations/ruby /instrumentations/ruby


### PR DESCRIPTION
- fixed CVE-2025-54418
- updated versions of existing libs
- added new libs for: cakephp, laravel, yii, and wordpress
- updated tests to include apps for new frameworks

https://github.com/odigos-io/opentelemetry-php/pull/16

emergency-ticket id: EMR-898
