### PR TITLE
fix: add CURRENT_NS env var to central-proxy helm chart

### DIFF
--- a/helm/odigos/templates/centralproxy/deployment.yaml
+++ b/helm/odigos/templates/centralproxy/deployment.yaml
@@ -50,6 +50,10 @@ spec:
           ports:
             - containerPort: 8080
           env:
+            - name: CURRENT_NS
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: CLUSTER_NAME
               value: {{ .Values.clusterName | quote }}
             - name: CENTRAL_BACKEND_URL


### PR DESCRIPTION
The central-proxy deployment template was missing the CURRENT_NS environment variable that all other Odigos components have. Without it, central-proxy defaults to 'odigos-system' namespace when looking up ConfigMaps, causing crashes when installed in a different namespace.


```release-note
Fixed central-proxy crash when installed in a namespace other than odigos-system by adding the missing CURRENT_NS environment variable to the helm chart.
```

emergency-ticket id: EMR-1316
