### PR TITLE
chore: bump odiglet base to use go1.26

### DIFF
--- a/odiglet/base.Dockerfile
+++ b/odiglet/base.Dockerfile
@@ -23,7 +23,7 @@ RUN wget https://download.samba.org/pub/rsync/src/rsync-${RSYNC_VERSION}.tar.gz 
     && cd .. \
     && rm -rf rsync-${RSYNC_VERSION}*
 
-FROM golang:1.25.3-trixie
+FROM golang:1.26.0-trixie
 
 # fury is our registry for linux packages
 RUN echo "deb [trusted=yes] https://apt.fury.io/cli/ * *" > /etc/apt/sources.list.d/fury-cli.list


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->

Before bumping the go version we use, build a new odiglet base image.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```

emergency-ticket id: EMR-1085
