### PR TITLE
fix: remove RHEL image check from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,9 +119,6 @@ jobs:
       - name: Verify Components Image Ready
         run: |
           declare -a REPOS=("odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-enterprise-odiglet" "odigos-ui" "odigos-enterprise-instrumentor" "odigos-operator" "odigos-enterprise-agents" "odigos-enterprise-central-backend" "odigos-enterprise-central-proxy" "odigos-enterprise-central-ui")
-          for repo in "${REPOS[@]}"; do
-            REPOS+=("${repo}-rhel-certified")
-          done
 
           TAG_TO_CHECK=${{ env.TAG }}
 


### PR DESCRIPTION
RHEL images are now built via a separate manual workflow (publish-modules-rhel.yml) and should not block the main release flow. This check was left over from #4195 when the RHEL build was separated.

emergency-ticket id: EMR-1057
