### PR TITLE
fix: auto-configure HTTPS settings for central auth when externalUrl uses https

### DIFF
--- a/helm/odigos-central/templates/centralbackend/deployment.yaml
+++ b/helm/odigos-central/templates/centralbackend/deployment.yaml
@@ -39,6 +39,8 @@ spec:
             {{- if .Values.auth.externalUrl }}
             - name: CENTRAL_BACKEND_HOST
               value: {{ .Values.auth.externalUrl | quote }}
+            - name: CENTRAL_UI_HOST
+              value: {{ .Values.auth.externalUrl | quote }}
             {{- end }}
             - name: USE_K8S_SECRETS
               value: "true"

--- a/helm/odigos-central/templates/keycloak/deployment.yaml
+++ b/helm/odigos-central/templates/keycloak/deployment.yaml
@@ -77,7 +77,7 @@ spec:
               value: {{ regexReplaceAll "^[^:]*:" $hostWithPort "" | quote }}
             {{- end }}
             - name: KC_HOSTNAME_STRICT_HTTPS
-              value: "false"
+              value: {{ ternary "true" "false" (hasPrefix "https" $externalUrl) | quote }}
             - name: KC_HOSTNAME_STRICT_BACKCHANNEL
               value: "true"
             - name: KC_PROXY


### PR DESCRIPTION


When auth.externalUrl is set with an https:// scheme:
- KC_HOSTNAME_STRICT_HTTPS is now set to "true" on the Keycloak deployment so it generates https:// URLs for browser-facing redirects (e.g. Azure AD callback URIs).
- CENTRAL_UI_HOST is now set on the central-backend deployment from auth.externalUrl, ensuring the post-sign-in redirect goes to the correct origin.

Previously, KC_HOSTNAME_STRICT_HTTPS was always "false" and CENTRAL_UI_HOST was not set at all, requiring manual patching for any production deployment behind TLS-terminating ingress.



```release-note
NONE
```

emergency-ticket id: EMR-1105
