### PR TITLE
chore: remove unused config value psp

### DIFF
--- a/common/consts/consts.go
+++ b/common/consts/consts.go
@@ -76,7 +76,6 @@ const (
 const (
 	TelemetryEnabledProperty           = "telemetry-enabled"
 	OpenshiftEnabledProperty           = "openshift-enabled"
-	PspProperty                        = "psp"
 	SkipWebhookIssuerCreationProperty  = "skip-webhook-issuer-creation"
 	AllowConcurrentAgentsProperty      = "allow-concurrent-agents"
 	ImagePrefixProperty                = "image-prefix"

--- a/common/odigos_config.go
+++ b/common/odigos_config.go
@@ -419,7 +419,6 @@ type OdigosConfiguration struct {
 	IgnoredNamespaces         []string                       `json:"ignoredNamespaces,omitempty" yaml:"ignoredNamespaces"`
 	IgnoredContainers         []string                       `json:"ignoredContainers,omitempty" yaml:"ignoredContainers"`
 	IgnoreOdigosNamespace     *bool                          `json:"ignoreOdigosNamespace,omitempty" yaml:"ignoreOdigosNamespace"`
-	Psp                       bool                           `json:"psp,omitempty" yaml:"psp"`
 	ImagePrefix               string                         `json:"imagePrefix,omitempty" yaml:"imagePrefix"`
 	SkipWebhookIssuerCreation bool                           `json:"skipWebhookIssuerCreation,omitempty" yaml:"skipWebhookIssuerCreation"`
 	CollectorGateway          *CollectorGatewayConfiguration `json:"collectorGateway,omitempty" yaml:"collectorGateway"`

--- a/docs/api-reference/operator.odigos.io.v1alpha1.mdx
+++ b/docs/api-reference/operator.odigos.io.v1alpha1.mdx
@@ -176,18 +176,6 @@ Default=false</p>
 </tr>
 <tr>
 <td>
-<code>podSecurityPolicy</code> <B>[Required]</B>
-</td>
-<td>
-<code>bool</code>
-</td>
-<td>
-   <p>(Optional) PodSecurityPolicy allows Odigos pods to use a privileged pod security policy.
-Default=false</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>imagePrefix</code> <B>[Required]</B>
 </td>
 <td>

--- a/docs/permissions.mdx
+++ b/docs/permissions.mdx
@@ -228,7 +228,7 @@ This section lists the RBAC policies used by the Odigos Operator. Many of these 
 | \* | events | \* | create<br />patch |
 | \* | namespaces | \* | get<br />list<br />patch<br />watch |
 | \* | nodes | \* | get<br />list<br />patch<br />update<br />watch |
-| \* | nodes/proxy<br />nodes/stats | \* | get<br />list |
+| \* | nodes/stats | \* | get<br />list<br />watch |
 | \* | pods | \* | delete<br />get<br />list<br />watch |
 | \* | pods/log<br />pods/status | \* | get |
 | \* | serviceaccounts | \* | create<br />delete<br />get<br />list<br />patch<br />watch |
@@ -252,6 +252,7 @@ This section lists the RBAC policies used by the Odigos Operator. Many of these 
 | odigos.io | collectorsgroups/finalizers<br />sources/finalizers | \* | update |
 | odigos.io | collectorsgroups/status<br />destinations/status<br />instrumentationconfigs/status<br />instrumentationinstances/status | \* | get<br />list<br />patch<br />update<br />watch |
 | odigos.io | instrumentationrules/status | \* | get<br />patch<br />update |
+| odigos.io | sampling | \* | create<br />delete<br />get<br />list<br />patch<br />update<br />watch |
 | operator.odigos.io | odigos | \* | create<br />delete<br />get<br />list<br />patch<br />update<br />watch |
 | operator.odigos.io | odigos/finalizers | \* | update |
 | operator.odigos.io | odigos/status | \* | get<br />patch<br />update |

--- a/frontend/graph/configs.graphqls
+++ b/frontend/graph/configs.graphqls
@@ -167,7 +167,6 @@ type EffectiveConfig {
   ignoredNamespaces: [String!]
   ignoredContainers: [String!]
   ignoreOdigosNamespace: Boolean
-  psp: Boolean
   imagePrefix: String
   skipWebhookIssuerCreation: Boolean
   collectorGateway: CollectorGatewayConfig

--- a/frontend/graph/conversions.go
+++ b/frontend/graph/conversions.go
@@ -173,9 +173,6 @@ func setEffectiveConfigBooleans(result *model.EffectiveConfig, config *common.Od
 	openshiftEnabled := config.OpenshiftEnabled
 	result.OpenshiftEnabled = &openshiftEnabled
 
-	psp := config.Psp
-	result.Psp = &psp
-
 	skipWebhookIssuerCreation := config.SkipWebhookIssuerCreation
 	result.SkipWebhookIssuerCreation = &skipWebhookIssuerCreation
 

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -375,7 +375,6 @@ type ComplexityRoot struct {
 		Oidc                             func(childComplexity int) int
 		OpenshiftEnabled                 func(childComplexity int) int
 		Profiles                         func(childComplexity int) int
-		Psp                              func(childComplexity int) int
 		ResourceSizePreset               func(childComplexity int) int
 		RollbackDisabled                 func(childComplexity int) int
 		RollbackGraceTime                func(childComplexity int) int
@@ -2852,13 +2851,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.EffectiveConfig.Profiles(childComplexity), true
-
-	case "EffectiveConfig.psp":
-		if e.complexity.EffectiveConfig.Psp == nil {
-			break
-		}
-
-		return e.complexity.EffectiveConfig.Psp(childComplexity), true
 
 	case "EffectiveConfig.resourceSizePreset":
 		if e.complexity.EffectiveConfig.ResourceSizePreset == nil {
@@ -16966,47 +16958,6 @@ func (ec *executionContext) _EffectiveConfig_ignoreOdigosNamespace(ctx context.C
 }
 
 func (ec *executionContext) fieldContext_EffectiveConfig_ignoreOdigosNamespace(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "EffectiveConfig",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Boolean does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _EffectiveConfig_psp(ctx context.Context, field graphql.CollectedField, obj *model.EffectiveConfig) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_EffectiveConfig_psp(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Psp, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*bool)
-	fc.Result = res
-	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_EffectiveConfig_psp(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "EffectiveConfig",
 		Field:      field,
@@ -35961,8 +35912,6 @@ func (ec *executionContext) fieldContext_Query_effectiveConfig(_ context.Context
 				return ec.fieldContext_EffectiveConfig_ignoredContainers(ctx, field)
 			case "ignoreOdigosNamespace":
 				return ec.fieldContext_EffectiveConfig_ignoreOdigosNamespace(ctx, field)
-			case "psp":
-				return ec.fieldContext_EffectiveConfig_psp(ctx, field)
 			case "imagePrefix":
 				return ec.fieldContext_EffectiveConfig_imagePrefix(ctx, field)
 			case "skipWebhookIssuerCreation":
@@ -46439,8 +46388,6 @@ func (ec *executionContext) _EffectiveConfig(ctx context.Context, sel ast.Select
 			out.Values[i] = ec._EffectiveConfig_ignoredContainers(ctx, field, obj)
 		case "ignoreOdigosNamespace":
 			out.Values[i] = ec._EffectiveConfig_ignoreOdigosNamespace(ctx, field, obj)
-		case "psp":
-			out.Values[i] = ec._EffectiveConfig_psp(ctx, field, obj)
 		case "imagePrefix":
 			out.Values[i] = ec._EffectiveConfig_imagePrefix(ctx, field, obj)
 		case "skipWebhookIssuerCreation":

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -392,7 +392,6 @@ type EffectiveConfig struct {
 	IgnoredNamespaces                []string                            `json:"ignoredNamespaces,omitempty"`
 	IgnoredContainers                []string                            `json:"ignoredContainers,omitempty"`
 	IgnoreOdigosNamespace            *bool                               `json:"ignoreOdigosNamespace,omitempty"`
-	Psp                              *bool                               `json:"psp,omitempty"`
 	ImagePrefix                      *string                             `json:"imagePrefix,omitempty"`
 	SkipWebhookIssuerCreation        *bool                               `json:"skipWebhookIssuerCreation,omitempty"`
 	CollectorGateway                 *CollectorGatewayConfig             `json:"collectorGateway,omitempty"`

--- a/helm/odigos/templates/odigos-configuration-cm.yaml
+++ b/helm/odigos/templates/odigos-configuration-cm.yaml
@@ -126,7 +126,6 @@ data:
     {{- end }}
     telemetryEnabled: {{ .Values.telemetry.enabled }}
     openshiftEnabled: {{ .Values.openshift.enabled }}
-    psp: {{ .Values.psp.enabled }}
     {{- if .Values.ignoredNamespaces }}
     ignoredNamespaces:
       {{- toYaml .Values.ignoredNamespaces | nindent 6 }}

--- a/helm/odigos/values.schema.json
+++ b/helm/odigos/values.schema.json
@@ -1391,19 +1391,6 @@
       "required": [],
       "title": "profiles"
     },
-    "psp": {
-      "additionalProperties": false,
-      "description": "Pod Security Policy",
-      "properties": {
-        "enabled": {
-          "default": false,
-          "title": "enabled",
-          "type": "boolean"
-        }
-      },
-      "required": [],
-      "title": "psp"
-    },
     "rollout": {
       "additionalProperties": false,
       "description": "Odigos automatically triggers a one-time rollout for workloads when instrumenting or uninstrumenting, to apply changes.\nIf workload restarts are sensitive, this setting can be used to disable the automatic rollout.\nWhen disabled, users are responsible for manually triggering rollouts after adding or removing sources.\nAny new pods created after enabling or disabling the agent (via manual rollout, autoscaling, etc.)\nwill still have the agent injected, regardless of this setting.\nWhen set to true, all additional configurations related to automated rollouts or rollbacks are ignored.",

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -906,12 +906,6 @@ centralProxy:
   # priorityClassName: ''
 
 # @schema
-# description: Pod Security Policy
-# @schema
-psp:
-  enabled: false
-
-# @schema
 # description: Telemetry configuration for Odigos.
 # @schema
 telemetry:

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -51,7 +51,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.39.1
+OPERATOR_SDK_VERSION ?= v1.41.1
 # Image URL to use all building/pushing image targets
 IMG ?= registry.connect.redhat.com/odigos/odigos-operator-certified:v$(VERSION)
 AUTOSCALER_IMG ?= $(ORG)/odigos-autoscaler-certified:v$(VERSION)

--- a/operator/api/v1alpha1/odigos_types.go
+++ b/operator/api/v1alpha1/odigos_types.go
@@ -68,11 +68,6 @@ type OdigosSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	SkipWebhookIssuerCreation bool `json:"skipWebhookIssuerCreation,omitempty"`
 
-	// (Optional) PodSecurityPolicy allows Odigos pods to use a privileged pod security policy.
-	// Default=false
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	PodSecurityPolicy bool `json:"podSecurityPolicy,omitempty"`
-
 	// (Optional) ImagePrefix is a prefix for all container images.
 	// This should only be used if you are pulling Odigos images from the non-default registry.
 	// Default: registry.odigos.io

--- a/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
@@ -20,7 +20,7 @@ metadata:
     capabilities: Basic Install
     categories: Logging & Tracing
     containerImage: registry.connect.redhat.com/odigos/odigos-operator-certified:v1.8.7
-    createdAt: "2026-01-22T17:18:22Z"
+    createdAt: "2026-03-07T01:46:34Z"
     description: Odigos enables automatic distributed tracing with OpenTelemetry and
       eBPF.
     features.operators.openshift.io/disconnected: "false"
@@ -101,11 +101,6 @@ spec:
           DEPRECATED: OpenShift clusters are auto-detected and this API field will be removed in a future release.
         displayName: OpenShift Enabled
         path: openshiftEnabled
-      - description: |-
-          (Optional) PodSecurityPolicy allows Odigos pods to use a privileged pod security policy.
-          Default=false
-        displayName: Pod Security Policy
-        path: podSecurityPolicy
       - description: |-
           (Optional) SkipWebhookIssuerCreation skips creating the Issuer and Certificate for the Instrumentor pod webhook if cert-manager is installed.
           Default=false
@@ -188,11 +183,11 @@ spec:
         - apiGroups:
           - ""
           resources:
-          - nodes/proxy
           - nodes/stats
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
           - ""
           resources:
@@ -426,6 +421,18 @@ spec:
           - get
           - patch
           - update
+        - apiGroups:
+          - odigos.io
+          resources:
+          - sampling
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - operator.odigos.io
           resources:

--- a/operator/bundle/manifests/operator.odigos.io_odigos.yaml
+++ b/operator/bundle/manifests/operator.odigos.io_odigos.yaml
@@ -92,11 +92,6 @@ spec:
                   (Optional) OpenShiftEnabled configures selinux on OpenShift nodes.
                   DEPRECATED: OpenShift clusters are auto-detected and this API field will be removed in a future release.
                 type: boolean
-              podSecurityPolicy:
-                description: |-
-                  (Optional) PodSecurityPolicy allows Odigos pods to use a privileged pod security policy.
-                  Default=false
-                type: boolean
               profiles:
                 description: (Optional) Profiles is a list of preset profiles with
                   a specific configuration.

--- a/operator/config/crd/bases/operator.odigos.io_odigos.yaml
+++ b/operator/config/crd/bases/operator.odigos.io_odigos.yaml
@@ -92,11 +92,6 @@ spec:
                   (Optional) OpenShiftEnabled configures selinux on OpenShift nodes.
                   DEPRECATED: OpenShift clusters are auto-detected and this API field will be removed in a future release.
                 type: boolean
-              podSecurityPolicy:
-                description: |-
-                  (Optional) PodSecurityPolicy allows Odigos pods to use a privileged pod security policy.
-                  Default=false
-                type: boolean
               profiles:
                 description: (Optional) Profiles is a list of preset profiles with
                   a specific configuration.

--- a/operator/config/manifests/bases/odigos-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/odigos-operator.clusterserviceversion.yaml
@@ -86,11 +86,6 @@ spec:
         displayName: OpenShift Enabled
         path: openshiftEnabled
       - description: |-
-          (Optional) PodSecurityPolicy allows Odigos pods to use a privileged pod security policy.
-          Default=false
-        displayName: Pod Security Policy
-        path: podSecurityPolicy
-      - description: |-
           (Optional) SkipWebhookIssuerCreation skips creating the Issuer and Certificate for the Instrumentor pod webhook if cert-manager is installed.
           Default=false
         displayName: Skip Webhook Issuer Creation

--- a/operator/internal/controller/helm.go
+++ b/operator/internal/controller/helm.go
@@ -322,13 +322,6 @@ func odigosSpecToHelmValues(odigos *operatorv1alpha1.Odigos, openshiftEnabled bo
 		vals["nodeSelector"] = odigos.Spec.NodeSelector
 	}
 
-	// Pod Security Policy
-	if odigos.Spec.PodSecurityPolicy {
-		psp := make(map[string]interface{})
-		psp["enabled"] = true
-		vals["psp"] = psp
-	}
-
 	// OpenShift
 	openshift := make(map[string]interface{})
 	openshift["enabled"] = openshiftEnabled


### PR DESCRIPTION
#### What this PR does / why we need it:

psp is pod security policy, and it is effectively unused in code for anything, so I think it is safe to remove it.
originally it was added for one user, which had since upgrade his k8s version.

[PodSecurityPolicy was [deprecated](https://kubernetes.io/blog/2021/04/08/kubernetes-1-21-release-announcement/#podsecuritypolicy-deprecation) in Kubernetes v1.21, and removed from Kubernetes in v1.25.](https://kubernetes.io/docs/concepts/security/pod-security-policy/?utm_source=chatgpt.com)

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
remove unused config option "psp" (PodSecurityPolicy)
```
