### PR TITLE
fix: pass group context to fd server to handle proper shutting down

### DIFF
--- a/instrumentation/manager.go
+++ b/instrumentation/manager.go
@@ -350,7 +350,7 @@ func (m *manager[ProcessGroup, ConfigGroup, ProcessDetails]) Run(ctx context.Con
 		// Run server in background to serve the map FD to relevant data collection client.
 		// The server will continue running until odiglet shuts down, allowing collectors to reconnect after restarts
 		// and ask for a new FD.
-		if err := server.Run(ctx); err != nil {
+		if err := server.Run(errCtx); err != nil {
 			m.logger.Error(err, "unixfd server failed")
 		}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
fix: handle shutdown gracefully when eBPF manager fails to start (e.g on older kernels)
```

emergency-ticket id: EMR-1048
