### PR TITLE
feat: add comprehensive K8s resource linter for helm charts

### DIFF
--- a/.github/workflows/helm-go-runtime-lint.yml
+++ b/.github/workflows/helm-go-runtime-lint.yml
@@ -1,0 +1,33 @@
+name: Lint Helm K8s Resources
+
+on:
+  pull_request:
+    paths:
+      - helm/**
+      - scripts/validate-helm-k8s-resources.py
+      - scripts/lint-helm-k8s-resources.sh
+      - .github/workflows/helm-go-runtime-lint.yml
+
+jobs:
+  lint-k8s-resources:
+    name: Validate K8s Resource Configuration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python dependencies
+        run: pip install pyyaml
+
+      - name: Run K8s resource configuration linter
+        run: |
+          chmod +x scripts/lint-helm-k8s-resources.sh
+          ./scripts/lint-helm-k8s-resources.sh

--- a/helm/odigos-central/templates/centralbackend/deployment.yaml
+++ b/helm/odigos-central/templates/centralbackend/deployment.yaml
@@ -46,6 +46,13 @@ spec:
             - name: MAX_MESSAGE_SIZE
               value: {{ .Values.centralBackend.maxMessageSize | quote }}
             {{- end }}
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: central-backend
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              value: {{ include "odigos.gomemlimitFromResources" (dict "Resources" .Values.centralBackend.resources) }}
           ports:
             - containerPort: 8081
               name: http

--- a/helm/odigos-central/templates/centralui/deployment.yaml
+++ b/helm/odigos-central/templates/centralui/deployment.yaml
@@ -28,6 +28,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: central-ui
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              value: {{ include "odigos.gomemlimitFromResources" (dict "Resources" .Values.centralUI.resources) }}
           resources:
             requests:
               cpu: {{ .Values.centralUI.resources.requests.cpu }}

--- a/helm/odigos-central/templates/keycloak/deployment.yaml
+++ b/helm/odigos-central/templates/keycloak/deployment.yaml
@@ -44,6 +44,7 @@ spec:
       securityContext:
         fsGroup: {{ .Values.auth.podSecurityContext.fsGroup }}
       {{- end }}
+      {{ include "odigos.renderPullSecrets" . | nindent 6 }}
       containers:
         - name: keycloak
           image: {{ .Values.auth.image | quote }}

--- a/helm/odigos-central/templates/redis/redis.yaml
+++ b/helm/odigos-central/templates/redis/redis.yaml
@@ -28,6 +28,7 @@ spec:
               app: redis
         {{- end }}
         {{- end }}
+      {{ include "odigos.renderPullSecrets" . | nindent 6 }}
       containers:
         - name: redis
           image: {{ .Values.redis.image | quote }}

--- a/helm/odigos/templates/autoscaler/deployment.yaml
+++ b/helm/odigos/templates/autoscaler/deployment.yaml
@@ -51,6 +51,11 @@ spec:
           - /app
         image: {{ template "utils.imageName" (dict "Values" .Values "Component" "autoscaler" "Tag" $imageTag) }}
         env:
+          - name: GOMAXPROCS
+            valueFrom:
+              resourceFieldRef:
+                containerName: manager
+                resource: limits.cpu
           - name: OTEL_SERVICE_NAME
             value: auto-scaler
           - name: CURRENT_NS

--- a/helm/odigos/templates/centralproxy/deployment.yaml
+++ b/helm/odigos/templates/centralproxy/deployment.yaml
@@ -68,6 +68,11 @@ spec:
             - name: TLS_KEY_FILE
               value: "/etc/tls/client/tls.key"
             {{- end }}
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: central-proxy
+                  resource: limits.cpu
             - name: GOMEMLIMIT
               value: {{ include "odigos.gomemlimitFromResources" (dict "Resources" .Values.centralProxy.resources) }}
           {{- if or .Values.centralProxy.tls.caSecretName .Values.centralProxy.tls.clientCertSecretName }}

--- a/helm/odigos/templates/cleanup/cleanup-job.yaml
+++ b/helm/odigos/templates/cleanup/cleanup-job.yaml
@@ -20,5 +20,15 @@ spec:
       - name: cleanup
         image: {{ template "utils.imageName" (dict "Values" .Values "Component" "cli" "Tag" $imageTag) }}
         args: ["cleanup", "--yes", "--instrumentation-only", "--namespace", "{{ .Release.Namespace }}"]
+        env:
+          - name: GOMAXPROCS
+            valueFrom:
+              resourceFieldRef:
+                containerName: cleanup
+                resource: limits.cpu
+          - name: GOMEMLIMIT
+            value: {{ include "odigos.gomemlimitFromResources" (dict "Resources" .Values.cleanup.resources) }}
+        resources:
+{{ toYaml .Values.cleanup.resources | indent 10 }}
       restartPolicy: Never
       {{ include "odigos.renderPullSecrets" . | nindent 6 }}

--- a/helm/odigos/templates/instrumentor/deployment.yaml
+++ b/helm/odigos/templates/instrumentor/deployment.yaml
@@ -68,6 +68,11 @@ spec:
             name: webhook-server
             protocol: TCP
         env:
+          - name: GOMAXPROCS
+            valueFrom:
+              resourceFieldRef:
+                containerName: manager
+                resource: limits.cpu
           - name: OTEL_SERVICE_NAME
             value: instrumentor
           - name: CURRENT_NS

--- a/helm/odigos/templates/odiglet/daemonset.yaml
+++ b/helm/odigos/templates/odiglet/daemonset.yaml
@@ -101,6 +101,8 @@ spec:
                 resourceFieldRef:
                   containerName: init
                   resource: limits.cpu
+            - name: GOMEMLIMIT
+              value: {{ include "odigos.gomemlimitFromResources" (dict "Resources" .Values.odiglet.initContainerResources) }}
           resources:
 {{ toYaml .Values.odiglet.initContainerResources | indent 12 }}
       {{- end }}
@@ -199,6 +201,11 @@ spec:
                   name: odigos-pro
                   key: odigos-onprem-token
           {{- end }}
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: odiglet
+                  resource: limits.cpu
             - name: GOMEMLIMIT
               value: {{ include "odigos.gomemlimitFromResources" (dict "Resources" (include "odigos.odiglet.resolvedResources" . | fromYaml)) }}
           {{- if .Values.odiglet.noHostPid }}
@@ -367,6 +374,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: deviceplugin
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              value: {{ include "odigos.gomemlimitFromResources" (dict "Resources" .Values.odiglet.deviceplugin.resources) }}
           volumeMounts:
             - name: device-plugins-dir
               mountPath: /var/lib/kubelet/device-plugins

--- a/helm/odigos/templates/scheduler/deployment.yaml
+++ b/helm/odigos/templates/scheduler/deployment.yaml
@@ -51,6 +51,11 @@ spec:
         {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
         image: {{ template "utils.imageName" (dict "Values" .Values "Component" "scheduler" "Tag" $imageTag) }}
         env:
+          - name: GOMAXPROCS
+            valueFrom:
+              resourceFieldRef:
+                containerName: manager
+                resource: limits.cpu
           - name: OTEL_SERVICE_NAME
             value: scheduler
           - name: CURRENT_NS

--- a/helm/odigos/templates/ui/deployment.yaml
+++ b/helm/odigos/templates/ui/deployment.yaml
@@ -49,6 +49,11 @@ spec:
           - --namespace=$(CURRENT_NS)
           - --address=0.0.0.0
         env:
+          - name: GOMAXPROCS
+            valueFrom:
+              resourceFieldRef:
+                containerName: ui
+                resource: limits.cpu
           - name: CURRENT_NS
             valueFrom:
               fieldRef:

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -505,6 +505,16 @@ centralProxy:
   # Priority class name. Set to use your existing cluster priority classes.
   # priorityClassName: ''
 
+# Cleanup job configuration (runs during helm uninstall)
+cleanup:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      cpu: 500m
+      memory: 128Mi
+
 # Pod Security Policy
 psp:
   enabled: false

--- a/scripts/lint-helm-k8s-resources.sh
+++ b/scripts/lint-helm-k8s-resources.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+#
+# Lint Helm charts to ensure Kubernetes workloads have proper configuration:
+# - Resource limits and requests
+# - GOMAXPROCS and GOMEMLIMIT for Go containers
+# - imagePullSecrets support (when configured)
+#
+# Usage:
+#   ./scripts/lint-helm-k8s-resources.sh
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LINTER="${SCRIPT_DIR}/validate-helm-k8s-resources.py"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo "=== Kubernetes Resource Configuration Linter ==="
+echo ""
+
+# Check if helm is installed
+if ! command -v helm &> /dev/null; then
+    echo -e "${RED}Error: helm is not installed${NC}" >&2
+    exit 1
+fi
+
+# Check if python3 is installed
+if ! command -v python3 &> /dev/null; then
+    echo -e "${RED}Error: python3 is not installed${NC}" >&2
+    exit 1
+fi
+
+# Check if PyYAML is installed
+if ! python3 -c "import yaml" &> /dev/null; then
+    echo -e "${RED}Error: PyYAML is not installed. Install with: pip install pyyaml${NC}" >&2
+    exit 1
+fi
+
+ERRORS=0
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf ${TEMP_DIR}" EXIT
+
+# Function to lint a helm chart
+lint_chart() {
+    local chart_path="$1"
+    local chart_name="$(basename "${chart_path}")"
+    local values_file="$2"
+    local description="$3"
+    local extra_args="${4:-}"
+
+    echo -e "${YELLOW}Checking ${chart_name} (${description})...${NC}"
+
+    local output_file="${TEMP_DIR}/${chart_name}-${description//[^a-zA-Z0-9]/-}.yaml"
+
+    # Render the helm template
+    if ! helm template test-release "${chart_path}" ${values_file:+--values "${values_file}"} > "${output_file}" 2>&1; then
+        echo -e "${RED}  Failed to render helm template${NC}"
+        cat "${output_file}" >&2
+        ((ERRORS++))
+        return 1
+    fi
+
+    # Run the linter
+    if python3 "${LINTER}" --strict ${extra_args} "${output_file}"; then
+        echo -e "${GREEN}  Passed${NC}"
+    else
+        ((ERRORS++))
+    fi
+
+    echo ""
+}
+
+# ==================== Test 1: Default values ====================
+echo -e "${BLUE}=== Test 1: Basic validation (resources, GOMAXPROCS, GOMEMLIMIT) ===${NC}"
+echo ""
+
+lint_chart "${REPO_ROOT}/helm/odigos" "" "default values"
+
+# ==================== Test 2: Enterprise mode ====================
+echo -e "${BLUE}=== Test 2: Enterprise mode ===${NC}"
+echo ""
+
+ENTERPRISE_VALUES="${TEMP_DIR}/enterprise-values.yaml"
+cat > "${ENTERPRISE_VALUES}" <<EOF
+onPremToken: "test-token-for-linting"
+clusterName: "test-cluster"
+centralProxy:
+  centralBackendURL: "https://example.com"
+EOF
+lint_chart "${REPO_ROOT}/helm/odigos" "${ENTERPRISE_VALUES}" "enterprise mode"
+
+# ==================== Test 3: imagePullSecrets support ====================
+echo -e "${BLUE}=== Test 3: imagePullSecrets support ===${NC}"
+echo ""
+
+PULL_SECRETS_VALUES="${TEMP_DIR}/pull-secrets-values.yaml"
+cat > "${PULL_SECRETS_VALUES}" <<EOF
+imagePullSecrets:
+  - my-registry-secret
+EOF
+lint_chart "${REPO_ROOT}/helm/odigos" "${PULL_SECRETS_VALUES}" "with imagePullSecrets" "--require-image-pull-secrets"
+
+# ==================== Test 4: odigos-central chart ====================
+if [ -d "${REPO_ROOT}/helm/odigos-central" ]; then
+    echo -e "${BLUE}=== Test 4: odigos-central chart ===${NC}"
+    echo ""
+
+    CENTRAL_VALUES="${TEMP_DIR}/central-values.yaml"
+    cat > "${CENTRAL_VALUES}" <<EOF
+onPremToken: "test-token-for-linting"
+EOF
+    lint_chart "${REPO_ROOT}/helm/odigos-central" "${CENTRAL_VALUES}" "default values"
+
+    # Test imagePullSecrets in odigos-central
+    CENTRAL_PULL_SECRETS="${TEMP_DIR}/central-pull-secrets.yaml"
+    cat > "${CENTRAL_PULL_SECRETS}" <<EOF
+onPremToken: "test-token-for-linting"
+imagePullSecrets:
+  - my-registry-secret
+EOF
+    lint_chart "${REPO_ROOT}/helm/odigos-central" "${CENTRAL_PULL_SECRETS}" "with imagePullSecrets" "--require-image-pull-secrets"
+fi
+
+# ==================== Summary ====================
+echo "=== Summary ==="
+if [ ${ERRORS} -eq 0 ]; then
+    echo -e "${GREEN}All checks passed!${NC}"
+    exit 0
+else
+    echo -e "${RED}${ERRORS} check(s) failed${NC}"
+    exit 1
+fi

--- a/scripts/validate-helm-k8s-resources.py
+++ b/scripts/validate-helm-k8s-resources.py
@@ -1,0 +1,579 @@
+#!/usr/bin/env python3
+"""
+Linter to validate Kubernetes workloads in Helm charts have proper configuration:
+- Resource limits and requests (cpu and memory)
+- GOMAXPROCS and GOMEMLIMIT for Go containers
+- ImagePullSecrets support (when --require-image-pull-secrets is set)
+
+Usage:
+    python validate-helm-k8s-resources.py <rendered_manifests.yaml>
+
+    # Or pipe helm template output:
+    helm template myrelease ./helm/odigos | python validate-helm-k8s-resources.py -
+
+    # Check that imagePullSecrets are rendered (for templates that should support it):
+    helm template myrelease ./helm/odigos --set imagePullSecrets[0]=my-secret | \
+        python validate-helm-k8s-resources.py - --require-image-pull-secrets
+"""
+
+import argparse
+import re
+import sys
+import yaml
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class ContainerChecks:
+    """Configuration for what to check on a container."""
+    check_resources: bool = True          # Check for resource limits/requests
+    check_gomaxprocs: bool = False        # Check for GOMAXPROCS env var
+    check_gomemlimit: bool = False        # Check for GOMEMLIMIT env var
+    is_go_container: bool = False         # Container runs Go code
+
+
+# Container configuration registry
+# Format: (workload_name_pattern, container_name_pattern) -> ContainerChecks
+CONTAINER_CONFIG: list[tuple[str, str, ContainerChecks]] = [
+    # ============ odigos chart - Go containers ============
+    (r"^odigos-autoscaler$", r"^manager$", ContainerChecks(
+        check_resources=True, check_gomaxprocs=True, check_gomemlimit=True, is_go_container=True
+    )),
+    (r"^odigos-scheduler$", r"^manager$", ContainerChecks(
+        check_resources=True, check_gomaxprocs=True, check_gomemlimit=True, is_go_container=True
+    )),
+    (r"^odigos-instrumentor$", r"^manager$", ContainerChecks(
+        check_resources=True, check_gomaxprocs=True, check_gomemlimit=True, is_go_container=True
+    )),
+    (r"^odigos-ui$", r"^ui$", ContainerChecks(
+        check_resources=True, check_gomaxprocs=True, check_gomemlimit=True, is_go_container=True
+    )),
+    (r"^central-proxy$", r"^central-proxy$", ContainerChecks(
+        check_resources=True, check_gomaxprocs=True, check_gomemlimit=True, is_go_container=True
+    )),
+    (r"^odiglet$", r"^odiglet$", ContainerChecks(
+        check_resources=True, check_gomaxprocs=True, check_gomemlimit=True, is_go_container=True
+    )),
+    (r"^odiglet$", r"^data-collection$", ContainerChecks(
+        check_resources=True, check_gomaxprocs=True, check_gomemlimit=True, is_go_container=True
+    )),
+    (r"^odiglet$", r"^deviceplugin$", ContainerChecks(
+        check_resources=True, check_gomaxprocs=True, check_gomemlimit=True, is_go_container=True
+    )),
+    (r"^odiglet$", r"^init$", ContainerChecks(
+        check_resources=True, check_gomaxprocs=True, check_gomemlimit=True, is_go_container=True
+    )),
+    (r"^cleanup-job$", r"^cleanup$", ContainerChecks(
+        check_resources=True, check_gomaxprocs=True, check_gomemlimit=True, is_go_container=True
+    )),
+
+    # ============ odigos-central chart - Go containers ============
+    (r"^central-backend$", r"^central-backend$", ContainerChecks(
+        check_resources=True, check_gomaxprocs=True, check_gomemlimit=True, is_go_container=True
+    )),
+    (r"^central-ui$", r"^central-ui$", ContainerChecks(
+        check_resources=True, check_gomaxprocs=True, check_gomemlimit=True, is_go_container=True
+    )),
+
+    # ============ Third-party / non-Go containers ============
+    # VictoriaMetrics - third-party Go app, manages its own memory
+    (r"^odigos-victoriametrics$", r"^vm$", ContainerChecks(
+        check_resources=True, check_gomaxprocs=False, check_gomemlimit=False, is_go_container=False
+    )),
+    # Keycloak - Java application
+    (r"^keycloak$", r".*", ContainerChecks(
+        check_resources=True, check_gomaxprocs=False, check_gomemlimit=False, is_go_container=False
+    )),
+    # Redis - C application
+    (r"^redis$", r".*", ContainerChecks(
+        check_resources=True, check_gomaxprocs=False, check_gomemlimit=False, is_go_container=False
+    )),
+    # Image pull init container - just pulls image, doesn't run code
+    (r"^odiglet$", r"^odigos-agents-image-pull$", ContainerChecks(
+        check_resources=True, check_gomaxprocs=False, check_gomemlimit=False, is_go_container=False
+    )),
+]
+
+# Workloads that use third-party images and don't need imagePullSecrets from Odigos registry
+THIRD_PARTY_IMAGE_WORKLOADS = [
+    r"^odigos-victoriametrics$",  # Uses public VictoriaMetrics image
+]
+
+# Workload kinds to check
+WORKLOAD_KINDS = {"Deployment", "StatefulSet", "DaemonSet", "Job", "CronJob"}
+
+
+@dataclass
+class LintError:
+    workload_kind: str
+    workload_name: str
+    container_name: str
+    category: str
+    message: str
+
+    def __str__(self):
+        if self.container_name:
+            return f"[{self.category}] {self.workload_kind}/{self.workload_name} container={self.container_name}: {self.message}"
+        return f"[{self.category}] {self.workload_kind}/{self.workload_name}: {self.message}"
+
+
+def parse_memory_value(value: str) -> int | None:
+    """Parse a Kubernetes memory value to bytes."""
+    if not value:
+        return None
+
+    value = str(value).strip()
+
+    # Handle pure numbers (bytes)
+    if value.isdigit():
+        return int(value)
+
+    # Parse with units
+    match = re.match(r'^(\d+(?:\.\d+)?)\s*([EPTGMK]i?|[eptgmk])?[bB]?$', value)
+    if not match:
+        return None
+
+    num = float(match.group(1))
+    unit = match.group(2) or ''
+
+    multipliers = {
+        '': 1,
+        'K': 1000,
+        'Ki': 1024,
+        'M': 1000**2,
+        'Mi': 1024**2,
+        'G': 1000**3,
+        'Gi': 1024**3,
+        'T': 1000**4,
+        'Ti': 1024**4,
+        'P': 1000**5,
+        'Pi': 1024**5,
+        'E': 1000**6,
+        'Ei': 1024**6,
+    }
+
+    return int(num * multipliers.get(unit, 1))
+
+
+def parse_gomemlimit_value(value: str) -> int | None:
+    """Parse a GOMEMLIMIT value to bytes."""
+    if not value:
+        return None
+
+    value = str(value).strip()
+
+    # Handle pure numbers (bytes)
+    if value.isdigit():
+        return int(value)
+
+    # GOMEMLIMIT uses B suffix (e.g., MiB, GiB)
+    match = re.match(r'^(\d+(?:\.\d+)?)\s*([EPTGMK]i)?[bB]$', value)
+    if not match:
+        # Try without B suffix
+        match = re.match(r'^(\d+(?:\.\d+)?)\s*([EPTGMK]i)?$', value)
+        if not match:
+            return None
+
+    num = float(match.group(1))
+    unit = match.group(2) or ''
+
+    multipliers = {
+        '': 1,
+        'Ki': 1024,
+        'Mi': 1024**2,
+        'Gi': 1024**3,
+        'Ti': 1024**4,
+        'Pi': 1024**5,
+        'Ei': 1024**6,
+    }
+
+    return int(num * multipliers.get(unit, 1))
+
+
+def get_container_config(workload_name: str, container_name: str) -> ContainerChecks | None:
+    """Get the check configuration for a container."""
+    for pattern, container_pattern, config in CONTAINER_CONFIG:
+        if re.match(pattern, workload_name) and re.match(container_pattern, container_name):
+            return config
+    return None
+
+
+def get_env_var(env_list: list, name: str) -> dict | None:
+    """Get an environment variable from a list of env vars."""
+    if not env_list:
+        return None
+    for env in env_list:
+        if env.get("name") == name:
+            return env
+    return None
+
+
+def validate_resources(
+    container: dict,
+    workload_kind: str,
+    workload_name: str,
+    container_name: str
+) -> list[LintError]:
+    """Validate that a container has proper resource limits and requests."""
+    errors = []
+    resources = container.get("resources", {})
+
+    if not resources:
+        errors.append(LintError(
+            workload_kind, workload_name, container_name,
+            "resources", "No resources defined"
+        ))
+        return errors
+
+    limits = resources.get("limits", {})
+    requests = resources.get("requests", {})
+
+    # Check limits
+    if not limits:
+        errors.append(LintError(
+            workload_kind, workload_name, container_name,
+            "resources", "No resource limits defined"
+        ))
+    else:
+        if "cpu" not in limits:
+            errors.append(LintError(
+                workload_kind, workload_name, container_name,
+                "resources", "No CPU limit defined"
+            ))
+        if "memory" not in limits:
+            errors.append(LintError(
+                workload_kind, workload_name, container_name,
+                "resources", "No memory limit defined"
+            ))
+
+    # Check requests
+    if not requests:
+        errors.append(LintError(
+            workload_kind, workload_name, container_name,
+            "resources", "No resource requests defined"
+        ))
+    else:
+        if "cpu" not in requests:
+            errors.append(LintError(
+                workload_kind, workload_name, container_name,
+                "resources", "No CPU request defined"
+            ))
+        if "memory" not in requests:
+            errors.append(LintError(
+                workload_kind, workload_name, container_name,
+                "resources", "No memory request defined"
+            ))
+
+    return errors
+
+
+def validate_gomaxprocs(
+    env_var: dict | None,
+    container_name: str,
+    has_cpu_limit: bool,
+    workload_kind: str,
+    workload_name: str
+) -> LintError | None:
+    """Validate GOMAXPROCS configuration."""
+    if not has_cpu_limit:
+        if not env_var:
+            return None
+        # If set, it should still be via resourceFieldRef
+
+    if not env_var:
+        if has_cpu_limit:
+            return LintError(
+                workload_kind, workload_name, container_name,
+                "GOMAXPROCS", "GOMAXPROCS not set but container has CPU limit"
+            )
+        return None
+
+    value_from = env_var.get("valueFrom")
+    if not value_from:
+        value = env_var.get("value")
+        if value:
+            return LintError(
+                workload_kind, workload_name, container_name,
+                "GOMAXPROCS", f"GOMAXPROCS set to static value '{value}' instead of resourceFieldRef"
+            )
+        return LintError(
+            workload_kind, workload_name, container_name,
+            "GOMAXPROCS", "GOMAXPROCS has no value or valueFrom"
+        )
+
+    resource_field_ref = value_from.get("resourceFieldRef")
+    if not resource_field_ref:
+        return LintError(
+            workload_kind, workload_name, container_name,
+            "GOMAXPROCS", f"GOMAXPROCS should use resourceFieldRef, not {list(value_from.keys())}"
+        )
+
+    resource = resource_field_ref.get("resource", "")
+    if resource != "limits.cpu":
+        return LintError(
+            workload_kind, workload_name, container_name,
+            "GOMAXPROCS", f"GOMAXPROCS resourceFieldRef should reference 'limits.cpu', not '{resource}'"
+        )
+
+    return None
+
+
+def validate_gomemlimit(
+    env_var: dict | None,
+    memory_limit_bytes: int | None,
+    workload_kind: str,
+    workload_name: str,
+    container_name: str
+) -> LintError | None:
+    """Validate GOMEMLIMIT configuration."""
+    if not memory_limit_bytes:
+        if not env_var:
+            return None
+        return None
+
+    if not env_var:
+        return LintError(
+            workload_kind, workload_name, container_name,
+            "GOMEMLIMIT", "GOMEMLIMIT not set but container has memory limit"
+        )
+
+    value = env_var.get("value")
+    value_from = env_var.get("valueFrom")
+
+    if value_from:
+        return None
+
+    if not value:
+        return LintError(
+            workload_kind, workload_name, container_name,
+            "GOMEMLIMIT", "GOMEMLIMIT has no value"
+        )
+
+    # Handle Helm template expressions
+    if "{{" in str(value) or "}}" in str(value):
+        return None
+
+    gomemlimit_bytes = parse_gomemlimit_value(value)
+    if gomemlimit_bytes is None:
+        return LintError(
+            workload_kind, workload_name, container_name,
+            "GOMEMLIMIT", f"GOMEMLIMIT has unparseable value: '{value}'"
+        )
+
+    expected_min = int(memory_limit_bytes * 0.70)
+    expected_max = int(memory_limit_bytes * 0.90)
+
+    if gomemlimit_bytes < expected_min or gomemlimit_bytes > expected_max:
+        expected = int(memory_limit_bytes * 0.80)
+        return LintError(
+            workload_kind, workload_name, container_name,
+            "GOMEMLIMIT", f"GOMEMLIMIT ({value}) is not within 70-90% of memory limit. Expected ~{expected} bytes, got {gomemlimit_bytes} bytes"
+        )
+
+    return None
+
+
+def is_third_party_image_workload(workload_name: str) -> bool:
+    """Check if a workload uses third-party images."""
+    for pattern in THIRD_PARTY_IMAGE_WORKLOADS:
+        if re.match(pattern, workload_name):
+            return True
+    return False
+
+
+def validate_image_pull_secrets(
+    spec: dict,
+    workload_kind: str,
+    workload_name: str
+) -> LintError | None:
+    """Validate that imagePullSecrets is configured for Odigos images."""
+    # Skip workloads that use third-party images
+    if is_third_party_image_workload(workload_name):
+        return None
+
+    image_pull_secrets = spec.get("imagePullSecrets")
+
+    if not image_pull_secrets:
+        return LintError(
+            workload_kind, workload_name, "",
+            "imagePullSecrets", "imagePullSecrets not rendered (template may not support imagePullSecrets)"
+        )
+
+    return None
+
+
+def get_containers(spec: dict) -> list[tuple[str, dict, bool]]:
+    """Get all containers from a pod spec."""
+    containers = []
+
+    for container in spec.get("initContainers", []):
+        containers.append((container.get("name", "unknown"), container, True))
+
+    for container in spec.get("containers", []):
+        containers.append((container.get("name", "unknown"), container, False))
+
+    return containers
+
+
+def validate_workload(doc: dict, require_image_pull_secrets: bool = False) -> list[LintError]:
+    """Validate a single Kubernetes workload document."""
+    errors = []
+
+    kind = doc.get("kind", "")
+    if kind not in WORKLOAD_KINDS:
+        return errors
+
+    metadata = doc.get("metadata", {})
+    name = metadata.get("name", "unknown")
+
+    # Get the pod template spec
+    spec = doc.get("spec", {})
+
+    if kind == "CronJob":
+        spec = spec.get("jobTemplate", {}).get("spec", {}).get("template", {}).get("spec", {})
+    elif kind == "Job":
+        spec = spec.get("template", {}).get("spec", {})
+    else:  # Deployment, StatefulSet, DaemonSet
+        spec = spec.get("template", {}).get("spec", {})
+
+    if not spec:
+        return errors
+
+    # Check imagePullSecrets at pod level (only when required)
+    if require_image_pull_secrets:
+        error = validate_image_pull_secrets(spec, kind, name)
+        if error:
+            errors.append(error)
+
+    containers = get_containers(spec)
+
+    for container_name, container, is_init in containers:
+        config = get_container_config(name, container_name)
+        if config is None:
+            # Unknown container - skip
+            continue
+
+        resources = container.get("resources", {})
+        limits = resources.get("limits", {})
+        requests = resources.get("requests", {})
+
+        # Check resources
+        if config.check_resources:
+            resource_errors = validate_resources(container, kind, name, container_name)
+            errors.extend(resource_errors)
+
+        # Get limits for GOMAXPROCS/GOMEMLIMIT checks
+        memory_limit = limits.get("memory") or requests.get("memory")
+        cpu_limit = limits.get("cpu") or requests.get("cpu")
+        memory_limit_bytes = parse_memory_value(memory_limit) if memory_limit else None
+        has_cpu_limit = cpu_limit is not None
+
+        env_list = container.get("env", [])
+
+        # Check GOMEMLIMIT
+        if config.check_gomemlimit:
+            gomemlimit_env = get_env_var(env_list, "GOMEMLIMIT")
+            error = validate_gomemlimit(gomemlimit_env, memory_limit_bytes, kind, name, container_name)
+            if error:
+                errors.append(error)
+
+        # Check GOMAXPROCS
+        if config.check_gomaxprocs:
+            gomaxprocs_env = get_env_var(env_list, "GOMAXPROCS")
+            error = validate_gomaxprocs(gomaxprocs_env, container_name, has_cpu_limit, kind, name)
+            if error:
+                errors.append(error)
+
+    return errors
+
+
+def load_yaml_documents(content: str) -> list[dict]:
+    """Load all YAML documents from a string."""
+    docs = []
+    for doc in yaml.safe_load_all(content):
+        if doc:
+            docs.append(doc)
+    return docs
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Validate Kubernetes workloads in Helm charts"
+    )
+    parser.add_argument(
+        "file",
+        nargs="?",
+        default="-",
+        help="YAML file to validate (use '-' for stdin)",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit with error if any issues are found",
+    )
+    parser.add_argument(
+        "--require-image-pull-secrets",
+        action="store_true",
+        help="Require imagePullSecrets to be present (use when testing with imagePullSecrets values set)",
+    )
+    parser.add_argument(
+        "--category",
+        action="append",
+        dest="categories",
+        help="Only check specific categories (resources, GOMAXPROCS, GOMEMLIMIT, imagePullSecrets)",
+    )
+
+    args = parser.parse_args()
+
+    # Read input
+    if args.file == "-":
+        content = sys.stdin.read()
+    else:
+        with open(args.file, "r") as f:
+            content = f.read()
+
+    # Parse YAML
+    try:
+        docs = load_yaml_documents(content)
+    except yaml.YAMLError as e:
+        print(f"Error parsing YAML: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Validate each document
+    all_errors: list[LintError] = []
+    for doc in docs:
+        errors = validate_workload(doc, require_image_pull_secrets=args.require_image_pull_secrets)
+        all_errors.extend(errors)
+
+    # Filter by category if specified
+    if args.categories:
+        all_errors = [e for e in all_errors if e.category in args.categories]
+
+    # Report results
+    if all_errors:
+        # Group errors by category for better readability
+        by_category: dict[str, list[LintError]] = {}
+        for error in all_errors:
+            by_category.setdefault(error.category, []).append(error)
+
+        print(f"Found {len(all_errors)} issue(s):\n", file=sys.stderr)
+        for category, errors in sorted(by_category.items()):
+            print(f"  {category} ({len(errors)} issues):", file=sys.stderr)
+            for error in errors:
+                print(f"    - {error.workload_kind}/{error.workload_name}", end="", file=sys.stderr)
+                if error.container_name:
+                    print(f" container={error.container_name}", end="", file=sys.stderr)
+                print(f": {error.message}", file=sys.stderr)
+            print(file=sys.stderr)
+
+        if args.strict:
+            sys.exit(1)
+    else:
+        print("All workloads pass validation.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Add a CI linter that validates Kubernetes workloads have proper configuration:

1. Resource limits and requests (cpu and memory) for all containers
2. GOMAXPROCS set via resourceFieldRef to limits.cpu for Go containers
3. GOMEMLIMIT set to ~80% of memory limit for Go containers
4. imagePullSecrets support in templates (verified when values are set)

Helm chart fixes:
- cleanup-job: Added resources, GOMAXPROCS, GOMEMLIMIT configuration
- values.yaml: Added cleanup.resources configuration
- keycloak/deployment.yaml: Added imagePullSecrets support
- redis/redis.yaml: Added imagePullSecrets support

The linter validates:
- odigos chart with default values
- odigos chart with enterprise mode enabled
- odigos chart with imagePullSecrets configured
- odigos-central chart with default values
- odigos-central chart with imagePullSecrets configured

emergency-ticket id: EMR-974
