### PR TITLE
Odiglet base fixes

### DIFF
--- a/.github/workflows/publish-odiglet-base-builder.yaml
+++ b/.github/workflows/publish-odiglet-base-builder.yaml
@@ -148,7 +148,18 @@ jobs:
         with:
           token: ${{ steps.create-pr-sts.outputs.GH_TOKEN }}
           title: "Update Odiglet Base Builder image to ${{ github.event.inputs.image_tag }}"
-          body: "This is an automated PR generated after a new release of the odiglet base builder, to update it's version in odiglet dockerfiles to ${{ github.event.inputs.image_tag }}"
+          body: |
+            #### What this PR does / why we need it:
+            This is an automated PR generated after a new release of the odiglet base builder. It updates the base builder image reference in `odiglet/Dockerfile` and `odiglet/debug.Dockerfile` to `${{ github.event.inputs.image_tag }}`.
+
+            #### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
+            <!--
+            If this update includes any **user-facing** changes that users should know about—for example: dropped support for versions, new features, or breaking changes—replace `NONE` in the block below and document them in the release notes.
+            -->
+
+            ```release-note
+            NONE
+            ```
           base: "main"
           commit-message: "Update Odiglet Base Builder image to ${{ github.event.inputs.image_tag }}"
           labels: |

--- a/odiglet/base.Dockerfile
+++ b/odiglet/base.Dockerfile
@@ -17,7 +17,7 @@ RUN wget https://download.samba.org/pub/rsync/src/rsync-${RSYNC_VERSION}.tar.gz 
     && tar -xzf rsync-${RSYNC_VERSION}.tar.gz \
     && cd rsync-${RSYNC_VERSION} \
     && ./configure --prefix=/usr LDFLAGS="-static" \
-    && make \
+    && make -j"$(nproc)" \
     && make install DESTDIR=/rsync-install \
     && cd .. \
     && rm -rf rsync-${RSYNC_VERSION}*


### PR DESCRIPTION
#### What this PR does / why we need it:

Small fixes after #4504 to address:

- the automated PR fails the release notes check
- add `-j` to the make command for a bit faster build

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

Internal build, not user facing

```release-note
NONE
```

emergency-ticket id: EMR-1342
