### PR TITLE
ci: allow instrumentations to trigger workflow dispatch for version update

### DIFF
--- a/.github/chainguard/trigger-agent-version-updater.sts.yaml
+++ b/.github/chainguard/trigger-agent-version-updater.sts.yaml
@@ -1,0 +1,7 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: repo:odigos-io/*:ref:refs/tags/.*
+
+permissions:
+
+  # needed to trigger repository_dispatch event
+  contents: write


### PR DESCRIPTION
#### What this PR does / why we need it:

To allow agents repos to trigger the version update when they publish 

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```

emergency-ticket id: EMR-1327
