### PR TITLE
fix: skip Homebrew tap update when releasing older patch versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,6 +168,43 @@ jobs:
         with:
           node-version: 18
 
+      - name: Check if Homebrew tap should be updated
+        run: |
+          # Pre-releases always update their respective tap (homebrew-odigos-cli-rc)
+          if [ "${{ env.IS_PRERELEASE }}" = "true" ]; then
+            echo "Pre-release detected, will update Homebrew RC tap"
+            echo "SKIP_HOMEBREW_UPDATE=false" >> $GITHUB_ENV
+            exit 0
+          fi
+
+          # For stable releases, check if this version is newer than what's currently in the tap.
+          # This prevents older patch releases (e.g. v1.16.9) from overwriting a newer version (e.g. v1.17.0).
+          CURRENT_TAP_VERSION=$(curl -sf https://raw.githubusercontent.com/odigos-io/homebrew-odigos-cli/main/odigos.rb \
+            | grep 'version "' | head -1 | sed 's/.*version "\(.*\)"/\1/')
+
+          if [ -z "$CURRENT_TAP_VERSION" ]; then
+            echo "Could not fetch current tap version, will update Homebrew tap"
+            echo "SKIP_HOMEBREW_UPDATE=false" >> $GITHUB_ENV
+            exit 0
+          fi
+
+          # Strip 'v' prefix from release tag for comparison
+          RELEASE_VERSION="${TAG#v}"
+
+          echo "Current Homebrew tap version: $CURRENT_TAP_VERSION"
+          echo "New release version: $RELEASE_VERSION"
+
+          # Use sort -V (version sort) to determine which version is greater
+          HIGHEST=$(printf '%s\n%s' "$CURRENT_TAP_VERSION" "$RELEASE_VERSION" | sort -V | tail -1)
+
+          if [ "$HIGHEST" = "$RELEASE_VERSION" ] && [ "$CURRENT_TAP_VERSION" != "$RELEASE_VERSION" ]; then
+            echo "Release version $RELEASE_VERSION is newer than tap version $CURRENT_TAP_VERSION — will update Homebrew tap"
+            echo "SKIP_HOMEBREW_UPDATE=false" >> $GITHUB_ENV
+          else
+            echo "Release version $RELEASE_VERSION is NOT newer than tap version $CURRENT_TAP_VERSION — skipping Homebrew tap update"
+            echo "SKIP_HOMEBREW_UPDATE=true" >> $GITHUB_ENV
+          fi
+
       - uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
@@ -177,6 +214,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
           IS_PRERELEASE: ${{ env.IS_PRERELEASE }}
+          SKIP_HOMEBREW_UPDATE: ${{ env.SKIP_HOMEBREW_UPDATE }}
           GORELEASER_CURRENT_TAG: ${{ env.TAG }}
 
       - uses: ko-build/setup-ko@v0.9

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,6 +45,7 @@ brews:
       owner: odigos-io
       name: '{{ if eq .Env.IS_PRERELEASE "true" }}homebrew-odigos-cli-rc{{ else }}homebrew-odigos-cli{{ end }}'
       token: "{{ .Env.HOMEBREW_GITHUB_API_TOKEN }}"
+    skip_upload: '{{ .Env.SKIP_HOMEBREW_UPDATE }}'
     commit_msg_template: "release: {{ .Tag }}"
     ids:
       - odigos


### PR DESCRIPTION
Adds a semver comparison check before GoReleaser publishes the Homebrew formula. This prevents older patch releases (e.g. v1.16.9) from overwriting a newer version (e.g. v1.17.0) in the homebrew-odigos-cli tap.

emergency-ticket id: EMR-1016
