### PR TITLE
feat: add sampling rules management page

### DIFF
--- a/docs/snippets/shared/permissions.mdx
+++ b/docs/snippets/shared/permissions.mdx
@@ -103,7 +103,7 @@ Below are the ClusterRoles used by Odigos components.
 | \* | services | \* | get<br />list |
 | \* | pods | \* | get<br />list<br />watch<br />delete |
 | odigos.io | \* | \* | get<br />list<br />watch |
-| odigos.io | instrumentationconfigs<br />instrumentationinstances<br />sources | \* | update<br />patch<br />create<br />delete |
+| odigos.io | instrumentationconfigs<br />instrumentationinstances<br />sources<br />samplings | \* | update<br />patch<br />create<br />delete |
 | actions.odigos.io | \* | \* | get<br />list<br />watch |
 
 ## Roles
@@ -209,7 +209,7 @@ Below are the Roles used by Odigos components. These Roles are only scoped to th
 | apps | replicasets | \* | get<br />list |
 | autoscaling | horizontalpodautoscalers | \* | get |
 | odigos.io | \* | \* | get<br />list<br />watch |
-| odigos.io | instrumentationrules<br />destinations<br />actions | \* | create<br />patch<br />update<br />delete |
+| odigos.io | instrumentationrules<br />destinations<br />actions<br />samplings | \* | create<br />patch<br />update<br />delete |
 | odigos.io | collectorsgroups | \* | get<br />list<br />watch |
 | actions.odigos.io | \* | \* | get<br />list<br />watch<br />create<br />patch<br />update<br />delete |
 | apps | deployments/scale | odigos-instrumentor | get<br />update<br />patch |

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -44129,9 +44129,9 @@ func (ec *executionContext) _SourcesScope_workloadLanguage(ctx context.Context, 
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*model.ProgrammingLanguage)
+	res := resTmp.(*model.SamplingWorkloadLanguage)
 	fc.Result = res
-	return ec.marshalOProgrammingLanguage2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐProgrammingLanguage(ctx, field.Selections, res)
+	return ec.marshalOSamplingWorkloadLanguage2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSamplingWorkloadLanguage(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_SourcesScope_workloadLanguage(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -44141,7 +44141,7 @@ func (ec *executionContext) fieldContext_SourcesScope_workloadLanguage(_ context
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type ProgrammingLanguage does not have child fields")
+			return nil, errors.New("field of type SamplingWorkloadLanguage does not have child fields")
 		},
 	}
 	return fc, nil
@@ -49832,7 +49832,7 @@ func (ec *executionContext) unmarshalInputSourcesScopeInput(ctx context.Context,
 			it.WorkloadNamespace = data
 		case "workloadLanguage":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("workloadLanguage"))
-			data, err := ec.unmarshalOProgrammingLanguage2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐProgrammingLanguage(ctx, v)
+			data, err := ec.unmarshalOSamplingWorkloadLanguage2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSamplingWorkloadLanguage(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -66161,6 +66161,22 @@ func (ec *executionContext) unmarshalOSamplingConfigInput2ᚖgithubᚗcomᚋodig
 	}
 	res, err := ec.unmarshalInputSamplingConfigInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOSamplingWorkloadLanguage2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSamplingWorkloadLanguage(ctx context.Context, v any) (*model.SamplingWorkloadLanguage, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var res = new(model.SamplingWorkloadLanguage)
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOSamplingWorkloadLanguage2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSamplingWorkloadLanguage(ctx context.Context, sel ast.SelectionSet, v *model.SamplingWorkloadLanguage) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return v
 }
 
 func (ec *executionContext) marshalOServiceNameFilter2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐServiceNameFilterᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.ServiceNameFilter) graphql.Marshaler {

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -1420,17 +1420,17 @@ type SourceContainer struct {
 }
 
 type SourcesScope struct {
-	WorkloadName      *string              `json:"workloadName,omitempty"`
-	WorkloadKind      *K8sResourceKind     `json:"workloadKind,omitempty"`
-	WorkloadNamespace *string              `json:"workloadNamespace,omitempty"`
-	WorkloadLanguage  *ProgrammingLanguage `json:"workloadLanguage,omitempty"`
+	WorkloadName      *string                   `json:"workloadName,omitempty"`
+	WorkloadKind      *K8sResourceKind          `json:"workloadKind,omitempty"`
+	WorkloadNamespace *string                   `json:"workloadNamespace,omitempty"`
+	WorkloadLanguage  *SamplingWorkloadLanguage `json:"workloadLanguage,omitempty"`
 }
 
 type SourcesScopeInput struct {
-	WorkloadName      *string              `json:"workloadName,omitempty"`
-	WorkloadKind      *K8sResourceKind     `json:"workloadKind,omitempty"`
-	WorkloadNamespace *string              `json:"workloadNamespace,omitempty"`
-	WorkloadLanguage  *ProgrammingLanguage `json:"workloadLanguage,omitempty"`
+	WorkloadName      *string                   `json:"workloadName,omitempty"`
+	WorkloadKind      *K8sResourceKind          `json:"workloadKind,omitempty"`
+	WorkloadNamespace *string                   `json:"workloadNamespace,omitempty"`
+	WorkloadLanguage  *SamplingWorkloadLanguage `json:"workloadLanguage,omitempty"`
 }
 
 type SpanAttributeFilter struct {
@@ -2651,6 +2651,57 @@ func (e *ProgrammingLanguage) UnmarshalGQL(v any) error {
 }
 
 func (e ProgrammingLanguage) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type SamplingWorkloadLanguage string
+
+const (
+	SamplingWorkloadLanguageJava       SamplingWorkloadLanguage = "java"
+	SamplingWorkloadLanguagePython     SamplingWorkloadLanguage = "python"
+	SamplingWorkloadLanguageGo         SamplingWorkloadLanguage = "go"
+	SamplingWorkloadLanguageDotnet     SamplingWorkloadLanguage = "dotnet"
+	SamplingWorkloadLanguageJavascript SamplingWorkloadLanguage = "javascript"
+	SamplingWorkloadLanguagePhp        SamplingWorkloadLanguage = "php"
+	SamplingWorkloadLanguageRuby       SamplingWorkloadLanguage = "ruby"
+)
+
+var AllSamplingWorkloadLanguage = []SamplingWorkloadLanguage{
+	SamplingWorkloadLanguageJava,
+	SamplingWorkloadLanguagePython,
+	SamplingWorkloadLanguageGo,
+	SamplingWorkloadLanguageDotnet,
+	SamplingWorkloadLanguageJavascript,
+	SamplingWorkloadLanguagePhp,
+	SamplingWorkloadLanguageRuby,
+}
+
+func (e SamplingWorkloadLanguage) IsValid() bool {
+	switch e {
+	case SamplingWorkloadLanguageJava, SamplingWorkloadLanguagePython, SamplingWorkloadLanguageGo, SamplingWorkloadLanguageDotnet, SamplingWorkloadLanguageJavascript, SamplingWorkloadLanguagePhp, SamplingWorkloadLanguageRuby:
+		return true
+	}
+	return false
+}
+
+func (e SamplingWorkloadLanguage) String() string {
+	return string(e)
+}
+
+func (e *SamplingWorkloadLanguage) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = SamplingWorkloadLanguage(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid SamplingWorkloadLanguage", str)
+	}
+	return nil
+}
+
+func (e SamplingWorkloadLanguage) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 

--- a/frontend/graph/sampling.graphqls
+++ b/frontend/graph/sampling.graphqls
@@ -1,277 +1,303 @@
-
 type TailSamplingConfig {
+  # if set to true, tail sampling will be disabled globally
+  # regardless of any other configurations or rules set.
+  # can be used to reduce collectors resource usage, troubleshooting, etc,
+  # or when tail-sampling is not needed or desired and should be shut off.
+  disabled: Boolean
 
-	# if set to true, tail sampling will be disabled globally
-	# regardless of any other configurations or rules set.
-	# can be used to reduce collectors resource usage, troubleshooting, etc,
-	# or when tail-sampling is not needed or desired and should be shut off.
-    disabled: Boolean
-
-	# time to wait from the first span of a trace until a trace is considered completed.
-	# at this time, all spans received for this trace are aggregated and a tail-sampling decision is applied.
-	# introduces this amount of latency in the pipeline and for trace to hit the destination.
-	# also increases memory usage for keeping spans in memory until the wait duration time is reached.
-	# setting it too low might introduce fragmentation of traces - sampling decisions based on incomplete traces,
-	# and broken traces due to sampling each trace in few pieces.
-	traceAggregationWaitDuration: String
+  # time to wait from the first span of a trace until a trace is considered completed.
+  # at this time, all spans received for this trace are aggregated and a tail-sampling decision is applied.
+  # introduces this amount of latency in the pipeline and for trace to hit the destination.
+  # also increases memory usage for keeping spans in memory until the wait duration time is reached.
+  # setting it too low might introduce fragmentation of traces - sampling decisions based on incomplete traces,
+  # and broken traces due to sampling each trace in few pieces.
+  traceAggregationWaitDuration: String
 }
 
 type K8sHealthProbesSamplingConfig {
-    # if set to true, odigos will automatically detect and sample out health probes.
-    # this is a global knob to enable health probes auto-detection and sampling completely for all sources in the cluster.
-    # users that are uninterested in tracing health probes (or collect less of these traces) can set this to true.
-    enabled: Boolean
+  # if set to true, odigos will automatically detect and sample out health probes.
+  # this is a global knob to enable health probes auto-detection and sampling completely for all sources in the cluster.
+  # users that are uninterested in tracing health probes (or collect less of these traces) can set this to true.
+  enabled: Boolean
 
-    # percentage % (0-100) of health probes to keep.
-    # if not set, it is defaulted to 0% -> all health probes will be sampled out.
-    # set to some low value (like 1%) to still keep some health-probes traces.
-    keepPercentage: Float
+  # percentage % (0-100) of health probes to keep.
+  # if not set, it is defaulted to 0% -> all health probes will be sampled out.
+  # set to some low value (like 1%) to still keep some health-probes traces.
+  keepPercentage: Float
 }
 
 type SamplingConfig {
+  # configuration for tail sampling.
+  tailSampling: TailSamplingConfig
 
-    # configuration for tail sampling.
-    tailSampling: TailSamplingConfig
-
-    # configuration for odigos auto-kubelet-probes detection and sampling.
-    k8sHealthProbesSampling: K8sHealthProbesSamplingConfig
+  # configuration for odigos auto-kubelet-probes detection and sampling.
+  k8sHealthProbesSampling: K8sHealthProbesSamplingConfig
 }
 
 # Input type for mutation arguments (GraphQL only allows input types as operation args).
 input TailSamplingConfigInput {
-    disabled: Boolean
-    traceAggregationWaitDuration: String
+  disabled: Boolean
+  traceAggregationWaitDuration: String
 }
 
 input K8sHealthProbesSamplingConfigInput {
-    enabled: Boolean
-    keepPercentage: Float
+  enabled: Boolean
+  keepPercentage: Float
 }
 
 input SamplingConfigInput {
-    tailSampling: TailSamplingConfigInput
-    k8sHealthProbesSampling: K8sHealthProbesSamplingConfigInput
+  tailSampling: TailSamplingConfigInput
+  k8sHealthProbesSampling: K8sHealthProbesSamplingConfigInput
 }
 
 type SamplingConfigs {
+  # shows the effective config which is used in practice in odigos.
+  # this is the merge of all configs and potentially profiles.
+  effective: SamplingConfig
 
-    # shows the effective config which is used in practice in odigos.
-    # this is the merge of all configs and potentially profiles.
-    effective: SamplingConfig
+  # shows the config which is used in the helm deployment or cli.
+  helmDeployment: SamplingConfig
 
-    # shows the config which is used in the helm deployment or cli.
-    helmDeployment: SamplingConfig
+  # shows the config which is managed by central-backend.
+  remoteConfigFromCentral: SamplingConfig
 
-    # shows the config which is managed by central-backend.
-    remoteConfigFromCentral: SamplingConfig
-
-    # shows the config which is managed by local ui.
-    localUiConfig: SamplingConfig
+  # shows the config which is managed by local ui.
+  localUiConfig: SamplingConfig
 }
 
 # ---- Shared types for sampling rules ----
 
+enum SamplingWorkloadLanguage {
+  java
+  python
+  go
+  dotnet
+  javascript
+  php
+  ruby
+}
+
 # scope to limit a sampling rule to specific sources
 type SourcesScope {
-    workloadName: String
-    workloadKind: K8sResourceKind
-    workloadNamespace: String
-    workloadLanguage: ProgrammingLanguage
+  workloadName: String
+  workloadKind: K8sResourceKind
+  workloadNamespace: String
+  workloadLanguage: SamplingWorkloadLanguage
 }
 
 input SourcesScopeInput {
-    workloadName: String
-    workloadKind: K8sResourceKind
-    workloadNamespace: String
-    workloadLanguage: ProgrammingLanguage
+  workloadName: String
+  workloadKind: K8sResourceKind
+  workloadNamespace: String
+  workloadLanguage: SamplingWorkloadLanguage
 }
 
 # ---- Head sampling operation matchers (used by noisy operations) ----
 
 type HeadSamplingHttpServerMatcher {
-    route: String
-    routePrefix: String
-    method: String
+  route: String
+  routePrefix: String
+  method: String
 }
 
 type HeadSamplingHttpClientMatcher {
-    serverAddress: String
-    templatedPath: String
-    templatedPathPrefix: String
-    method: String
+  serverAddress: String
+  templatedPath: String
+  templatedPathPrefix: String
+  method: String
 }
 
 type HeadSamplingOperationMatcher {
-    httpServer: HeadSamplingHttpServerMatcher
-    httpClient: HeadSamplingHttpClientMatcher
+  httpServer: HeadSamplingHttpServerMatcher
+  httpClient: HeadSamplingHttpClientMatcher
 }
 
 input HeadSamplingHttpServerMatcherInput {
-    route: String
-    routePrefix: String
-    method: String
+  route: String
+  routePrefix: String
+  method: String
 }
 
 input HeadSamplingHttpClientMatcherInput {
-    serverAddress: String
-    templatedPath: String
-    templatedPathPrefix: String
-    method: String
+  serverAddress: String
+  templatedPath: String
+  templatedPathPrefix: String
+  method: String
 }
 
 input HeadSamplingOperationMatcherInput {
-    httpServer: HeadSamplingHttpServerMatcherInput
-    httpClient: HeadSamplingHttpClientMatcherInput
+  httpServer: HeadSamplingHttpServerMatcherInput
+  httpClient: HeadSamplingHttpClientMatcherInput
 }
 
 # ---- Tail sampling operation matchers (used by highly relevant + cost reduction) ----
 
 type TailSamplingHttpServerMatcher {
-    route: String
-    routePrefix: String
-    method: String
+  route: String
+  routePrefix: String
+  method: String
 }
 
 type TailSamplingKafkaMatcher {
-    kafkaTopic: String
+  kafkaTopic: String
 }
 
 type TailSamplingOperationMatcher {
-    httpServer: TailSamplingHttpServerMatcher
-    kafkaConsumer: TailSamplingKafkaMatcher
-    kafkaProducer: TailSamplingKafkaMatcher
+  httpServer: TailSamplingHttpServerMatcher
+  kafkaConsumer: TailSamplingKafkaMatcher
+  kafkaProducer: TailSamplingKafkaMatcher
 }
 
 input TailSamplingHttpServerMatcherInput {
-    route: String
-    routePrefix: String
-    method: String
+  route: String
+  routePrefix: String
+  method: String
 }
 
 input TailSamplingKafkaMatcherInput {
-    kafkaTopic: String
+  kafkaTopic: String
 }
 
 input TailSamplingOperationMatcherInput {
-    httpServer: TailSamplingHttpServerMatcherInput
-    kafkaConsumer: TailSamplingKafkaMatcherInput
-    kafkaProducer: TailSamplingKafkaMatcherInput
+  httpServer: TailSamplingHttpServerMatcherInput
+  kafkaConsumer: TailSamplingKafkaMatcherInput
+  kafkaProducer: TailSamplingKafkaMatcherInput
 }
 
 # ---- Sampling rule types ----
 
 type NoisyOperationRule {
-    ruleId: ID!
-    name: String
-    disabled: Boolean!
-    sourceScopes: [SourcesScope!]
-    operation: HeadSamplingOperationMatcher
-    # percentage (0-100) of matching traces to keep. unset defaults to 0% (drop all).
-    percentageAtMost: Float
-    notes: String
+  ruleId: ID!
+  name: String
+  disabled: Boolean!
+  sourceScopes: [SourcesScope!]
+  operation: HeadSamplingOperationMatcher
+  # percentage (0-100) of matching traces to keep. unset defaults to 0% (drop all).
+  percentageAtMost: Float
+  notes: String
 }
 
 type HighlyRelevantOperationRule {
-    ruleId: ID!
-    name: String
-    disabled: Boolean!
-    sourceScopes: [SourcesScope!]
-    # if true, only spans with SpanStatus set to Error are considered
-    error: Boolean!
-    # if set, only operations with duration in ms larger than this value are considered
-    durationAtLeastMs: Int
-    operation: TailSamplingOperationMatcher
-    # percentage (0-100) of matching traces to keep. unset defaults to 100% (keep all).
-    percentageAtLeast: Float
-    notes: String
+  ruleId: ID!
+  name: String
+  disabled: Boolean!
+  sourceScopes: [SourcesScope!]
+  # if true, only spans with SpanStatus set to Error are considered
+  error: Boolean!
+  # if set, only operations with duration in ms larger than this value are considered
+  durationAtLeastMs: Int
+  operation: TailSamplingOperationMatcher
+  # percentage (0-100) of matching traces to keep. unset defaults to 100% (keep all).
+  percentageAtLeast: Float
+  notes: String
 }
 
 type CostReductionRule {
-    ruleId: ID!
-    name: String
-    disabled: Boolean!
-    sourceScopes: [SourcesScope!]
-    operation: TailSamplingOperationMatcher
-    # percentage (0-100) of matching traces to keep. required field.
-    percentageAtMost: Float!
-    notes: String
+  ruleId: ID!
+  name: String
+  disabled: Boolean!
+  sourceScopes: [SourcesScope!]
+  operation: TailSamplingOperationMatcher
+  # percentage (0-100) of matching traces to keep. required field.
+  percentageAtMost: Float!
+  notes: String
 }
 
 # ---- Sampling rule inputs ----
 
 input NoisyOperationRuleInput {
-    name: String
-    disabled: Boolean
-    sourceScopes: [SourcesScopeInput!]
-    operation: HeadSamplingOperationMatcherInput
-    percentageAtMost: Float
-    notes: String
+  name: String
+  disabled: Boolean
+  sourceScopes: [SourcesScopeInput!]
+  operation: HeadSamplingOperationMatcherInput
+  percentageAtMost: Float
+  notes: String
 }
 
 input HighlyRelevantOperationRuleInput {
-    name: String
-    disabled: Boolean
-    sourceScopes: [SourcesScopeInput!]
-    error: Boolean
-    durationAtLeastMs: Int
-    operation: TailSamplingOperationMatcherInput
-    percentageAtLeast: Float
-    notes: String
+  name: String
+  disabled: Boolean
+  sourceScopes: [SourcesScopeInput!]
+  error: Boolean
+  durationAtLeastMs: Int
+  operation: TailSamplingOperationMatcherInput
+  percentageAtLeast: Float
+  notes: String
 }
 
 input CostReductionRuleInput {
-    name: String
-    disabled: Boolean
-    sourceScopes: [SourcesScopeInput!]
-    operation: TailSamplingOperationMatcherInput
-    percentageAtMost: Float!
-    notes: String
+  name: String
+  disabled: Boolean
+  sourceScopes: [SourcesScopeInput!]
+  operation: TailSamplingOperationMatcherInput
+  percentageAtMost: Float!
+  notes: String
 }
 
 # ---- Container for all sampling rules ----
 
 type SamplingRules {
-    # stable identifier for this rule group (k8s metadata.name of the Sampling CR)
-    id: ID!
-    # user-facing display name for this rule group
-    name: String
-    noisyOperations: [NoisyOperationRule!]!
-    highlyRelevantOperations: [HighlyRelevantOperationRule!]!
-    costReductionRules: [CostReductionRule!]!
+  # stable identifier for this rule group (k8s metadata.name of the Sampling CR)
+  id: ID!
+  # user-facing display name for this rule group
+  name: String
+  noisyOperations: [NoisyOperationRule!]!
+  highlyRelevantOperations: [HighlyRelevantOperationRule!]!
+  costReductionRules: [CostReductionRule!]!
 }
 
 # ---- Root sampling type ----
 
 type Sampling {
-    # global sampling configs (tail sampling, health probes, etc.)
-    configs: SamplingConfigs!
-    # sampling rule groups (one per Sampling CR)
-    rules: [SamplingRules!]!
+  # global sampling configs (tail sampling, health probes, etc.)
+  configs: SamplingConfigs!
+  # sampling rule groups (one per Sampling CR)
+  rules: [SamplingRules!]!
 }
 
 extend type Query {
-    sampling: Sampling!
+  sampling: Sampling!
 }
 
 extend type Mutation {
+  # update the local ui sampling config.
+  # if nil is provided, the local ui config will be reset (using helm deployment, remote config from central, or defaults)
+  # each value in the config is optional, and if not provided, the corresponding config will be left unchanged.
+  updateLocalUiSamplingConfig(config: SamplingConfigInput): Boolean!
 
-    # update the local ui sampling config.
-    # if nil is provided, the local ui config will be reset (using helm deployment, remote config from central, or defaults)
-    # each value in the config is optional, and if not provided, the corresponding config will be left unchanged.
-    updateLocalUiSamplingConfig(config: SamplingConfigInput): Boolean!
+  # ---- Noisy operations CRUD ----
+  createNoisyOperationRule(
+    samplingId: ID!
+    rule: NoisyOperationRuleInput!
+  ): NoisyOperationRule!
+  updateNoisyOperationRule(
+    samplingId: ID!
+    ruleId: ID!
+    rule: NoisyOperationRuleInput!
+  ): NoisyOperationRule!
+  deleteNoisyOperationRule(samplingId: ID!, ruleId: ID!): Boolean!
 
-    # ---- Noisy operations CRUD ----
-    createNoisyOperationRule(samplingId: ID!, rule: NoisyOperationRuleInput!): NoisyOperationRule!
-    updateNoisyOperationRule(samplingId: ID!, ruleId: ID!, rule: NoisyOperationRuleInput!): NoisyOperationRule!
-    deleteNoisyOperationRule(samplingId: ID!, ruleId: ID!): Boolean!
+  # ---- Highly relevant operations CRUD ----
+  createHighlyRelevantOperationRule(
+    samplingId: ID!
+    rule: HighlyRelevantOperationRuleInput!
+  ): HighlyRelevantOperationRule!
+  updateHighlyRelevantOperationRule(
+    samplingId: ID!
+    ruleId: ID!
+    rule: HighlyRelevantOperationRuleInput!
+  ): HighlyRelevantOperationRule!
+  deleteHighlyRelevantOperationRule(samplingId: ID!, ruleId: ID!): Boolean!
 
-    # ---- Highly relevant operations CRUD ----
-    createHighlyRelevantOperationRule(samplingId: ID!, rule: HighlyRelevantOperationRuleInput!): HighlyRelevantOperationRule!
-    updateHighlyRelevantOperationRule(samplingId: ID!, ruleId: ID!, rule: HighlyRelevantOperationRuleInput!): HighlyRelevantOperationRule!
-    deleteHighlyRelevantOperationRule(samplingId: ID!, ruleId: ID!): Boolean!
-
-    # ---- Cost reduction CRUD ----
-    createCostReductionRule(samplingId: ID!, rule: CostReductionRuleInput!): CostReductionRule!
-    updateCostReductionRule(samplingId: ID!, ruleId: ID!, rule: CostReductionRuleInput!): CostReductionRule!
-    deleteCostReductionRule(samplingId: ID!, ruleId: ID!): Boolean!
+  # ---- Cost reduction CRUD ----
+  createCostReductionRule(
+    samplingId: ID!
+    rule: CostReductionRuleInput!
+  ): CostReductionRule!
+  updateCostReductionRule(
+    samplingId: ID!
+    ruleId: ID!
+    rule: CostReductionRuleInput!
+  ): CostReductionRule!
+  deleteCostReductionRule(samplingId: ID!, ruleId: ID!): Boolean!
 }

--- a/frontend/graph/workload.resolvers.go
+++ b/frontend/graph/workload.resolvers.go
@@ -592,6 +592,9 @@ func (r *k8sWorkloadResolver) NumberOfInstances(ctx context.Context, obj *model.
 	if err != nil {
 		return nil, err
 	}
+	if workloadManifest == nil {
+		return nil, nil
+	}
 	count := int(workloadManifest.AvailableReplicas)
 	return &count, nil
 }

--- a/frontend/services/config.go
+++ b/frontend/services/config.go
@@ -2,188 +2,81 @@ package services
 
 import (
 	"context"
-	"errors"
+	"encoding/json"
 	"fmt"
-	"log"
 
-	"github.com/odigos-io/odigos/api/k8sconsts"
 	"github.com/odigos-io/odigos/common"
 	"github.com/odigos-io/odigos/common/consts"
+	"github.com/odigos-io/odigos/config"
 	"github.com/odigos-io/odigos/frontend/graph/model"
-	"github.com/odigos-io/odigos/frontend/kube"
 	"github.com/odigos-io/odigos/k8sutils/pkg/env"
-	"github.com/odigos-io/odigos/k8sutils/pkg/installationmethod"
 
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
 
-type InstallationStatus string
+func GetConfigYamls() ([]*model.ConfigYaml, error) {
+	var resp []*model.ConfigYaml
 
-const (
-	NewInstallation InstallationStatus = "NEW"
-	Finished        InstallationStatus = "FINISHED"
-)
+	for _, cfg := range config.Get() {
+		var fields []*model.ConfigYamlField
+		for _, f := range cfg.Spec.Fields {
+			field := &model.ConfigYamlField{
+				DisplayName:   f.DisplayName,
+				ComponentType: model.FieldType(f.ComponentType),
+				IsHelmOnly:    f.IsHelmOnly,
+				Description:   f.Description,
+				HelmValuePath: f.HelmValuePath,
+			}
 
-var (
-	ErrorIsReadonly = errors.New("cannot execute this mutation in readonly mode")
-)
+			if f.DocsLink != "" {
+				field.DocsLink = &f.DocsLink
+			}
 
-func GetConfig(ctx context.Context) model.Config {
-	odigosDeployment, err := kube.DefaultClient.CoreV1().ConfigMaps(env.GetCurrentNamespace()).Get(ctx, k8sconsts.OdigosDeploymentConfigMapName, metav1.GetOptions{})
-	if err != nil {
-		// assign default values (should not happen in production, but we want to be safe)
-		odigosDeployment = &corev1.ConfigMap{}
-		odigosDeployment.Data = map[string]string{
-			k8sconsts.OdigosDeploymentConfigMapTierKey:               string(common.CommunityOdigosTier),
-			k8sconsts.OdigosDeploymentConfigMapInstallationMethodKey: string(installationmethod.K8sInstallationMethodOdigosCli),
+			if len(f.ComponentProps) > 0 {
+				propsJSON, err := json.Marshal(f.ComponentProps)
+				if err != nil {
+					return nil, fmt.Errorf("failed to marshal component props: %w", err)
+				}
+				s := string(propsJSON)
+				field.ComponentProps = &s
+			}
+
+			fields = append(fields, field)
 		}
+
+		resp = append(resp, &model.ConfigYaml{
+			Name:        cfg.Metadata.Name,
+			DisplayName: cfg.Metadata.DisplayName,
+			Fields:      fields,
+		})
 	}
 
-	response := buildConfigResponse(ctx, odigosDeployment.Data)
-
-	return response
+	return resp, nil
 }
 
-func buildConfigResponse(ctx context.Context, deploymentData map[string]string) model.Config {
-	var response model.Config
-	config, err := GetOdigosConfiguration(ctx)
-	if err != nil {
-		log.Printf("Failed to get Config map: %v\n", err)
-	}
-	response.Readonly = config.UiMode == common.UiModeReadonly
-	response.PlatformType = model.ComputePlatformTypeK8s
-	response.Tier = model.Tier(deploymentData[k8sconsts.OdigosDeploymentConfigMapTierKey])
-	response.OdigosVersion = deploymentData[k8sconsts.OdigosDeploymentConfigMapVersionKey]
-	response.InstallationMethod = string(deploymentData[k8sconsts.OdigosDeploymentConfigMapInstallationMethodKey])
-	response.ClusterName = &config.ClusterName
-	isConnected, err := isCentralProxyRunning(ctx)
-	if err != nil {
-		log.Printf("Error checking if central proxy connected: %v\n", err)
-	}
-	configured := isConfiguredForCentralBackend(common.OdigosTier(response.Tier), &config.ClusterName, config)
-	if configured && isConnected {
-		response.IsCentralProxyRunning = &isConnected
-	} else {
-		response.IsCentralProxyRunning = nil
-	}
-	response.InstallationStatus = getInstallationStatus(ctx, deploymentData)
-	return response
-}
-
-func GetOdigosConfiguration(ctx context.Context) (*common.OdigosConfiguration, error) {
+// GetEffectiveConfigWithRawYAML retrieves the effective config along with its raw YAML representation.
+func GetEffectiveConfigWithRawYAML(ctx context.Context, c client.Client) (*common.OdigosConfiguration, string, error) {
 	ns := env.GetCurrentNamespace()
 
-	configMap, err := kube.DefaultClient.CoreV1().ConfigMaps(ns).Get(ctx, consts.OdigosEffectiveConfigName, metav1.GetOptions{})
+	var cm v1.ConfigMap
+	err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: consts.OdigosEffectiveConfigName}, &cm)
 	if err != nil {
-		log.Printf("Error getting config maps: %v\n", err)
-		return nil, err
+		return nil, "", client.IgnoreNotFound(err)
 	}
 
-	var odigosConfiguration common.OdigosConfiguration
-	if err := yaml.Unmarshal([]byte(configMap.Data[consts.OdigosConfigurationFileName]), &odigosConfiguration); err != nil {
-		log.Printf("Error parsing YAML from ConfigMap %s: %v\n", configMap.Name, err)
-		return nil, err
+	if cm.Data == nil || cm.Data[consts.OdigosConfigurationFileName] == "" {
+		return nil, "", nil
 	}
 
-	return &odigosConfiguration, nil
-}
+	rawYAML := cm.Data[consts.OdigosConfigurationFileName]
 
-func IsReadonlyMode(ctx context.Context) bool {
-	config, err := GetOdigosConfiguration(ctx)
-	if err != nil {
-		return false
+	var odigosConfig common.OdigosConfiguration
+	if err := yaml.Unmarshal([]byte(rawYAML), &odigosConfig); err != nil {
+		return nil, "", fmt.Errorf("failed to parse odigos config: %w", err)
 	}
 
-	return config.UiMode == common.UiModeReadonly
-}
-
-func isConfiguredForCentralBackend(tier common.OdigosTier, clusterName *string, config *common.OdigosConfiguration) bool {
-	if tier != common.OnPremOdigosTier {
-		return false
-	}
-
-	if clusterName == nil || *clusterName == "" {
-		return false
-	}
-
-	if config.CentralBackendURL == "" {
-		return false
-	}
-	return true
-}
-
-func isCentralProxyRunning(ctx context.Context) (bool, error) {
-	ns := env.GetCurrentNamespace()
-	deployment, err := kube.DefaultClient.AppsV1().Deployments(ns).Get(ctx, k8sconsts.CentralProxyDeploymentName, metav1.GetOptions{})
-	if err != nil {
-		log.Printf("Central proxy deployment not found: %v\n", err)
-		return false, nil
-	}
-	if deployment.Status.AvailableReplicas == 0 {
-		return false, nil
-	}
-	return true, nil
-}
-
-// getInstallationStatus reads the installation status from the already-fetched
-// odigos-deployment ConfigMap data. If not yet persisted, it computes the status
-// from cluster state and persists the result for future calls.
-func getInstallationStatus(ctx context.Context, deploymentData map[string]string) model.InstallationStatus {
-	if status := deploymentData[k8sconsts.OdigosDeploymentConfigMapInstallationStatusKey]; status != "" {
-		return model.InstallationStatus(status)
-	}
-
-	// Compute from cluster state and persist the result
-	computed := string(NewInstallation)
-	if isSourceCreated(ctx) || isDestinationConnected(ctx) {
-		computed = string(Finished)
-	}
-
-	if err := persistInstallationStatus(ctx, computed); err != nil {
-		log.Printf("Error persisting installation status: %v\n", err)
-	}
-	return model.InstallationStatus(computed)
-}
-
-func MarkInstallationFinished(ctx context.Context) {
-	if err := persistInstallationStatus(ctx, string(Finished)); err != nil {
-		log.Printf("Error marking installation as finished: %v\n", err)
-	}
-}
-
-func persistInstallationStatus(ctx context.Context, status string) error {
-	ns := env.GetCurrentNamespace()
-	cm, err := kube.DefaultClient.CoreV1().ConfigMaps(ns).Get(ctx, k8sconsts.OdigosDeploymentConfigMapName, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to get odigos-deployment: %w", err)
-	}
-	if cm.Data == nil {
-		cm.Data = make(map[string]string)
-	}
-	cm.Data[k8sconsts.OdigosDeploymentConfigMapInstallationStatusKey] = status
-	_, err = kube.DefaultClient.CoreV1().ConfigMaps(ns).Update(ctx, cm, metav1.UpdateOptions{})
-	return err
-}
-
-func isSourceCreated(ctx context.Context) bool {
-	sourceList, err := kube.DefaultClient.OdigosClient.Sources("").List(ctx, metav1.ListOptions{Limit: 1})
-	if err != nil {
-		return false
-	}
-
-	return len(sourceList.Items) > 0
-}
-
-func isDestinationConnected(ctx context.Context) bool {
-	ns := env.GetCurrentNamespace()
-
-	dests, err := kube.DefaultClient.OdigosClient.Destinations(ns).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		log.Printf("Error listing destinations: %v\n", err)
-		return false
-	}
-
-	return len(dests.Items) > 0
+	return &odigosConfig, rawYAML, nil
 }

--- a/frontend/services/deployment_config.go
+++ b/frontend/services/deployment_config.go
@@ -1,0 +1,182 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/odigos-io/odigos/api/k8sconsts"
+	"github.com/odigos-io/odigos/common"
+	"github.com/odigos-io/odigos/common/consts"
+	"github.com/odigos-io/odigos/frontend/graph/model"
+	"github.com/odigos-io/odigos/frontend/kube"
+	"github.com/odigos-io/odigos/k8sutils/pkg/env"
+	"github.com/odigos-io/odigos/k8sutils/pkg/installationmethod"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+type InstallationStatus string
+
+const (
+	NewInstallation InstallationStatus = "NEW"
+	Finished        InstallationStatus = "FINISHED"
+)
+
+var (
+	ErrorIsReadonly = errors.New("cannot execute this mutation in readonly mode")
+)
+
+func GetConfig(ctx context.Context) model.Config {
+	odigosDeployment, err := kube.DefaultClient.CoreV1().ConfigMaps(env.GetCurrentNamespace()).Get(ctx, k8sconsts.OdigosDeploymentConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		odigosDeployment = &corev1.ConfigMap{}
+		odigosDeployment.Data = map[string]string{
+			k8sconsts.OdigosDeploymentConfigMapTierKey:               string(common.CommunityOdigosTier),
+			k8sconsts.OdigosDeploymentConfigMapInstallationMethodKey: string(installationmethod.K8sInstallationMethodOdigosCli),
+		}
+	}
+
+	return buildConfigResponse(ctx, odigosDeployment.Data)
+}
+
+func buildConfigResponse(ctx context.Context, deploymentData map[string]string) model.Config {
+	var response model.Config
+	config, err := GetOdigosConfiguration(ctx)
+	if err != nil {
+		log.Printf("Failed to get Config map: %v\n", err)
+	}
+	response.Readonly = config.UiMode == common.UiModeReadonly
+	response.PlatformType = model.ComputePlatformTypeK8s
+	response.Tier = model.Tier(deploymentData[k8sconsts.OdigosDeploymentConfigMapTierKey])
+	response.OdigosVersion = deploymentData[k8sconsts.OdigosDeploymentConfigMapVersionKey]
+	response.InstallationMethod = string(deploymentData[k8sconsts.OdigosDeploymentConfigMapInstallationMethodKey])
+	response.ClusterName = &config.ClusterName
+	isConnected, err := isCentralProxyRunning(ctx)
+	if err != nil {
+		log.Printf("Error checking if central proxy connected: %v\n", err)
+	}
+	configured := isConfiguredForCentralBackend(common.OdigosTier(response.Tier), &config.ClusterName, config)
+	if configured && isConnected {
+		response.IsCentralProxyRunning = &isConnected
+	} else {
+		response.IsCentralProxyRunning = nil
+	}
+	response.InstallationStatus = getInstallationStatus(ctx, deploymentData)
+	return response
+}
+
+func GetOdigosConfiguration(ctx context.Context) (*common.OdigosConfiguration, error) {
+	ns := env.GetCurrentNamespace()
+
+	configMap, err := kube.DefaultClient.CoreV1().ConfigMaps(ns).Get(ctx, consts.OdigosEffectiveConfigName, metav1.GetOptions{})
+	if err != nil {
+		log.Printf("Error getting config maps: %v\n", err)
+		return nil, err
+	}
+
+	var odigosConfiguration common.OdigosConfiguration
+	if err := yaml.Unmarshal([]byte(configMap.Data[consts.OdigosConfigurationFileName]), &odigosConfiguration); err != nil {
+		log.Printf("Error parsing YAML from ConfigMap %s: %v\n", configMap.Name, err)
+		return nil, err
+	}
+
+	return &odigosConfiguration, nil
+}
+
+func IsReadonlyMode(ctx context.Context) bool {
+	config, err := GetOdigosConfiguration(ctx)
+	if err != nil {
+		return false
+	}
+
+	return config.UiMode == common.UiModeReadonly
+}
+
+func isConfiguredForCentralBackend(tier common.OdigosTier, clusterName *string, config *common.OdigosConfiguration) bool {
+	if tier != common.OnPremOdigosTier {
+		return false
+	}
+
+	if clusterName == nil || *clusterName == "" {
+		return false
+	}
+
+	if config.CentralBackendURL == "" {
+		return false
+	}
+	return true
+}
+
+func isCentralProxyRunning(ctx context.Context) (bool, error) {
+	ns := env.GetCurrentNamespace()
+	deployment, err := kube.DefaultClient.AppsV1().Deployments(ns).Get(ctx, k8sconsts.CentralProxyDeploymentName, metav1.GetOptions{})
+	if err != nil {
+		log.Printf("Central proxy deployment not found: %v\n", err)
+		return false, nil
+	}
+	if deployment.Status.AvailableReplicas == 0 {
+		return false, nil
+	}
+	return true, nil
+}
+
+func getInstallationStatus(ctx context.Context, deploymentData map[string]string) model.InstallationStatus {
+	if status := deploymentData[k8sconsts.OdigosDeploymentConfigMapInstallationStatusKey]; status != "" {
+		return model.InstallationStatus(status)
+	}
+
+	computed := string(NewInstallation)
+	if isSourceCreated(ctx) || isDestinationConnected(ctx) {
+		computed = string(Finished)
+	}
+
+	if err := persistInstallationStatus(ctx, computed); err != nil {
+		log.Printf("Error persisting installation status: %v\n", err)
+	}
+	return model.InstallationStatus(computed)
+}
+
+func MarkInstallationFinished(ctx context.Context) {
+	if err := persistInstallationStatus(ctx, string(Finished)); err != nil {
+		log.Printf("Error marking installation as finished: %v\n", err)
+	}
+}
+
+func persistInstallationStatus(ctx context.Context, status string) error {
+	ns := env.GetCurrentNamespace()
+	cm, err := kube.DefaultClient.CoreV1().ConfigMaps(ns).Get(ctx, k8sconsts.OdigosDeploymentConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get odigos-deployment: %w", err)
+	}
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+	cm.Data[k8sconsts.OdigosDeploymentConfigMapInstallationStatusKey] = status
+	_, err = kube.DefaultClient.CoreV1().ConfigMaps(ns).Update(ctx, cm, metav1.UpdateOptions{})
+	return err
+}
+
+func isSourceCreated(ctx context.Context) bool {
+	sourceList, err := kube.DefaultClient.OdigosClient.Sources("").List(ctx, metav1.ListOptions{Limit: 1})
+	if err != nil {
+		return false
+	}
+
+	return len(sourceList.Items) > 0
+}
+
+func isDestinationConnected(ctx context.Context) bool {
+	ns := env.GetCurrentNamespace()
+
+	dests, err := kube.DefaultClient.OdigosClient.Destinations(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		log.Printf("Error listing destinations: %v\n", err)
+		return false
+	}
+
+	return len(dests.Items) > 0
+}

--- a/frontend/services/log_level.go
+++ b/frontend/services/log_level.go
@@ -2,73 +2,18 @@ package services
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/odigos-io/odigos/api/k8sconsts"
 	"github.com/odigos-io/odigos/common"
-	"github.com/odigos-io/odigos/common/consts"
 	commonlogger "github.com/odigos-io/odigos/common/logger"
-	"github.com/odigos-io/odigos/k8sutils/pkg/env"
-	v1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/yaml"
 )
 
 func SetComponentLogLevel(ctx context.Context, c client.Client, component string, level common.OdigosLogLevel) error {
-	ns := env.GetCurrentNamespace()
-	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		var cm v1.ConfigMap
-		if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: consts.OdigosLocalUiConfigName}, &cm); err != nil {
-			if apierrors.IsNotFound(err) {
-				// Create odigos-local-ui-config if missing (e.g. first time setting log level from UI).
-				ownerCm := v1.ConfigMap{}
-				if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: consts.OdigosConfigurationName}, &ownerCm); err != nil {
-					return fmt.Errorf("failed to get odigos-configuration for owner reference: %w", err)
-				}
-				cfg := common.OdigosConfiguration{ComponentLogLevels: &common.ComponentLogLevels{}}
-				setComponentLogLevelField(cfg.ComponentLogLevels, component, level)
-				data, marshalErr := yaml.Marshal(cfg)
-				if marshalErr != nil {
-					return marshalErr
-				}
-				newCm := v1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      consts.OdigosLocalUiConfigName,
-						Namespace: ns,
-						Labels:    map[string]string{k8sconsts.OdigosSystemConfigLabelKey: "local-ui"},
-						OwnerReferences: []metav1.OwnerReference{{
-							APIVersion: "v1", Kind: "ConfigMap", Name: ownerCm.Name, UID: ownerCm.UID,
-						}},
-					},
-					Data: map[string]string{consts.OdigosConfigurationFileName: string(data)},
-				}
-				return c.Create(ctx, &newCm)
-			}
-			return err
-		}
-		var cfg common.OdigosConfiguration
-		if cm.Data != nil && cm.Data[consts.OdigosConfigurationFileName] != "" {
-			if err := yaml.Unmarshal([]byte(cm.Data[consts.OdigosConfigurationFileName]), &cfg); err != nil {
-				return fmt.Errorf("parse existing config: %w", err)
-			}
-		}
+	err := upsertLocalUiConfig(ctx, c, func(cfg *common.OdigosConfiguration) {
 		if cfg.ComponentLogLevels == nil {
 			cfg.ComponentLogLevels = &common.ComponentLogLevels{}
 		}
 		setComponentLogLevelField(cfg.ComponentLogLevels, component, level)
-		data, err := yaml.Marshal(cfg)
-		if err != nil {
-			return err
-		}
-		if cm.Data == nil {
-			cm.Data = make(map[string]string)
-		}
-		cm.Data[consts.OdigosConfigurationFileName] = string(data)
-		return c.Update(ctx, &cm)
 	})
 	if err != nil {
 		return err

--- a/frontend/services/odigos_config.go
+++ b/frontend/services/odigos_config.go
@@ -2,16 +2,16 @@ package services
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
+	"github.com/odigos-io/odigos/api/k8sconsts"
 	"github.com/odigos-io/odigos/common"
 	"github.com/odigos-io/odigos/common/consts"
-	"github.com/odigos-io/odigos/config"
-	"github.com/odigos-io/odigos/frontend/graph/model"
 	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -41,8 +41,7 @@ func getOdigosConfigFromConfigMap(ctx context.Context, c client.Client, configMa
 
 // GetEffectiveConfig retrieves the current effective configuration from the effective-config ConfigMap.
 func GetEffectiveConfig(ctx context.Context, c client.Client) (*common.OdigosConfiguration, error) {
-	config, _, err := GetEffectiveConfigWithRawYAML(ctx, c)
-	return config, err
+	return getOdigosConfigFromConfigMap(ctx, c, consts.OdigosEffectiveConfigName)
 }
 
 // GetHelmDeploymentConfig retrieves the current helm deployment configuration from the odigos-helm-deployment-config ConfigMap.
@@ -60,89 +59,62 @@ func GetLocalUIConfig(ctx context.Context, c client.Client) (*common.OdigosConfi
 	return getOdigosConfigFromConfigMap(ctx, c, consts.OdigosLocalUiConfigName)
 }
 
-func GetConfigYamls() ([]*model.ConfigYaml, error) {
-	var resp []*model.ConfigYaml
-
-	for _, cfg := range config.Get() {
-		var fields []*model.ConfigYamlField
-		for _, f := range cfg.Spec.Fields {
-			field := &model.ConfigYamlField{
-				DisplayName:   f.DisplayName,
-				ComponentType: model.FieldType(f.ComponentType),
-				IsHelmOnly:    f.IsHelmOnly,
-				Description:   f.Description,
-				HelmValuePath: f.HelmValuePath,
-			}
-
-			if f.DocsLink != "" {
-				field.DocsLink = &f.DocsLink
-			}
-
-			if len(f.ComponentProps) > 0 {
-				propsJSON, err := json.Marshal(f.ComponentProps)
-				if err != nil {
-					return nil, fmt.Errorf("failed to marshal component props: %w", err)
-				}
-				s := string(propsJSON)
-				field.ComponentProps = &s
-			}
-
-			fields = append(fields, field)
-		}
-
-		resp = append(resp, &model.ConfigYaml{
-			Name:        cfg.Metadata.Name,
-			DisplayName: cfg.Metadata.DisplayName,
-			Fields:      fields,
-		})
-	}
-
-	return resp, nil
-}
-
-// GetEffectiveConfigWithRawYAML retrieves the effective config along with its raw YAML representation.
-func GetEffectiveConfigWithRawYAML(ctx context.Context, c client.Client) (*common.OdigosConfiguration, string, error) {
-	ns := env.GetCurrentNamespace()
-
-	var cm v1.ConfigMap
-	err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: consts.OdigosEffectiveConfigName}, &cm)
-	if err != nil {
-		return nil, "", client.IgnoreNotFound(err)
-	}
-
-	if cm.Data == nil || cm.Data[consts.OdigosConfigurationFileName] == "" {
-		return nil, "", nil
-	}
-
-	rawYAML := cm.Data[consts.OdigosConfigurationFileName]
-
-	var odigosConfig common.OdigosConfiguration
-	if err := yaml.Unmarshal([]byte(rawYAML), &odigosConfig); err != nil {
-		return nil, "", fmt.Errorf("failed to parse odigos config: %w", err)
-	}
-
-	return &odigosConfig, rawYAML, nil
-}
-
-func PersistUiLocalSamplingConfig(ctx context.Context, c client.Client, samplingConfig *common.SamplingConfiguration) error {
+// upsertLocalUiConfig applies a mutation to the odigos-local-ui-config ConfigMap,
+// creating it with proper owner references if it does not yet exist.
+func upsertLocalUiConfig(ctx context.Context, c client.Client, mutate func(cfg *common.OdigosConfiguration)) error {
 	ns := env.GetCurrentNamespace()
 
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		var cm v1.ConfigMap
-		err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: consts.OdigosLocalUiConfigName}, &cm)
+		if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: consts.OdigosLocalUiConfigName}, &cm); err != nil {
+			if apierrors.IsNotFound(err) {
+				ownerCm := v1.ConfigMap{}
+				if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: consts.OdigosConfigurationName}, &ownerCm); err != nil {
+					return fmt.Errorf("failed to get odigos-configuration for owner reference: %w", err)
+				}
+				cfg := common.OdigosConfiguration{}
+				mutate(&cfg)
+				data, marshalErr := yaml.Marshal(cfg)
+				if marshalErr != nil {
+					return marshalErr
+				}
+				newCm := v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      consts.OdigosLocalUiConfigName,
+						Namespace: ns,
+						Labels:    map[string]string{k8sconsts.OdigosSystemConfigLabelKey: "local-ui"},
+						OwnerReferences: []metav1.OwnerReference{{
+							APIVersion: "v1", Kind: "ConfigMap", Name: ownerCm.Name, UID: ownerCm.UID,
+						}},
+					},
+					Data: map[string]string{consts.OdigosConfigurationFileName: string(data)},
+				}
+				return c.Create(ctx, &newCm)
+			}
+			return err
+		}
+
+		var cfg common.OdigosConfiguration
+		if cm.Data != nil && cm.Data[consts.OdigosConfigurationFileName] != "" {
+			if err := yaml.Unmarshal([]byte(cm.Data[consts.OdigosConfigurationFileName]), &cfg); err != nil {
+				return fmt.Errorf("parse existing config: %w", err)
+			}
+		}
+		mutate(&cfg)
+		data, err := yaml.Marshal(cfg)
 		if err != nil {
 			return err
 		}
-		config := common.OdigosConfiguration{}
-		if err := yaml.Unmarshal([]byte(cm.Data[consts.OdigosConfigurationFileName]), &config); err != nil {
-			return err
+		if cm.Data == nil {
+			cm.Data = make(map[string]string)
 		}
-		config.Sampling = samplingConfig
-		yamlText, err := yaml.Marshal(config)
-		if err != nil {
-			return err
-		}
-		cm.Data[consts.OdigosConfigurationFileName] = string(yamlText)
+		cm.Data[consts.OdigosConfigurationFileName] = string(data)
 		return c.Update(ctx, &cm)
+	})
+}
+
+func PersistUiLocalSamplingConfig(ctx context.Context, c client.Client, samplingConfig *common.SamplingConfiguration) error {
+	return upsertLocalUiConfig(ctx, c, func(cfg *common.OdigosConfiguration) {
+		cfg.Sampling = samplingConfig
 	})
 }

--- a/frontend/services/sampling/conversions.go
+++ b/frontend/services/sampling/conversions.go
@@ -97,7 +97,7 @@ func sourcesScopeInputToCRD(scopes []*model.SourcesScopeInput) []k8sconsts.Sourc
 			WorkloadName:      services.DerefString(s.WorkloadName),
 			WorkloadKind:      services.DerefK8sResourceKind(s.WorkloadKind),
 			WorkloadNamespace: services.DerefString(s.WorkloadNamespace),
-			WorkloadLanguage:  services.DerefProgrammingLanguage(s.WorkloadLanguage),
+			WorkloadLanguage:  services.DerefSamplingWorkloadLanguage(s.WorkloadLanguage),
 		}
 	}
 	return result
@@ -113,7 +113,7 @@ func sourcesScopeCRDToModel(scopes []k8sconsts.SourcesScope) []*model.SourcesSco
 			WorkloadName:      services.StringPtrIfNotEmpty(s.WorkloadName),
 			WorkloadKind:      services.K8sResourceKindPtrIfNotEmpty(s.WorkloadKind),
 			WorkloadNamespace: services.StringPtrIfNotEmpty(s.WorkloadNamespace),
-			WorkloadLanguage:  services.ProgrammingLanguagePtrIfNotEmpty(s.WorkloadLanguage),
+			WorkloadLanguage:  services.SamplingWorkloadLanguagePtrIfNotEmpty(s.WorkloadLanguage),
 		}
 	}
 	return result

--- a/frontend/services/sampling/sampling_rules.go
+++ b/frontend/services/sampling/sampling_rules.go
@@ -9,6 +9,7 @@ import (
 	"github.com/odigos-io/odigos/frontend/kube"
 	"github.com/odigos-io/odigos/frontend/services"
 	"github.com/odigos-io/odigos/k8sutils/pkg/env"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -22,6 +23,34 @@ func getSamplingCRByID(ctx context.Context, samplingID string) (*v1alpha1.Sampli
 		return nil, fmt.Errorf("sampling CR %q not found: %w", samplingID, err)
 	}
 	return &cr, nil
+}
+
+func getOrCreateSamplingCR(ctx context.Context, samplingID string) (*v1alpha1.Sampling, error) {
+	cr, err := getSamplingCRByID(ctx, samplingID)
+	if err == nil {
+		return cr, nil
+	}
+
+	odigosNs := env.GetCurrentNamespace()
+
+	if !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+
+	newCR := &v1alpha1.Sampling{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      samplingID,
+			Namespace: odigosNs,
+		},
+		Spec: v1alpha1.SamplingSpec{
+			Name: samplingID,
+		},
+	}
+	created, createErr := kube.DefaultClient.OdigosClient.Samplings(odigosNs).Create(ctx, newCR, metav1.CreateOptions{})
+	if createErr != nil {
+		return nil, fmt.Errorf("failed to create sampling CR %q: %w", samplingID, createErr)
+	}
+	return created, nil
 }
 
 func updateSamplingCR(ctx context.Context, cr *v1alpha1.Sampling) (*v1alpha1.Sampling, error) {
@@ -83,7 +112,7 @@ func CreateNoisyOperationRule(ctx context.Context, samplingID string, input mode
 	var result *model.NoisyOperationRule
 
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		cr, err := getSamplingCRByID(ctx, samplingID)
+		cr, err := getOrCreateSamplingCR(ctx, samplingID)
 		if err != nil {
 			return err
 		}
@@ -156,7 +185,7 @@ func CreateHighlyRelevantOperationRule(ctx context.Context, samplingID string, i
 	var result *model.HighlyRelevantOperationRule
 
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		cr, err := getSamplingCRByID(ctx, samplingID)
+		cr, err := getOrCreateSamplingCR(ctx, samplingID)
 		if err != nil {
 			return err
 		}
@@ -229,7 +258,7 @@ func CreateCostReductionRule(ctx context.Context, samplingID string, input model
 	var result *model.CostReductionRule
 
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		cr, err := getSamplingCRByID(ctx, samplingID)
+		cr, err := getOrCreateSamplingCR(ctx, samplingID)
 		if err != nil {
 			return err
 		}

--- a/frontend/services/utils.go
+++ b/frontend/services/utils.go
@@ -160,6 +160,21 @@ func ProgrammingLanguagePtrIfNotEmpty(p common.ProgrammingLanguage) *model.Progr
 	return &pl
 }
 
+func DerefSamplingWorkloadLanguage(p *model.SamplingWorkloadLanguage) common.ProgrammingLanguage {
+	if p != nil {
+		return common.ProgrammingLanguage(*p)
+	}
+	return ""
+}
+
+func SamplingWorkloadLanguagePtrIfNotEmpty(p common.ProgrammingLanguage) *model.SamplingWorkloadLanguage {
+	if p == "" {
+		return nil
+	}
+	lang := model.SamplingWorkloadLanguage(p)
+	return &lang
+}
+
 func Metav1TimeToString(latestStatusTime metav1.Time) string {
 	if latestStatusTime.IsZero() {
 		return ""

--- a/frontend/webapp/app/(v2)/layout.tsx
+++ b/frontend/webapp/app/(v2)/layout.tsx
@@ -2,6 +2,7 @@
 
 import React, { type PropsWithChildren, useEffect } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
+import styled from 'styled-components';
 import { getNavbarIcons } from '@/utils';
 import { OverviewHeader } from '@/components';
 import { useDarkMode } from '@odigos/ui-kit/store';
@@ -10,6 +11,16 @@ import { ToastList } from '@odigos/ui-kit/containers';
 import { OdigosProvider } from '@odigos/ui-kit/contexts';
 import { useConfig, useSSE, useTokenTracker } from '@/hooks';
 import { ErrorBoundary, FlexColumn, FlexRow } from '@odigos/ui-kit/components';
+
+const ViewportColumn = styled(FlexColumn)`
+  height: 100vh;
+  overflow: hidden;
+`;
+
+const ContentRow = styled(FlexRow)`
+  flex: 1;
+  min-height: 0;
+`;
 
 function OverviewLayout({ children }: PropsWithChildren) {
   // call important hooks that should run on page-mount
@@ -30,13 +41,13 @@ function OverviewLayout({ children }: PropsWithChildren) {
   return (
     <ErrorBoundary>
       <OdigosProvider platformType={config?.platformType} tier={config?.tier} version={config?.odigosVersion || ''}>
-        <FlexColumn $gap={0}>
+        <ViewportColumn $gap={0}>
           <OverviewHeader v2 />
-          <FlexRow $gap={0}>
+          <ContentRow $gap={0}>
             <Navbar height='calc(100vh - 60px)' icons={getNavbarIcons(router, pathname)} />
             {children}
-          </FlexRow>
-        </FlexColumn>
+          </ContentRow>
+        </ViewportColumn>
 
         <ToastList />
       </OdigosProvider>

--- a/frontend/webapp/app/(v2)/sampling/constants.ts
+++ b/frontend/webapp/app/(v2)/sampling/constants.ts
@@ -1,0 +1,19 @@
+export const DOCS_URL = 'https://docs.odigos.io/sampling';
+
+export const PAGE_TITLE = 'Sampling Rules';
+export const PAGE_DESCRIPTION = 'Control how traces are categorized based on "Importance" and potential value, for fine grain control of what is kept and what is dropped.';
+
+export const BTN_SAMPLING_DOCS = 'Sampling docs';
+export const BTN_REFRESH = 'Refresh';
+export const BTN_CREATE_RULE = 'Create rule';
+
+export const DELETE_MODAL_TITLE = 'Delete rule?';
+export const DELETE_MODAL_DESCRIPTION = 'Are you sure you want to delete this sampling rule?';
+export const DELETE_MODAL_APPROVE = 'Delete';
+export const DELETE_MODAL_CANCEL = 'Cancel';
+
+export const AUTO_RULE_TITLE = 'Auto rule - Kubernetes Health Probes';
+export const HIGHLY_RELEVANT_AUTO_RULE_TITLE = 'Auto rule - Keep All Error Traces';
+export const COST_REDUCTION_AUTO_RULE_TITLE = 'Auto rule - Drop Traces Cluster-Wide';
+
+export const DUPLICATE_RULE_WARNING = 'A rule with the same matching conditions already exists.';

--- a/frontend/webapp/app/(v2)/sampling/page.tsx
+++ b/frontend/webapp/app/(v2)/sampling/page.tsx
@@ -1,0 +1,491 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useQuery } from '@apollo/client';
+import { GET_WORKLOADS } from '@/graphql';
+import { useSamplingRuleCRUD } from '@/hooks';
+import styled from 'styled-components';
+import { FlexColumn, FlexRow, PageContent } from '@odigos/ui-kit/components';
+import { PlusIcon, RefreshIcon, SamplingIcon } from '@odigos/ui-kit/icons';
+import {
+  RichTitle,
+  AutoRuleCard,
+  buildAutoRuleSummary,
+  findHighlyRelevantAutoRule,
+  buildHighlyRelevantAutoRuleSummary,
+  findCostReductionAutoRule,
+  buildCostReductionAutoRuleSummary,
+  EditAutoRuleDrawer,
+  EditHighlyRelevantAutoRuleDrawer,
+  EditCostReductionAutoRuleDrawer,
+  SamplingRulesList,
+  ViewSamplingRuleDrawer,
+  CreateSamplingRuleDrawer,
+  formStateToNoisyInput,
+  formStateToHighlyRelevantInput,
+  formStateToCostReductionInput,
+  findDuplicateRuleId,
+  type DuplicateValidationResult,
+  SamplingCategory,
+  SAMPLING_SEGMENT_OPTIONS,
+  SAMPLING_CATEGORY_NOTES,
+  SAMPLING_CATEGORY_LIST_TITLES,
+  CATEGORY_TO_RULE_CATEGORY,
+  buildSamplingRuleItems,
+  buildSummaryForRule,
+  refreshViewRuleData,
+  lookupViewRuleData,
+  type ViewRuleData,
+  type SamplingRuleItem,
+  type SamplingRuleFormState,
+} from '@odigos/ui-kit/containers/v2';
+import { StatusType } from '@odigos/ui-kit/types';
+import { PAGE_TITLE, PAGE_DESCRIPTION, BTN_REFRESH, BTN_CREATE_RULE, DELETE_MODAL_TITLE, DELETE_MODAL_DESCRIPTION, DELETE_MODAL_APPROVE, DELETE_MODAL_CANCEL, AUTO_RULE_TITLE, HIGHLY_RELEVANT_AUTO_RULE_TITLE, COST_REDUCTION_AUTO_RULE_TITLE, DUPLICATE_RULE_WARNING } from './constants';
+import { Button, ButtonSize, ButtonVariants, Note, Segment, SegmentVariant, WarningModal } from '@odigos/ui-kit/components/v2';
+
+const Header = styled(FlexRow)`
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export default function Page() {
+  const {
+    samplingRules,
+    k8sHealthProbesConfig,
+    loading,
+    fetchSamplingRules,
+    createNoisyOperationRule,
+    updateNoisyOperationRule,
+    createHighlyRelevantOperationRule,
+    updateHighlyRelevantOperationRule,
+    createCostReductionRule,
+    updateCostReductionRule,
+    deleteSamplingRule,
+    updateK8sHealthProbesConfig,
+  } = useSamplingRuleCRUD();
+  const { data: workloadsData } = useQuery<{ workloads: { id: { namespace: string; kind: string; name: string } }[] }>(GET_WORKLOADS, {
+    variables: { filter: { markedForInstrumentation: true } },
+  });
+  const [selectedCategory, setSelectedCategory] = useState<SamplingCategory>(SamplingCategory.Noisy);
+  const [viewRuleData, setViewRuleData] = useState<ViewRuleData | null>(null);
+  const [viewEditMode, setViewEditMode] = useState(false);
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<{ ruleId: string; samplingId: string } | null>(null);
+  const [isAutoRuleDrawerOpen, setIsAutoRuleDrawerOpen] = useState(false);
+  const [isHRAutoRuleDrawerOpen, setIsHRAutoRuleDrawerOpen] = useState(false);
+  const [isCRAutoRuleDrawerOpen, setIsCRAutoRuleDrawerOpen] = useState(false);
+
+  const autoRuleSummary = useMemo(() => buildAutoRuleSummary(k8sHealthProbesConfig), [k8sHealthProbesConfig]);
+
+  const highlyRelevantAutoRule = useMemo(() => findHighlyRelevantAutoRule(samplingRules), [samplingRules]);
+  const highlyRelevantAutoSummary = useMemo(() => buildHighlyRelevantAutoRuleSummary(highlyRelevantAutoRule?.rule ?? null), [highlyRelevantAutoRule]);
+
+  const costReductionAutoRule = useMemo(() => findCostReductionAutoRule(samplingRules), [samplingRules]);
+  const costReductionAutoSummary = useMemo(() => buildCostReductionAutoRuleSummary(costReductionAutoRule?.rule ?? null), [costReductionAutoRule]);
+
+  const viewRuleRef = useRef(viewRuleData);
+  viewRuleRef.current = viewRuleData;
+
+  useEffect(() => {
+    const current = viewRuleRef.current;
+    if (!current) return;
+
+    const refreshed = refreshViewRuleData(samplingRules, current);
+    if (refreshed) {
+      setViewRuleData(refreshed);
+    } else {
+      setViewRuleData(null);
+      setViewEditMode(false);
+    }
+  }, [samplingRules]);
+
+  const excludeRuleIds = useMemo(() => {
+    const ids = new Set<string>();
+    if (highlyRelevantAutoRule) ids.add(highlyRelevantAutoRule.rule.ruleId);
+    if (costReductionAutoRule) ids.add(costReductionAutoRule.rule.ruleId);
+    return ids;
+  }, [highlyRelevantAutoRule, costReductionAutoRule]);
+
+  const ruleItems = useMemo(() => buildSamplingRuleItems(samplingRules, selectedCategory, excludeRuleIds), [samplingRules, selectedCategory, excludeRuleIds]);
+
+  const workloads = workloadsData?.workloads ?? [];
+
+  const sourceOptions = useMemo(() => workloads.map(({ id: w }) => ({ id: `${w.namespace}/${w.kind}/${w.name}`, label: `${w.namespace} / ${w.kind} / ${w.name}` })), [workloads]);
+
+  const namespaceOptions = useMemo(() => {
+    const unique = Array.from(new Set(workloads.map(({ id: w }) => w.namespace))).sort();
+    return unique.map((ns) => ({ id: ns, label: ns }));
+  }, [workloads]);
+
+  const handleCreateRule = useCallback(() => {
+    setIsCreateOpen(true);
+  }, []);
+
+  const handleCloseCreateDrawer = useCallback(() => {
+    setIsCreateOpen(false);
+  }, []);
+
+  const handleCreateSubmit = useCallback(
+    (formState: SamplingRuleFormState) => {
+      // Currently assumes a single sampling group; will become dynamic when multiple groups are supported.
+      const samplingId = samplingRules[0]?.id ?? 'default';
+
+      const category = CATEGORY_TO_RULE_CATEGORY[selectedCategory];
+      switch (category) {
+        case 'noisy':
+          createNoisyOperationRule(samplingId, formStateToNoisyInput(formState));
+          break;
+        case 'highlyRelevant':
+          createHighlyRelevantOperationRule(samplingId, formStateToHighlyRelevantInput(formState));
+          break;
+        case 'costReduction':
+          createCostReductionRule(samplingId, formStateToCostReductionInput(formState));
+          break;
+      }
+
+      setIsCreateOpen(false);
+    },
+    [samplingRules, selectedCategory, createNoisyOperationRule, createHighlyRelevantOperationRule, createCostReductionRule],
+  );
+
+  const handleRuleClick = useCallback(
+    (item: SamplingRuleItem) => {
+      const data = lookupViewRuleData(samplingRules, item);
+      if (data) {
+        setViewEditMode(false);
+        setViewRuleData(data);
+      }
+    },
+    [samplingRules],
+  );
+
+  const handleCloseDrawer = useCallback(() => {
+    setViewRuleData(null);
+    setViewEditMode(false);
+  }, []);
+
+  const handleEditRule = useCallback(
+    (ruleId: string, samplingId: string) => {
+      const existing = viewRuleData;
+      if (existing && existing.rule.ruleId === ruleId && existing.samplingId === samplingId) {
+        setViewEditMode(true);
+        setViewRuleData({ ...existing });
+      } else {
+        for (const group of samplingRules) {
+          if (group.id !== samplingId) continue;
+          const all = [
+            ...group.noisyOperations.map((r) => ({ category: 'noisy' as const, rule: r })),
+            ...group.highlyRelevantOperations.map((r) => ({ category: 'highlyRelevant' as const, rule: r })),
+            ...group.costReductionRules.map((r) => ({ category: 'costReduction' as const, rule: r })),
+          ];
+          const match = all.find((x) => x.rule.ruleId === ruleId);
+          if (match) {
+            setViewEditMode(true);
+            setViewRuleData({ category: match.category, rule: match.rule, samplingId, summary: buildSummaryForRule(match.category, match.rule) } as ViewRuleData);
+            return;
+          }
+        }
+      }
+    },
+    [viewRuleData, samplingRules],
+  );
+
+  const handleSaveEdit = useCallback(
+    (formState: SamplingRuleFormState, ruleId: string, samplingId: string) => {
+      const category = viewRuleData?.category;
+      if (!category) return;
+
+      switch (category) {
+        case 'noisy':
+          updateNoisyOperationRule(samplingId, ruleId, formStateToNoisyInput(formState));
+          break;
+        case 'highlyRelevant':
+          updateHighlyRelevantOperationRule(samplingId, ruleId, formStateToHighlyRelevantInput(formState));
+          break;
+        case 'costReduction':
+          updateCostReductionRule(samplingId, ruleId, formStateToCostReductionInput(formState));
+          break;
+      }
+
+      setViewEditMode(false);
+    },
+    [viewRuleData, updateNoisyOperationRule, updateHighlyRelevantOperationRule, updateCostReductionRule],
+  );
+
+  const handleDeleteRule = useCallback((ruleId: string, samplingId: string) => {
+    setDeleteTarget({ ruleId, samplingId });
+  }, []);
+
+  const confirmDelete = useCallback(() => {
+    if (!deleteTarget) return;
+    const { ruleId, samplingId } = deleteTarget;
+    const cat = viewRuleData?.category || CATEGORY_TO_RULE_CATEGORY[selectedCategory];
+
+    deleteSamplingRule(samplingId, ruleId, cat);
+    setViewRuleData(null);
+    setViewEditMode(false);
+    setDeleteTarget(null);
+  }, [deleteTarget, viewRuleData, selectedCategory, deleteSamplingRule]);
+
+  const handleCancelDelete = useCallback(() => {
+    setDeleteTarget(null);
+  }, []);
+
+  const handleEditAutoRule = useCallback(() => {
+    setIsAutoRuleDrawerOpen(true);
+  }, []);
+
+  const handleCloseAutoRuleDrawer = useCallback(() => {
+    setIsAutoRuleDrawerOpen(false);
+  }, []);
+
+  const handleSaveAutoRule = useCallback(
+    (enabled: boolean, keepPercentage: number) => {
+      updateK8sHealthProbesConfig(enabled, keepPercentage);
+      setIsAutoRuleDrawerOpen(false);
+    },
+    [updateK8sHealthProbesConfig],
+  );
+
+  const handleEditHRAutoRule = useCallback(() => {
+    setIsHRAutoRuleDrawerOpen(true);
+  }, []);
+
+  const handleCloseHRAutoRuleDrawer = useCallback(() => {
+    setIsHRAutoRuleDrawerOpen(false);
+  }, []);
+
+  const handleSaveHRAutoRule = useCallback(
+    (enabled: boolean) => {
+      const samplingId = samplingRules[0]?.id ?? 'default';
+      const existing = highlyRelevantAutoRule;
+
+      if (existing) {
+        updateHighlyRelevantOperationRule(existing.samplingId, existing.rule.ruleId, {
+          name: existing.rule.name,
+          disabled: !enabled,
+          error: true,
+          sourceScopes: [],
+          operation: null,
+          percentageAtLeast: null,
+          notes: existing.rule.notes,
+        });
+      } else if (enabled) {
+        createHighlyRelevantOperationRule(samplingId, {
+          name: 'Auto - Keep All Error Traces',
+          disabled: false,
+          error: true,
+          sourceScopes: [],
+          operation: null,
+          percentageAtLeast: null,
+        });
+      }
+
+      setIsHRAutoRuleDrawerOpen(false);
+    },
+    [samplingRules, highlyRelevantAutoRule, createHighlyRelevantOperationRule, updateHighlyRelevantOperationRule],
+  );
+
+  const handleEditCRAutoRule = useCallback(() => {
+    setIsCRAutoRuleDrawerOpen(true);
+  }, []);
+
+  const handleCloseCRAutoRuleDrawer = useCallback(() => {
+    setIsCRAutoRuleDrawerOpen(false);
+  }, []);
+
+  const handleSaveCRAutoRule = useCallback(
+    (enabled: boolean, dropPercentage: number) => {
+      const samplingId = samplingRules[0]?.id ?? 'default';
+      const existing = costReductionAutoRule;
+
+      if (existing) {
+        updateCostReductionRule(existing.samplingId, existing.rule.ruleId, {
+          name: existing.rule.name,
+          disabled: !enabled,
+          sourceScopes: [],
+          operation: null,
+          percentageAtMost: dropPercentage,
+          notes: existing.rule.notes,
+        });
+      } else if (enabled) {
+        createCostReductionRule(samplingId, {
+          name: 'Auto - Drop Traces Cluster-Wide',
+          disabled: false,
+          sourceScopes: [],
+          operation: null,
+          percentageAtMost: dropPercentage,
+        });
+      }
+
+      setIsCRAutoRuleDrawerOpen(false);
+    },
+    [samplingRules, costReductionAutoRule, createCostReductionRule, updateCostReductionRule],
+  );
+
+  const validateCreateForm = useCallback(
+    (formState: SamplingRuleFormState): DuplicateValidationResult | null => {
+      const category = CATEGORY_TO_RULE_CATEGORY[selectedCategory];
+      let dupId: string | null = null;
+      switch (category) {
+        case 'noisy': {
+          const input = formStateToNoisyInput(formState);
+          dupId = findDuplicateRuleId(samplingRules, category, { sourceScopes: input.sourceScopes, operation: input.operation });
+          break;
+        }
+        case 'highlyRelevant': {
+          const input = formStateToHighlyRelevantInput(formState);
+          dupId = findDuplicateRuleId(samplingRules, category, { sourceScopes: input.sourceScopes, operation: input.operation, error: input.error ?? false, durationAtLeastMs: input.durationAtLeastMs });
+          break;
+        }
+        case 'costReduction': {
+          const input = formStateToCostReductionInput(formState);
+          dupId = findDuplicateRuleId(samplingRules, category, { sourceScopes: input.sourceScopes, operation: input.operation });
+          break;
+        }
+      }
+      return dupId ? { message: DUPLICATE_RULE_WARNING, ruleId: dupId } : null;
+    },
+    [samplingRules, selectedCategory],
+  );
+
+  const validateEditForm = useCallback(
+    (formState: SamplingRuleFormState): DuplicateValidationResult | null => {
+      const category = viewRuleData?.category;
+      const excludeId = viewRuleData?.rule.ruleId;
+      if (!category) return null;
+
+      let dupId: string | null = null;
+      switch (category) {
+        case 'noisy': {
+          const input = formStateToNoisyInput(formState);
+          dupId = findDuplicateRuleId(samplingRules, category, { sourceScopes: input.sourceScopes, operation: input.operation }, excludeId);
+          break;
+        }
+        case 'highlyRelevant': {
+          const input = formStateToHighlyRelevantInput(formState);
+          dupId = findDuplicateRuleId(samplingRules, category, { sourceScopes: input.sourceScopes, operation: input.operation, error: input.error ?? false, durationAtLeastMs: input.durationAtLeastMs }, excludeId);
+          break;
+        }
+        case 'costReduction': {
+          const input = formStateToCostReductionInput(formState);
+          dupId = findDuplicateRuleId(samplingRules, category, { sourceScopes: input.sourceScopes, operation: input.operation }, excludeId);
+          break;
+        }
+      }
+      return dupId ? { message: DUPLICATE_RULE_WARNING, ruleId: dupId } : null;
+    },
+    [samplingRules, viewRuleData],
+  );
+
+  const handleNavigateToDuplicate = useCallback(
+    (ruleId: string) => {
+      setIsCreateOpen(false);
+      const category = CATEGORY_TO_RULE_CATEGORY[selectedCategory];
+      const samplingId = samplingRules[0]?.id ?? 'default';
+
+      for (const group of samplingRules) {
+        const all = [
+          ...group.noisyOperations.map((r) => ({ category: 'noisy' as const, rule: r })),
+          ...group.highlyRelevantOperations.map((r) => ({ category: 'highlyRelevant' as const, rule: r })),
+          ...group.costReductionRules.map((r) => ({ category: 'costReduction' as const, rule: r })),
+        ];
+        const match = all.find((x) => x.rule.ruleId === ruleId);
+        if (match) {
+          setViewEditMode(true);
+          setViewRuleData({ category: match.category, rule: match.rule, samplingId: group.id, summary: buildSummaryForRule(match.category, match.rule) } as ViewRuleData);
+          return;
+        }
+      }
+    },
+    [samplingRules, selectedCategory],
+  );
+
+  return (
+    <PageContent>
+      <Header>
+        <RichTitle icon={SamplingIcon} title={PAGE_TITLE} subTitle={PAGE_DESCRIPTION} />
+
+        <FlexRow $gap={8} $alignItems='center'>
+          <Button label={BTN_REFRESH} leftIcon={RefreshIcon} size={ButtonSize.S} variant={ButtonVariants.Text} onClick={fetchSamplingRules} loading={loading} />
+          <Button label={BTN_CREATE_RULE} rightIcon={PlusIcon} size={ButtonSize.S} variant={ButtonVariants.Primary} onClick={handleCreateRule} />
+        </FlexRow>
+      </Header>
+
+      <FlexColumn $gap={12} $alignItems='flex-start'>
+        <Segment variant={SegmentVariant.Underline} options={SAMPLING_SEGMENT_OPTIONS} selected={selectedCategory} setSelected={setSelectedCategory} />
+        <Note status={StatusType.Default} message={SAMPLING_CATEGORY_NOTES[selectedCategory]} />
+      </FlexColumn>
+
+      {selectedCategory === SamplingCategory.Noisy && <AutoRuleCard title={AUTO_RULE_TITLE} summary={autoRuleSummary} onEdit={handleEditAutoRule} />}
+      {selectedCategory === SamplingCategory.HighlyRelevant && <AutoRuleCard title={HIGHLY_RELEVANT_AUTO_RULE_TITLE} summary={highlyRelevantAutoSummary} onEdit={handleEditHRAutoRule} />}
+      {selectedCategory === SamplingCategory.CostReduction && <AutoRuleCard title={COST_REDUCTION_AUTO_RULE_TITLE} summary={costReductionAutoSummary} onEdit={handleEditCRAutoRule} />}
+
+      <SamplingRulesList
+        title={SAMPLING_CATEGORY_LIST_TITLES[selectedCategory]}
+        items={ruleItems}
+        isLoading={loading}
+        showTypeFilter={selectedCategory === SamplingCategory.HighlyRelevant}
+        onRuleClick={handleRuleClick}
+        onEditRule={handleEditRule}
+        onDeleteRule={handleDeleteRule}
+      />
+
+      <ViewSamplingRuleDrawer
+        data={viewRuleData}
+        defaultEditMode={viewEditMode}
+        onClose={handleCloseDrawer}
+        onDelete={handleDeleteRule}
+        onSaveEdit={handleSaveEdit}
+        sourceOptions={sourceOptions}
+        namespaceOptions={namespaceOptions}
+        validateForm={validateEditForm}
+        onNavigateToDuplicate={handleNavigateToDuplicate}
+      />
+
+      <CreateSamplingRuleDrawer
+        isOpen={isCreateOpen}
+        category={CATEGORY_TO_RULE_CATEGORY[selectedCategory]}
+        onClose={handleCloseCreateDrawer}
+        onSubmit={handleCreateSubmit}
+        sourceOptions={sourceOptions}
+        namespaceOptions={namespaceOptions}
+        validateForm={validateCreateForm}
+        onNavigateToDuplicate={handleNavigateToDuplicate}
+      />
+
+      <EditAutoRuleDrawer
+        isOpen={isAutoRuleDrawerOpen}
+        enabled={k8sHealthProbesConfig?.enabled ?? false}
+        keepPercentage={k8sHealthProbesConfig?.keepPercentage ?? 0}
+        onClose={handleCloseAutoRuleDrawer}
+        onSave={handleSaveAutoRule}
+      />
+
+      <EditHighlyRelevantAutoRuleDrawer
+        isOpen={isHRAutoRuleDrawerOpen}
+        enabled={!!highlyRelevantAutoRule && !highlyRelevantAutoRule.rule.disabled}
+        onClose={handleCloseHRAutoRuleDrawer}
+        onSave={handleSaveHRAutoRule}
+      />
+
+      <EditCostReductionAutoRuleDrawer
+        isOpen={isCRAutoRuleDrawerOpen}
+        enabled={!!costReductionAutoRule && !costReductionAutoRule.rule.disabled}
+        dropPercentage={costReductionAutoRule?.rule.percentageAtMost ?? 25}
+        onClose={handleCloseCRAutoRuleDrawer}
+        onSave={handleSaveCRAutoRule}
+      />
+
+      <WarningModal
+        title={DELETE_MODAL_TITLE}
+        description={DELETE_MODAL_DESCRIPTION}
+        isOpen={!!deleteTarget}
+        onClose={handleCancelDelete}
+        onApprove={confirmDelete}
+        approveLabel={DELETE_MODAL_APPROVE}
+        denyLabel={DELETE_MODAL_CANCEL}
+      />
+    </PageContent>
+  );
+}

--- a/frontend/webapp/graphql/mutations/sampling.ts
+++ b/frontend/webapp/graphql/mutations/sampling.ts
@@ -133,3 +133,11 @@ export const DELETE_COST_REDUCTION_RULE = gql`
     deleteCostReductionRule(samplingId: $samplingId, ruleId: $ruleId)
   }
 `;
+
+// ---- Sampling Config ----
+
+export const UPDATE_LOCAL_UI_SAMPLING_CONFIG = gql`
+  mutation UpdateLocalUiSamplingConfig($config: SamplingConfigInput) {
+    updateLocalUiSamplingConfig(config: $config)
+  }
+`;

--- a/frontend/webapp/graphql/queries/sampling.ts
+++ b/frontend/webapp/graphql/queries/sampling.ts
@@ -53,6 +53,14 @@ const COST_REDUCTION_RULE_FIELDS = `
 export const GET_SAMPLING_RULES = gql`
   query GetSamplingRules {
     sampling {
+      configs {
+        effective {
+          k8sHealthProbesSampling {
+            enabled
+            keepPercentage
+          }
+        }
+      }
       rules {
         id
         name

--- a/frontend/webapp/hooks/sampling/useSamplingRuleCRUD.ts
+++ b/frontend/webapp/hooks/sampling/useSamplingRuleCRUD.ts
@@ -13,42 +13,55 @@ import {
   CREATE_COST_REDUCTION_RULE,
   UPDATE_COST_REDUCTION_RULE,
   DELETE_COST_REDUCTION_RULE,
+  UPDATE_LOCAL_UI_SAMPLING_CONFIG,
 } from '@/graphql/mutations';
 import type {
   SamplingRules,
+  SamplingRuleType,
+  SamplingQueryResponse,
   NoisyOperationRule,
   NoisyOperationRuleInput,
   HighlyRelevantOperationRule,
   HighlyRelevantOperationRuleInput,
   CostReductionRule,
   CostReductionRuleInput,
+  K8sHealthProbesSamplingConfig,
 } from '@/types';
 
 interface UseSamplingRuleCrud {
   samplingRules: SamplingRules[];
+  k8sHealthProbesConfig: K8sHealthProbesSamplingConfig | null;
   loading: boolean;
   fetchSamplingRules: () => void;
 
   createNoisyOperationRule: (samplingId: string, rule: NoisyOperationRuleInput) => void;
   updateNoisyOperationRule: (samplingId: string, ruleId: string, rule: NoisyOperationRuleInput) => void;
-  deleteNoisyOperationRule: (samplingId: string, ruleId: string) => void;
 
   createHighlyRelevantOperationRule: (samplingId: string, rule: HighlyRelevantOperationRuleInput) => void;
   updateHighlyRelevantOperationRule: (samplingId: string, ruleId: string, rule: HighlyRelevantOperationRuleInput) => void;
-  deleteHighlyRelevantOperationRule: (samplingId: string, ruleId: string) => void;
 
   createCostReductionRule: (samplingId: string, rule: CostReductionRuleInput) => void;
   updateCostReductionRule: (samplingId: string, ruleId: string, rule: CostReductionRuleInput) => void;
-  deleteCostReductionRule: (samplingId: string, ruleId: string) => void;
+
+  deleteSamplingRule: (samplingId: string, ruleId: string, category: SamplingRuleType) => void;
+
+  updateK8sHealthProbesConfig: (enabled: boolean, keepPercentage: number) => void;
 }
 
 function updateGroup(groups: SamplingRules[], samplingId: string, updater: (group: SamplingRules) => SamplingRules): SamplingRules[] {
-  return groups.map((g) => (g.id === samplingId ? updater(g) : g));
+  const found = groups.some((g) => g.id === samplingId);
+  if (found) {
+    return groups.map((g) => (g.id === samplingId ? updater(g) : g));
+  }
+
+  const emptyGroup: SamplingRules = { id: samplingId, noisyOperations: [], highlyRelevantOperations: [], costReductionRules: [] };
+  return [...groups, updater(emptyGroup)];
 }
 
 export const useSamplingRuleCRUD = (): UseSamplingRuleCrud => {
   const { addNotification } = useNotificationStore();
   const [samplingRules, setSamplingRules] = useState<SamplingRules[]>([]);
+  const [k8sHealthProbesConfig, setK8sHealthProbesConfig] = useState<K8sHealthProbesSamplingConfig | null>(null);
   const [loading, setLoading] = useState(false);
 
   const notifyUser = useCallback(
@@ -60,7 +73,7 @@ export const useSamplingRuleCRUD = (): UseSamplingRuleCrud => {
 
   // ---- Fetch ----
 
-  const [fetchAll] = useLazyQuery<{ sampling: { rules: SamplingRules[] } }>(GET_SAMPLING_RULES, { fetchPolicy: 'network-only' });
+  const [fetchAll] = useLazyQuery<SamplingQueryResponse>(GET_SAMPLING_RULES, { fetchPolicy: 'network-only' });
 
   const fetchSamplingRules = useCallback(async () => {
     setLoading(true);
@@ -68,8 +81,9 @@ export const useSamplingRuleCRUD = (): UseSamplingRuleCrud => {
 
     if (error) {
       notifyUser(StatusType.Error, Crud.Read, error.cause?.message || error.message);
-    } else if (data?.sampling?.rules) {
+    } else if (data?.sampling) {
       setSamplingRules(data.sampling.rules);
+      setK8sHealthProbesConfig(data.sampling.configs?.effective?.k8sHealthProbesSampling ?? null);
     }
     setLoading(false);
   }, [fetchAll, notifyUser]);
@@ -86,23 +100,21 @@ export const useSamplingRuleCRUD = (): UseSamplingRuleCrud => {
     },
   });
 
-  const [mutateUpdateNoisy] = useMutation<{ updateNoisyOperationRule: NoisyOperationRule }, { samplingId: string; ruleId: string; rule: NoisyOperationRuleInput }>(
-    UPDATE_NOISY_OPERATION_RULE,
-    {
-      onError: (error) => notifyUser(StatusType.Error, Crud.Update, error.cause?.message || error.message),
-      onCompleted: (res, opts) => {
-        const updated = res.updateNoisyOperationRule;
-        const sid = opts?.variables?.samplingId as string;
-        setSamplingRules((prev) =>
-          updateGroup(prev, sid, (g) => ({
-            ...g,
-            noisyOperations: g.noisyOperations.map((r) => (r.ruleId === updated.ruleId ? updated : r)),
-          })),
-        );
-        notifyUser(StatusType.Success, Crud.Update, `Successfully updated noisy operation rule "${updated.name || updated.ruleId}"`);
-      },
+  const [mutateUpdateNoisy] = useMutation<{ updateNoisyOperationRule: NoisyOperationRule }, { samplingId: string; ruleId: string; rule: NoisyOperationRuleInput }>(UPDATE_NOISY_OPERATION_RULE, {
+    onError: (error) => notifyUser(StatusType.Error, Crud.Update, error.cause?.message || error.message),
+    onCompleted: (res, opts) => {
+      const updated = res.updateNoisyOperationRule;
+      const sid = opts?.variables?.samplingId as string;
+      const oldRuleId = opts?.variables?.ruleId as string;
+      setSamplingRules((prev) =>
+        updateGroup(prev, sid, (g) => ({
+          ...g,
+          noisyOperations: g.noisyOperations.map((r) => (r.ruleId === oldRuleId ? updated : r)),
+        })),
+      );
+      notifyUser(StatusType.Success, Crud.Update, `Successfully updated noisy operation rule "${updated.name || updated.ruleId}"`);
     },
-  );
+  });
 
   const [mutateDeleteNoisy] = useMutation<{ deleteNoisyOperationRule: boolean }, { samplingId: string; ruleId: string }>(DELETE_NOISY_OPERATION_RULE, {
     onError: (error) => notifyUser(StatusType.Error, Crud.Delete, error.cause?.message || error.message),
@@ -134,23 +146,24 @@ export const useSamplingRuleCRUD = (): UseSamplingRuleCrud => {
     },
   );
 
-  const [mutateUpdateHighlyRelevant] = useMutation<
-    { updateHighlyRelevantOperationRule: HighlyRelevantOperationRule },
-    { samplingId: string; ruleId: string; rule: HighlyRelevantOperationRuleInput }
-  >(UPDATE_HIGHLY_RELEVANT_OPERATION_RULE, {
-    onError: (error) => notifyUser(StatusType.Error, Crud.Update, error.cause?.message || error.message),
-    onCompleted: (res, opts) => {
-      const updated = res.updateHighlyRelevantOperationRule;
-      const sid = opts?.variables?.samplingId as string;
-      setSamplingRules((prev) =>
-        updateGroup(prev, sid, (g) => ({
-          ...g,
-          highlyRelevantOperations: g.highlyRelevantOperations.map((r) => (r.ruleId === updated.ruleId ? updated : r)),
-        })),
-      );
-      notifyUser(StatusType.Success, Crud.Update, `Successfully updated highly relevant operation rule "${updated.name || updated.ruleId}"`);
+  const [mutateUpdateHighlyRelevant] = useMutation<{ updateHighlyRelevantOperationRule: HighlyRelevantOperationRule }, { samplingId: string; ruleId: string; rule: HighlyRelevantOperationRuleInput }>(
+    UPDATE_HIGHLY_RELEVANT_OPERATION_RULE,
+    {
+      onError: (error) => notifyUser(StatusType.Error, Crud.Update, error.cause?.message || error.message),
+      onCompleted: (res, opts) => {
+        const updated = res.updateHighlyRelevantOperationRule;
+        const sid = opts?.variables?.samplingId as string;
+        const oldRuleId = opts?.variables?.ruleId as string;
+        setSamplingRules((prev) =>
+          updateGroup(prev, sid, (g) => ({
+            ...g,
+            highlyRelevantOperations: g.highlyRelevantOperations.map((r) => (r.ruleId === oldRuleId ? updated : r)),
+          })),
+        );
+        notifyUser(StatusType.Success, Crud.Update, `Successfully updated highly relevant operation rule "${updated.name || updated.ruleId}"`);
+      },
     },
-  });
+  );
 
   const [mutateDeleteHighlyRelevant] = useMutation<{ deleteHighlyRelevantOperationRule: boolean }, { samplingId: string; ruleId: string }>(DELETE_HIGHLY_RELEVANT_OPERATION_RULE, {
     onError: (error) => notifyUser(StatusType.Error, Crud.Delete, error.cause?.message || error.message),
@@ -179,23 +192,21 @@ export const useSamplingRuleCRUD = (): UseSamplingRuleCrud => {
     },
   });
 
-  const [mutateUpdateCostReduction] = useMutation<{ updateCostReductionRule: CostReductionRule }, { samplingId: string; ruleId: string; rule: CostReductionRuleInput }>(
-    UPDATE_COST_REDUCTION_RULE,
-    {
-      onError: (error) => notifyUser(StatusType.Error, Crud.Update, error.cause?.message || error.message),
-      onCompleted: (res, opts) => {
-        const updated = res.updateCostReductionRule;
-        const sid = opts?.variables?.samplingId as string;
-        setSamplingRules((prev) =>
-          updateGroup(prev, sid, (g) => ({
-            ...g,
-            costReductionRules: g.costReductionRules.map((r) => (r.ruleId === updated.ruleId ? updated : r)),
-          })),
-        );
-        notifyUser(StatusType.Success, Crud.Update, `Successfully updated cost reduction rule "${updated.name || updated.ruleId}"`);
-      },
+  const [mutateUpdateCostReduction] = useMutation<{ updateCostReductionRule: CostReductionRule }, { samplingId: string; ruleId: string; rule: CostReductionRuleInput }>(UPDATE_COST_REDUCTION_RULE, {
+    onError: (error) => notifyUser(StatusType.Error, Crud.Update, error.cause?.message || error.message),
+    onCompleted: (res, opts) => {
+      const updated = res.updateCostReductionRule;
+      const sid = opts?.variables?.samplingId as string;
+      const oldRuleId = opts?.variables?.ruleId as string;
+      setSamplingRules((prev) =>
+        updateGroup(prev, sid, (g) => ({
+          ...g,
+          costReductionRules: g.costReductionRules.map((r) => (r.ruleId === oldRuleId ? updated : r)),
+        })),
+      );
+      notifyUser(StatusType.Success, Crud.Update, `Successfully updated cost reduction rule "${updated.name || updated.ruleId}"`);
     },
-  );
+  });
 
   const [mutateDeleteCostReduction] = useMutation<{ deleteCostReductionRule: boolean }, { samplingId: string; ruleId: string }>(DELETE_COST_REDUCTION_RULE, {
     onError: (error) => notifyUser(StatusType.Error, Crud.Delete, error.cause?.message || error.message),
@@ -212,6 +223,22 @@ export const useSamplingRuleCRUD = (): UseSamplingRuleCrud => {
     },
   });
 
+  // ---- Sampling Config ----
+
+  const [mutateUpdateConfig] = useMutation<{ updateLocalUiSamplingConfig: boolean }, { config: { k8sHealthProbesSampling: { enabled: boolean; keepPercentage: number } } }>(
+    UPDATE_LOCAL_UI_SAMPLING_CONFIG,
+    {
+      onError: (error) => notifyUser(StatusType.Error, Crud.Update, error.cause?.message || error.message),
+      onCompleted: (_res, opts) => {
+        const input = opts?.variables?.config.k8sHealthProbesSampling;
+        if (input) {
+          setK8sHealthProbesConfig({ enabled: input.enabled, keepPercentage: input.keepPercentage });
+        }
+        notifyUser(StatusType.Success, Crud.Update, 'Successfully updated auto rule configuration');
+      },
+    },
+  );
+
   // ---- Public API ----
 
   const createNoisyOperationRule: UseSamplingRuleCrud['createNoisyOperationRule'] = (samplingId, rule) => {
@@ -222,20 +249,12 @@ export const useSamplingRuleCRUD = (): UseSamplingRuleCrud => {
     mutateUpdateNoisy({ variables: { samplingId, ruleId, rule } });
   };
 
-  const deleteNoisyOperationRule: UseSamplingRuleCrud['deleteNoisyOperationRule'] = (samplingId, ruleId) => {
-    mutateDeleteNoisy({ variables: { samplingId, ruleId } });
-  };
-
   const createHighlyRelevantOperationRule: UseSamplingRuleCrud['createHighlyRelevantOperationRule'] = (samplingId, rule) => {
     mutateCreateHighlyRelevant({ variables: { samplingId, rule } });
   };
 
   const updateHighlyRelevantOperationRule: UseSamplingRuleCrud['updateHighlyRelevantOperationRule'] = (samplingId, ruleId, rule) => {
     mutateUpdateHighlyRelevant({ variables: { samplingId, ruleId, rule } });
-  };
-
-  const deleteHighlyRelevantOperationRule: UseSamplingRuleCrud['deleteHighlyRelevantOperationRule'] = (samplingId, ruleId) => {
-    mutateDeleteHighlyRelevant({ variables: { samplingId, ruleId } });
   };
 
   const createCostReductionRule: UseSamplingRuleCrud['createCostReductionRule'] = (samplingId, rule) => {
@@ -246,8 +265,22 @@ export const useSamplingRuleCRUD = (): UseSamplingRuleCrud => {
     mutateUpdateCostReduction({ variables: { samplingId, ruleId, rule } });
   };
 
-  const deleteCostReductionRule: UseSamplingRuleCrud['deleteCostReductionRule'] = (samplingId, ruleId) => {
-    mutateDeleteCostReduction({ variables: { samplingId, ruleId } });
+  const deleteSamplingRule: UseSamplingRuleCrud['deleteSamplingRule'] = (samplingId, ruleId, category) => {
+    switch (category) {
+      case 'noisy':
+        mutateDeleteNoisy({ variables: { samplingId, ruleId } });
+        break;
+      case 'highlyRelevant':
+        mutateDeleteHighlyRelevant({ variables: { samplingId, ruleId } });
+        break;
+      case 'costReduction':
+        mutateDeleteCostReduction({ variables: { samplingId, ruleId } });
+        break;
+    }
+  };
+
+  const updateK8sHealthProbesConfig: UseSamplingRuleCrud['updateK8sHealthProbesConfig'] = (enabled, keepPercentage) => {
+    mutateUpdateConfig({ variables: { config: { k8sHealthProbesSampling: { enabled, keepPercentage } } } });
   };
 
   useEffect(() => {
@@ -256,16 +289,16 @@ export const useSamplingRuleCRUD = (): UseSamplingRuleCrud => {
 
   return {
     samplingRules,
+    k8sHealthProbesConfig,
     loading,
     fetchSamplingRules,
     createNoisyOperationRule,
     updateNoisyOperationRule,
-    deleteNoisyOperationRule,
     createHighlyRelevantOperationRule,
     updateHighlyRelevantOperationRule,
-    deleteHighlyRelevantOperationRule,
     createCostReductionRule,
     updateCostReductionRule,
-    deleteCostReductionRule,
+    deleteSamplingRule,
+    updateK8sHealthProbesConfig,
   };
 };

--- a/frontend/webapp/package.json
+++ b/frontend/webapp/package.json
@@ -16,13 +16,13 @@
   "dependencies": {
     "@apollo/client": "^3.13.9",
     "@apollo/experimental-nextjs-app-support": "^0.12.3",
-    "@odigos/ui-kit": "0.0.211",
+    "@odigos/ui-kit": "0.0.215",
     "graphql": "^16.12.0",
     "next": "15.5.12",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-error-boundary": "^6.1.0",
-    "styled-components": "6.2.0",
+    "styled-components": "6.3.12",
     "zustand": "^5.0.11"
   },
   "devDependencies": {

--- a/frontend/webapp/types/sampling.ts
+++ b/frontend/webapp/types/sampling.ts
@@ -118,3 +118,19 @@ export interface CostReductionRuleInput {
   percentageAtMost: number;
   notes?: string | null;
 }
+
+export interface K8sHealthProbesSamplingConfig {
+  enabled: boolean | null;
+  keepPercentage: number | null;
+}
+
+export interface SamplingQueryResponse {
+  sampling: {
+    configs: {
+      effective: {
+        k8sHealthProbesSampling: K8sHealthProbesSamplingConfig | null;
+      };
+    };
+    rules: SamplingRules[];
+  };
+}

--- a/frontend/webapp/utils/constants/routes.tsx
+++ b/frontend/webapp/utils/constants/routes.tsx
@@ -11,6 +11,7 @@ export const ROUTES = {
   INSTRUMENTATION_RULES: '/instrumentation-rules',
   SERVICE_MAP: '/service-map',
   PIPELINE_COLLECTORS: '/pipeline-collectors',
+  SAMPLING: '/sampling',
 };
 
 export const SKIP_TO_SUMMERY_QUERY_PARAM = 'skipToSummary';

--- a/frontend/webapp/utils/functions/navigation.ts
+++ b/frontend/webapp/utils/functions/navigation.ts
@@ -2,7 +2,7 @@ import { ROUTES } from '../constants';
 import { SVG } from '@odigos/ui-kit/types';
 import { NavbarProps } from '@odigos/ui-kit/components/v2';
 import { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
-import { ActionIcon, DestinationIcon, InstrumentationRuleIcon, OverviewIcon, PipelineCollectorIcon, ServiceMapIcon, SourceIcon } from '@odigos/ui-kit/icons';
+import { ActionIcon, DestinationIcon, InstrumentationRuleIcon, OverviewIcon, PipelineCollectorIcon, SamplingIcon, ServiceMapIcon, SourceIcon } from '@odigos/ui-kit/icons';
 
 const getPayloadForIcon = (router: AppRouterInstance, currentPath: string, targetPath: string, icon: SVG): NavbarProps['icons'][number] => {
   return {
@@ -22,6 +22,7 @@ export const getNavbarIcons = (router: AppRouterInstance, currentPath: string) =
     getPayloadForIcon(router, currentPath, ROUTES.INSTRUMENTATION_RULES, InstrumentationRuleIcon),
     getPayloadForIcon(router, currentPath, ROUTES.SERVICE_MAP, ServiceMapIcon),
     getPayloadForIcon(router, currentPath, ROUTES.PIPELINE_COLLECTORS, PipelineCollectorIcon),
+    // getPayloadForIcon(router, currentPath, ROUTES.SAMPLING, SamplingIcon),
   ];
 
   return navIcons;

--- a/frontend/webapp/yarn.lock
+++ b/frontend/webapp/yarn.lock
@@ -242,22 +242,22 @@
   dependencies:
     tslib "^2.4.0"
 
-"@emotion/is-prop-valid@1.2.2":
-  version "1.2.2"
-  resolved "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz"
-  integrity sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==
+"@emotion/is-prop-valid@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz#e9ad47adff0b5c94c72db3669ce46de33edf28c0"
+  integrity sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==
   dependencies:
-    "@emotion/memoize" "^0.8.1"
+    "@emotion/memoize" "^0.9.0"
 
-"@emotion/memoize@^0.8.1":
-  version "0.8.1"
-  resolved "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz"
-  integrity sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==
+"@emotion/memoize@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.9.0.tgz#745969d649977776b43fc7648c556aaa462b4102"
+  integrity sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==
 
-"@emotion/unitless@0.8.1":
-  version "0.8.1"
-  resolved "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz"
-  integrity sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==
+"@emotion/unitless@0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.10.0.tgz#2af2f7c7e5150f497bdabd848ce7b218a27cf745"
+  integrity sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==
 
 "@epic-web/invariant@^1.0.0":
   version "1.0.0"
@@ -635,22 +635,22 @@
   resolved "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
-"@odigos/ui-kit@0.0.211":
-  version "0.0.211"
-  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.211.tgz#defa480012fc90e07ae2016529f51e6587aef93d"
-  integrity sha512-VFyj+1fGAhA4VH3BiVimHNKSaHTauUXzUpFs+9XVnSq46e8TUr5/IfUk2DKiQ4RTikoN9Uyet6SDw/mIvXKXyg==
+"@odigos/ui-kit@0.0.215":
+  version "0.0.215"
+  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.215.tgz#de2166639dc76019d6d41b69f93b2e62b5c6fe90"
+  integrity sha512-XilF1bsghTBuD7xkC8Tu2qNVQYtw5O9dORbX6uClhx9QGxvwWcBHe0NtnwZnnIop4bEs6/fLG1ymJjv02ZfNFw==
   dependencies:
-    "@xyflow/react" "^12.10.1"
+    "@xyflow/react" "^12.10.2"
     elkjs "^0.11.1"
-    javascript-time-ago "^2.6.2"
+    javascript-time-ago "^2.6.4"
     lottie-react "^2.4.1"
     prism-react-renderer "^2.4.1"
     react "19.2.4"
     react-dom "19.2.4"
     react-error-boundary "^6.1.1"
-    styled-components "6.2.0"
-    virtua "^0.48.6"
-    zustand "^5.0.11"
+    styled-components "6.3.12"
+    virtua "^0.49.0"
+    zustand "^5.0.12"
 
 "@polka/url@^1.0.0-next.24":
   version "1.0.0-next.29"
@@ -1009,19 +1009,19 @@
   dependencies:
     tslib "^2.3.0"
 
-"@xyflow/react@^12.10.1":
-  version "12.10.1"
-  resolved "https://registry.npmjs.org/@xyflow/react/-/react-12.10.1.tgz"
-  integrity sha512-5eSWtIK/+rkldOuFbOOz44CRgQRjtS9v5nufk77DV+XBnfCGL9HAQ8PG00o2ZYKqkEU/Ak6wrKC95Tu+2zuK3Q==
+"@xyflow/react@^12.10.2":
+  version "12.10.2"
+  resolved "https://registry.yarnpkg.com/@xyflow/react/-/react-12.10.2.tgz#40f6d71944f674f0ffbb83c660f9473018adbe61"
+  integrity sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==
   dependencies:
-    "@xyflow/system" "0.0.75"
+    "@xyflow/system" "0.0.76"
     classcat "^5.0.3"
     zustand "^4.4.0"
 
-"@xyflow/system@0.0.75":
-  version "0.0.75"
-  resolved "https://registry.npmjs.org/@xyflow/system/-/system-0.0.75.tgz"
-  integrity sha512-iXs+AGFLi8w/VlAoc/iSxk+CxfT6o64Uw/k0CKASOPqjqz6E0rb5jFZgJtXGZCpfQI6OQpu5EnumP5fGxQheaQ==
+"@xyflow/system@0.0.76":
+  version "0.0.76"
+  resolved "https://registry.yarnpkg.com/@xyflow/system/-/system-0.0.76.tgz#57da5e4d230cdbec56548a6d5eec115f22858259"
+  integrity sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==
   dependencies:
     "@types/d3-drag" "^3.0.7"
     "@types/d3-interpolate" "^3.0.4"
@@ -2973,9 +2973,9 @@ iterator.prototype@^1.1.5:
     has-symbols "^1.1.0"
     set-function-name "^2.0.2"
 
-javascript-time-ago@^2.6.2:
+javascript-time-ago@^2.6.4:
   version "2.6.4"
-  resolved "https://registry.npmjs.org/javascript-time-ago/-/javascript-time-ago-2.6.4.tgz"
+  resolved "https://registry.yarnpkg.com/javascript-time-ago/-/javascript-time-ago-2.6.4.tgz#3149de049ffe3c374eb5a357cd9aaa911aa98fb9"
   integrity sha512-7K/Z37LuwVaxxjutUDd1pXpznufPcox0b1UYu00ksAMMlV6IsxIvduwL3kgfPxuBVF8jVj7nhrKMPDslMq94aQ==
   dependencies:
     relative-time-format "^1.1.12"
@@ -4088,20 +4088,20 @@ strip-json-comments@^3.1.1:
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-styled-components@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.npmjs.org/styled-components/-/styled-components-6.2.0.tgz"
-  integrity sha512-ryFCkETE++8jlrBmC+BoGPUN96ld1/Yp0s7t5bcXDobrs4XoXroY1tN+JbFi09hV6a5h3MzbcVi8/BGDP0eCgQ==
+styled-components@6.3.12:
+  version "6.3.12"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-6.3.12.tgz#263a1c52bd1c5d1cdd2667e9605e5ffa8df592d0"
+  integrity sha512-hFR6xsVkVYbsdcUlzPYFvFfoc6o2KlV0VvgRIQwSYMtdThM7SCxnjX9efh/cWce2kTq16I/Kl3xM98xiLptsXA==
   dependencies:
-    "@emotion/is-prop-valid" "1.2.2"
-    "@emotion/unitless" "0.8.1"
+    "@emotion/is-prop-valid" "1.4.0"
+    "@emotion/unitless" "0.10.0"
     "@types/stylis" "4.2.7"
     css-to-react-native "3.2.0"
     csstype "3.2.3"
     postcss "8.4.49"
     shallowequal "1.1.0"
     stylis "4.3.6"
-    tslib "2.6.2"
+    tslib "2.8.1"
 
 styled-jsx@5.1.6:
   version "5.1.6"
@@ -4230,12 +4230,7 @@ tslib@1.14.1:
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@2.6.2:
-  version "2.6.2"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz"
-  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
-
-tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0, tslib@^2.8.0:
+tslib@2.8.1, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0, tslib@^2.8.0:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -4420,10 +4415,10 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-virtua@^0.48.6:
-  version "0.48.6"
-  resolved "https://registry.npmjs.org/virtua/-/virtua-0.48.6.tgz"
-  integrity sha512-Cl4uMvMV5c9RuOy9zhkFMYwx/V4YLBMYLRSWkO8J46opQZ3P7KMq0CqCVOOAKUckjl/r//D2jWTBGYWzmgtzrQ==
+virtua@^0.49.0:
+  version "0.49.0"
+  resolved "https://registry.yarnpkg.com/virtua/-/virtua-0.49.0.tgz#594fed54518d9b73a284757092180fe09f847eeb"
+  integrity sha512-yra9TIPqkVIn+LOjCZO8e6C6UsCiCIHJXt3yfnCP02r2sLpgr6mlispn3SHtWZv2aK2tuZLo6Sp2v6qmSrSVfw==
 
 webpack-bundle-analyzer@4.10.1:
   version "4.10.1"
@@ -4611,3 +4606,8 @@ zustand@^5.0.11:
   version "5.0.11"
   resolved "https://registry.npmjs.org/zustand/-/zustand-5.0.11.tgz"
   integrity sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==
+
+zustand@^5.0.12:
+  version "5.0.12"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-5.0.12.tgz#ed36f647aa89965c4019b671dfc23ef6c6e3af8c"
+  integrity sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==

--- a/helm/odigos/templates/ui/clusterrole.yaml
+++ b/helm/odigos/templates/ui/clusterrole.yaml
@@ -108,6 +108,7 @@ rules:
       - instrumentationconfigs
       - instrumentationinstances
       - sources
+      - samplings
     verbs:
       - update
       - patch

--- a/helm/odigos/templates/ui/role.yaml
+++ b/helm/odigos/templates/ui/role.yaml
@@ -60,6 +60,7 @@ rules:
       - 'instrumentationrules'
       - 'destinations'
       - 'actions'
+      - 'samplings'
     verbs:
       - create
       - patch


### PR DESCRIPTION
Add sampling rules page with auto-create default CR, view drawer, CRUD hook, route configuration, and docs permissions update.

> **Depends on:** #4558 (merge backend PR first)

#### What this PR does / why we need it:
This PR adds the frontend sampling rules management page on top of the GraphQL API from #4558. It includes the sampling page component, constants, GraphQL query/mutation strings, a React CRUD hook, TypeScript types, route and navigation updates, a ui-kit version bump, docs permissions update, and a layout scroll fix.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
feat: add sampling rules management page with auto-create and view drawer
```

emergency-ticket id: EMR-1429
