### PR TITLE
chore: bump runtime detector for better processes fork handling

### DIFF
--- a/instrumentation/go.mod
+++ b/instrumentation/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/odigos-io/odigos/common v0.0.0
 	github.com/odigos-io/odigos/distros v0.0.0
-	github.com/odigos-io/runtime-detector v0.0.22
+	github.com/odigos-io/runtime-detector v0.0.24
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/metric v1.38.0
 	golang.org/x/sync v0.18.0

--- a/instrumentation/go.sum
+++ b/instrumentation/go.sum
@@ -25,8 +25,8 @@ github.com/mdlayher/netlink v1.7.2 h1:/UtM3ofJap7Vl4QWCPDGXY8d3GIY2UGSDbK+QWmY8/
 github.com/mdlayher/netlink v1.7.2/go.mod h1:xraEF7uJbxLhc5fpHL4cPe221LI2bdttWlU+ZGLfQSw=
 github.com/mdlayher/socket v0.4.1 h1:eM9y2/jlbs1M615oshPQOHZzj6R6wMT7bX5NPiQvn2U=
 github.com/mdlayher/socket v0.4.1/go.mod h1:cAqeGjoufqdxWkD7DkpyS+wcefOtmu5OQ8KuoJGIReA=
-github.com/odigos-io/runtime-detector v0.0.22 h1:6jkqdWB0sLWXj433f/R13kzv7SHNSEoKNKi1LHZcFac=
-github.com/odigos-io/runtime-detector v0.0.22/go.mod h1:Iww/+1F0b1mk8/BDsV9kmAOPVotiqgGhDr2vBP6wwgU=
+github.com/odigos-io/runtime-detector v0.0.24 h1:5CZqP8JDajoubW0HumGllJdoYK99Jwuq3M28ATmrvrM=
+github.com/odigos-io/runtime-detector v0.0.24/go.mod h1:Iww/+1F0b1mk8/BDsV9kmAOPVotiqgGhDr2vBP6wwgU=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/odiglet/go.mod
+++ b/odiglet/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/odigos-io/odigos/opampserver v0.0.0-00010101000000-000000000000
 	github.com/odigos-io/odigos/procdiscovery v0.0.0-00010101000000-000000000000
 	github.com/odigos-io/opentelemetry-zap-bridge v0.0.5
-	github.com/odigos-io/runtime-detector v0.0.22
+	github.com/odigos-io/runtime-detector v0.0.24
 	go.opentelemetry.io/auto v0.21.0
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.38.0

--- a/odiglet/go.sum
+++ b/odiglet/go.sum
@@ -104,8 +104,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/odigos-io/opentelemetry-zap-bridge v0.0.5 h1:UDEKtgab42nGVSvA/F3lLKUYFPETtpl7kpxM9BKBlWk=
 github.com/odigos-io/opentelemetry-zap-bridge v0.0.5/go.mod h1:K98wHhktQ6vCTqeFztcpBDtPTe88vxVgZFlbeGobt24=
-github.com/odigos-io/runtime-detector v0.0.22 h1:6jkqdWB0sLWXj433f/R13kzv7SHNSEoKNKi1LHZcFac=
-github.com/odigos-io/runtime-detector v0.0.22/go.mod h1:Iww/+1F0b1mk8/BDsV9kmAOPVotiqgGhDr2vBP6wwgU=
+github.com/odigos-io/runtime-detector v0.0.24 h1:5CZqP8JDajoubW0HumGllJdoYK99Jwuq3M28ATmrvrM=
+github.com/odigos-io/runtime-detector v0.0.24/go.mod h1:Iww/+1F0b1mk8/BDsV9kmAOPVotiqgGhDr2vBP6wwgU=
 github.com/onsi/ginkgo/v2 v2.25.1 h1:Fwp6crTREKM+oA6Cz4MsO8RhKQzs2/gOIVOUscMAfZY=
 github.com/onsi/ginkgo/v2 v2.25.1/go.mod h1:ppTWQ1dh9KM/F1XgpeRqelR+zHVwV81DGRSDnFxK7Sk=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Fix a bug where processes that were added by TrackPIDs were not reporting fork events.
This cause a bug where odiglet restarts and new forks triggered we didn't instrument them properly

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Properly handle exec and fork events performed post odiglet restarts
```

emergency-ticket id: EMR-1144
