### PR TITLE
Add Reactor: spanmetrics messaging dimensions + Helm templates

### DIFF
--- a/autoscaler/controllers/nodecollector/collectorconfig/spanmetrics.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/spanmetrics.go
@@ -42,6 +42,9 @@ func getSpanMetricsConnectorConfig(spanMetricsConfig common.MetricsSourceSpanMet
 		"http.response.status_code",
 		"http.route",
 		SpanInstrumentationScopeNameAttributeName,
+		"messaging.system",
+		"messaging.destination.name",
+		"messaging.operation",
 	}
 	if spanMetricsConfig.AdditionalDimensions != nil {
 		dimensionsAttributeNames = append(dimensionsAttributeNames, spanMetricsConfig.AdditionalDimensions...)

--- a/destinations/data/otlp.yaml
+++ b/destinations/data/otlp.yaml
@@ -11,6 +11,7 @@ spec:
       supported: true
     metrics:
       supported: true
+      spanMetricsEnabledByDefault: true
     logs:
       supported: true
   fields:

--- a/destinations/data/otlphttp.yaml
+++ b/destinations/data/otlphttp.yaml
@@ -11,6 +11,7 @@ spec:
       supported: true
     metrics:
       supported: true
+      spanMetricsEnabledByDefault: true
     logs:
       supported: true
   fields:

--- a/helm/odigos/templates/reactor/clusterrole.yaml
+++ b/helm/odigos/templates/reactor/clusterrole.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.reactor.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: odigos-reactor
+  labels:
+    odigos.io/system-object: "true"
+rules:
+  - apiGroups:
+      - odigos.io
+    resources:
+      - instrumentationrules
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - odigos.io
+    resources:
+      - samplings
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+{{- end }}

--- a/helm/odigos/templates/reactor/clusterrolebinding.yaml
+++ b/helm/odigos/templates/reactor/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.reactor.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: odigos-reactor
+  labels:
+    odigos.io/system-object: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: odigos-reactor
+subjects:
+  - kind: ServiceAccount
+    name: odigos-reactor
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/odigos/templates/reactor/deployment.yaml
+++ b/helm/odigos/templates/reactor/deployment.yaml
@@ -1,0 +1,109 @@
+{{- if .Values.reactor.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: odigos-reactor
+    odigos.io/system-object: "true"
+  name: odigos-reactor
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: odigos-reactor
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/name: odigos-reactor
+    spec:
+      {{- if .Values.reactor.nodeSelector }}
+      # Component-specific nodeSelector (overrides global values.yaml nodeSelector)
+      nodeSelector:
+      {{- toYaml .Values.reactor.nodeSelector | nindent 8 }}
+      {{- else if .Values.nodeSelector }}
+      # Global nodeSelector from values.yaml
+      nodeSelector:
+      {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- range .Values.topologySpreadConstraints }}
+        - maxSkew: {{ .maxSkew }}
+          topologyKey: {{ .topologyKey | quote }}
+          whenUnsatisfiable: {{ .whenUnsatisfiable | quote }}
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: odigos-reactor
+        {{- end }}
+      {{- end }}
+      {{- if .Values.reactor.priorityClassName }}
+      priorityClassName: {{ .Values.reactor.priorityClassName }}
+      {{- end }}
+      containers:
+      - name: manager
+        {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
+        image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-reactor" "Tag" $imageTag) }}
+        ports:
+          - containerPort: 8080
+            protocol: TCP
+        env:
+          - name: OTEL_SERVICE_NAME
+            value: reactor
+          - name: REACTOR_PORT
+            value: "8080"
+          - name: REACTOR_BEARER_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: odigos-reactor-token
+                key: token
+          - name: REACTOR_COOLDOWN_PERIOD
+            value: {{ .Values.reactor.cooldownPeriod | quote }}
+          - name: REACTOR_NAMESPACE
+            value: {{ .Release.Namespace | quote }}
+          {{- if include "odigos.secretExists" . }}
+          - name: ODIGOS_ONPREM_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: odigos-pro
+                key: odigos-onprem-token
+          {{- end }}
+          - name: GOMEMLIMIT
+            value: {{ include "odigos.gomemlimitFromResources" (dict "Resources" .Values.reactor.resources) }}
+        envFrom:
+          - configMapRef:
+              name: odigos-own-telemetry-otel-config
+              optional: true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8080
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+{{ toYaml .Values.reactor.resources | indent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: odigos-reactor
+      terminationGracePeriodSeconds: 10
+      {{ include "odigos.renderPullSecrets" . | nindent 6 }}
+{{- with .Values.reactor }}
+  {{- if .tolerations }}
+      tolerations: {{ toYaml .tolerations | nindent 8 }}
+  {{- end }}
+  {{- if .affinity }}
+      affinity: {{ toYaml .affinity | nindent 8 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/odigos/templates/reactor/service.yaml
+++ b/helm/odigos/templates/reactor/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.reactor.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: odigos-reactor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: odigos-reactor
+spec:
+  selector:
+    app.kubernetes.io/name: odigos-reactor
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+{{- end }}

--- a/helm/odigos/templates/reactor/serviceaccount.yaml
+++ b/helm/odigos/templates/reactor/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.reactor.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: odigos-reactor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    odigos.io/system-object: "true"
+{{- end }}

--- a/helm/odigos/values.schema.json
+++ b/helm/odigos/values.schema.json
@@ -1783,6 +1783,96 @@
       "required": [],
       "title": "sampling"
     },
+    "reactor": {
+      "additionalProperties": false,
+      "description": "Configuration for the reactor component (enterprise only).",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Enable the reactor component. Requires an enterprise license.",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "cooldownPeriod": {
+          "default": "5m",
+          "description": "Cooldown period between reactor actions.",
+          "title": "cooldownPeriod",
+          "type": "string"
+        },
+        "affinity": {
+          "additionalProperties": false,
+          "required": [],
+          "title": "affinity",
+          "type": "object"
+        },
+        "nodeSelector": {
+          "default": "",
+          "description": "Override the global nodeSelector (values.nodeSelector) for this component",
+          "required": [],
+          "title": "nodeSelector"
+        },
+        "priorityClassName": {
+          "default": "",
+          "description": "Priority class name. Set to use your existing cluster priority classes.",
+          "required": [],
+          "title": "priorityClassName"
+        },
+        "resources": {
+          "additionalProperties": false,
+          "properties": {
+            "limits": {
+              "additionalProperties": false,
+              "properties": {
+                "cpu": {
+                  "default": "500m",
+                  "title": "cpu",
+                  "type": "string"
+                },
+                "memory": {
+                  "default": "256Mi",
+                  "title": "memory",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "limits",
+              "type": "object"
+            },
+            "requests": {
+              "additionalProperties": false,
+              "properties": {
+                "cpu": {
+                  "default": "10m",
+                  "title": "cpu",
+                  "type": "string"
+                },
+                "memory": {
+                  "default": "64Mi",
+                  "title": "memory",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "requests",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "resources",
+          "type": "object"
+        },
+        "tolerations": {
+          "default": [],
+          "description": "Tolerations for the reactor deployment.",
+          "items": {},
+          "title": "tolerations",
+          "type": "array"
+        }
+      },
+      "required": [],
+      "title": "reactor",
+      "type": "object"
+    },
     "scheduler": {
       "additionalProperties": false,
       "description": "Configuration for the scheduler component.",

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -1550,6 +1550,52 @@ sampling:
     # keepPercentage: 2
 
 # @schema
+# description: Configuration for the reactor component (enterprise only).
+# @schema
+reactor:
+  # @schema
+  # description: |-
+  #   Enable the reactor component. Requires an enterprise license.
+  # @schema
+  enabled: false
+
+  # @schema
+  # description: |-
+  #   Cooldown period between reactor actions.
+  # @schema
+  cooldownPeriod: "5m"
+
+  # @schema
+  # description: Override the global nodeSelector (values.nodeSelector) for this component
+  # @schema
+  # nodeSelector:
+  #   kubernetes.io/os: linux
+
+  # @schema
+  # description: |-
+  #   tolerations for the reactor deployment.
+  # @schema
+  tolerations: []
+  affinity: {}
+
+  # @schema
+  # description: |-
+  #   resources for the reactor deployment.
+  # @schema
+  resources:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+
+  # @schema
+  # description: Priority class name. Set to use your existing cluster priority classes.
+  # @schema
+  # priorityClassName: ''
+
+# @schema
 # description: |-
 #   On-prem token for Odigos Pro/Enterprise features.
 #   When set, Odigos will create a secret with this token to enable Pro features.


### PR DESCRIPTION
## Summary

- Add 3 messaging span attributes as default dimensions in the spanmetricsconnector
- Add Helm templates for the Reactor component (enterprise only, gated behind `reactor.enabled: false`)

emergency-ticket id: EMR-1344
