### PR TITLE
CORE-863: add heuristics for runtime selection for java and python

### DIFF
--- a/odiglet/go.mod
+++ b/odiglet/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/odigos-io/odigos/opampserver v0.0.0-00010101000000-000000000000
 	github.com/odigos-io/odigos/procdiscovery v0.0.0-00010101000000-000000000000
 	github.com/odigos-io/runtime-detector v0.0.24
+	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/auto v0.21.0
 	go.opentelemetry.io/otel v1.42.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.42.0

--- a/odiglet/pkg/kube/runtime_details/inspection.go
+++ b/odiglet/pkg/kube/runtime_details/inspection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/odigos-io/odigos/procdiscovery/pkg/libc"
@@ -16,16 +17,22 @@ import (
 	"github.com/odigos-io/odigos/common"
 	"github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/common/envOverwrite"
+	commonlogger "github.com/odigos-io/odigos/common/logger"
 	criwrapper "github.com/odigos-io/odigos/k8sutils/pkg/cri"
 	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
-	commonlogger "github.com/odigos-io/odigos/common/logger"
 	"github.com/odigos-io/odigos/procdiscovery/pkg/inspectors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+var LowPriorityLanguages = []common.ProgrammingLanguage{
+	common.CPlusPlusProgrammingLanguage, // can be a wrapper around the real application
+	common.NginxProgrammingLanguage,     // can run as a sidecar process in the same container
+	common.PythonProgrammingLanguage,    // can be a ML/AI serving runtime alongside a server
+}
 
 var errNoKnownLanguageDetected = errors.New("no known programming language detected in the container")
 
@@ -47,36 +54,11 @@ func relevantProcessesDetailsInContainer(knownLangByPid map[int]common.ProgramLa
 		}
 	}
 
-	// resolve the language detected for the container
-	// depending on the number of unique languages detected and their types
-	selectedLangDetails := common.ProgramLanguageDetails{Language: common.UnknownProgrammingLanguage}
-	switch len(uniqueLangsSlice) {
-	case 0:
-		return nil, selectedLangDetails, errNoKnownLanguageDetected
-	case 1:
-		selectedLangDetails.Language = uniqueLangsSlice[0]
-	case 2:
-		switch {
-		// c++ can be a wrapper of script etc.
-		// we want to detect the "later" language to get the real application.
-		// but we also want to detect c++ if it is the only language detected.
-		// hence if c++ is detected with another language, we select the other language.
-		case uniqueLangsSlice[0] == common.CPlusPlusProgrammingLanguage:
-			selectedLangDetails.Language = uniqueLangsSlice[1]
-		case uniqueLangsSlice[1] == common.CPlusPlusProgrammingLanguage:
-			selectedLangDetails.Language = uniqueLangsSlice[0]
-		// nginx can be used as a separate process in the same container
-		// in this case, we give priority to the other language as it is more likely to be the main application.
-		case uniqueLangsSlice[0] == common.NginxProgrammingLanguage:
-			selectedLangDetails.Language = uniqueLangsSlice[1]
-		case uniqueLangsSlice[1] == common.NginxProgrammingLanguage:
-			selectedLangDetails.Language = uniqueLangsSlice[0]
-		default:
-			return nil, selectedLangDetails, fmt.Errorf("two different programming languages detected in the same container, cannot determine the main language: %v", uniqueLangsSlice)
-		}
-	default:
-		return nil, selectedLangDetails, fmt.Errorf("more than two programming languages detected in the same container, cannot determine the main language: %v", uniqueLangsSlice)
+	selectedLanguage, selectionError := SelectContainerMainLanguage(uniqueLangsSlice)
+	if selectionError != nil {
+		return nil, common.ProgramLanguageDetails{Language: common.UnknownProgrammingLanguage}, selectionError
 	}
+	selectedLangDetails := common.ProgramLanguageDetails{Language: selectedLanguage}
 
 	// construct the list of relevant processes and determine runtime version if possible
 	// relevant processes are those that match the selected programming language
@@ -115,6 +97,29 @@ func runtimeInspection(ctx context.Context, pods []corev1.Pod, criClient *criwra
 	}
 
 	return runtimeInspectionFromGroupedPIDs(ctx, pods, groups, criClient, runtimeDetectionEnvs)
+}
+
+// resolves which programming language is the "main" one for a container according to the unique known languages detected.
+func SelectContainerMainLanguage(uniqueKnownLanguages []common.ProgrammingLanguage) (common.ProgrammingLanguage, error) {
+	switch len(uniqueKnownLanguages) {
+	case 0:
+		return common.UnknownProgrammingLanguage, errNoKnownLanguageDetected
+	case 1:
+		return uniqueKnownLanguages[0], nil
+	case 2:
+		switch {
+		case uniqueKnownLanguages[0] == common.JavaProgrammingLanguage || uniqueKnownLanguages[1] == common.JavaProgrammingLanguage:
+			return common.JavaProgrammingLanguage, nil
+		case slices.Contains(LowPriorityLanguages, uniqueKnownLanguages[0]):
+			return uniqueKnownLanguages[1], nil
+		case slices.Contains(LowPriorityLanguages, uniqueKnownLanguages[1]):
+			return uniqueKnownLanguages[0], nil
+		default:
+			return common.UnknownProgrammingLanguage, fmt.Errorf("two different programming languages detected in the same container, cannot determine the main language: %v", uniqueKnownLanguages)
+		}
+	default:
+		return common.UnknownProgrammingLanguage, fmt.Errorf("more than two programming languages detected in the same container, cannot determine the main language: %v", uniqueKnownLanguages)
+	}
 }
 
 // runtimeInspectionFromGroupedPIDs is like runtimeInspection but uses pre-grouped PIDs.

--- a/odiglet/pkg/kube/runtime_details/inspection.go
+++ b/odiglet/pkg/kube/runtime_details/inspection.go
@@ -53,7 +53,6 @@ func relevantProcessesDetailsInContainer(knownLangByPid map[int]common.ProgramLa
 			uniqueLangsSlice = append(uniqueLangsSlice, lang)
 		}
 	}
-	slices.Sort(uniqueLangsSlice)
 
 	selectedLanguage, selectionError := SelectContainerMainLanguage(uniqueLangsSlice)
 	if selectionError != nil {
@@ -102,6 +101,9 @@ func runtimeInspection(ctx context.Context, pods []corev1.Pod, criClient *criwra
 
 // resolves which programming language is the "main" one for a container according to the unique known languages detected.
 func SelectContainerMainLanguage(uniqueKnownLanguages []common.ProgrammingLanguage) (common.ProgrammingLanguage, error) {
+	// sort uniqueKnownLanguages to make sure the list is iterated upon in a deterministic way
+	slices.Sort(uniqueKnownLanguages)
+
 	switch len(uniqueKnownLanguages) {
 	case 0:
 		return common.UnknownProgrammingLanguage, errNoKnownLanguageDetected

--- a/odiglet/pkg/kube/runtime_details/inspection.go
+++ b/odiglet/pkg/kube/runtime_details/inspection.go
@@ -53,6 +53,7 @@ func relevantProcessesDetailsInContainer(knownLangByPid map[int]common.ProgramLa
 			uniqueLangsSlice = append(uniqueLangsSlice, lang)
 		}
 	}
+	slices.Sort(uniqueLangsSlice)
 
 	selectedLanguage, selectionError := SelectContainerMainLanguage(uniqueLangsSlice)
 	if selectionError != nil {

--- a/odiglet/pkg/kube/runtime_details/inspection_test.go
+++ b/odiglet/pkg/kube/runtime_details/inspection_test.go
@@ -1,0 +1,125 @@
+package runtime_details
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/odigos-io/odigos/common"
+	"github.com/stretchr/testify/assert"
+)
+
+// ******************************************
+// SelectContainerMainLanguage tests
+// ******************************************
+
+func Test_SelectMainLanguage_NoLanguages_ReturnsError(t *testing.T) {
+	// no known languages detected — should fail with the sentinel error (before the heuristics come into play)
+	languages := []common.ProgrammingLanguage{}
+
+	result, selectionError := SelectContainerMainLanguage(languages)
+
+	assert.ErrorIs(t, selectionError, errNoKnownLanguageDetected)
+	assert.Equal(t, common.UnknownProgrammingLanguage, result)
+}
+
+func Test_SelectMainLanguage_SingleLanguage_ReturnsThatLanguage(t *testing.T) {
+	// exactly one language detected — should return it directly
+	languages := []common.ProgrammingLanguage{common.GoProgrammingLanguage}
+
+	result, selectionError := SelectContainerMainLanguage(languages)
+
+	assert.NoError(t, selectionError)
+	assert.Equal(t, common.GoProgrammingLanguage, result)
+}
+
+func Test_SelectMainLanguage_JavaWithHighPriority_JavaSelected(t *testing.T) {
+	// Java paired with another high-priority language — Java always wins
+	languages := []common.ProgrammingLanguage{common.JavaProgrammingLanguage, common.GoProgrammingLanguage}
+
+	result, selectionError := SelectContainerMainLanguage(languages)
+
+	assert.NoError(t, selectionError)
+	assert.Equal(t, common.JavaProgrammingLanguage, result)
+}
+
+func Test_SelectMainLanguage_HighPriorityWithJava_JavaSelected(t *testing.T) {
+	// Java in second position — should still be selected over the other language
+	languages := []common.ProgrammingLanguage{common.DotNetProgrammingLanguage, common.JavaProgrammingLanguage}
+
+	result, selectionError := SelectContainerMainLanguage(languages)
+
+	assert.NoError(t, selectionError)
+	assert.Equal(t, common.JavaProgrammingLanguage, result)
+}
+
+func Test_SelectMainLanguage_LowPriorityCppFirst_HighPrioritySelected(t *testing.T) {
+	// C++ (low priority) paired with Go — Go should be selected
+	languages := []common.ProgrammingLanguage{common.CPlusPlusProgrammingLanguage, common.GoProgrammingLanguage}
+
+	result, selectionError := SelectContainerMainLanguage(languages)
+
+	assert.NoError(t, selectionError)
+	assert.Equal(t, common.GoProgrammingLanguage, result)
+}
+
+func Test_SelectMainLanguage_LowPriorityNginxSecond_HighPrioritySelected(t *testing.T) {
+	// Nginx (low priority) in second position paired with DotNet — DotNet wins
+	languages := []common.ProgrammingLanguage{common.DotNetProgrammingLanguage, common.NginxProgrammingLanguage}
+
+	result, selectionError := SelectContainerMainLanguage(languages)
+
+	assert.NoError(t, selectionError)
+	assert.Equal(t, common.DotNetProgrammingLanguage, result)
+}
+
+func Test_SelectMainLanguage_LowPriorityPythonFirst_HighPrioritySelected(t *testing.T) {
+	// Python (low priority) paired with JavaScript — JavaScript wins
+	languages := []common.ProgrammingLanguage{common.PythonProgrammingLanguage, common.JavascriptProgrammingLanguage}
+
+	result, selectionError := SelectContainerMainLanguage(languages)
+
+	assert.NoError(t, selectionError)
+	assert.Equal(t, common.JavascriptProgrammingLanguage, result)
+}
+
+func Test_SelectMainLanguage_TwoLowPriorityLanguages_SecondSelected(t *testing.T) {
+	// both languages are low priority — the first is deprioritized so the second wins
+	languages := []common.ProgrammingLanguage{common.CPlusPlusProgrammingLanguage, common.PythonProgrammingLanguage}
+
+	result, selectionError := SelectContainerMainLanguage(languages)
+
+	assert.NoError(t, selectionError)
+	assert.Equal(t, common.PythonProgrammingLanguage, result)
+}
+
+func Test_SelectMainLanguage_TwoHighPriorityNonJava_ReturnsError(t *testing.T) {
+	// two high-priority non-Java languages — ambiguous, should error
+	languages := []common.ProgrammingLanguage{common.GoProgrammingLanguage, common.DotNetProgrammingLanguage}
+
+	result, selectionError := SelectContainerMainLanguage(languages)
+
+	assert.Error(t, selectionError)
+	assert.False(t, errors.Is(selectionError, errNoKnownLanguageDetected))
+	assert.Equal(t, common.UnknownProgrammingLanguage, result)
+}
+
+func Test_SelectMainLanguage_ThreeLanguages_ReturnsError(t *testing.T) {
+	// more than two languages — always ambiguous regardless of which languages
+	languages := []common.ProgrammingLanguage{common.GoProgrammingLanguage, common.JavaProgrammingLanguage, common.PythonProgrammingLanguage}
+
+	result, selectionError := SelectContainerMainLanguage(languages)
+
+	assert.Error(t, selectionError)
+	assert.False(t, errors.Is(selectionError, errNoKnownLanguageDetected))
+	assert.Equal(t, common.UnknownProgrammingLanguage, result)
+}
+
+func Test_SelectMainLanguage_JavaWithLowPriority_JavaSelected(t *testing.T) {
+	// Java paired with a low-priority language — Java rule takes precedence over low-priority rule
+	languages := []common.ProgrammingLanguage{common.NginxProgrammingLanguage, common.JavaProgrammingLanguage}
+
+	result, selectionError := SelectContainerMainLanguage(languages)
+
+	assert.NoError(t, selectionError)
+	assert.Equal(t, common.JavaProgrammingLanguage, result)
+}


### PR DESCRIPTION
* add heuristics for runtime selection for java and python
* add determinism of the languages found, by sorting the result list

#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Adds runtime selection improvements for multi-runtime containers (specifically for python and java)
```
