### PR TITLE
chore: update Ruby agent version in Dockerfiles to v0.0.8

### DIFF
--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -61,7 +61,7 @@ COPY --from=dotnet-builder /dotnet-instrumentation /instrumentations/dotnet
 COPY --from=public.ecr.aws/odigos/agents/php-community:v0.2.5 /instrumentations/php /instrumentations/php
 
 # Ruby
-COPY --from=public.ecr.aws/odigos/agents/ruby-community:v0.0.7 /instrumentations/ruby /instrumentations/ruby
+COPY --from=public.ecr.aws/odigos/agents/ruby-community:v0.0.8 /instrumentations/ruby /instrumentations/ruby
 
 # loader
 ARG TARGETARCH

--- a/odiglet/debug.Dockerfile
+++ b/odiglet/debug.Dockerfile
@@ -82,7 +82,7 @@ COPY --from=dotnet-builder /dotnet-instrumentation /instrumentations/dotnet
 COPY --from=public.ecr.aws/odigos/agents/php-community:v0.2.5 /instrumentations/php /instrumentations/php
 
 # Ruby
-COPY --from=public.ecr.aws/odigos/agents/ruby-community:v0.0.7 /instrumentations/ruby /instrumentations/ruby
+COPY --from=public.ecr.aws/odigos/agents/ruby-community:v0.0.8 /instrumentations/ruby /instrumentations/ruby
 
 # loader
 ARG ODIGOS_LOADER_VERSION=v0.0.6


### PR DESCRIPTION
Contains a fix to prevent `bundler` version conflicts, e.g:

```
/var/odigos/ruby/3.2/bundle/gems/bundler-2.6.9/lib/bundler/source/metadata.rb:14:in `block in specs': The running version of Bundler (2.6.9) does not match the version of the specification installed for it (2.5.22). This can be caused by reinstalling Ruby without removing previous installation, leaving around an upgraded default version of Bundler. Reinstalling Ruby from scratch should fix the problem. (Bundler::CorruptBundlerInstallError)
```

---

Changelog entry:

```release-note
NONE
```

emergency-ticket id: EMR-1054
