### PR TITLE
ci: add missing user for create pr and always trigger slack

### DIFF
--- a/.github/workflows/create-patch.yml
+++ b/.github/workflows/create-patch.yml
@@ -60,6 +60,11 @@ jobs:
           echo "patch_version=$NEW_PATCH_VERSION" >> $GITHUB_OUTPUT
           echo "pr_branch=patch-release/$NEW_PATCH_VERSION" >> $GITHUB_OUTPUT
 
+      - name: Configure Git for bot commits
+        run: |
+          git config user.email "bot@odigos.io"
+          git config user.name "Odigos Release Bot"
+
       - name: Create or Update Patch Release PR
         env:
           GH_TOKEN: ${{ steps.sts-create-patch.outputs.GH_TOKEN }}

--- a/.github/workflows/create-release-candidate.yml
+++ b/.github/workflows/create-release-candidate.yml
@@ -130,7 +130,12 @@ jobs:
           event-type: ensure-release-branch
           client-payload: '{"branch":"${{ steps.rc_version.outputs.release_branch_name }}"}'
 
-      - name: Create or Update Pre-release PR
+      - name: Configure Git for bot commits
+        run: |
+          git config user.email "bot@odigos.io"
+          git config user.name "Odigos Release Bot"
+
+      - name: Create or Update Release Candidate PR
         env:
           GH_TOKEN: ${{ steps.sts-create-rc.outputs.GH_TOKEN }}
         run: |

--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -56,6 +56,7 @@ jobs:
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
       - name: Notify Slack Start
+        if: always()
         uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
         with:
           webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
@@ -90,6 +91,7 @@ jobs:
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
       - name: Notify Slack Start
+        if: always()
         uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
         with:
           webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
@@ -136,6 +138,7 @@ jobs:
           client-payload: '{"tag": "${{ needs.decide.outputs.tag }}"}'
 
       - name: Notify Slack
+        if: always()
         uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
         with:
           webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
@@ -197,6 +200,7 @@ jobs:
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
       - name: Notify Slack Start
+        if: always()
         uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
         with:
           webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}

--- a/.github/workflows/publish-odiglet-base-builder.yaml
+++ b/.github/workflows/publish-odiglet-base-builder.yaml
@@ -101,6 +101,7 @@ jobs:
             us-central1-docker.pkg.dev/odigos-cloud/components/odiglet-base:${{ github.event.inputs.image_tag }}
       
       - name: Notify Slack
+        if: always()
         uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
         with:
           webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
@@ -175,7 +176,7 @@ jobs:
           merge-method: squash
 
       - name: Notify Slack
-        if: steps.create-pr.outputs.pull-request-number != ''
+        if: always() && steps.create-pr.outputs.pull-request-number != ''
         uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
         with:
           webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
           path: helm/odigos-*.tgz
 
       - name: Notify Slack
+        if: always()
         uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
         with:
           webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
@@ -114,6 +115,7 @@ jobs:
           echo "date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
 
       - name: Notify Slack Start
+        if: always()
         uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
         with:
           webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
@@ -228,6 +230,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Notify Slack (release notes)
+        if: always()
         uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
         with:
           webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
@@ -270,6 +273,7 @@ jobs:
           fi
 
       - name: Notify Slack
+        if: always()
         uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
         with:
           webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
@@ -320,6 +324,7 @@ jobs:
         run: bash ./scripts/publish-charts.sh
 
       - name: Notify Slack
+        if: always()
         uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
         with:
           webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}

--- a/.github/workflows/update-instrumentation-agents-version.yml
+++ b/.github/workflows/update-instrumentation-agents-version.yml
@@ -119,7 +119,7 @@ jobs:
           merge-method: squash
 
       - name: Notify Slack
-        if: steps.cpr.outputs.pull-request-number != ''
+        if: always() && steps.cpr.outputs.pull-request-number != ''
         uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
         with:
           webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}


### PR DESCRIPTION
#### What this PR does / why we need it:

2 fixes to release ci workflows:

- set git username and email for the commit (should be taken care by sts by not working for some reason)
- make sure to use `if: always()` whenever using slack notification, so errors are reported

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```

emergency-ticket id: EMR-1374
