### PR TITLE
chore: cleanup unused places of k8sNodeLogsDirectory

### DIFF
--- a/api/config/crd/bases/odigos.io_collectorsgroups.yaml
+++ b/api/config/crd/bases/odigos.io_collectorsgroups.yaml
@@ -68,11 +68,6 @@ spec:
                   for destinations that uses https for exporting data, this value can be used to set the address for an https proxy.
                   when unset or empty, no proxy will be used.
                 type: string
-              k8sNodeLogsDirectory:
-                description: |-
-                  Additional directory to mount in the node collector pod for logs.
-                  This is used to allow the collector to read logs from the host node if /var/log is  symlinked to another directory.
-                type: string
               metrics:
                 description: |-
                   configuration for metrics handling in this collectors group

--- a/api/generated/odigos/applyconfiguration/odigos/v1alpha1/collectorsgroupspec.go
+++ b/api/generated/odigos/applyconfiguration/odigos/v1alpha1/collectorsgroupspec.go
@@ -28,7 +28,6 @@ import (
 type CollectorsGroupSpecApplyConfiguration struct {
 	Role                                  *odigosv1alpha1.CollectorsGroupRole                         `json:"role,omitempty"`
 	CollectorOwnMetricsPort               *int32                                                      `json:"collectorOwnMetricsPort,omitempty"`
-	K8sNodeLogsDirectory                  *string                                                     `json:"k8sNodeLogsDirectory,omitempty"`
 	ResourcesSettings                     *CollectorsGroupResourcesSettingsApplyConfiguration         `json:"resourcesSettings,omitempty"`
 	ServiceGraphDisabled                  *bool                                                       `json:"serviceGraphDisabled,omitempty"`
 	ServiceGraphExtraDimensions           []string                                                    `json:"serviceGraphExtraDimensions,omitempty"`
@@ -64,14 +63,6 @@ func (b *CollectorsGroupSpecApplyConfiguration) WithRole(value odigosv1alpha1.Co
 // If called multiple times, the CollectorOwnMetricsPort field is set to the value of the last call.
 func (b *CollectorsGroupSpecApplyConfiguration) WithCollectorOwnMetricsPort(value int32) *CollectorsGroupSpecApplyConfiguration {
 	b.CollectorOwnMetricsPort = &value
-	return b
-}
-
-// WithK8sNodeLogsDirectory sets the K8sNodeLogsDirectory field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the K8sNodeLogsDirectory field is set to the value of the last call.
-func (b *CollectorsGroupSpecApplyConfiguration) WithK8sNodeLogsDirectory(value string) *CollectorsGroupSpecApplyConfiguration {
-	b.K8sNodeLogsDirectory = &value
 	return b
 }
 

--- a/api/odigos/v1alpha1/collectorsgroup_types.go
+++ b/api/odigos/v1alpha1/collectorsgroup_types.go
@@ -154,10 +154,6 @@ type CollectorsGroupSpec struct {
 	// This can be used to resolve conflicting ports when a collector is using the host network.
 	CollectorOwnMetricsPort int32 `json:"collectorOwnMetricsPort"`
 
-	// Additional directory to mount in the node collector pod for logs.
-	// This is used to allow the collector to read logs from the host node if /var/log is  symlinked to another directory.
-	K8sNodeLogsDirectory string `json:"k8sNodeLogsDirectory,omitempty"`
-
 	// Resources [memory/cpu] settings for the collectors group.
 	// these settings are used to protect the collectors instances from:
 	// - running out of memory and being killed by the k8s OOM killer

--- a/common/consts/consts.go
+++ b/common/consts/consts.go
@@ -88,7 +88,6 @@ const (
 	IgnoredContainersProperty          = "ignored-containers"
 	MountMethodProperty                = "mount-method"
 	CustomContainerRuntimeSocketPath   = "custom-container-runtime-socket-path"
-	K8sNodeLogsDirectory               = "k8s-node-logs-directory"
 	UserInstrumentationEnvsProperty    = "user-instrumentation-envs"
 	AgentEnvVarsInjectionMethod        = "agent-env-vars-injection-method"
 	NodeSelectorProperty               = "node-selector"

--- a/common/odigos_config.go
+++ b/common/odigos_config.go
@@ -111,13 +111,6 @@ type CollectorNodeConfiguration struct {
 	// if not specified, it will be set to 80% of the hard limit of the memory limiter.
 	GoMemLimitMib int `json:"goMemLimitMiB,omitempty"`
 
-	// Odigos will by default attempt to collect logs from '/var/log' on each k8s node.
-	// Sometimes, this directory is actually a symlink to another directory.
-	// In this case, for logs collection to work, we need to add a mount to the target directory.
-	// This field is used to specify this target directory in these cases.
-	// A common target directory is '/mnt/var/log'.
-	K8sNodeLogsDirectory string `json:"k8sNodeLogsDirectory,omitempty"`
-
 	// Deprecated - use OtlpExporterConfiguration instead.
 	// EnableDataCompression is a feature that allows you to enable data compression before sending data to the Gateway collector.
 	// It is disabled by default and can be enabled by setting the enabled flag to true.

--- a/docs/snippets/shared/api-reference/odigos.io.v1alpha1.mdx
+++ b/docs/snippets/shared/api-reference/odigos.io.v1alpha1.mdx
@@ -1260,18 +1260,6 @@ This can be used to resolve conflicting ports when a collector is using the host
 </tr>
 <tr>
 <td>
-<code>k8sNodeLogsDirectory</code> <B>[Required]</B>
-</td>
-<td>
-<code>string</code>
-</td>
-<td>
-   <p>Additional directory to mount in the node collector pod for logs.
-This is used to allow the collector to read logs from the host node if /var/log is  symlinked to another directory.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>resourcesSettings</code> <B>[Required]</B>
 </td>
 <td>

--- a/frontend/graph/conversions.go
+++ b/frontend/graph/conversions.go
@@ -498,9 +498,6 @@ func convertCollectorNodeToModel(node *common.CollectorNodeConfiguration) *model
 	if node.GoMemLimitMib != 0 {
 		result.GoMemLimitMiB = &node.GoMemLimitMib
 	}
-	if node.K8sNodeLogsDirectory != "" {
-		result.K8sNodeLogsDirectory = &node.K8sNodeLogsDirectory
-	}
 	result.EnableDataCompression = node.EnableDataCompression
 
 	if node.OtlpExporterConfiguration != nil {

--- a/helm/odigos/templates/crds/odigos.io_collectorsgroups.yaml
+++ b/helm/odigos/templates/crds/odigos.io_collectorsgroups.yaml
@@ -68,11 +68,6 @@ spec:
                   for destinations that uses https for exporting data, this value can be used to set the address for an https proxy.
                   when unset or empty, no proxy will be used.
                 type: string
-              k8sNodeLogsDirectory:
-                description: |-
-                  Additional directory to mount in the node collector pod for logs.
-                  This is used to allow the collector to read logs from the host node if /var/log is  symlinked to another directory.
-                type: string
               metrics:
                 description: |-
                   configuration for metrics handling in this collectors group

--- a/profiles/aggregators/greatwall.go
+++ b/profiles/aggregators/greatwall.go
@@ -20,9 +20,6 @@ var GreatwallProfile = profile.Profile{
 		if config.CollectorNode == nil {
 			config.CollectorNode = &common.CollectorNodeConfiguration{}
 		}
-		if config.CollectorNode.K8sNodeLogsDirectory == "" {
-			config.CollectorNode.K8sNodeLogsDirectory = "/mnt/var/log"
-		}
 		if config.CheckDeviceHealthBeforeInjection == nil {
 			checkDeviceHealthBeforeInjection := true
 			config.CheckDeviceHealthBeforeInjection = &checkDeviceHealthBeforeInjection

--- a/scheduler/controllers/nodecollectorsgroup/common.go
+++ b/scheduler/controllers/nodecollectorsgroup/common.go
@@ -281,11 +281,6 @@ func newNodeCollectorGroup(odigosConfiguration common.OdigosConfiguration, allDe
 		ownMetricsPort = odigosConfiguration.CollectorNode.CollectorOwnMetricsPort
 	}
 
-	k8sNodeLogsDirectory := ""
-	if odigosConfiguration.CollectorNode != nil && odigosConfiguration.CollectorNode.K8sNodeLogsDirectory != "" {
-		k8sNodeLogsDirectory = odigosConfiguration.CollectorNode.K8sNodeLogsDirectory
-	}
-
 	otlpExporterConfiguration := odigosConfiguration.CollectorNode.OtlpExporterConfiguration
 	// TODO: remove after sometime it is a temporary workaround to support the deprecated field CollectorNode.EnableDataCompression
 	// which replaced with OtlpExporterConfiguration.EnableDataCompression.
@@ -307,7 +302,6 @@ func newNodeCollectorGroup(odigosConfiguration common.OdigosConfiguration, allDe
 		Spec: odigosv1.CollectorsGroupSpec{
 			Role:                      odigosv1.CollectorsGroupRoleNodeCollector,
 			CollectorOwnMetricsPort:   ownMetricsPort,
-			K8sNodeLogsDirectory:      k8sNodeLogsDirectory,
 			ResourcesSettings:         getResourceSettings(odigosConfiguration),
 			OtlpExporterConfiguration: otlpExporterConfiguration,
 			Metrics:                   metricsConfig,
@@ -360,4 +354,3 @@ func sync(ctx context.Context, c client.Client, scheme *runtime.Scheme) error {
 
 	return nil
 }
-


### PR DESCRIPTION
#### What this PR does / why we need it:

In the past, we used create the data-collection daemonset from the autoscaler, thus we persisted and propgated the `k8sNodeLogsDirectory` option to the collector group so auto-scaler can populate it in the manifest

after odiglet and data-collection were merged into a single pod, the `k8sNodeLogsDirectory` is now set in helm template, and have no meaning in odigos config or our operators. It also means that it's useless to set it in the token as a profile 

This PR cleanup this code which is not doing anything currently 


#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

Internal refactor and house-keeping

```release-note
NONE
```

emergency-ticket id: EMR-1331
