### PR TITLE
fix: restore SERVICE_NAME build-arg in publish-modules workflow

### DIFF
--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -215,6 +215,7 @@ jobs:
             keyval/odigos-${{ matrix.service }}:${{ env.ODIGOS_TAG }}
             ghcr.io/odigos-io/odigos-${{ matrix.service }}:${{ env.ODIGOS_TAG }}
           build-args: |
+            SERVICE_NAME=${{ matrix.service }}
             LD_FLAGS=-s -w
             RHEL=false
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
The SERVICE_NAME build-arg was accidentally removed in #4195 when separating out the RHEL release flow. This arg is required by the root Dockerfile to know which service directory to build.

#### What this PR does / why we need it:
Restores the `SERVICE_NAME` build-arg that was accidentally removed from the `publish-modules.yml` workflow in #4195. Without it, the root Dockerfile cannot determine which service to build, causing all image publishes to fail with `"/go.mod": not found`.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

NONE

emergency-ticket id: EMR-1059
