### PR TITLE
feat: add sources RBAC to central-proxy ClusterRole

### DIFF
--- a/helm/odigos/templates/centralproxy/clusterrole.yaml
+++ b/helm/odigos/templates/centralproxy/clusterrole.yaml
@@ -16,7 +16,7 @@ rules:
     resources: ["cronjobs"]
     verbs: ["list", "watch"]
   - apiGroups: ["odigos.io"]
-    resources: ["instrumentationconfigs"]
+    resources: ["instrumentationconfigs", "sources"]
     verbs: ["list", "watch"]
   - apiGroups: [""]
     resources: ["configmaps"]


### PR DESCRIPTION


#### What this PR does / why we need it:
<!--
Allow central-proxy to list and watch Source CRDs so it can determine namespace auto-instrumentation status for workload snapshots.
-->



```release-note
NONE
```

emergency-ticket id: EMR-1067
