### PR TITLE
fix: [cherry-pick v1.23.0] bump OpenTelemetry Java agent to v2.26.1 (jackson-core vulnerability)

### DIFF
--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -36,7 +36,7 @@ FROM --platform=$BUILDPLATFORM ${ODIGLET_BASE_IMAGE} AS agents-builder
 WORKDIR /instrumentations
 
 # Java
-ARG JAVA_OTEL_VERSION=v2.10.0
+ARG JAVA_OTEL_VERSION=v2.26.1
 ADD --chmod=644 https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/$JAVA_OTEL_VERSION/opentelemetry-javaagent.jar /instrumentations/java/javaagent.jar
 
 # Python

--- a/odiglet/debug.Dockerfile
+++ b/odiglet/debug.Dockerfile
@@ -57,7 +57,7 @@ RUN go install github.com/go-delve/delve/cmd/dlv@latest
 WORKDIR /instrumentations
 
 # Java
-ARG JAVA_OTEL_VERSION=v2.10.0
+ARG JAVA_OTEL_VERSION=v2.26.1
 ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/$JAVA_OTEL_VERSION/opentelemetry-javaagent.jar /instrumentations/java/javaagent.jar
 RUN chmod 644 /instrumentations/java/javaagent.jar
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Cherry-pick of #4530 to `releases/v1.23.0`.

Bumps the OpenTelemetry Java instrumentation agent from **v2.10.0** to **v2.26.1** in both `odiglet/Dockerfile` and `odiglet/debug.Dockerfile`.

This resolves:
| Severity | CVE/GHSA | Package | Previous | Fixed |
|----------|----------|---------|----------|-------|
| **Medium** | GHSA-72hv-8253-57qq | jackson-core | 2.17.2 | ≥2.18.6 (bundled in OTel Java v2.26.0+) |
| **Critical** | CVE-2026-33701 | RMI instrumentation | — | v2.26.1 |

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
Bumped OpenTelemetry Java agent from v2.10.0 to v2.26.1, fixing jackson-core vulnerability (GHSA-72hv-8253-57qq) and RMI deserialization RCE (CVE-2026-33701).
```

emergency-ticket id: EMR-1387
