### PR TITLE
feat: auto-change mount method

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -98,6 +98,8 @@ jobs:
           - "env-injection"
           - "data-streams"
           - "mount-method"
+          - "mount-method-override"
+          - "psa-baseline"
           - "argo-rollouts"
         include:
           - kube-version: "1.21.12"

--- a/api/k8sconsts/odiglet.go
+++ b/api/k8sconsts/odiglet.go
@@ -23,6 +23,16 @@ const (
 	OdigletOSSInstalledLabel          = "odigos.io/odiglet-oss-installed"
 	OdigletEnterpriseInstalledLabel   = "odigos.io/odiglet-enterprise-installed"
 	OdigletInstalledLabelValue        = "true"
+
+	// MountMethodOverrideNodeLabel is set by odiglet on nodes where the default
+	// mount method is known not to work (e.g., Bottlerocket with SELinux).
+	// The webhook reads this label and overrides the mount method accordingly.
+	MountMethodOverrideNodeLabel = "odigos.io/mount-method-override"
+
+	// MountMethodOverrideNSAnnotation allows per-namespace mount method overrides.
+	// Support/customers can set this annotation on a namespace to force a specific
+	// mount method (e.g., "k8s-init-container") without changing global config.
+	MountMethodOverrideNSAnnotation = "odigos.io/mount-method"
 	OdigletDefaultHealthProbeBindPort = 55683
 
 	// ConfigMap used to store custom/updated Go instrumentation offsets

--- a/tests/common/assert/simple-demo-instrumented-basic.yaml
+++ b/tests/common/assert/simple-demo-instrumented-basic.yaml
@@ -1,0 +1,248 @@
+### Simple-demo Deployments ###
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: default
+status:
+  conditions:
+    - type: Available
+      status: "True"
+    - type: Progressing
+      status: "True"
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coupon
+  namespace: default
+status:
+  conditions:
+    - type: Available
+      status: "True"
+    - type: Progressing
+      status: "True"
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inventory
+  namespace: default
+status:
+  conditions:
+    - type: Available
+      status: "True"
+    - type: Progressing
+      status: "True"
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: membership
+  namespace: default
+status:
+  conditions:
+    - type: Available
+      status: "True"
+    - type: Progressing
+      status: "True"
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pricing
+  namespace: default
+status:
+  conditions:
+    - type: Available
+      status: "True"
+    - type: Progressing
+      status: "True"
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: currency
+  namespace: default
+status:
+  conditions:
+    - type: Available
+      status: "True"
+    - type: Progressing
+      status: "True"
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: geolocation
+  namespace: default
+status:
+  conditions:
+    - type: Available
+      status: "True"
+    - type: Progressing
+      status: "True"
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1
+  availableReplicas: 1
+---
+#### Instrumentation Configs ####
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-coupon
+  namespace: default
+  ownerReferences:
+    - apiVersion: apps/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Deployment
+      name: coupon
+status:
+  runtimeDetailsByContainer:
+    - containerName: coupon
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-frontend
+  namespace: default
+  ownerReferences:
+    - apiVersion: apps/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Deployment
+      name: frontend
+status:
+  runtimeDetailsByContainer:
+    - containerName: frontend
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-inventory
+  namespace: default
+  ownerReferences:
+    - apiVersion: apps/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Deployment
+      name: inventory
+status:
+  runtimeDetailsByContainer:
+    - containerName: inventory
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-membership
+  namespace: default
+  ownerReferences:
+    - apiVersion: apps/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Deployment
+      name: membership
+status:
+  runtimeDetailsByContainer:
+    - containerName: membership
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-pricing
+  namespace: default
+  ownerReferences:
+    - apiVersion: apps/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Deployment
+      name: pricing
+status:
+  runtimeDetailsByContainer:
+    - containerName: pricing
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-currency
+  namespace: default
+  ownerReferences:
+    - apiVersion: apps/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Deployment
+      name: currency
+status:
+  (runtimeDetailsByContainer[?containerName=='currency']):
+    - language: php
+  (runtimeDetailsByContainer[?containerName=='nginx']):
+    - language: nginx
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-geolocation
+  namespace: default
+  ownerReferences:
+    - apiVersion: apps/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Deployment
+      name: geolocation
+status:
+  (runtimeDetailsByContainer[?containerName=='geolocation']):
+    - language: ruby
+---
+### Instrumentation Instances ###
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationInstance
+metadata:
+  namespace: default
+  labels:
+    instrumented-app: deployment-coupon
+status:
+  healthy: true
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationInstance
+metadata:
+  namespace: default
+  labels:
+    instrumented-app: deployment-inventory
+status:
+  healthy: true
+---
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationInstance
+metadata:
+  namespace: default
+  labels:
+    instrumented-app: deployment-membership
+status:
+  healthy: true

--- a/tests/e2e/mount-method-override/chainsaw-test.yaml
+++ b/tests/e2e/mount-method-override/chainsaw-test.yaml
@@ -1,0 +1,312 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mount-method-override
+spec:
+  description: >
+    Tests the mount method override mechanisms (namespace annotation and node label).
+    Odigos is installed with the default mount method (k8s-virtual-device), then
+    overrides are applied to verify the webhook auto-switches to k8s-init-container.
+  skipDelete: true
+  steps:
+    ########################################################################
+    # Phase 1: Setup - Install Odigos with DEFAULT mount method, deploy apps
+    ########################################################################
+
+    - name: '[1 - Setup] Install - Simple Demo Apps'
+      try:
+        - apply:
+            file: ../../common/apply/install-simple-demo.yaml
+
+    - name: '[1 - Setup] Prepare destination'
+      try:
+        - apply:
+            file: ../../common/apply/simple-trace-db-deployment.yaml
+
+    - name: '[1 - Setup] Install Odigos with default settings (virtual-device)'
+      try:
+        - script:
+            timeout: 4m
+            content: |
+              if [ "$MODE" = "cross-cloud-tests" ]; then
+                ../../../cli/odigos install --ns odigos-test --set image.tag="$COMMIT_HASH" --set imagePrefix=public.ecr.aws/y2v0v6s7
+              else
+                ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test
+              fi
+              kubectl label namespace odigos-test odigos.io/system-object="true"
+              ../../common/verify_odigos_installation.sh odigos-test
+        - assert:
+            timeout: 3m
+            file: ../../common/assert/odigos-installed.yaml
+
+    - name: '[1 - Setup] Assert - Simple Demo Apps Installed'
+      try:
+        - assert:
+            timeout: 3m
+            file: ../../common/assert/simple-demo-installed.yaml
+
+    - name: '[1 - Setup] Assert Trace DB is up'
+      try:
+        - assert:
+            timeout: 1m
+            file: ../../common/assert/simple-trace-db-running.yaml
+
+    - name: '[1 - Setup] Add Destination'
+      try:
+        - apply:
+            file: ../../common/apply/add-simple-trace-db-destination.yaml
+
+    ########################################################################
+    # Phase 2: Namespace annotation override
+    # Apply the odigos.io/mount-method annotation to the default namespace
+    # and verify the webhook switches to init-container mount method.
+    ########################################################################
+
+    - name: '[2 - NS Override] Annotate namespace with mount method override'
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              kubectl annotate namespace default odigos.io/mount-method=k8s-init-container --overwrite
+              echo "Namespace annotation applied:"
+              kubectl get namespace default -o jsonpath='{.metadata.annotations}' | jq .
+
+    - name: '[2 - NS Override] Instrument default namespace'
+      try:
+        - apply:
+            file: ../../common/apply/instrument-default-ns.yaml
+
+    - name: '[2 - NS Override] Assert Runtime Detected'
+      try:
+        - assert:
+            timeout: 3m
+            file: ../../common/assert/simple-demo-runtime-detected.yaml
+
+    - name: '[2 - NS Override] Odigos pipeline ready'
+      try:
+        - assert:
+            timeout: 1m
+            file: ../../common/assert/pipeline-ready.yaml
+
+    - name: '[2 - NS Override] Wait for rollout'
+      try:
+        - script:
+            timeout: 3m
+            content: ../../common/wait_for_rollout.sh
+
+    - name: '[2 - NS Override] Verify init container was used (namespace annotation override)'
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              echo "=== Verifying namespace annotation override ==="
+              echo "Checking that pods use init-container mount method..."
+
+              # Check that at least one pod has the odigos-agents init container
+              INIT_PODS=$(kubectl get pods -n default -o jsonpath='{range .items[*]}{.metadata.name}{" initContainers: "}{range .spec.initContainers[*]}{.name}{" "}{end}{"\n"}{end}' | grep "odigos-agents" | wc -l)
+              if [ "$INIT_PODS" -eq 0 ]; then
+                echo "FAIL: No pods found with odigos-agents init container"
+                kubectl get pods -n default -o yaml
+                exit 1
+              fi
+              echo "Found $INIT_PODS pods with odigos-agents init container"
+
+              # Verify emptyDir volume is used (not hostPath)
+              EMPTY_DIR_PODS=$(kubectl get pods -n default -o jsonpath='{range .items[*]}{.metadata.name}{" "}{range .spec.volumes[*]}{.name}{"="}{.emptyDir}{" "}{end}{"\n"}{end}' | grep "odigos-agent={}" | wc -l)
+              if [ "$EMPTY_DIR_PODS" -eq 0 ]; then
+                echo "FAIL: No pods found with emptyDir volume for odigos-agent"
+                exit 1
+              fi
+              echo "Found $EMPTY_DIR_PODS pods with emptyDir volume"
+
+              # Verify NO hostPath volumes are used for odigos
+              HOST_PATH_PODS=$(kubectl get pods -n default -o json | jq '[.items[].spec.volumes[]? | select(.name == "odigos-agent" and .hostPath != null)] | length')
+              if [ "$HOST_PATH_PODS" -ne 0 ]; then
+                echo "FAIL: Found pods with hostPath volume for odigos-agent"
+                exit 1
+              fi
+              echo "Namespace annotation override verification PASSED"
+      catch:
+        - script:
+            content: |
+              echo "=== Pod details ==="
+              kubectl get pods -n default -o wide
+              echo "=== Pod specs (volumes) ==="
+              kubectl get pods -n default -o jsonpath='{range .items[*]}{"Pod: "}{.metadata.name}{"\n  volumes: "}{range .spec.volumes[*]}{.name}{" "}{end}{"\n  initContainers: "}{range .spec.initContainers[*]}{.name}{" "}{end}{"\n"}{end}'
+              echo "=== Instrumentor logs ==="
+              kubectl logs -n odigos-test -l app.kubernetes.io/name=odigos-instrumentor --tail=100
+
+    - name: '[2 - NS Override] Generate Traffic'
+      try:
+        - apply:
+            file: ../../common/apply/generate-traffic-job.yaml
+        - script:
+            timeout: 1m
+            content: |
+              kubectl wait --for=condition=complete job/$(kubectl get -f ../../common/apply/generate-traffic-job.yaml -o=jsonpath='{.metadata.name}')
+        - delete:
+            file: ../../common/apply/generate-traffic-job.yaml
+
+    - name: '[2 - NS Override] Wait For Trace'
+      try:
+        - script:
+            timeout: 1m
+            content: |
+              while true; do
+                ../../common/simple_trace_db_query_runner.sh ../../common/queries/wait-for-trace.yaml
+                if [ $? -eq 0 ]; then
+                  break
+                fi
+                sleep 1
+              done
+      catch:
+        - script:
+            content: |
+              java_pod_name=$(kubectl get pods -n default -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep ^frontend)
+              kubectl logs $java_pod_name -n default
+
+    - name: '[2 - NS Override] Verify Trace - Context Propagation'
+      try:
+        - script:
+            timeout: 3m
+            content: |
+              ../../common/simple_trace_db_query_runner.sh ../../common/queries/context-propagation.yaml
+      catch:
+        - podLogs:
+            name: odiglet
+            namespace: odigos-test
+
+    ########################################################################
+    # Phase 3: Node label override
+    # Remove the namespace annotation, apply the node label instead,
+    # restart workloads, and verify init-container is still used.
+    ########################################################################
+
+    - name: '[3 - Node Override] Remove namespace annotation and apply node label'
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              # Remove namespace annotation so only the node label drives the override
+              kubectl annotate namespace default odigos.io/mount-method- --overwrite
+              echo "Namespace annotation removed"
+
+              # Label the kind node(s) to simulate Bottlerocket auto-detection
+              for node in $(kubectl get nodes -o jsonpath='{.items[*].metadata.name}'); do
+                kubectl label node "$node" odigos.io/mount-method-override=k8s-init-container --overwrite
+                echo "Labeled node $node with mount-method-override"
+              done
+
+    - name: '[3 - Node Override] Restart workloads to trigger re-injection'
+      try:
+        - script:
+            timeout: 3m
+            content: |
+              # Restart deployments so the webhook re-evaluates mount method
+              kubectl rollout restart deployment -n default -l odigos.io/e2e=source
+              ../../common/wait_for_rollout.sh
+
+    - name: '[3 - Node Override] Verify init container was used (node label override)'
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              echo "=== Verifying node label override ==="
+
+              # Check that at least one pod has the odigos-agents init container
+              INIT_PODS=$(kubectl get pods -n default -o jsonpath='{range .items[*]}{.metadata.name}{" initContainers: "}{range .spec.initContainers[*]}{.name}{" "}{end}{"\n"}{end}' | grep "odigos-agents" | wc -l)
+              if [ "$INIT_PODS" -eq 0 ]; then
+                echo "FAIL: No pods found with odigos-agents init container after node label override"
+                kubectl get pods -n default -o yaml
+                exit 1
+              fi
+              echo "Found $INIT_PODS pods with odigos-agents init container"
+
+              # Verify emptyDir volume is used
+              EMPTY_DIR_PODS=$(kubectl get pods -n default -o jsonpath='{range .items[*]}{.metadata.name}{" "}{range .spec.volumes[*]}{.name}{"="}{.emptyDir}{" "}{end}{"\n"}{end}' | grep "odigos-agent={}" | wc -l)
+              if [ "$EMPTY_DIR_PODS" -eq 0 ]; then
+                echo "FAIL: No pods found with emptyDir volume for odigos-agent"
+                exit 1
+              fi
+              echo "Found $EMPTY_DIR_PODS pods with emptyDir volume"
+              echo "Node label override verification PASSED"
+      catch:
+        - script:
+            content: |
+              echo "=== Node labels ==="
+              kubectl get nodes --show-labels
+              echo "=== Pod details ==="
+              kubectl get pods -n default -o wide
+              echo "=== Instrumentor logs ==="
+              kubectl logs -n odigos-test -l app.kubernetes.io/name=odigos-instrumentor --tail=100
+
+    - name: '[3 - Node Override] Generate Traffic'
+      try:
+        - apply:
+            file: ../../common/apply/generate-traffic-job.yaml
+        - script:
+            timeout: 1m
+            content: |
+              kubectl wait --for=condition=complete job/$(kubectl get -f ../../common/apply/generate-traffic-job.yaml -o=jsonpath='{.metadata.name}')
+        - delete:
+            file: ../../common/apply/generate-traffic-job.yaml
+
+    - name: '[3 - Node Override] Wait For Trace'
+      try:
+        - script:
+            timeout: 1m
+            content: |
+              while true; do
+                ../../common/simple_trace_db_query_runner.sh ../../common/queries/wait-for-trace.yaml
+                if [ $? -eq 0 ]; then
+                  break
+                fi
+                sleep 1
+              done
+
+    - name: '[3 - Node Override] Verify Trace - Context Propagation'
+      try:
+        - script:
+            timeout: 3m
+            content: |
+              ../../common/simple_trace_db_query_runner.sh ../../common/queries/context-propagation.yaml
+      catch:
+        - podLogs:
+            name: odiglet
+            namespace: odigos-test
+
+    ########################################################################
+    # Cleanup
+    ########################################################################
+
+    - name: 'Cleanup - Remove overrides'
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              # Remove node labels
+              for node in $(kubectl get nodes -o jsonpath='{.items[*].metadata.name}'); do
+                kubectl label node "$node" odigos.io/mount-method-override- || true
+              done
+              # Remove namespace annotation (in case it's still there)
+              kubectl annotate namespace default odigos.io/mount-method- || true
+              echo "Override labels and annotations cleaned up"
+
+    - name: 'Uninstall Odigos'
+      try:
+        - script:
+            timeout: 2m
+            content: ../../../cli/odigos uninstall --ns odigos-test
+        - script:
+            timeout: 1m
+            content: |
+              for i in $(seq 1 10); do
+                if ../../common/assert_odigos_uninstalled.sh; then
+                  exit 0
+                fi
+                echo "Attempt $i: Odigos uninstallation verification failed, retrying in 5 seconds..."
+                sleep 5
+              done
+
+              echo "Failed to verify Odigos uninstallation after 10 attempts"
+              exit 1

--- a/tests/e2e/mount-method-override/chainsaw-test.yaml
+++ b/tests/e2e/mount-method-override/chainsaw-test.yaml
@@ -91,7 +91,8 @@ spec:
     - name: "[2 - NS Override] Wait for instrumentation to be active"
       try:
         - assert:
-            file: ../../common/assert/simple-demo-instrumented.yaml
+            timeout: 3m
+            file: ../../common/assert/simple-demo-instrumented-basic.yaml
         - script:
             timeout: 2m
             content: ../../common/wait_for_rollout.sh

--- a/tests/e2e/mount-method-override/chainsaw-test.yaml
+++ b/tests/e2e/mount-method-override/chainsaw-test.yaml
@@ -13,17 +13,17 @@ spec:
     # Phase 1: Setup - Install Odigos with DEFAULT mount method, deploy apps
     ########################################################################
 
-    - name: '[1 - Setup] Install - Simple Demo Apps'
+    - name: "[1 - Setup] Install - Simple Demo Apps"
       try:
         - apply:
             file: ../../common/apply/install-simple-demo.yaml
 
-    - name: '[1 - Setup] Prepare destination'
+    - name: "[1 - Setup] Prepare destination"
       try:
         - apply:
             file: ../../common/apply/simple-trace-db-deployment.yaml
 
-    - name: '[1 - Setup] Install Odigos with default settings (virtual-device)'
+    - name: "[1 - Setup] Install Odigos with default settings (virtual-device)"
       try:
         - script:
             timeout: 4m
@@ -39,19 +39,19 @@ spec:
             timeout: 3m
             file: ../../common/assert/odigos-installed.yaml
 
-    - name: '[1 - Setup] Assert - Simple Demo Apps Installed'
+    - name: "[1 - Setup] Assert - Simple Demo Apps Installed"
       try:
         - assert:
             timeout: 3m
             file: ../../common/assert/simple-demo-installed.yaml
 
-    - name: '[1 - Setup] Assert Trace DB is up'
+    - name: "[1 - Setup] Assert Trace DB is up"
       try:
         - assert:
             timeout: 1m
             file: ../../common/assert/simple-trace-db-running.yaml
 
-    - name: '[1 - Setup] Add Destination'
+    - name: "[1 - Setup] Add Destination"
       try:
         - apply:
             file: ../../common/apply/add-simple-trace-db-destination.yaml
@@ -62,7 +62,7 @@ spec:
     # and verify the webhook switches to init-container mount method.
     ########################################################################
 
-    - name: '[2 - NS Override] Annotate namespace with mount method override'
+    - name: "[2 - NS Override] Annotate namespace with mount method override"
       try:
         - script:
             timeout: 30s
@@ -71,30 +71,32 @@ spec:
               echo "Namespace annotation applied:"
               kubectl get namespace default -o jsonpath='{.metadata.annotations}' | jq .
 
-    - name: '[2 - NS Override] Instrument default namespace'
+    - name: "[2 - NS Override] Instrument default namespace"
       try:
         - apply:
             file: ../../common/apply/instrument-default-ns.yaml
 
-    - name: '[2 - NS Override] Assert Runtime Detected'
+    - name: "[2 - NS Override] Assert Runtime Detected"
       try:
         - assert:
             timeout: 3m
             file: ../../common/assert/simple-demo-runtime-detected.yaml
 
-    - name: '[2 - NS Override] Odigos pipeline ready'
+    - name: "[2 - NS Override] Odigos pipeline ready"
       try:
         - assert:
             timeout: 1m
             file: ../../common/assert/pipeline-ready.yaml
 
-    - name: '[2 - NS Override] Wait for rollout'
+    - name: "[2 - NS Override] Wait for instrumentation to be active"
       try:
+        - assert:
+            file: ../../common/assert/simple-demo-instrumented.yaml
         - script:
-            timeout: 3m
+            timeout: 2m
             content: ../../common/wait_for_rollout.sh
 
-    - name: '[2 - NS Override] Verify init container was used (namespace annotation override)'
+    - name: "[2 - NS Override] Verify init container was used (namespace annotation override)"
       try:
         - script:
             timeout: 2m
@@ -136,7 +138,7 @@ spec:
               echo "=== Instrumentor logs ==="
               kubectl logs -n odigos-test -l app.kubernetes.io/name=odigos-instrumentor --tail=100
 
-    - name: '[2 - NS Override] Generate Traffic'
+    - name: "[2 - NS Override] Generate Traffic"
       try:
         - apply:
             file: ../../common/apply/generate-traffic-job.yaml
@@ -147,7 +149,7 @@ spec:
         - delete:
             file: ../../common/apply/generate-traffic-job.yaml
 
-    - name: '[2 - NS Override] Wait For Trace'
+    - name: "[2 - NS Override] Wait For Trace"
       try:
         - script:
             timeout: 1m
@@ -165,7 +167,7 @@ spec:
               java_pod_name=$(kubectl get pods -n default -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep ^frontend)
               kubectl logs $java_pod_name -n default
 
-    - name: '[2 - NS Override] Verify Trace - Context Propagation'
+    - name: "[2 - NS Override] Verify Trace - Context Propagation"
       try:
         - script:
             timeout: 3m
@@ -182,7 +184,7 @@ spec:
     # restart workloads, and verify init-container is still used.
     ########################################################################
 
-    - name: '[3 - Node Override] Remove namespace annotation and apply node label'
+    - name: "[3 - Node Override] Remove namespace annotation and apply node label"
       try:
         - script:
             timeout: 30s
@@ -197,7 +199,7 @@ spec:
                 echo "Labeled node $node with mount-method-override"
               done
 
-    - name: '[3 - Node Override] Restart workloads to trigger re-injection'
+    - name: "[3 - Node Override] Restart workloads to trigger re-injection"
       try:
         - script:
             timeout: 3m
@@ -206,7 +208,7 @@ spec:
               kubectl rollout restart deployment -n default -l odigos.io/e2e=source
               ../../common/wait_for_rollout.sh
 
-    - name: '[3 - Node Override] Verify init container was used (node label override)'
+    - name: "[3 - Node Override] Verify init container was used (node label override)"
       try:
         - script:
             timeout: 2m
@@ -240,7 +242,7 @@ spec:
               echo "=== Instrumentor logs ==="
               kubectl logs -n odigos-test -l app.kubernetes.io/name=odigos-instrumentor --tail=100
 
-    - name: '[3 - Node Override] Generate Traffic'
+    - name: "[3 - Node Override] Generate Traffic"
       try:
         - apply:
             file: ../../common/apply/generate-traffic-job.yaml
@@ -251,7 +253,7 @@ spec:
         - delete:
             file: ../../common/apply/generate-traffic-job.yaml
 
-    - name: '[3 - Node Override] Wait For Trace'
+    - name: "[3 - Node Override] Wait For Trace"
       try:
         - script:
             timeout: 1m
@@ -264,7 +266,7 @@ spec:
                 sleep 1
               done
 
-    - name: '[3 - Node Override] Verify Trace - Context Propagation'
+    - name: "[3 - Node Override] Verify Trace - Context Propagation"
       try:
         - script:
             timeout: 3m
@@ -279,7 +281,7 @@ spec:
     # Cleanup
     ########################################################################
 
-    - name: 'Cleanup - Remove overrides'
+    - name: "Cleanup - Remove overrides"
       try:
         - script:
             timeout: 30s
@@ -292,7 +294,7 @@ spec:
               kubectl annotate namespace default odigos.io/mount-method- || true
               echo "Override labels and annotations cleaned up"
 
-    - name: 'Uninstall Odigos'
+    - name: "Uninstall Odigos"
       try:
         - script:
             timeout: 2m

--- a/tests/e2e/psa-baseline/chainsaw-test.yaml
+++ b/tests/e2e/psa-baseline/chainsaw-test.yaml
@@ -1,0 +1,225 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: psa-baseline
+spec:
+  description: This e2e test verifies that Odigos auto-detects PSA baseline enforcement and switches to the init-container mount method
+  skipDelete: true
+  steps:
+    - name: '[1 - Setup] Apply PSA baseline labels to default namespace'
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              kubectl label namespace default pod-security.kubernetes.io/enforce=baseline --overwrite
+              kubectl label namespace default pod-security.kubernetes.io/enforce-version=latest --overwrite
+              kubectl label namespace default pod-security.kubernetes.io/warn=baseline --overwrite
+              kubectl label namespace default pod-security.kubernetes.io/audit=baseline --overwrite
+              echo "PSA baseline labels applied to default namespace"
+              kubectl get namespace default --show-labels
+
+    - name: '[1 - Setup] Install - Simple Demo Apps'
+      try:
+        - apply:
+            file: ../../common/apply/install-simple-demo.yaml
+
+    - name: '[1 - Setup] Prepare destination'
+      try:
+        - apply:
+            file: ../../common/apply/simple-trace-db-deployment.yaml
+
+    # Install Odigos with DEFAULT settings (no explicit mount method).
+    # The webhook should auto-detect PSA baseline on the default namespace
+    # and switch to init-container mount method automatically.
+    - name: '[1 - Setup] Install Odigos with default settings'
+      try:
+        - script:
+            timeout: 4m
+            content: |
+              if [ "$MODE" = "cross-cloud-tests" ]; then
+                ../../../cli/odigos install --ns odigos-test --set image.tag="$COMMIT_HASH" --set imagePrefix=public.ecr.aws/y2v0v6s7
+              else
+                ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test
+              fi
+              kubectl label namespace odigos-test odigos.io/system-object="true"
+              ../../common/verify_odigos_installation.sh odigos-test
+        - assert:
+            timeout: 3m
+            file: ../../common/assert/odigos-installed.yaml
+
+    - name: '[1 - Setup] Assert - Simple Demo Apps Installed'
+      try:
+        - assert:
+            timeout: 3m
+            file: ../../common/assert/simple-demo-installed.yaml
+
+    - name: '[1 - Setup] Assert Trace DB is up'
+      try:
+        - assert:
+            timeout: 1m
+            file: ../../common/assert/simple-trace-db-running.yaml
+
+    - name: '[1 - Setup] Add Destination'
+      try:
+        - apply:
+            file: ../../common/apply/add-simple-trace-db-destination.yaml
+
+    - name: '[2 - Instrumentation] Instrument default namespace'
+      try:
+        - apply:
+            file: ../../common/apply/instrument-default-ns.yaml
+
+    - name: '[2 - Instrumentation] Assert Runtime Detected'
+      try:
+        - assert:
+            timeout: 3m
+            file: ../../common/assert/simple-demo-runtime-detected.yaml
+
+    - name: '[2 - Instrumentation] Odigos pipeline ready'
+      try:
+        - assert:
+            timeout: 1m
+            file: ../../common/assert/pipeline-ready.yaml
+
+    - name: '[2 - Instrumentation] Wait for rollout'
+      try:
+        - script:
+            timeout: 3m
+            content: ../../common/wait_for_rollout.sh
+
+    # Verify that Odigos auto-detected PSA and used init-container mount method.
+    # Pods in the PSA-enforced namespace should have the odigos-agents init container
+    # with an emptyDir volume, NOT hostPath or device plugin mounts.
+    - name: '[3 - Verification] Verify init container was used (PSA auto-detection)'
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              echo "Checking that pods in PSA-enforced namespace use init-container mount method..."
+
+              # Check that at least one pod has the odigos-agents init container
+              INIT_PODS=$(kubectl get pods -n default -o jsonpath='{range .items[*]}{.metadata.name}{" initContainers: "}{range .spec.initContainers[*]}{.name}{" "}{end}{"\n"}{end}' | grep "odigos-agents" | wc -l)
+              if [ "$INIT_PODS" -eq 0 ]; then
+                echo "FAIL: No pods found with odigos-agents init container"
+                kubectl get pods -n default -o yaml
+                exit 1
+              fi
+              echo "Found $INIT_PODS pods with odigos-agents init container"
+
+              # Verify emptyDir volume is used (not hostPath)
+              EMPTY_DIR_PODS=$(kubectl get pods -n default -o jsonpath='{range .items[*]}{.metadata.name}{" "}{range .spec.volumes[*]}{.name}{"="}{.emptyDir}{" "}{end}{"\n"}{end}' | grep "odigos-agent={}" | wc -l)
+              if [ "$EMPTY_DIR_PODS" -eq 0 ]; then
+                echo "FAIL: No pods found with emptyDir volume for odigos-agent"
+                exit 1
+              fi
+              echo "Found $EMPTY_DIR_PODS pods with emptyDir volume (init-container mount method confirmed)"
+
+              # Verify NO hostPath volumes are used for odigos
+              HOST_PATH_PODS=$(kubectl get pods -n default -o json | jq '[.items[].spec.volumes[]? | select(.name == "odigos-agent" and .hostPath != null)] | length')
+              if [ "$HOST_PATH_PODS" -ne 0 ]; then
+                echo "FAIL: Found pods with hostPath volume for odigos-agent (PSA incompatible)"
+                exit 1
+              fi
+              echo "Confirmed: no hostPath volumes used for odigos-agent"
+              echo "PSA auto-detection verification PASSED"
+      catch:
+        - script:
+            content: |
+              echo "=== Pod details ==="
+              kubectl get pods -n default -o wide
+              echo "=== Pod specs ==="
+              kubectl get pods -n default -o yaml
+              echo "=== Instrumentor logs ==="
+              kubectl logs -n odigos-test -l app.kubernetes.io/name=odigos-instrumentor --tail=100
+
+    - name: '[4 - Traces] Generate Traffic'
+      try:
+        - apply:
+            file: ../../common/apply/generate-traffic-job.yaml
+        - script:
+            timeout: 1m
+            content: |
+              kubectl wait --for=condition=complete job/$(kubectl get -f ../../common/apply/generate-traffic-job.yaml -o=jsonpath='{.metadata.name}')
+        - delete:
+            file: ../../common/apply/generate-traffic-job.yaml
+
+    - name: '[4 - Traces] Wait For Trace'
+      try:
+        - script:
+            timeout: 1m
+            content: |
+              while true; do
+                ../../common/simple_trace_db_query_runner.sh ../../common/queries/wait-for-trace.yaml
+                if [ $? -eq 0 ]; then
+                  break
+                fi
+                sleep 1
+              done
+      catch:
+        - script:
+            content: |
+              java_pod_name=$(kubectl get pods -n default -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep ^frontend)
+              kubectl logs $java_pod_name -n default
+
+    - name: '[4 - Traces] Verify Trace - Context Propagation'
+      try:
+        - script:
+            timeout: 3m
+            content: |
+              ../../common/simple_trace_db_query_runner.sh ../../common/queries/context-propagation.yaml
+      catch:
+        - podLogs:
+            name: odiglet
+            namespace: odigos-test
+
+    - name: '[4 - Traces] Verify Trace - Resource Attributes'
+      try:
+        - script:
+            timeout: 3m
+            content: |
+              ../../common/simple_trace_db_query_runner.sh ../../common/queries/resource-attributes.yaml
+      catch:
+        - podLogs:
+            name: odiglet
+            namespace: odigos-test
+
+    - name: '[4 - Traces] Verify Trace - Span Attributes'
+      try:
+        - script:
+            timeout: 3m
+            content: |
+              ../../common/simple_trace_db_query_runner.sh ../../common/queries/span-attributes.yaml
+      catch:
+        - podLogs:
+            name: odiglet
+            namespace: odigos-test
+
+    - name: 'Uninstall Odigos'
+      try:
+        - script:
+            timeout: 2m
+            content: ../../../cli/odigos uninstall --ns odigos-test
+        - script:
+            timeout: 1m
+            content: |
+              for i in $(seq 1 10); do
+                if ../../common/assert_odigos_uninstalled.sh; then
+                  exit 0
+                fi
+                echo "Attempt $i: Odigos uninstallation verification failed, retrying in 5 seconds..."
+                sleep 5
+              done
+
+              echo "Failed to verify Odigos uninstallation after 10 attempts"
+              exit 1
+
+    - name: 'Clean up PSA labels'
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              kubectl label namespace default pod-security.kubernetes.io/enforce- || true
+              kubectl label namespace default pod-security.kubernetes.io/enforce-version- || true
+              kubectl label namespace default pod-security.kubernetes.io/warn- || true
+              kubectl label namespace default pod-security.kubernetes.io/audit- || true
+              echo "PSA labels removed from default namespace"

--- a/tests/e2e/psa-baseline/chainsaw-test.yaml
+++ b/tests/e2e/psa-baseline/chainsaw-test.yaml
@@ -84,7 +84,8 @@ spec:
     - name: "[2 - Instrumentation] Wait for instrumentation to be active"
       try:
         - assert:
-            file: ../../common/assert/simple-demo-instrumented.yaml
+            timeout: 3m
+            file: ../../common/assert/simple-demo-instrumented-basic.yaml
         - script:
             timeout: 2m
             content: ../../common/wait_for_rollout.sh

--- a/tests/e2e/psa-baseline/chainsaw-test.yaml
+++ b/tests/e2e/psa-baseline/chainsaw-test.yaml
@@ -6,7 +6,7 @@ spec:
   description: This e2e test verifies that Odigos auto-detects PSA baseline enforcement and switches to the init-container mount method
   skipDelete: true
   steps:
-    - name: '[1 - Setup] Apply PSA baseline labels to default namespace'
+    - name: "[1 - Setup] Apply PSA baseline labels to default namespace"
       try:
         - script:
             timeout: 30s
@@ -18,12 +18,12 @@ spec:
               echo "PSA baseline labels applied to default namespace"
               kubectl get namespace default --show-labels
 
-    - name: '[1 - Setup] Install - Simple Demo Apps'
+    - name: "[1 - Setup] Install - Simple Demo Apps"
       try:
         - apply:
             file: ../../common/apply/install-simple-demo.yaml
 
-    - name: '[1 - Setup] Prepare destination'
+    - name: "[1 - Setup] Prepare destination"
       try:
         - apply:
             file: ../../common/apply/simple-trace-db-deployment.yaml
@@ -31,7 +31,7 @@ spec:
     # Install Odigos with DEFAULT settings (no explicit mount method).
     # The webhook should auto-detect PSA baseline on the default namespace
     # and switch to init-container mount method automatically.
-    - name: '[1 - Setup] Install Odigos with default settings'
+    - name: "[1 - Setup] Install Odigos with default settings"
       try:
         - script:
             timeout: 4m
@@ -47,50 +47,52 @@ spec:
             timeout: 3m
             file: ../../common/assert/odigos-installed.yaml
 
-    - name: '[1 - Setup] Assert - Simple Demo Apps Installed'
+    - name: "[1 - Setup] Assert - Simple Demo Apps Installed"
       try:
         - assert:
             timeout: 3m
             file: ../../common/assert/simple-demo-installed.yaml
 
-    - name: '[1 - Setup] Assert Trace DB is up'
+    - name: "[1 - Setup] Assert Trace DB is up"
       try:
         - assert:
             timeout: 1m
             file: ../../common/assert/simple-trace-db-running.yaml
 
-    - name: '[1 - Setup] Add Destination'
+    - name: "[1 - Setup] Add Destination"
       try:
         - apply:
             file: ../../common/apply/add-simple-trace-db-destination.yaml
 
-    - name: '[2 - Instrumentation] Instrument default namespace'
+    - name: "[2 - Instrumentation] Instrument default namespace"
       try:
         - apply:
             file: ../../common/apply/instrument-default-ns.yaml
 
-    - name: '[2 - Instrumentation] Assert Runtime Detected'
+    - name: "[2 - Instrumentation] Assert Runtime Detected"
       try:
         - assert:
             timeout: 3m
             file: ../../common/assert/simple-demo-runtime-detected.yaml
 
-    - name: '[2 - Instrumentation] Odigos pipeline ready'
+    - name: "[2 - Instrumentation] Odigos pipeline ready"
       try:
         - assert:
             timeout: 1m
             file: ../../common/assert/pipeline-ready.yaml
 
-    - name: '[2 - Instrumentation] Wait for rollout'
+    - name: "[2 - Instrumentation] Wait for instrumentation to be active"
       try:
+        - assert:
+            file: ../../common/assert/simple-demo-instrumented.yaml
         - script:
-            timeout: 3m
+            timeout: 2m
             content: ../../common/wait_for_rollout.sh
 
     # Verify that Odigos auto-detected PSA and used init-container mount method.
     # Pods in the PSA-enforced namespace should have the odigos-agents init container
     # with an emptyDir volume, NOT hostPath or device plugin mounts.
-    - name: '[3 - Verification] Verify init container was used (PSA auto-detection)'
+    - name: "[3 - Verification] Verify init container was used (PSA auto-detection)"
       try:
         - script:
             timeout: 2m
@@ -132,7 +134,7 @@ spec:
               echo "=== Instrumentor logs ==="
               kubectl logs -n odigos-test -l app.kubernetes.io/name=odigos-instrumentor --tail=100
 
-    - name: '[4 - Traces] Generate Traffic'
+    - name: "[4 - Traces] Generate Traffic"
       try:
         - apply:
             file: ../../common/apply/generate-traffic-job.yaml
@@ -143,7 +145,7 @@ spec:
         - delete:
             file: ../../common/apply/generate-traffic-job.yaml
 
-    - name: '[4 - Traces] Wait For Trace'
+    - name: "[4 - Traces] Wait For Trace"
       try:
         - script:
             timeout: 1m
@@ -161,7 +163,7 @@ spec:
               java_pod_name=$(kubectl get pods -n default -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep ^frontend)
               kubectl logs $java_pod_name -n default
 
-    - name: '[4 - Traces] Verify Trace - Context Propagation'
+    - name: "[4 - Traces] Verify Trace - Context Propagation"
       try:
         - script:
             timeout: 3m
@@ -172,7 +174,7 @@ spec:
             name: odiglet
             namespace: odigos-test
 
-    - name: '[4 - Traces] Verify Trace - Resource Attributes'
+    - name: "[4 - Traces] Verify Trace - Resource Attributes"
       try:
         - script:
             timeout: 3m
@@ -183,7 +185,7 @@ spec:
             name: odiglet
             namespace: odigos-test
 
-    - name: '[4 - Traces] Verify Trace - Span Attributes'
+    - name: "[4 - Traces] Verify Trace - Span Attributes"
       try:
         - script:
             timeout: 3m
@@ -194,7 +196,7 @@ spec:
             name: odiglet
             namespace: odigos-test
 
-    - name: 'Uninstall Odigos'
+    - name: "Uninstall Odigos"
       try:
         - script:
             timeout: 2m
@@ -213,7 +215,7 @@ spec:
               echo "Failed to verify Odigos uninstallation after 10 attempts"
               exit 1
 
-    - name: 'Clean up PSA labels'
+    - name: "Clean up PSA labels"
       try:
         - script:
             timeout: 30s


### PR DESCRIPTION
## Root Cause
Pods crashlooped on **Bottlerocket** because the webhook injected:

- `PHP_INI_SCAN_DIR=/var/odigos/php/8.2`

…but `/var/odigos` was never accessible inside the container.

With the default **`k8s-virtual-device`** method, kubelet is supposed to bind-mount host `/var/odigos` (populated by Odiglet) into the pod. On Bottlerocket this mount path became unreadable - likely **SELinux** or a **silent device-plugin mount failure**.

## Fix
We avoided the host-mount path entirely by auto-switching to **`k8s-init-container`**, which copies agent files into an `emptyDir` volume.

### 3 override layers
1. **Namespace annotation (manual):** `odigos.io/mount-method=k8s-init-container`  
2. **PSA detection:** `baseline` / `restricted` → force init-container  
3. **Bottlerocket detection:** Odiglet labels nodes → webhook switches cluster-wide (60s cache)

Init-container was also hardened to be **PSA-restricted compliant**.

## Result
Bottlerocket clusters now self-heal automatically, and support can force the safe method instantly via namespace annotation.

---

#### Changelog entry:
```release-note
NONE
```

emergency-ticket id: EMR-1032
