### PR TITLE
fix: ensure offset PR check only targets main branch

### DIFF
--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -34,7 +34,7 @@ jobs:
           # Fetch open PRs and filter by "offsets" label
           result=$(curl -s -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.RELEASE_BOT_TOKEN }}" \
-            "https://api.github.com/repos/odigos-io/${{ matrix.repo }}/pulls?state=open&per_page=100")
+            "https://api.github.com/repos/odigos-io/${{ matrix.repo }}/pulls?state=open&per_page=100&base=main")
 
           pr_links=$(echo "$result" \
             | jq -r '[.[] | select(.labels | any(.name == "offsets")) | .html_url] | join(" ")')


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
offset check failure only if it is targets main branch (avoid development run and prs of offset generator)

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```

emergency-ticket id: EMR-1436
