### PR TITLE
fix: sts to reference the allowed subject repos

### DIFF
--- a/.github/chainguard/trigger-agent-version-updater.sts.yaml
+++ b/.github/chainguard/trigger-agent-version-updater.sts.yaml
@@ -1,5 +1,5 @@
 issuer: https://token.actions.githubusercontent.com
-subject_pattern: repo:odigos-io/*:ref:refs/tags/.*
+subject_pattern: repo:odigos-io/(opentelemetry-node|opentelemetry-ruby|opentelemetry-php):ref:refs/tags/.*
 
 permissions:
 


### PR DESCRIPTION
#### What this PR does / why we need it:

To overcome this error from opentelemetry-node:

```
Error: STS exchange failed for odigos-io/odigos/trigger-agent-version-updater: HTTP 403 — {"code":7, "message":"trust policy: subject \"repo:odigos-io/opentelemetry-node:ref:refs/tags/v0.0.14\" did not match pattern \"repo:odigos-io/*:ref:refs/tags/.*\"", "details":[]}
Error: Process completed with exit code 1.
```

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```

emergency-ticket id: EMR-1326
