### PR TITLE
fix(helm): preserve odigos-deployment-id across upgrades

### DIFF
--- a/helm/odigos/templates/odigos-deployment.yaml
+++ b/helm/odigos/templates/odigos-deployment.yaml
@@ -1,3 +1,4 @@
+{{- $existingCM := lookup "v1" "ConfigMap" .Release.Namespace "odigos-deployment" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,4 +10,4 @@ data:
   ODIGOS_VERSION: '{{ .Values.image.tag | default .Chart.AppVersion }}'
   ODIGOS_TIER: '{{- if include "odigos.secretExists" . }}onprem{{- else }}community{{- end }}'
   installation-method: helm
-  odigos-deployment-id: '{{ uuidv4 }}'
+  odigos-deployment-id: '{{ if and $existingCM $existingCM.data (index $existingCM.data "odigos-deployment-id") }}{{ index $existingCM.data "odigos-deployment-id" }}{{ else }}{{ uuidv4 }}{{ end }}'

--- a/helm/odigos/templates/odigos-deployment.yaml
+++ b/helm/odigos/templates/odigos-deployment.yaml
@@ -10,4 +10,4 @@ data:
   ODIGOS_VERSION: "{{ .Values.image.tag | default .Chart.AppVersion }}"
   ODIGOS_TIER: '{{- if include "odigos.secretExists" . }}onprem{{- else }}community{{- end }}'
   installation-method: helm
-  odigos-deployment-id: '{{ if and $existingCM $existingCM.data (index $existingCM.data "odigos-deployment-id") }}{{ index $existingCM.data "odigos-deployment-id" }}{{ else }}{{ uuidv4 }}{{ end }}'
+  odigos-deployment-id: '{{- if $existingCM }}{{- if $existingCM.data }}{{- if index $existingCM.data "odigos-deployment-id" }}{{ index $existingCM.data "odigos-deployment-id" }}{{- else }}{{ uuidv4 }}{{- end }}{{- else }}{{ uuidv4 }}{{- end }}{{- else }}{{ uuidv4 }}{{- end }}'


### PR DESCRIPTION
Use Helm lookup function to check for existing ConfigMap and preserve the odigos-deployment-id value during helm upgrade operations. This prevents duplicate compute platform entries in central-backend when upgrading Odigos.

The fix handles edge cases:
- Fresh install (no existing ConfigMap) - generates new UUID
- ConfigMap exists with valid ID - preserves existing ID
- ConfigMap exists but ID is empty/missing - generates new UUID

emergency-ticket id: EMR-923
