### PR TITLE
fix: pass commit message via env to avoid shell injection in release tag workflow (#4266)

### DIFF
--- a/.github/workflows/push-release-branch-tag.yml
+++ b/.github/workflows/push-release-branch-tag.yml
@@ -21,8 +21,9 @@ jobs:
 
       - name: Extract tag from commit message
         id: extract_tag
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
-          COMMIT_MSG="${{ github.event.head_commit.message }}"
           echo "Commit message: $COMMIT_MSG"
 
           # Extract the tag version from the message (e.g., v1.1.1, v1.2.3-rc4, v1.2.3-foobar)


### PR DESCRIPTION
#### What this PR does / why we need it:

The commit message was interpolated directly into the shell script, causing backticks in PR descriptions (e.g. ```release-note blocks) to be interpreted as command substitution. Moving it to the env block lets the runner set it safely without shell interpretation. https://github.com/odigos-io/odigos/pull/4266

```release-note
NONE
```

emergency-ticket id: EMR-1064
