### PR TITLE
cherry-pick: add CURRENT_NS env var to central-proxy helm chart (v1.22.0)

### DIFF
--- a/helm/odigos/templates/centralproxy/deployment.yaml
+++ b/helm/odigos/templates/centralproxy/deployment.yaml
@@ -50,6 +50,10 @@ spec:
           ports:
             - containerPort: 8080
           env:
+            - name: CURRENT_NS
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: CLUSTER_NAME
               value: {{ .Values.clusterName | quote }}
             - name: CENTRAL_BACKEND_URL


### PR DESCRIPTION
Cherry-pick of #4472 to the v1.22.0 release branch.

#### What this PR does / why we need it:
The central-proxy deployment template was missing the `CURRENT_NS` environment variable that all other Odigos components have. Without it, central-proxy defaults to `odigos-system` namespace when looking up ConfigMaps and constructing service URLs, causing failures when installed in a different namespace.

This was discovered in a production deployment where Odigos was installed in the `odigos` namespace instead of the default `odigos-system`.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
Fixed central-proxy crash when installed in a namespace other than odigos-system by adding the missing CURRENT_NS environment variable to the helm chart.
```

emergency-ticket id: EMR-1345
