### PR TITLE
fix: restore ODIGOS_VERSION build-arg in publish-modules workflow

### DIFF
--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -216,6 +216,7 @@ jobs:
             ghcr.io/odigos-io/odigos-${{ matrix.service }}:${{ env.ODIGOS_TAG }}
           build-args: |
             SERVICE_NAME=${{ matrix.service }}
+            ODIGOS_VERSION=${{ env.ODIGOS_TAG }}
             LD_FLAGS=-s -w
             RHEL=false
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
ODIGOS_VERSION was also removed in #4195 alongside SERVICE_NAME. It is required by the operator Dockerfile (Helm chart packaging) and the odiglet Dockerfile (Python agent version embedding).

emergency-ticket id: EMR-1058
