### PR TITLE
perf(node-collector): raise filelog poll_interval to 5s

### DIFF
--- a/autoscaler/controllers/nodecollector/collectorconfig/logs.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/logs.go
@@ -41,17 +41,7 @@ func getReceivers(logger logr.Logger, sources *odigosv1.InstrumentationConfigLis
 		filelogReceiverName: config.GenericMap{
 			"include": includes,
 			"exclude": []string{"/var/log/pods/kube-system_*/**/*", "/var/log/pods/" + odigosNamespace + "_*/**/*"},
-			// poll_interval controls how often the stanza fileconsumer matcher re-scans the
-			// include globs. The upstream default is 200ms. With hundreds of per-workload
-			// include patterns the upstream matcher (finder.FindFiles in
-			// pkg/stanza/fileconsumer/matcher/internal/finder) calls doublestar.FilepathGlob
-			// independently for every include with no directory-listing cache shared across
-			// globs. On busy nodes a single matcher call can exceed 200ms, so the poll loop
-			// runs back-to-back with no idle time, pinning the goroutine in continuous GC
-			// mark phase and starving co-located receivers (notably the eBPF receiver) of
-			// CPU. Setting poll_interval to 5s gives the goroutine ~86% idle time per cycle,
-			// drops the matcher allocation rate roughly 7x, and lets GC complete cleanly
-			// between polls. Tradeoff: log tail latency may increase by up to 5s.
+			// 5s (vs upstream 200ms default) avoids a readdir storm from stanza's per-include glob loop on busy nodes.
 			"poll_interval":     "5s",
 			"start_at":          "end",
 			"include_file_path": true,

--- a/autoscaler/controllers/nodecollector/collectorconfig/logs.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/logs.go
@@ -39,8 +39,20 @@ func getReceivers(logger logr.Logger, sources *odigosv1.InstrumentationConfigLis
 
 	return config.GenericMap{
 		filelogReceiverName: config.GenericMap{
-			"include":           includes,
-			"exclude":           []string{"/var/log/pods/kube-system_*/**/*", "/var/log/pods/" + odigosNamespace + "_*/**/*"},
+			"include": includes,
+			"exclude": []string{"/var/log/pods/kube-system_*/**/*", "/var/log/pods/" + odigosNamespace + "_*/**/*"},
+			// poll_interval controls how often the stanza fileconsumer matcher re-scans the
+			// include globs. The upstream default is 200ms. With hundreds of per-workload
+			// include patterns the upstream matcher (finder.FindFiles in
+			// pkg/stanza/fileconsumer/matcher/internal/finder) calls doublestar.FilepathGlob
+			// independently for every include with no directory-listing cache shared across
+			// globs. On busy nodes a single matcher call can exceed 200ms, so the poll loop
+			// runs back-to-back with no idle time, pinning the goroutine in continuous GC
+			// mark phase and starving co-located receivers (notably the eBPF receiver) of
+			// CPU. Setting poll_interval to 5s gives the goroutine ~86% idle time per cycle,
+			// drops the matcher allocation rate roughly 7x, and lets GC complete cleanly
+			// between polls. Tradeoff: log tail latency may increase by up to 5s.
+			"poll_interval":     "5s",
 			"start_at":          "end",
 			"include_file_path": true,
 			"include_file_name": false,

--- a/autoscaler/controllers/nodecollector/testdata/logs_included.yaml
+++ b/autoscaler/controllers/nodecollector/testdata/logs_included.yaml
@@ -93,6 +93,7 @@ receivers:
     operators:
     - id: container-parser
       type: container
+    poll_interval: 5s
     retry_on_failure:
       enabled: true
     start_at: end


### PR DESCRIPTION
## Summary

Sets `poll_interval: 5s` on the autoscaler-generated filelog receiver (upstream default is 200ms).

## Why

Stanza's matcher walks each include glob with an independent `doublestar.FilepathGlob` call and shares no directory listing across patterns. With many instrumented workloads, a single matcher call can exceed 200ms, so the poll loop runs back-to-back, pinning the goroutine in continuous GC mark and starving the eBPF receiver of CPU.

5s gives ~86% idle time per cycle, drops matcher alloc rate ~7x, and lets GC and the eBPF receiver run.

Tradeoff: log tail latency may increase by up to 5s.

## Test plan

- [ ] CI passes
- [ ] Staging: `os.(*File).readdir` no longer dominates allocs profile on the data-collection pod

```release-note
node-collector: raise filelog poll_interval to 5s to avoid stanza matcher readdir storm on busy nodes
```

emergency-ticket id: EMR-1448
