### PR TITLE
fix: add KC_HOSTNAME_STRICT_BACKCHANNEL to Keycloak deployment

### DIFF
--- a/cli/cmd/resources/centralodigos/keycloak.go
+++ b/cli/cmd/resources/centralodigos/keycloak.go
@@ -161,10 +161,22 @@ func NewKeycloakDeployment(ns string, config AuthConfig, withPvc bool) *appsv1.D
 											Key: k8sconsts.KeycloakAdminPasswordKey,
 										},
 									},
-								},
+							},
 								{
 									Name:  "KC_HOSTNAME",
 									Value: "localhost",
+								},
+								{
+									Name:  "KC_HOSTNAME_STRICT_HTTPS",
+									Value: "false",
+								},
+								{
+									Name:  "KC_HOSTNAME_STRICT_BACKCHANNEL",
+									Value: "true",
+								},
+								{
+									Name:  "KC_PROXY",
+									Value: "edge",
 								},
 							},
 							Ports: []corev1.ContainerPort{

--- a/helm/odigos-central/templates/keycloak/deployment.yaml
+++ b/helm/odigos-central/templates/keycloak/deployment.yaml
@@ -78,6 +78,8 @@ spec:
             {{- end }}
             - name: KC_HOSTNAME_STRICT_HTTPS
               value: "false"
+            - name: KC_HOSTNAME_STRICT_BACKCHANNEL
+              value: "true"
             - name: KC_PROXY
               value: "edge"
           {{- if .Values.auth.persistence.enabled }}


### PR DESCRIPTION


#### What this PR does / why we need it:
<!--
Forces Keycloak to use the configured KC_HOSTNAME as the issuer for backchannel requests, preventing issuer mismatch errors when the central backend communicates with Keycloak internally.
-->

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
NONE
-->

```release-note

```

emergency-ticket id: EMR-1052
