### PR TITLE
Remove rhel images from promote comment

### DIFF
--- a/.github/workflows/promote-rc-to-stable.yml
+++ b/.github/workflows/promote-rc-to-stable.yml
@@ -112,7 +112,7 @@ jobs:
 
             DOCKERHUB_IMAGE_NAMES=("odigos-agents" "odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-ui" "odigos-operator" "odigos-enterprise-agents" "odigos-enterprise-instrumentor" "odigos-enterprise-odiglet")
 
-            // Keep this empty for now to support another image SUFFIXES in the future if needed (e.g. rhel-certified)
+            # Keep this empty for now to support another image SUFFIXES in the future if needed (e.g. rhel-certified)
             IMAGE_SUFFIXES=("")
             # Track failed copies for potential rollback
             FAILED_COPIES=()

--- a/.github/workflows/promote-rc-to-stable.yml
+++ b/.github/workflows/promote-rc-to-stable.yml
@@ -112,7 +112,7 @@ jobs:
 
             DOCKERHUB_IMAGE_NAMES=("odigos-agents" "odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-ui" "odigos-operator" "odigos-enterprise-agents" "odigos-enterprise-instrumentor" "odigos-enterprise-odiglet")
 
-            IMAGE_SUFFIXES=("" "-rhel-certified")
+            IMAGE_SUFFIXES=("")
             # Track failed copies for potential rollback
             FAILED_COPIES=()
 

--- a/.github/workflows/promote-rc-to-stable.yml
+++ b/.github/workflows/promote-rc-to-stable.yml
@@ -112,6 +112,7 @@ jobs:
 
             DOCKERHUB_IMAGE_NAMES=("odigos-agents" "odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-ui" "odigos-operator" "odigos-enterprise-agents" "odigos-enterprise-instrumentor" "odigos-enterprise-odiglet")
 
+            // Keep this empty for now to support another image SUFFIXES in the future if needed (e.g. rhel-certified)
             IMAGE_SUFFIXES=("")
             # Track failed copies for potential rollback
             FAILED_COPIES=()


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Due to the fact we separate the rhel-certified images build, we shouldn't promote them.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```

emergency-ticket id: EMR-1092
