### PR TITLE
Cherry pick/plat 855 v1.22.0

### DIFF
--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -1148,6 +1148,7 @@ type ComplexityRoot struct {
 
 	ServiceMapToSource struct {
 		DateTime    func(childComplexity int) int
+		IsVirtual   func(childComplexity int) int
 		Requests    func(childComplexity int) int
 		ServiceName func(childComplexity int) int
 	}
@@ -6412,6 +6413,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ServiceMapToSource.DateTime(childComplexity), true
+
+	case "ServiceMapToSource.isVirtual":
+		if e.complexity.ServiceMapToSource.IsVirtual == nil {
+			break
+		}
+
+		return e.complexity.ServiceMapToSource.IsVirtual(childComplexity), true
 
 	case "ServiceMapToSource.requests":
 		if e.complexity.ServiceMapToSource.Requests == nil {
@@ -36796,6 +36804,8 @@ func (ec *executionContext) fieldContext_PeerSources_inbound(_ context.Context, 
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "isVirtual":
+				return ec.fieldContext_ServiceMapToSource_isVirtual(ctx, field)
 			case "serviceName":
 				return ec.fieldContext_ServiceMapToSource_serviceName(ctx, field)
 			case "requests":
@@ -36848,6 +36858,8 @@ func (ec *executionContext) fieldContext_PeerSources_outbound(_ context.Context,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "isVirtual":
+				return ec.fieldContext_ServiceMapToSource_isVirtual(ctx, field)
 			case "serviceName":
 				return ec.fieldContext_ServiceMapToSource_serviceName(ctx, field)
 			case "requests":
@@ -41579,6 +41591,8 @@ func (ec *executionContext) fieldContext_ServiceMapFromSource_services(_ context
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "isVirtual":
+				return ec.fieldContext_ServiceMapToSource_isVirtual(ctx, field)
 			case "serviceName":
 				return ec.fieldContext_ServiceMapToSource_serviceName(ctx, field)
 			case "requests":
@@ -41587,6 +41601,50 @@ func (ec *executionContext) fieldContext_ServiceMapFromSource_services(_ context
 				return ec.fieldContext_ServiceMapToSource_dateTime(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceMapToSource", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceMapToSource_isVirtual(ctx context.Context, field graphql.CollectedField, obj *model.ServiceMapToSource) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceMapToSource_isVirtual(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IsVirtual, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceMapToSource_isVirtual(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceMapToSource",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -58150,6 +58208,11 @@ func (ec *executionContext) _ServiceMapToSource(ctx context.Context, sel ast.Sel
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("ServiceMapToSource")
+		case "isVirtual":
+			out.Values[i] = ec._ServiceMapToSource_isVirtual(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "serviceName":
 			out.Values[i] = ec._ServiceMapToSource_serviceName(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -1142,6 +1142,7 @@ type ComplexityRoot struct {
 	}
 
 	ServiceMapFromSource struct {
+		NodeID      func(childComplexity int) int
 		ServiceName func(childComplexity int) int
 		Services    func(childComplexity int) int
 	}
@@ -1149,6 +1150,7 @@ type ComplexityRoot struct {
 	ServiceMapToSource struct {
 		DateTime    func(childComplexity int) int
 		IsVirtual   func(childComplexity int) int
+		NodeID      func(childComplexity int) int
 		Requests    func(childComplexity int) int
 		ServiceName func(childComplexity int) int
 	}
@@ -6393,6 +6395,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ServiceMap.Services(childComplexity), true
 
+	case "ServiceMapFromSource.nodeId":
+		if e.complexity.ServiceMapFromSource.NodeID == nil {
+			break
+		}
+
+		return e.complexity.ServiceMapFromSource.NodeID(childComplexity), true
+
 	case "ServiceMapFromSource.serviceName":
 		if e.complexity.ServiceMapFromSource.ServiceName == nil {
 			break
@@ -6420,6 +6429,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ServiceMapToSource.IsVirtual(childComplexity), true
+
+	case "ServiceMapToSource.nodeId":
+		if e.complexity.ServiceMapToSource.NodeID == nil {
+			break
+		}
+
+		return e.complexity.ServiceMapToSource.NodeID(childComplexity), true
 
 	case "ServiceMapToSource.requests":
 		if e.complexity.ServiceMapToSource.Requests == nil {
@@ -36804,6 +36820,8 @@ func (ec *executionContext) fieldContext_PeerSources_inbound(_ context.Context, 
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "nodeId":
+				return ec.fieldContext_ServiceMapToSource_nodeId(ctx, field)
 			case "isVirtual":
 				return ec.fieldContext_ServiceMapToSource_isVirtual(ctx, field)
 			case "serviceName":
@@ -36858,6 +36876,8 @@ func (ec *executionContext) fieldContext_PeerSources_outbound(_ context.Context,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "nodeId":
+				return ec.fieldContext_ServiceMapToSource_nodeId(ctx, field)
 			case "isVirtual":
 				return ec.fieldContext_ServiceMapToSource_isVirtual(ctx, field)
 			case "serviceName":
@@ -41497,12 +41517,58 @@ func (ec *executionContext) fieldContext_ServiceMap_services(_ context.Context, 
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "nodeId":
+				return ec.fieldContext_ServiceMapFromSource_nodeId(ctx, field)
 			case "serviceName":
 				return ec.fieldContext_ServiceMapFromSource_serviceName(ctx, field)
 			case "services":
 				return ec.fieldContext_ServiceMapFromSource_services(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceMapFromSource", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceMapFromSource_nodeId(ctx context.Context, field graphql.CollectedField, obj *model.ServiceMapFromSource) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceMapFromSource_nodeId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NodeID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceMapFromSource_nodeId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceMapFromSource",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -41591,6 +41657,8 @@ func (ec *executionContext) fieldContext_ServiceMapFromSource_services(_ context
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "nodeId":
+				return ec.fieldContext_ServiceMapToSource_nodeId(ctx, field)
 			case "isVirtual":
 				return ec.fieldContext_ServiceMapToSource_isVirtual(ctx, field)
 			case "serviceName":
@@ -41601,6 +41669,50 @@ func (ec *executionContext) fieldContext_ServiceMapFromSource_services(_ context
 				return ec.fieldContext_ServiceMapToSource_dateTime(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceMapToSource", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceMapToSource_nodeId(ctx context.Context, field graphql.CollectedField, obj *model.ServiceMapToSource) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceMapToSource_nodeId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NodeID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceMapToSource_nodeId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceMapToSource",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -58164,6 +58276,11 @@ func (ec *executionContext) _ServiceMapFromSource(ctx context.Context, sel ast.S
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("ServiceMapFromSource")
+		case "nodeId":
+			out.Values[i] = ec._ServiceMapFromSource_nodeId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "serviceName":
 			out.Values[i] = ec._ServiceMapFromSource_serviceName(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -58208,6 +58325,11 @@ func (ec *executionContext) _ServiceMapToSource(ctx context.Context, sel ast.Sel
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("ServiceMapToSource")
+		case "nodeId":
+			out.Values[i] = ec._ServiceMapToSource_nodeId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "isVirtual":
 			out.Values[i] = ec._ServiceMapToSource_isVirtual(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -1334,11 +1334,13 @@ type ServiceMap struct {
 }
 
 type ServiceMapFromSource struct {
+	NodeID      string                `json:"nodeId"`
 	ServiceName string                `json:"serviceName"`
 	Services    []*ServiceMapToSource `json:"services"`
 }
 
 type ServiceMapToSource struct {
+	NodeID      string `json:"nodeId"`
 	IsVirtual   bool   `json:"isVirtual"`
 	ServiceName string `json:"serviceName"`
 	Requests    int    `json:"requests"`

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -1339,6 +1339,7 @@ type ServiceMapFromSource struct {
 }
 
 type ServiceMapToSource struct {
+	IsVirtual   bool   `json:"isVirtual"`
 	ServiceName string `json:"serviceName"`
 	Requests    int    `json:"requests"`
 	DateTime    string `json:"dateTime"`

--- a/frontend/graph/schema.graphqls
+++ b/frontend/graph/schema.graphqls
@@ -884,6 +884,11 @@ type ServiceMapFromSource {
 }
 
 type ServiceMapToSource {
+
+  # Virtual nodes, for example: databases, external services, are not instrumented,
+  # and are inferred from the client span that calls them.
+  # we do not know anything about them (name, language, external connections, etc.)
+  isVirtual: Boolean!
   serviceName: String!
   requests: Int!
   dateTime: String!

--- a/frontend/graph/schema.graphqls
+++ b/frontend/graph/schema.graphqls
@@ -879,12 +879,13 @@ type ServiceMap {
 }
 
 type ServiceMapFromSource {
+  nodeId: String!
   serviceName: String!
   services: [ServiceMapToSource!]!
 }
 
 type ServiceMapToSource {
-
+  nodeId: String!
   # Virtual nodes, for example: databases, external services, are not instrumented,
   # and are inferred from the client span that calls them.
   # we do not know anything about them (name, language, external connections, etc.)

--- a/frontend/graph/schema.resolvers.go
+++ b/frontend/graph/schema.resolvers.go
@@ -918,27 +918,29 @@ func (r *queryResolver) GetServiceMap(ctx context.Context) (*model.ServiceMap, e
 	}
 
 	serviceMap := r.MetricsConsumer.GetServiceGraphEdges()
-	services := make([]*model.ServiceMapFromSource, 0)
+	mapServices := make([]*model.ServiceMapFromSource, 0)
 
-	for serviceName, toServices := range serviceMap {
+	for compositeKey, toServices := range serviceMap {
 		to := make([]*model.ServiceMapToSource, 0)
 
-		for toServiceName, info := range toServices {
+		for toCompositeKey, info := range toServices {
 			to = append(to, &model.ServiceMapToSource{
-				ServiceName: toServiceName,
+				NodeID:      toCompositeKey,
+				ServiceName: services.BaseServiceName(toCompositeKey),
 				IsVirtual:   info.ToNodeIsVirtual,
 				Requests:    int(info.RequestCount),
 				DateTime:    info.LastUpdated.Format(time.RFC3339),
 			})
 		}
 
-		services = append(services, &model.ServiceMapFromSource{
-			ServiceName: serviceName,
+		mapServices = append(mapServices, &model.ServiceMapFromSource{
+			NodeID:      compositeKey,
+			ServiceName: services.BaseServiceName(compositeKey),
 			Services:    to,
 		})
 	}
 
-	return &model.ServiceMap{Services: services}, nil
+	return &model.ServiceMap{Services: mapServices}, nil
 }
 
 // PeerSources is the resolver for the peerSources field.

--- a/frontend/graph/schema.resolvers.go
+++ b/frontend/graph/schema.resolvers.go
@@ -926,6 +926,7 @@ func (r *queryResolver) GetServiceMap(ctx context.Context) (*model.ServiceMap, e
 		for toServiceName, info := range toServices {
 			to = append(to, &model.ServiceMapToSource{
 				ServiceName: toServiceName,
+				IsVirtual:   info.ToNodeIsVirtual,
 				Requests:    int(info.RequestCount),
 				DateTime:    info.LastUpdated.Format(time.RFC3339),
 			})

--- a/frontend/services/collector_metrics/cluster_collector.go
+++ b/frontend/services/collector_metrics/cluster_collector.go
@@ -427,8 +427,11 @@ type ServiceGraph struct {
 }
 
 type ServiceGraphEdge struct {
-	RequestCount int64
-	LastUpdated  time.Time
+
+	// set to true if the "To" side of the edge is for a virtual node
+	ToNodeIsVirtual bool
+	RequestCount    int64
+	LastUpdated     time.Time
 }
 
 func newServiceGraph() *ServiceGraph {
@@ -469,9 +472,12 @@ func (sg *ServiceGraph) UpdateFromDataPoint(dp pmetric.NumberDataPoint) {
 
 	edge, exists := sg.edges[clientID][serverID]
 	if !exists {
+		// a server node is not virtual if it has service.name attribute
+		_, isServerInstrumentedNode := attrs.Get("server_service_name")
 		sg.edges[clientID][serverID] = &ServiceGraphEdge{
-			RequestCount: val,
-			LastUpdated:  timestamp,
+			ToNodeIsVirtual: !isServerInstrumentedNode,
+			RequestCount:    val,
+			LastUpdated:     timestamp,
 		}
 	} else {
 		// always overwrite because it's a cumulative counter

--- a/frontend/services/peer_sources.go
+++ b/frontend/services/peer_sources.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"strings"
 	"time"
 
 	"github.com/odigos-io/odigos/frontend/graph/model"
@@ -9,31 +10,76 @@ import (
 
 type ServiceGraphEdges = map[string]map[string]collectormetrics.ServiceGraphEdge
 
-func edgeToModel(name string, edge collectormetrics.ServiceGraphEdge) *model.ServiceMapToSource {
+// BaseServiceName extracts the service name from a composite node ID.
+// Composite IDs follow the format "serviceName|dim1|dim2|..." where the
+// service name is everything before the first "|" separator.
+// If the ID contains no "|", it is returned as-is.
+func BaseServiceName(compositeID string) string {
+	if i := strings.Index(compositeID, "|"); i >= 0 {
+		return compositeID[:i]
+	}
+	return compositeID
+}
+
+func edgeToModel(compositeKey string, edge collectormetrics.ServiceGraphEdge) *model.ServiceMapToSource {
 	return &model.ServiceMapToSource{
-		ServiceName: name,
+		NodeID:      compositeKey,
+		ServiceName: BaseServiceName(compositeKey),
+		IsVirtual:   edge.ToNodeIsVirtual,
 		Requests:    int(edge.RequestCount),
 		DateTime:    edge.LastUpdated.Format(time.RFC3339),
 	}
 }
 
-func PeerSources(allEdges ServiceGraphEdges, serviceName string) *model.PeerSources {
-	var inbound, outbound []*model.ServiceMapToSource
-
-	if targets, ok := allEdges[serviceName]; ok {
-		for targetName, edge := range targets {
-			outbound = append(outbound, edgeToModel(targetName, edge))
+// mergeEdge aggregates an edge into m keyed by base service name,
+// summing request counts and keeping the most recent timestamp.
+func mergeEdge(m map[string]*model.ServiceMapToSource, compositeKey string, edge collectormetrics.ServiceGraphEdge) {
+	base := BaseServiceName(compositeKey)
+	if existing, ok := m[base]; ok {
+		existing.Requests += int(edge.RequestCount)
+		ts := edge.LastUpdated.Format(time.RFC3339)
+		if ts > existing.DateTime {
+			existing.DateTime = ts
 		}
+		if edge.ToNodeIsVirtual {
+			existing.IsVirtual = true
+		}
+	} else {
+		m[base] = edgeToModel(compositeKey, edge)
 	}
+}
 
-	for callerName, targets := range allEdges {
-		if edge, ok := targets[serviceName]; ok {
-			inbound = append(inbound, edgeToModel(callerName, edge))
+func mapValues(m map[string]*model.ServiceMapToSource) []*model.ServiceMapToSource {
+	out := make([]*model.ServiceMapToSource, 0, len(m))
+	for _, v := range m {
+		out = append(out, v)
+	}
+	return out
+}
+
+// PeerSources finds all inbound and outbound peers for a given base service name.
+// The allEdges map may contain composite keys (e.g. "redis|ns1") so we compare
+// against the base name extracted from each key. Results are deduplicated by
+// base service name, summing request counts and keeping the latest timestamp.
+func PeerSources(allEdges ServiceGraphEdges, serviceName string) *model.PeerSources {
+	inboundMap := make(map[string]*model.ServiceMapToSource)
+	outboundMap := make(map[string]*model.ServiceMapToSource)
+
+	for callerKey, targets := range allEdges {
+		if BaseServiceName(callerKey) == serviceName {
+			for targetKey, edge := range targets {
+				mergeEdge(outboundMap, targetKey, edge)
+			}
+		}
+		for targetKey, edge := range targets {
+			if BaseServiceName(targetKey) == serviceName {
+				mergeEdge(inboundMap, callerKey, edge)
+			}
 		}
 	}
 
 	return &model.PeerSources{
-		Inbound:  inbound,
-		Outbound: outbound,
+		Inbound:  mapValues(inboundMap),
+		Outbound: mapValues(outboundMap),
 	}
 }

--- a/frontend/webapp/graphql/queries/service-map.ts
+++ b/frontend/webapp/graphql/queries/service-map.ts
@@ -4,8 +4,11 @@ export const GET_SERVICE_MAP = gql`
   query GetServiceMap {
     getServiceMap {
       services {
+        nodeId
         serviceName
         services {
+          nodeId
+          isVirtual
           serviceName
           requests
           dateTime

--- a/frontend/webapp/hooks/metrics/useServiceMap.ts
+++ b/frontend/webapp/hooks/metrics/useServiceMap.ts
@@ -8,7 +8,8 @@ export const useServiceMap = () => {
 
   const { data } = useQuery<{ getServiceMap: { services: ServiceMapSources } }>(GET_SERVICE_MAP, {
     skip: !sources.length,
-    pollInterval: 3000,
+    // Poll every 15s to keep the service map near-real-time without causing layout flicker
+    pollInterval: 15000,
   });
 
   return {

--- a/frontend/webapp/package.json
+++ b/frontend/webapp/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@apollo/client": "^3.13.9",
     "@apollo/experimental-nextjs-app-support": "^0.12.3",
-    "@odigos/ui-kit": "0.0.209",
+    "@odigos/ui-kit": "0.0.211",
     "graphql": "^16.12.0",
     "next": "15.5.12",
     "react": "19.2.4",

--- a/frontend/webapp/yarn.lock
+++ b/frontend/webapp/yarn.lock
@@ -635,10 +635,10 @@
   resolved "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
-"@odigos/ui-kit@0.0.209":
-  version "0.0.209"
-  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.209.tgz#219881c32268fe051b0a86ba6f067bc1c90c2aa3"
-  integrity sha512-hZsvJPDKew+f2tXb2D5ddDRHvqAiyPNak9O5rMvlXCNXijXyJfbXa9XV4uJcqmO6NVsrOeSAPI7eS9kCzrCQfg==
+"@odigos/ui-kit@0.0.211":
+  version "0.0.211"
+  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.211.tgz#defa480012fc90e07ae2016529f51e6587aef93d"
+  integrity sha512-VFyj+1fGAhA4VH3BiVimHNKSaHTauUXzUpFs+9XVnSq46e8TUr5/IfUk2DKiQ4RTikoN9Uyet6SDw/mIvXKXyg==
   dependencies:
     "@xyflow/react" "^12.10.1"
     elkjs "^0.11.1"


### PR DESCRIPTION
Cherry-pick three commits from main to the v1.22.0 release branch to bring service map multi-dimension support into the release.

#### What this PR does / why we need it:
Brings three features from main into v1.22.0:
1. **Virtual node detection** — service map API now marks uninstrumented services (databases, external services) with `isVirtual`, so the UI can render them distinctly instead of showing error icons.
2. **Distro envs refactor** — uses distro environment variables instead of the env overwriter, simplifying SDK configuration.
3. **Composite nodeId** — adds a `nodeId` field to the service map GraphQL schema that carries a composite key (e.g. `frontend|default`) alongside the display `serviceName`. This enables the frontend to distinguish services that share a base name but differ by namespace or other configured dimensions.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change?

```release-note
feat: service map now supports additional dimensions (namespace, route, etc.) for unique service identification, and correctly renders uninstrumented virtual services
```

emergency-ticket id: EMR-1296
