### PR TITLE
chore: update PHP agent version to v0.2.6 in Dockerfiles (#4282)

### DIFF
--- a/docs/instrumentations/overview.mdx
+++ b/docs/instrumentations/overview.mdx
@@ -21,7 +21,7 @@ Odigos provides automatic instrumentations for the following runtimes:
   javaUrl="/instrumentations/java/native"
   javaDescription="Versions 8 and above are supported"
   phpUrl="/instrumentations/php/native"
-  phpDescription="Versions 8.0.0 - 8.4.x are supported"
+  phpDescription="Versions 8.1.0 - 8.4.x are supported"
   rubyUrl="/instrumentations/ruby/native"
   rubyDescription="Versions 3.1.0 - 3.5.x are supported"
   dotnetUrl="/instrumentations/dotnet/native"

--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -58,7 +58,7 @@ COPY --from=public.ecr.aws/odigos/agents/nodejs-community:v0.0.8 /instrumentatio
 COPY --from=dotnet-builder /dotnet-instrumentation /instrumentations/dotnet
 
 # PHP
-COPY --from=public.ecr.aws/odigos/agents/php-community:v0.2.5 /instrumentations/php /instrumentations/php
+COPY --from=public.ecr.aws/odigos/agents/php-community:v0.2.6 /instrumentations/php /instrumentations/php
 
 # Ruby
 COPY --from=public.ecr.aws/odigos/agents/ruby-community:v0.0.8 /instrumentations/ruby /instrumentations/ruby

--- a/odiglet/debug.Dockerfile
+++ b/odiglet/debug.Dockerfile
@@ -79,7 +79,7 @@ COPY --from=public.ecr.aws/odigos/agents/nodejs-community:v0.0.8 /instrumentatio
 COPY --from=dotnet-builder /dotnet-instrumentation /instrumentations/dotnet
 
 # PHP
-COPY --from=public.ecr.aws/odigos/agents/php-community:v0.2.5 /instrumentations/php /instrumentations/php
+COPY --from=public.ecr.aws/odigos/agents/php-community:v0.2.6 /instrumentations/php /instrumentations/php
 
 # Ruby
 COPY --from=public.ecr.aws/odigos/agents/ruby-community:v0.0.8 /instrumentations/ruby /instrumentations/ruby

--- a/odiglet/pkg/instrumentation/fs/agents.go
+++ b/odiglet/pkg/instrumentation/fs/agents.go
@@ -42,11 +42,19 @@ func CopyAgentsDirectoryToHost() error {
 		"/var/odigos/java-ext-ebpf/otel_agent_extension.jar":                                           {},
 		"/var/odigos/python-ebpf/pythonUSDT.abi3.so":                                                   {},
 		"/var/odigos/loader/loader.so":                                                                 {},
-		// Google protobuf library shared object loaded by Python processes.
-		// This file gets mapped into process memory and cannot be replaced while loaded.
-		// Therefore, we need to keep this file in the host filesystem to avoid removing it.
-		// This file is versioned and renamed if changed (python protobuf library version changes).
-		"/var/odigos/python/google/_upb/_message.abi3.so": {},
+		// Python dependency shared objects - special handling:
+		// These shared objects (.so files) are loaded by Python processes and mapped into process memory.
+		// They cannot be replaced while loaded, so we must keep them in the host filesystem to avoid removal.
+		// These files are versioned and renamed when their respective library versions change.
+		"/var/odigos/python/google/_upb/_message.abi3.so":                     {}, // Google protobuf library
+		"/var/odigos/python/wrapt/_wrappers.cpython-311-aarch64-linux-gnu.so": {}, // Wrapt library on arm64
+		"/var/odigos/python/wrapt/_wrappers.cpython-311-x86_64-linux-gnu.so":  {}, // Wrapt library on x86_64
+		// PHP native extension loaded by the PHP runtime via dlopen().
+		// Must be preserved during upgrades to avoid crashing running PHP-FPM processes.
+		"/var/odigos/php/8.1/opentelemetry.so": {},
+		"/var/odigos/php/8.2/opentelemetry.so": {},
+		"/var/odigos/php/8.3/opentelemetry.so": {},
+		"/var/odigos/php/8.4/opentelemetry.so": {},
 	}
 	empty, err := isDirEmptyOrNotExist(k8sconsts.OdigosAgentsDirectory)
 	if err != nil {

--- a/odiglet/pkg/instrumentation/fs/agents.go
+++ b/odiglet/pkg/instrumentation/fs/agents.go
@@ -42,13 +42,11 @@ func CopyAgentsDirectoryToHost() error {
 		"/var/odigos/java-ext-ebpf/otel_agent_extension.jar":                                           {},
 		"/var/odigos/python-ebpf/pythonUSDT.abi3.so":                                                   {},
 		"/var/odigos/loader/loader.so":                                                                 {},
-		// Python dependency shared objects - special handling:
-		// These shared objects (.so files) are loaded by Python processes and mapped into process memory.
-		// They cannot be replaced while loaded, so we must keep them in the host filesystem to avoid removal.
-		// These files are versioned and renamed when their respective library versions change.
-		"/var/odigos/python/google/_upb/_message.abi3.so":                     {}, // Google protobuf library
-		"/var/odigos/python/wrapt/_wrappers.cpython-311-aarch64-linux-gnu.so": {}, // Wrapt library on arm64
-		"/var/odigos/python/wrapt/_wrappers.cpython-311-x86_64-linux-gnu.so":  {}, // Wrapt library on x86_64
+		// Google protobuf library shared object loaded by Python processes.
+		// This file gets mapped into process memory and cannot be replaced while loaded.
+		// Therefore, we need to keep this file in the host filesystem to avoid removing it.
+		// This file is versioned and renamed if changed (python protobuf library version changes).
+		"/var/odigos/python/google/_upb/_message.abi3.so": {},
 		// PHP native extension loaded by the PHP runtime via dlopen().
 		// Must be preserved during upgrades to avoid crashing running PHP-FPM processes.
 		"/var/odigos/php/8.1/opentelemetry.so": {},


### PR DESCRIPTION
#### What this PR does / why we need it:
- Removed pre-load from PHP agents (caused crashloops for non `www-data` users)
- Scoped some vendors/libs to isolate the code and prevent version miss-matches (e.g. grpc export)

#### Changelog entry:

```release-note
update PHP agent version to v0.2.6
```

emergency-ticket id: EMR-1088
