### PR TITLE
fix: preserve all pod labels in k8s cache to fix workload health status (#4217)

### DIFF
--- a/frontend/kube/cache.go
+++ b/frontend/kube/cache.go
@@ -43,19 +43,12 @@ func podsTransformFunc(obj interface{}) (interface{}, error) {
 			Resources: c.Resources,
 		}
 	}
-
-	// Only keep the specific label needed for agent injection status calculation
-	var minimalLabels map[string]string
-	if agentHashValue, exists := pod.Labels[k8sconsts.OdigosAgentsMetaHashLabel]; exists {
-		minimalLabels = map[string]string{k8sconsts.OdigosAgentsMetaHashLabel: agentHashValue}
-	}
-
 	minimalPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:         pod.Namespace,
 			Name:              pod.Name,
 			CreationTimestamp: pod.CreationTimestamp,
-			Labels:            minimalLabels,
+			Labels:            pod.Labels,
 			OwnerReferences:   pod.OwnerReferences,
 		},
 		Spec: corev1.PodSpec{


### PR DESCRIPTION
The podsTransformFunc was stripping all pod labels except OdigosAgentsMetaHashLabel for memory optimization. This caused single-workload GraphQL queries to fail finding pods when using the deployment's label selector (e.g., app=coupon), resulting in incorrect AgentNoRunningPod health status. Preserving all labels fixes the filtering.

emergency-ticket id: EMR-1018
