### PR TITLE
fix: write url templatization even when rules are empty

### DIFF
--- a/instrumentor/controllers/agentenabled/pods_webhook.go
+++ b/instrumentor/controllers/agentenabled/pods_webhook.go
@@ -351,7 +351,7 @@ func (p *PodsWebhook) injectOdigosToContainer(containerConfig *odigosv1.Containe
 	}
 
 	// URL Templatization configuration
-	urlTemplatizationEnabled := containerConfig.Traces != nil && containerConfig.Traces.UrlTemplatization != nil && len(containerConfig.Traces.UrlTemplatization.Rules) > 0
+	urlTemplatizationEnabled := containerConfig.Traces != nil && containerConfig.Traces.UrlTemplatization != nil
 	supportsUrlTemplatization := distroMetadata.Traces != nil && distroMetadata.Traces.UrlTemplatization != nil && distroMetadata.Traces.UrlTemplatization.Supported
 	if urlTemplatizationEnabled && supportsUrlTemplatization && distroMetadata.ConfigAsEnvVars {
 		// parse URL templatization config to json using the existing AgentTracesConfig struct


### PR DESCRIPTION
#### What this PR does / why we need it:

With java, url templatization can be run in the in the agent. the configuration is passed as env variables.
Currently, if there are no rules configured, then the env var is not injected, which is incorrect behavior.

This PR makes it so that  we still inject the url templatization with empty rules when this configured.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
fix: allow empty url templatization rules list for java-enterprise
```

emergency-ticket id: EMR-1117
