### PR TITLE
fix: argocd tests for k8s<1.23

### DIFF
--- a/tests/e2e/argo-rollouts/chainsaw-test.yaml
+++ b/tests/e2e/argo-rollouts/chainsaw-test.yaml
@@ -20,7 +20,8 @@ spec:
               # Create the argo-rollouts namespace if it doesn't exist
               kubectl create namespace argo-rollouts --dry-run=client -o yaml | kubectl apply -f -
               # Install Argo Rollouts controller
-              kubectl apply -n argo-rollouts -f https://github.com/argoproj/argo-rollouts/releases/download/v1.8.4/install.yaml
+              # Adding --validate=false since argo dropped support for k8s < 1.23 which we test.
+              kubectl apply -n argo-rollouts --validate=false -f https://github.com/argoproj/argo-rollouts/releases/download/v1.8.4/install.yaml
               # Wait for the controller to be ready
               kubectl wait --for=condition=available --timeout=120s deployment/argo-rollouts -n argo-rollouts
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Argo published a new version of https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml which uses a new feature `x-kubernetes-validations` which is not supported in k8s v1.21 which we support and test.

This PR adds `--validate=false` to bypass this issue.

error from CI:

```
    sink.go:41: | 10:52:56 | argo-rollouts | Install Argo Rollouts Controller                       | CMD       | RUN   |
        === COMMAND
        /usr/bin/sh -c # Create the argo-rollouts namespace if it doesn't exist
        kubectl create namespace argo-rollouts --dry-run=client -o yaml | kubectl apply -f -
        # Install Argo Rollouts controller
        kubectl apply -n argo-rollouts -f https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml
        # Wait for the controller to be ready
        kubectl wait --for=condition=available --timeout=120s deployment/argo-rollouts -n argo-rollouts
    sink.go:41: | 10:52:57 | argo-rollouts | Install Argo Rollouts Controller                       | SCRIPT    | LOG   |
        === STDOUT
        namespace/argo-rollouts created
        customresourcedefinition.apiextensions.k8s.io/analysisruns.argoproj.io created
        customresourcedefinition.apiextensions.k8s.io/analysistemplates.argoproj.io created
        customresourcedefinition.apiextensions.k8s.io/clusteranalysistemplates.argoproj.io created
        customresourcedefinition.apiextensions.k8s.io/experiments.argoproj.io created
        === STDERR
        error: error validating "https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml": error validating data: ValidationError(CustomResourceDefinition.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.selector): unknown field "x-kubernetes-validations" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps; if you choose to ignore these errors, turn validation off with --validate=false
        Error from server (NotFound): deployments.apps "argo-rollouts" not found
Error: some tests failed
```

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??


```release-note
NONE
```

emergency-ticket id: EMR-1298
