### PR TITLE
feat: enhance environment variable handling in PHP integration

### DIFF
--- a/distros/distro/oteldistribution.go
+++ b/distros/distro/oteldistribution.go
@@ -36,6 +36,13 @@ type StaticEnvironmentVariable struct {
 	// The value of the environment variable to set.
 	EnvValue string `yaml:"envValue"`
 
+	// When true, if the env var already exists in the container manifest, the value is
+	// appended (string concatenation) to the existing value rather than being skipped.
+	// When the env var is absent from the manifest but a CRI-detected runtime value exists
+	// in distroParams (keyed by EnvName), that runtime value is prepended to the rendered value.
+	// This is useful for colon-separated path variables like PHP_INI_SCAN_DIR.
+	AppendToExisting bool `yaml:"appendToExisting,omitempty"`
+
 	// pre-parsed template that is ready to be executed with the relevant parameters.
 	// if the EnvValue field is templated (e.g. contains {{.PARAM_NAME}}), this field is set.
 	// it indicates that the value should be templated with the relevant parameters.

--- a/distros/yamls/php-community.yaml
+++ b/distros/yamls/php-community.yaml
@@ -17,16 +17,23 @@ spec:
     otlpHttpLocalNode: true
     signalsAsStaticOtelEnvVars: true
     staticVariables:
-      # How to use PHP_INI_SCAN_DIR env with colon (:) separator...
+      # PHP_INI_SCAN_DIR uses appendToExisting so that:
+      # 1. If the user already sets it in their pod manifest, we append our path.
+      # 2. If the container image sets it at runtime (detected via CRI), we prepend that value.
+      # 3. If neither is set, the leading ":" preserves the compile-time default scan directory.
       # See https://github.com/odigos-io/opentelemetry-php?tab=readme-ov-file#deploying-an-agent
       - envName: PHP_INI_SCAN_DIR
         envValue: ':/var/odigos/php/{{.RUNTIME_VERSION_MAJOR_MINOR}}'
+        appendToExisting: true
       - envName: OTEL_PHP_AUTOLOAD_ENABLED
         envValue: 'true'
       - envName: OTEL_EXPORTER_OTLP_PROTOCOL
         envValue: 'http/protobuf'
       - envName: OTEL_PROPAGATORS
         envValue: 'tracecontext,baggage'
+    appendOdigosVariables:
+      - envName: PHP_INI_SCAN_DIR
+        replacePattern: '{{ORIGINAL_ENV_VALUE}}:/var/odigos/php'
   runtimeAgent:
     directoryNames:
       - '{{ODIGOS_AGENTS_DIR}}/php'

--- a/instrumentor/controllers/agentenabled/podswebhook/env_test.go
+++ b/instrumentor/controllers/agentenabled/podswebhook/env_test.go
@@ -1,0 +1,351 @@
+package podswebhook
+
+import (
+	"testing"
+	"text/template"
+
+	"github.com/odigos-io/odigos/distros/distro"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func parseTemplate(t *testing.T, text string) *template.Template {
+	t.Helper()
+	tmpl, err := template.New("test").Option("missingkey=error").Parse(text)
+	if err != nil {
+		t.Fatalf("failed to parse template %q: %v", text, err)
+	}
+	return tmpl
+}
+
+func findEnvVar(container *corev1.Container, name string) *corev1.EnvVar {
+	for i := range container.Env {
+		if container.Env[i].Name == name {
+			return &container.Env[i]
+		}
+	}
+	return nil
+}
+
+func TestAppendEnvVar_NoExisting_NoCRI(t *testing.T) {
+	container := &corev1.Container{Name: "app"}
+	existing := EnvVarNamesMap{}
+
+	ev := distro.StaticEnvironmentVariable{
+		EnvName:          "PHP_INI_SCAN_DIR",
+		EnvValue:         ":/var/odigos/php/8.2",
+		AppendToExisting: true,
+	}
+
+	result, err := appendEnvVarToPodContainer(existing, container, ev, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := result["PHP_INI_SCAN_DIR"]; !ok {
+		t.Error("expected PHP_INI_SCAN_DIR in returned env names map")
+	}
+	got := findEnvVar(container, "PHP_INI_SCAN_DIR")
+	if got == nil {
+		t.Fatal("expected PHP_INI_SCAN_DIR to be set on container")
+	}
+	if got.Value != ":/var/odigos/php/8.2" {
+		t.Errorf("expected ':/var/odigos/php/8.2', got %q", got.Value)
+	}
+}
+
+func TestAppendEnvVar_NoExisting_WithCRI(t *testing.T) {
+	container := &corev1.Container{Name: "app"}
+	existing := EnvVarNamesMap{}
+	params := map[string]string{
+		"PHP_INI_SCAN_DIR": "/etc/php/custom-ini",
+	}
+
+	ev := distro.StaticEnvironmentVariable{
+		EnvName:          "PHP_INI_SCAN_DIR",
+		EnvValue:         ":/var/odigos/php/8.2",
+		AppendToExisting: true,
+	}
+
+	_, err := appendEnvVarToPodContainer(existing, container, ev, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := findEnvVar(container, "PHP_INI_SCAN_DIR")
+	if got == nil {
+		t.Fatal("expected PHP_INI_SCAN_DIR to be set on container")
+	}
+	if got.Value != "/etc/php/custom-ini:/var/odigos/php/8.2" {
+		t.Errorf("expected '/etc/php/custom-ini:/var/odigos/php/8.2', got %q", got.Value)
+	}
+}
+
+func TestAppendEnvVar_ExistingInManifest_Appends(t *testing.T) {
+	container := &corev1.Container{
+		Name: "app",
+		Env: []corev1.EnvVar{
+			{Name: "PHP_INI_SCAN_DIR", Value: "/my/custom/dir"},
+		},
+	}
+	existing := EnvVarNamesMap{"PHP_INI_SCAN_DIR": {}}
+
+	ev := distro.StaticEnvironmentVariable{
+		EnvName:          "PHP_INI_SCAN_DIR",
+		EnvValue:         ":/var/odigos/php/8.2",
+		AppendToExisting: true,
+	}
+
+	_, err := appendEnvVarToPodContainer(existing, container, ev, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := findEnvVar(container, "PHP_INI_SCAN_DIR")
+	if got.Value != "/my/custom/dir:/var/odigos/php/8.2" {
+		t.Errorf("expected '/my/custom/dir:/var/odigos/php/8.2', got %q", got.Value)
+	}
+}
+
+func TestAppendEnvVar_ExistingWithLeadingColon_Appends(t *testing.T) {
+	container := &corev1.Container{
+		Name: "app",
+		Env: []corev1.EnvVar{
+			{Name: "PHP_INI_SCAN_DIR", Value: ":/my/custom/dir"},
+		},
+	}
+	existing := EnvVarNamesMap{"PHP_INI_SCAN_DIR": {}}
+
+	ev := distro.StaticEnvironmentVariable{
+		EnvName:          "PHP_INI_SCAN_DIR",
+		EnvValue:         ":/var/odigos/php/8.2",
+		AppendToExisting: true,
+	}
+
+	_, err := appendEnvVarToPodContainer(existing, container, ev, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := findEnvVar(container, "PHP_INI_SCAN_DIR")
+	if got.Value != ":/my/custom/dir:/var/odigos/php/8.2" {
+		t.Errorf("expected ':/my/custom/dir:/var/odigos/php/8.2', got %q", got.Value)
+	}
+}
+
+func TestAppendEnvVar_Idempotent_ManifestAlreadyHasValue(t *testing.T) {
+	container := &corev1.Container{
+		Name: "app",
+		Env: []corev1.EnvVar{
+			{Name: "PHP_INI_SCAN_DIR", Value: "/my/dir:/var/odigos/php/8.2"},
+		},
+	}
+	existing := EnvVarNamesMap{"PHP_INI_SCAN_DIR": {}}
+
+	ev := distro.StaticEnvironmentVariable{
+		EnvName:          "PHP_INI_SCAN_DIR",
+		EnvValue:         ":/var/odigos/php/8.2",
+		AppendToExisting: true,
+	}
+
+	_, err := appendEnvVarToPodContainer(existing, container, ev, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := findEnvVar(container, "PHP_INI_SCAN_DIR")
+	if got.Value != "/my/dir:/var/odigos/php/8.2" {
+		t.Errorf("value should be unchanged, got %q", got.Value)
+	}
+}
+
+func TestAppendEnvVar_Idempotent_CRIAlreadyHasValue(t *testing.T) {
+	container := &corev1.Container{Name: "app"}
+	existing := EnvVarNamesMap{}
+	params := map[string]string{
+		"PHP_INI_SCAN_DIR": "/image/path:/var/odigos/php/8.2",
+	}
+
+	ev := distro.StaticEnvironmentVariable{
+		EnvName:          "PHP_INI_SCAN_DIR",
+		EnvValue:         ":/var/odigos/php/8.2",
+		AppendToExisting: true,
+	}
+
+	_, err := appendEnvVarToPodContainer(existing, container, ev, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := findEnvVar(container, "PHP_INI_SCAN_DIR")
+	if got.Value != ":/var/odigos/php/8.2" {
+		t.Errorf("CRI already contains our value, should not double-prepend, got %q", got.Value)
+	}
+}
+
+func TestAppendEnvVar_WithTemplate(t *testing.T) {
+	container := &corev1.Container{
+		Name: "app",
+		Env: []corev1.EnvVar{
+			{Name: "PHP_INI_SCAN_DIR", Value: "/user/ini"},
+		},
+	}
+	existing := EnvVarNamesMap{"PHP_INI_SCAN_DIR": {}}
+	params := map[string]string{
+		"RUNTIME_VERSION_MAJOR_MINOR": "8.3",
+	}
+
+	ev := distro.StaticEnvironmentVariable{
+		EnvName:          "PHP_INI_SCAN_DIR",
+		EnvValue:         ":/var/odigos/php/{{.RUNTIME_VERSION_MAJOR_MINOR}}",
+		AppendToExisting: true,
+		Template:         parseTemplate(t, ":/var/odigos/php/{{.RUNTIME_VERSION_MAJOR_MINOR}}"),
+	}
+
+	_, err := appendEnvVarToPodContainer(existing, container, ev, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := findEnvVar(container, "PHP_INI_SCAN_DIR")
+	if got.Value != "/user/ini:/var/odigos/php/8.3" {
+		t.Errorf("expected '/user/ini:/var/odigos/php/8.3', got %q", got.Value)
+	}
+}
+
+func TestAppendEnvVar_TemplateWithCRI_NoManifest(t *testing.T) {
+	container := &corev1.Container{Name: "app"}
+	existing := EnvVarNamesMap{}
+	params := map[string]string{
+		"RUNTIME_VERSION_MAJOR_MINOR": "8.2",
+		"PHP_INI_SCAN_DIR":           "/image/ini",
+	}
+
+	ev := distro.StaticEnvironmentVariable{
+		EnvName:          "PHP_INI_SCAN_DIR",
+		EnvValue:         ":/var/odigos/php/{{.RUNTIME_VERSION_MAJOR_MINOR}}",
+		AppendToExisting: true,
+		Template:         parseTemplate(t, ":/var/odigos/php/{{.RUNTIME_VERSION_MAJOR_MINOR}}"),
+	}
+
+	_, err := appendEnvVarToPodContainer(existing, container, ev, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := findEnvVar(container, "PHP_INI_SCAN_DIR")
+	if got.Value != "/image/ini:/var/odigos/php/8.2" {
+		t.Errorf("expected '/image/ini:/var/odigos/php/8.2', got %q", got.Value)
+	}
+}
+
+func TestAppendEnvVar_TemplateError(t *testing.T) {
+	container := &corev1.Container{Name: "app"}
+	existing := EnvVarNamesMap{}
+	tmpl := parseTemplate(t, "{{.MISSING_KEY}}")
+
+	ev := distro.StaticEnvironmentVariable{
+		EnvName:          "PHP_INI_SCAN_DIR",
+		AppendToExisting: true,
+		Template:         tmpl,
+	}
+
+	_, err := appendEnvVarToPodContainer(existing, container, ev, map[string]string{})
+	if err == nil {
+		t.Error("expected template execution error for missing key")
+	}
+}
+
+func TestAppendEnvVar_EmptyCRIValue_Ignored(t *testing.T) {
+	container := &corev1.Container{Name: "app"}
+	existing := EnvVarNamesMap{}
+	params := map[string]string{
+		"PHP_INI_SCAN_DIR": "",
+	}
+
+	ev := distro.StaticEnvironmentVariable{
+		EnvName:          "PHP_INI_SCAN_DIR",
+		EnvValue:         ":/var/odigos/php/8.2",
+		AppendToExisting: true,
+	}
+
+	_, err := appendEnvVarToPodContainer(existing, container, ev, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := findEnvVar(container, "PHP_INI_SCAN_DIR")
+	if got.Value != ":/var/odigos/php/8.2" {
+		t.Errorf("empty CRI value should be ignored, got %q", got.Value)
+	}
+}
+
+func TestInjectStaticEnvVars_MixedAppendAndNormal(t *testing.T) {
+	container := &corev1.Container{
+		Name: "app",
+		Env: []corev1.EnvVar{
+			{Name: "PHP_INI_SCAN_DIR", Value: "/existing"},
+		},
+	}
+	existing := GetEnvVarNamesSet(container)
+	params := map[string]string{}
+
+	envVars := []distro.StaticEnvironmentVariable{
+		{
+			EnvName:          "PHP_INI_SCAN_DIR",
+			EnvValue:         ":/var/odigos/php/8.2",
+			AppendToExisting: true,
+		},
+		{
+			EnvName:  "OTEL_PHP_AUTOLOAD_ENABLED",
+			EnvValue: "true",
+		},
+		{
+			EnvName:  "ALREADY_SET",
+			EnvValue: "should-be-skipped",
+		},
+	}
+
+	container.Env = append(container.Env, corev1.EnvVar{Name: "ALREADY_SET", Value: "original"})
+	existing["ALREADY_SET"] = struct{}{}
+
+	result, err := InjectStaticEnvVarsToPodContainer(existing, container, envVars, params)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	scanDir := findEnvVar(container, "PHP_INI_SCAN_DIR")
+	if scanDir.Value != "/existing:/var/odigos/php/8.2" {
+		t.Errorf("PHP_INI_SCAN_DIR: expected '/existing:/var/odigos/php/8.2', got %q", scanDir.Value)
+	}
+
+	autoload := findEnvVar(container, "OTEL_PHP_AUTOLOAD_ENABLED")
+	if autoload == nil || autoload.Value != "true" {
+		t.Errorf("OTEL_PHP_AUTOLOAD_ENABLED: expected 'true', got %v", autoload)
+	}
+	if _, ok := result["OTEL_PHP_AUTOLOAD_ENABLED"]; !ok {
+		t.Error("OTEL_PHP_AUTOLOAD_ENABLED should be in returned env names map")
+	}
+
+	alreadySet := findEnvVar(container, "ALREADY_SET")
+	if alreadySet.Value != "original" {
+		t.Errorf("ALREADY_SET should be unchanged, got %q", alreadySet.Value)
+	}
+}
+
+func TestInjectStaticEnvVars_AppendFalse_SkipsExisting(t *testing.T) {
+	container := &corev1.Container{
+		Name: "app",
+		Env: []corev1.EnvVar{
+			{Name: "MY_VAR", Value: "original"},
+		},
+	}
+	existing := GetEnvVarNamesSet(container)
+
+	envVars := []distro.StaticEnvironmentVariable{
+		{
+			EnvName:          "MY_VAR",
+			EnvValue:         "new-value",
+			AppendToExisting: false,
+		},
+	}
+
+	_, err := InjectStaticEnvVarsToPodContainer(existing, container, envVars, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := findEnvVar(container, "MY_VAR")
+	if got.Value != "original" {
+		t.Errorf("non-append var should keep original value, got %q", got.Value)
+	}
+}

--- a/instrumentor/controllers/agentenabled/sync.go
+++ b/instrumentor/controllers/agentenabled/sync.go
@@ -420,7 +420,7 @@ func getEnvInjectionDecision(
 	distroHasAppendEnvVar := len(distro.EnvironmentVariables.AppendOdigosVariables) > 0
 	if !distroHasAppendEnvVar {
 		// this is a common case, where a distro doesn't support nor loader or append env var injection.
-		// at the time of writing, this is golang, dotnet, php, ruby.
+		// at the time of writing, this is golang, dotnet, ruby.
 		// for those we mark env injection as nil to denote "no injection"
 		// and return err as nil to denote "no error".
 		return nil, nil


### PR DESCRIPTION
- Added `AppendToExisting` field to `StaticEnvironmentVariable` struct to allow appending values to existing environment variables in the container manifest.
- Updated `InjectStaticEnvVarsToPodContainer` function to handle appending logic for environment variables.
- Modified `php-community.yaml` to utilize the new `AppendToExisting` feature for `PHP_INI_SCAN_DIR`, ensuring proper handling of colon-separated paths.

Changelog entry:
```release-note
enhance PHP_INI_SCAN_DIR environment variable handling in PHP integration
```

emergency-ticket id: EMR-1066
