### PR TITLE
ci: sts fix the enterprise call scope

### DIFF
--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -124,7 +124,7 @@ jobs:
         uses: odigos-io/ci-core/sts@main
         with:
           scope: odigos-io/odigos-enterprise
-          identity: create-release-pr.sts
+          identity: create-release-pr
           output-git-config: "false"
 
       - name: Trigger create release PR workflow


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix the name of the scope, it should not have the `.sts` suffix

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```

emergency-ticket id: EMR-1362
