### PR TITLE
Revert "cherry-pick: add CURRENT_NS env var to central-proxy helm chart (v1.22.0)"

### DIFF
--- a/helm/odigos/templates/centralproxy/deployment.yaml
+++ b/helm/odigos/templates/centralproxy/deployment.yaml
@@ -50,10 +50,6 @@ spec:
           ports:
             - containerPort: 8080
           env:
-            - name: CURRENT_NS
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
             - name: CLUSTER_NAME
               value: {{ .Values.clusterName | quote }}
             - name: CENTRAL_BACKEND_URL


### PR DESCRIPTION
Reverts odigos-io/odigos#4490

emergency-ticket id: EMR-1346
