### PR TITLE
Extended odiglet with legacy instrumentations

### DIFF
--- a/helm/odigos/templates/odiglet/daemonset.yaml
+++ b/helm/odigos/templates/odiglet/daemonset.yaml
@@ -1,6 +1,6 @@
 {{- $imageTag := .Values.image.tag | default .Chart.AppVersion -}}
 {{- $extendedSuffix := "" -}}
-{{- if .Values.odiglet.extended -}}
+{{- if and .Values.odiglet.extended (include "odigos.secretExists" .) -}}
   {{- $extendedSuffix = "-extended" -}}
 {{- end -}}
 {{- $odigletImageTag := printf "%s%s" $imageTag $extendedSuffix -}}

--- a/helm/odigos/templates/odiglet/daemonset.yaml
+++ b/helm/odigos/templates/odiglet/daemonset.yaml
@@ -1,4 +1,9 @@
 {{- $imageTag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- $extendedSuffix := "" -}}
+{{- if .Values.odiglet.extended -}}
+  {{- $extendedSuffix = "-extended" -}}
+{{- end -}}
+{{- $odigletImageTag := printf "%s%s" $imageTag $extendedSuffix -}}
 {{- $signals := .Values.signals | default (list "traces") -}}
 {{- $collectLogs := has "logs" $signals -}}
 {{- $collectMetrics := has "metrics" $signals -}}
@@ -53,11 +58,10 @@ spec:
       initContainers:
       {{- if or (not .Values.odiglet.noHostPathMounts) (not (eq .Values.instrumentor.mountMethod "k8s-init-container")) }}
         - name: init
-          {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
           {{- if include "odigos.secretExists" . }}
-          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-odiglet" "Tag" $imageTag) }}
+          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-odiglet" "Tag" $odigletImageTag) }}
           {{- else }}
-          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "odiglet" "Tag" $imageTag) }}
+          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "odiglet" "Tag" $odigletImageTag) }}
           {{- end }}
           imagePullPolicy: IfNotPresent
           command:
@@ -106,13 +110,12 @@ spec:
       {{- end }}
       {{- if eq .Values.instrumentor.mountMethod "k8s-init-container" }}
         # This init container pre-pulls the odigos-agents image to the node
-        # so it's available in the image cache when user pods need it 
+        # so it's available in the image cache when user pods need it
         - name: odigos-agents-image-pull
-          {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
           {{- if include "odigos.secretExists" . }}
-          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-agents" "Tag" $imageTag) }}
+          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-agents" "Tag" $odigletImageTag) }}
           {{- else }}
-          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "agents" "Tag" $imageTag) }}
+          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "agents" "Tag" $odigletImageTag) }}
           {{- end }}
           imagePullPolicy: IfNotPresent
           # # it does not run any actual code, just pulls the image
@@ -128,11 +131,10 @@ spec:
       {{- end }}
       containers:
         - name: odiglet
-          {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
           {{- if include "odigos.secretExists" . }}
-          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-odiglet" "Tag" $imageTag) }}
+          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-odiglet" "Tag" $odigletImageTag) }}
           {{- else }}
-          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "odiglet" "Tag" $imageTag) }}
+          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "odiglet" "Tag" $odigletImageTag) }}
           {{- end }}
           args:
             - --health-probe-bind-port={{ .Values.odiglet.odiglet.livenessProbe.httpGet.port }}
@@ -345,11 +347,10 @@ spec:
 # and to have hostMounts allowed
 {{- if and (or (eq .Values.instrumentor.mountMethod "") (eq .Values.instrumentor.mountMethod "k8s-virtual-device")) (not .Values.odiglet.noHostPathMounts) }}
         - name: deviceplugin
-          {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
           {{- if include "odigos.secretExists" . }}
-          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-odiglet" "Tag" $imageTag) }}
+          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-odiglet" "Tag" $odigletImageTag) }}
           {{- else }}
-          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "odiglet" "Tag" $imageTag) }}
+          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "odiglet" "Tag" $odigletImageTag) }}
           {{- end }}
           imagePullPolicy: IfNotPresent
           command:

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -356,6 +356,10 @@ instrumentor:
   # podsWebhookTimeoutSeconds: 25
 
 odiglet:
+  # extended controls whether to use the extended odiglet image variant which includes legacy .NET instrumentation.
+  # When true, the image tag will have '-extended' appended (e.g., v1.0.0-extended).
+  # Default: false
+  extended: false
   odiglet:
     livenessProbe:
       httpGet:
@@ -474,6 +478,10 @@ odiglet:
   # Collecting code attributes in Go is resource-intensive and may affect odiglet performance in environments with many Go workloads.
   # Set this to true to turn off code attribute recording for Go instrumentation.
   disableGoCodeAttributes: false
+
+
+  # When set to true, odiglet will be installed with the extended version of the Odiglet image (with legacy .NET instrumentation).
+  extended: false
 
 centralProxy:
   # Central backend URL where this proxy will forward data

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -356,10 +356,6 @@ instrumentor:
   # podsWebhookTimeoutSeconds: 25
 
 odiglet:
-  # extended controls whether to use the extended odiglet image variant which includes legacy .NET instrumentation.
-  # When true, the image tag will have '-extended' appended (e.g., v1.0.0-extended).
-  # Default: false
-  extended: false
   odiglet:
     livenessProbe:
       httpGet:
@@ -480,7 +476,9 @@ odiglet:
   disableGoCodeAttributes: false
 
 
-  # When set to true, odiglet will be installed with the extended version of the Odiglet image (with legacy .NET instrumentation).
+  # extended controls whether to use the extended odiglet image variant which includes legacy .NET instrumentation.
+  # When true, the image tag will have '-extended' appended (e.g., v1.0.0-extended).
+  # Default: false
   extended: false
 
 centralProxy:


### PR DESCRIPTION
We don’t want the .NET legacy support to be included in the regular enterprise Odiglet variant.
It should be added only to the extended variant and enabled via a configuration value.

emergency-ticket id: EMR-989
