### PR TITLE
ci: improve odiglet base buidler workflow

### DIFF
--- a/.github/workflows/publish-odiglet-base-builder.yaml
+++ b/.github/workflows/publish-odiglet-base-builder.yaml
@@ -7,18 +7,20 @@ on:
         description: "The new image tag for the base builder docker image (e.g. v1.0)"
         required: true
 
-permissions:
-  contents: write
-  packages: write
-  id-token: 'write'
+permissions: read-all
 
 env:
   DOCKERHUB_ORG: "keyval"
 
 jobs:
   publish-odiglet-base-builder:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
+    permissions:
+      id-token: write
+
+
     steps:
+      
       - name: Validate New Version
         run: |
           # Fetch tags from Docker Hub
@@ -46,7 +48,18 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v5
+      - name: Get ro Token for this repo
+        id: sts-this-repo
+        uses: odigos-io/ci-core/sts@main
+        with:
+          scope: odigos-io/odigos
+          identity: ro
+          output-git-config: "false"
+
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ steps.sts-this-repo.outputs.GH_TOKEN }}
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -71,8 +84,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Publish Odiglet Base Builder
         uses: docker/build-push-action@v6
         with:
@@ -84,3 +99,75 @@ jobs:
             ${{ env.DOCKERHUB_ORG }}/odiglet-base:${{ github.event.inputs.image_tag }}
             ${{ env.DOCKERHUB_ORG }}/odiglet-base:latest
             us-central1-docker.pkg.dev/odigos-cloud/components/odiglet-base:${{ github.event.inputs.image_tag }}
+      
+      - name: Notify Slack
+        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
+        with:
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          success-description: "Successfully published new Odiglet Base Builder image ${{ github.event.inputs.image_tag }}"
+          failure-description: "ERROR: Failed to publish a new Odiglet Base Builder image ${{ github.event.inputs.image_tag }}"
+          tag: ${{ github.event.inputs.image_tag }}
+
+  update-odiglet-dockerfiles:
+    needs: publish-odiglet-base-builder
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+
+      - name: Get ro Token for this repo
+        id: sts-this-repo
+        uses: odigos-io/ci-core/sts@main
+        with:
+          scope: odigos-io/odigos
+          identity: ro
+          output-git-config: "false"
+
+      - name: Checkout main branch
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          token: ${{ steps.sts-this-repo.outputs.GH_TOKEN }}
+
+      - name: Update Odiglet Base Builder image in dockerfiles
+        run: |
+          sed -i "s|registry.odigos.io/odiglet-base:.*|registry.odigos.io/odiglet-base:${{ github.event.inputs.image_tag }}|g" odiglet/Dockerfile
+          sed -i "s|registry.odigos.io/odiglet-base:.*|registry.odigos.io/odiglet-base:${{ github.event.inputs.image_tag }}|g" odiglet/debug.Dockerfile        
+
+      - name: Create PR token
+        id: create-pr-sts
+        uses: odigos-io/ci-core/sts@main
+        with:
+          scope: odigos-io/odigos
+          identity: create-pr
+          output-git-config: true
+
+      - name: Open a PR to update the Odiglet Base Builder image
+        uses: peter-evans/create-pull-request@v8
+        id: create-pr
+        with:
+          token: ${{ steps.create-pr-sts.outputs.GH_TOKEN }}
+          title: "Update Odiglet Base Builder image to ${{ github.event.inputs.image_tag }}"
+          body: "This is an automated PR generated after a new release of the odiglet base builder, to update it's version in odiglet dockerfiles to ${{ github.event.inputs.image_tag }}"
+          base: "main"
+          commit-message: "Update Odiglet Base Builder image to ${{ github.event.inputs.image_tag }}"
+          labels: |
+            automated
+          delete-branch: true
+      
+      - name: Enable Pull Request Automerge
+        if: steps.create-pr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ steps.create-pr-sts.outputs.GH_TOKEN }}
+          pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
+          merge-method: squash
+
+      - name: Notify Slack
+        if: steps.create-pr.outputs.pull-request-number != ''
+        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
+        with:
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          success-description: "Successfully created PR to update the Odiglet Base Builder image to ${{ github.event.inputs.image_tag }}: ${{ steps.create-pr.outputs.pull-request-url }}"
+          failure-description: "ERROR: Failed to create PR to update the Odiglet Base Builder image to ${{ github.event.inputs.image_tag }}"
+          tag: ${{ github.event.inputs.image_tag }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Few improvements to the workflow, although it is rare, it's still nice to have :)

- reduce unneeded permissions, and migrate to sts-based permissions.
- add slack notifications
- automatically update the relevant dockerfiles and create a pr for the change

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

Internal tooling, not user facing

```release-note
NONE
```

emergency-ticket id: EMR-1343
