### PR TITLE
feat(helm): pass CENTRAL_BACKEND_URL env var to central-ui deployment

### DIFF
--- a/helm/odigos-central/templates/centralui/deployment.yaml
+++ b/helm/odigos-central/templates/centralui/deployment.yaml
@@ -28,6 +28,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: CENTRAL_BACKEND_URL
+              value: {{ .Values.centralUI.centralBackendURL | default (printf "http://central-backend.%s:8081" .Release.Namespace) | quote }}
           resources:
             requests:
               cpu: {{ .Values.centralUI.resources.requests.cpu }}


### PR DESCRIPTION
Wire the centralUI.centralBackendURL Helm value as an environment variable to the central-ui container. This allows the Next.js server-side rewrites to proxy API requests to the correct backend URL, enabling external access (via Ingress/LoadBalancer) without requiring the browser to reach the backend directly.


```release-note
feat: support external access to Odigos Central UI via Ingress/LoadBalancer by proxying API requests server-side
```

emergency-ticket id: EMR-1266
