### PR TITLE
fix(scheduler): scale memory_limiter hard limit for small collector containers

### DIFF
--- a/scheduler/controllers/clustercollectorsgroup/resource_config.go
+++ b/scheduler/controllers/clustercollectorsgroup/resource_config.go
@@ -20,8 +20,16 @@ const (
 	defaultMaxReplicas = 10
 
 	// this configures the processor limit_mib, which is the hard limit in MiB, afterwhich garbage collection will be forced.
-	// as recommended by the processor docs, if not set, this is set to 50MiB less than the memory limit of the collector
+	// as recommended by the processor docs, if not set, this is set to 50MiB less than the memory request of the collector.
+	// for small containers this fixed offset would leave too little headroom for the application,
+	// so we also enforce a minimum ratio via defaultMemoryLimiterLimitMinPercentage below.
 	defaultMemoryLimiterLimitDiffMib = 50
+
+	// minimum percentage of the memory request to use as the memory_limiter hard limit.
+	// the effective hard limit is max(request-50, request*85%), so small containers get a
+	// percentage-based floor while larger containers keep the fixed 50MiB headroom.
+	// crossover is at ~333MiB: below that the ratio wins, above that the fixed offset wins.
+	defaultMemoryLimiterLimitMinPercentage = 85.0
 
 	// the soft limit will be set to 80% of the hard limit.
 	// this value is used to derive the "spike_limit_mib" parameter in the processor configuration if a value is not set
@@ -37,6 +45,20 @@ const (
 	// instead of having the process killed, it can use extra memory available on the node without allocating it preemptively.
 	memoryLimitAboveRequestFactor = 1.25
 )
+
+// calculateMemoryLimiterHardLimitMiB returns the memory_limiter processor hard limit
+// in MiB given a base memory size (typically the container memory request for the
+// gateway). It uses max(base-50, base*85%) so that small containers get a
+// percentage-based floor, while larger containers keep the fixed 50MiB headroom that
+// the OTel memory_limiter docs recommend.
+func calculateMemoryLimiterHardLimitMiB(baseMemoryMiB int) int {
+	fixed := baseMemoryMiB - defaultMemoryLimiterLimitDiffMib
+	ratio := int(float64(baseMemoryMiB) * defaultMemoryLimiterLimitMinPercentage / 100.0)
+	if ratio > fixed {
+		return ratio
+	}
+	return fixed
+}
 
 // process the resources settings from odigos config and return the resources settings for the collectors group.
 // apply any defaulting and calculations here.
@@ -68,9 +90,8 @@ func getGatewayResourceSettings(odigosConfiguration *common.OdigosConfiguration)
 		cpuLimitm = gatewayConfig.LimitCPUm
 	}
 
-	// the memory limiter hard limit is set as 50 MiB less than the memory request
-
-	memoryLimiterLimitMiB := memoryRequestMiB - defaultMemoryLimiterLimitDiffMib
+	// the memory limiter hard limit is set as max(request-50, request*85%).
+	memoryLimiterLimitMiB := calculateMemoryLimiterHardLimitMiB(memoryRequestMiB)
 	if odigosConfiguration.CollectorGateway != nil && odigosConfiguration.CollectorGateway.MemoryLimiterLimitMiB > 0 {
 		memoryLimiterLimitMiB = odigosConfiguration.CollectorGateway.MemoryLimiterLimitMiB
 	}

--- a/scheduler/controllers/clustercollectorsgroup/resource_config_test.go
+++ b/scheduler/controllers/clustercollectorsgroup/resource_config_test.go
@@ -1,0 +1,81 @@
+package clustercollectorsgroup
+
+import (
+	"testing"
+
+	"github.com/odigos-io/odigos/common"
+)
+
+// TestCalculateMemoryLimiterHardLimitMiB_Gateway verifies the gateway uses the same
+// max(base-50, base*85%) formula as the node collector, so small base sizes get a
+// percentage-based floor instead of the fixed 50MiB offset eating the budget.
+func TestCalculateMemoryLimiterHardLimitMiB_Gateway(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseMiB  int
+		wantHard int
+	}{
+		{"64MiB", 64, 54},     // max(14, 54) = 54
+		{"128MiB", 128, 108},  // max(78, 108) = 108
+		{"256MiB", 256, 217},  // max(206, 217) = 217
+		{"333MiB (crossover)", 333, 283},
+		{"334MiB", 334, 284},
+		{"500MiB (default request)", 500, 450}, // max(450, 425) = 450 (unchanged)
+		{"1000MiB", 1000, 950}, // max(950, 850) = 950 (unchanged)
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := calculateMemoryLimiterHardLimitMiB(tt.baseMiB); got != tt.wantHard {
+				t.Errorf("calculateMemoryLimiterHardLimitMiB(%d) = %d, want %d", tt.baseMiB, got, tt.wantHard)
+			}
+		})
+	}
+}
+
+// TestGetGatewayResourceSettings_Defaults verifies the default gateway sizing —
+// should be unchanged by the ratio fix since the default request (500MiB) is well
+// above the ~333MiB crossover.
+func TestGetGatewayResourceSettings_Defaults(t *testing.T) {
+	got := getGatewayResourceSettings(&common.OdigosConfiguration{})
+
+	if got.MemoryRequestMiB != 500 {
+		t.Errorf("MemoryRequestMiB = %d, want 500", got.MemoryRequestMiB)
+	}
+	// hard limit = 500 - 50 = 450 (fixed offset wins above crossover).
+	if got.MemoryLimiterLimitMiB != 450 {
+		t.Errorf("MemoryLimiterLimitMiB = %d, want 450", got.MemoryLimiterLimitMiB)
+	}
+	// spike = 450 * 0.20 = 90.
+	if got.MemoryLimiterSpikeLimitMiB != 90 {
+		t.Errorf("MemoryLimiterSpikeLimitMiB = %d, want 90", got.MemoryLimiterSpikeLimitMiB)
+	}
+	// gomemlimit = 450 * 0.80 = 360.
+	if got.GomemlimitMiB != 360 {
+		t.Errorf("GomemlimitMiB = %d, want 360", got.GomemlimitMiB)
+	}
+}
+
+// TestGetGatewayResourceSettings_SmallOverride verifies the fix kicks in when a user
+// downsizes the gateway below the ~333MiB crossover.
+func TestGetGatewayResourceSettings_SmallOverride(t *testing.T) {
+	cfg := &common.OdigosConfiguration{
+		CollectorGateway: &common.CollectorGatewayConfiguration{
+			RequestMemoryMiB: 128,
+		},
+	}
+	got := getGatewayResourceSettings(cfg)
+
+	if got.MemoryRequestMiB != 128 {
+		t.Errorf("MemoryRequestMiB = %d, want 128", got.MemoryRequestMiB)
+	}
+	// Pre-fix: 128 - 50 = 78. Post-fix: max(78, int(128*0.85)) = 108.
+	if got.MemoryLimiterLimitMiB != 108 {
+		t.Errorf("MemoryLimiterLimitMiB = %d, want 108 (post-fix), was 78 pre-fix", got.MemoryLimiterLimitMiB)
+	}
+	if got.MemoryLimiterSpikeLimitMiB != 21 { // 108 * 0.20 = 21.6 → 21
+		t.Errorf("MemoryLimiterSpikeLimitMiB = %d, want 21", got.MemoryLimiterSpikeLimitMiB)
+	}
+	if got.GomemlimitMiB != 86 { // 108 * 0.80 = 86.4 → 86
+		t.Errorf("GomemlimitMiB = %d, want 86", got.GomemlimitMiB)
+	}
+}

--- a/scheduler/controllers/nodecollectorsgroup/common.go
+++ b/scheduler/controllers/nodecollectorsgroup/common.go
@@ -22,8 +22,17 @@ const (
 	defaultRequestMemoryMiB = 256
 
 	// this configures the processor limit_mib, which is the hard limit in MiB, afterwhich garbage collection will be forced.
-	// as recommended by the processor docs, if not set, this is set to 50MiB less than the memory limit of the collector
+	// as recommended by the processor docs, if not set, this is set to 50MiB less than the memory limit of the collector.
+	// for small containers this fixed offset would leave too little headroom for the application,
+	// so we also enforce a minimum ratio via defaultMemoryLimiterLimitMinPercentage below.
 	defaultMemoryLimiterLimitDiffMib = 50
+
+	// minimum percentage of the container memory limit to use as the memory_limiter hard limit.
+	// the effective hard limit is max(limit-50, limit*85%), so small containers (where the fixed
+	// 50MiB offset would eat most of the budget) get a percentage-based floor, while larger
+	// containers keep the 50MiB fixed headroom that the OTel docs recommend.
+	// crossover is at ~333MiB: below that the ratio wins, above that the fixed offset wins.
+	defaultMemoryLimiterLimitMinPercentage = 85.0
 
 	// the soft limit will be set to 80% of the hard limit.
 	// this value is used to derive the "spike_limit_mib" parameter in the processor configuration if a value is not set
@@ -46,6 +55,20 @@ const (
 
 	DEFAULT_OWNMETRICS_PERIODIC_READER_SCRAPE_INTERVAL = "10s"
 )
+
+// calculateMemoryLimiterHardLimitMiB returns the memory_limiter processor hard limit
+// in MiB given the container memory limit. It uses max(limit-50, limit*85%) so that
+// small containers (where a fixed 50MiB offset would eat most of the budget) get a
+// percentage-based floor, while larger containers keep the fixed 50MiB headroom that
+// the OTel memory_limiter docs recommend.
+func calculateMemoryLimiterHardLimitMiB(memoryLimitMiB int) int {
+	fixed := memoryLimitMiB - defaultMemoryLimiterLimitDiffMib
+	ratio := int(float64(memoryLimitMiB) * defaultMemoryLimiterLimitMinPercentage / 100.0)
+	if ratio > fixed {
+		return ratio
+	}
+	return fixed
+}
 
 func getResourceSettings(odigosConfiguration common.OdigosConfiguration) odigosv1.CollectorsGroupResourcesSettings {
 	// memory request is expensive on daemonsets since it will consume this memory
@@ -75,7 +98,7 @@ func getResourceSettings(odigosConfiguration common.OdigosConfiguration) odigosv
 		memoryLimitMiB = nodeCollectorConfig.LimitMemoryMiB
 	}
 
-	memoryLimiterLimitMiB := memoryLimitMiB - defaultMemoryLimiterLimitDiffMib
+	memoryLimiterLimitMiB := calculateMemoryLimiterHardLimitMiB(memoryLimitMiB)
 	if nodeCollectorConfig != nil && nodeCollectorConfig.MemoryLimiterLimitMiB > 0 {
 		memoryLimiterLimitMiB = nodeCollectorConfig.MemoryLimiterLimitMiB
 	}

--- a/scheduler/controllers/nodecollectorsgroup/common_test.go
+++ b/scheduler/controllers/nodecollectorsgroup/common_test.go
@@ -1,0 +1,205 @@
+package nodecollectorsgroup
+
+import (
+	"testing"
+
+	"github.com/odigos-io/odigos/common"
+)
+
+// TestCalculateMemoryLimiterHardLimitMiB verifies the memory_limiter hard limit formula
+// max(limit-50, limit*85%). The formula is designed so that:
+//   - small container limits (below ~333MiB) use the 85% ratio — avoids the old bug where
+//     a fixed 50MiB offset ate most of the budget (128MiB → 78MiB hard limit = 61%).
+//   - larger container limits (>=~333MiB) keep the fixed 50MiB headroom that the OTel
+//     memory_limiter docs recommend.
+func TestCalculateMemoryLimiterHardLimitMiB(t *testing.T) {
+	tests := []struct {
+		name          string
+		containerMiB  int
+		wantHardLimit int
+	}{
+		// small containers — 85% ratio wins
+		{"64MiB (tiny)", 64, 54},    // max(14, 54) = 54
+		{"128MiB", 128, 108},        // max(78, 108) = 108  (was 78 pre-fix)
+		{"192MiB", 192, 163},        // max(142, 163) = 163
+		{"256MiB", 256, 217},        // max(206, 217) = 217  (was 206 pre-fix)
+		{"320MiB", 320, 272},        // max(270, 272) = 272
+
+		// crossover region — around 333MiB the two strategies meet
+		{"333MiB", 333, 283},        // max(283, 283) = 283
+		{"334MiB", 334, 284},        // max(284, 283) = 284 (fixed offset wins by 1)
+
+		// larger containers — fixed -50 headroom wins (unchanged from pre-fix behavior)
+		{"384MiB", 384, 334},        // max(334, 326) = 334
+		{"512MiB (odigos default limit)", 512, 462}, // max(462, 435) = 462
+		{"768MiB", 768, 718},        // max(718, 652) = 718
+		{"1024MiB", 1024, 974},      // max(974, 870) = 974
+		{"2048MiB", 2048, 1998},     // max(1998, 1740) = 1998
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calculateMemoryLimiterHardLimitMiB(tt.containerMiB)
+			if got != tt.wantHardLimit {
+				t.Errorf("calculateMemoryLimiterHardLimitMiB(%d) = %d, want %d",
+					tt.containerMiB, got, tt.wantHardLimit)
+			}
+			// sanity: hard limit must always leave at least min(50, 15%) headroom —
+			// that is exactly what the max(limit-50, limit*85%) formula guarantees.
+			headroom := tt.containerMiB - got
+			wantMinHeadroom := tt.containerMiB * 15 / 100 // 15% rounded down
+			if wantMinHeadroom > defaultMemoryLimiterLimitDiffMib {
+				wantMinHeadroom = defaultMemoryLimiterLimitDiffMib
+			}
+			if headroom < wantMinHeadroom {
+				t.Errorf("hard limit %d leaves only %d MiB headroom in %d MiB container, want at least %d",
+					got, headroom, tt.containerMiB, wantMinHeadroom)
+			}
+		})
+	}
+}
+
+// TestGetResourceSettings_NodeCollector_Defaults verifies that with no user override the
+// node collector gets the Odigos defaults (256 request / 512 limit) and the ratios are
+// computed correctly.
+func TestGetResourceSettings_NodeCollector_Defaults(t *testing.T) {
+	got := getResourceSettings(common.OdigosConfiguration{})
+
+	checkInt(t, "MemoryRequestMiB", got.MemoryRequestMiB, 256)
+	checkInt(t, "MemoryLimitMiB", got.MemoryLimitMiB, 512)
+	// 512MiB is above the crossover, so the fixed -50 wins: 462.
+	checkInt(t, "MemoryLimiterLimitMiB", got.MemoryLimiterLimitMiB, 462)
+	// spike is 20% of hard: 462 * 0.2 = 92.
+	checkInt(t, "MemoryLimiterSpikeLimitMiB", got.MemoryLimiterSpikeLimitMiB, 92)
+	// gomemlimit is 80% of hard: 462 * 0.8 = 369.
+	checkInt(t, "GomemlimitMiB", got.GomemlimitMiB, 369)
+	checkInt(t, "CpuRequestMillicores", got.CpuRequestMillicores, 250)
+	checkInt(t, "CpuLimitMillicores", got.CpuLimitMillicores, 500)
+}
+
+// TestGetResourceSettings_NodeCollector_Sizes verifies the full chain of derived values
+// for several container sizes. This is the regression test for the customer scenario
+// where requestMemoryMiB=64 / limitMemoryMiB=128 was producing gomemlimit=62 (48% of
+// container), leaving no budget for the Go runtime baseline.
+func TestGetResourceSettings_NodeCollector_Sizes(t *testing.T) {
+	tests := []struct {
+		name              string
+		requestMiB        int
+		limitMiB          int
+		wantHardLimit     int
+		wantSpikeLimit    int
+		wantGomemlimit    int
+	}{
+		{
+			// the customer case — tiny container, previously produced 78/15/62.
+			name:           "64/128 (small override)",
+			requestMiB:     64,
+			limitMiB:       128,
+			wantHardLimit:  108, // was 78 pre-fix (61% of container)
+			wantSpikeLimit: 21,  // 108 * 0.20 (was 15)
+			wantGomemlimit: 86,  // 108 * 0.80 (was 62 — 48% of container)
+		},
+		{
+			// default-ish Odigos sizing.
+			name:           "128/256",
+			requestMiB:     128,
+			limitMiB:       256,
+			wantHardLimit:  217, // was 206 pre-fix
+			wantSpikeLimit: 43,  // 217 * 0.20
+			wantGomemlimit: 173, // 217 * 0.80
+		},
+		{
+			// Odigos defaults — should be unchanged from pre-fix.
+			name:           "256/512 (defaults)",
+			requestMiB:     256,
+			limitMiB:       512,
+			wantHardLimit:  462,
+			wantSpikeLimit: 92, // 462 * 0.20 = 92.4 → 92
+			wantGomemlimit: 369,
+		},
+		{
+			// Large container — unchanged from pre-fix.
+			name:           "512/1024",
+			requestMiB:     512,
+			limitMiB:       1024,
+			wantHardLimit:  974,
+			wantSpikeLimit: 194, // 974 * 0.20 = 194.8 → 194
+			wantGomemlimit: 779, // 974 * 0.80 = 779.2 → 779
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := common.OdigosConfiguration{
+				CollectorNode: &common.CollectorNodeConfiguration{
+					RequestMemoryMiB: tt.requestMiB,
+					LimitMemoryMiB:   tt.limitMiB,
+				},
+			}
+			got := getResourceSettings(cfg)
+
+			checkInt(t, "MemoryRequestMiB", got.MemoryRequestMiB, tt.requestMiB)
+			checkInt(t, "MemoryLimitMiB", got.MemoryLimitMiB, tt.limitMiB)
+			checkInt(t, "MemoryLimiterLimitMiB", got.MemoryLimiterLimitMiB, tt.wantHardLimit)
+			checkInt(t, "MemoryLimiterSpikeLimitMiB", got.MemoryLimiterSpikeLimitMiB, tt.wantSpikeLimit)
+			checkInt(t, "GomemlimitMiB", got.GomemlimitMiB, tt.wantGomemlimit)
+
+			// Invariants:
+			// - hard limit must be strictly below container limit (otherwise the limiter
+			//   fires at the same moment the kernel OOMKills).
+			if got.MemoryLimiterLimitMiB >= got.MemoryLimitMiB {
+				t.Errorf("hard limit (%d) must be < container limit (%d)",
+					got.MemoryLimiterLimitMiB, got.MemoryLimitMiB)
+			}
+			// - gomemlimit must be below hard limit (Go GC reacts before the limiter trips).
+			if got.GomemlimitMiB >= got.MemoryLimiterLimitMiB {
+				t.Errorf("gomemlimit (%d) must be < hard limit (%d)",
+					got.GomemlimitMiB, got.MemoryLimiterLimitMiB)
+			}
+			// - hard limit must leave at least min(50, 15%) headroom in the container,
+			//   matching the max(limit-50, limit*85%) formula.
+			headroom := got.MemoryLimitMiB - got.MemoryLimiterLimitMiB
+			wantMinHeadroom := got.MemoryLimitMiB * 15 / 100
+			if wantMinHeadroom > 50 {
+				wantMinHeadroom = 50
+			}
+			if headroom < wantMinHeadroom {
+				t.Errorf("hard limit %d leaves only %d MiB headroom in %d MiB container, want at least %d",
+					got.MemoryLimiterLimitMiB, headroom, got.MemoryLimitMiB, wantMinHeadroom)
+			}
+		})
+	}
+}
+
+// TestGetResourceSettings_NodeCollector_UserOverrides verifies that explicit user-provided
+// values take precedence over the computed defaults (i.e. we never recompute on top of a
+// user override).
+func TestGetResourceSettings_NodeCollector_UserOverrides(t *testing.T) {
+	cfg := common.OdigosConfiguration{
+		CollectorNode: &common.CollectorNodeConfiguration{
+			RequestMemoryMiB:           300,
+			LimitMemoryMiB:             600,
+			MemoryLimiterLimitMiB:      500,
+			MemoryLimiterSpikeLimitMiB: 77,
+			GoMemLimitMib:              400,
+			RequestCPUm:                111,
+			LimitCPUm:                  222,
+		},
+	}
+	got := getResourceSettings(cfg)
+
+	checkInt(t, "MemoryRequestMiB", got.MemoryRequestMiB, 300)
+	checkInt(t, "MemoryLimitMiB", got.MemoryLimitMiB, 600)
+	checkInt(t, "MemoryLimiterLimitMiB", got.MemoryLimiterLimitMiB, 500)
+	checkInt(t, "MemoryLimiterSpikeLimitMiB", got.MemoryLimiterSpikeLimitMiB, 77)
+	checkInt(t, "GomemlimitMiB", got.GomemlimitMiB, 400)
+	checkInt(t, "CpuRequestMillicores", got.CpuRequestMillicores, 111)
+	checkInt(t, "CpuLimitMillicores", got.CpuLimitMillicores, 222)
+}
+
+func checkInt(t *testing.T, field string, got, want int) {
+	t.Helper()
+	if got != want {
+		t.Errorf("%s = %d, want %d", field, got, want)
+	}
+}


### PR DESCRIPTION
## Summary

The memory_limiter hard limit and `GOMEMLIMIT` for both the node collector and the cluster gateway were computed as `limitMiB - 50`, a **fixed** offset that doesn't scale. For small containers this leaves almost no headroom:

| container limit | old hard | old gomemlimit | old spike |
|---|---|---|---|
| 128 MiB | 78 (61%) | 62 (48%) | 15 |

At 128 MiB, `GOMEMLIMIT=62` is below the Go runtime non-heap baseline (goroutine stacks, GC metadata, k8s informers, init allocs ≈ 60–70 MB), so the Go GC fights perpetually to stay under a limit it can barely meet with zero application data, and the `memory_limiter` processor sits at "above hard limit" indefinitely — dropping data and blocking the pipeline.

### Fix

Replace the fixed offset with `max(limit-50, limit*85%)`:

- **Small containers** (below ~333 MiB): the 85% ratio wins — gives a reasonable floor that scales with the container.
- **Larger containers** (≥~333 MiB): the fixed 50 MiB headroom still wins, preserving the OTel memory_limiter docs' recommendation.
- **Crossover** is at 333 MiB. Default Odigos sizing (256 req / 512 lim for node collector, 500 req for gateway) is **unchanged byte-for-byte**.

### New values

| container limit | hard (old → new) | gomemlimit (old → new) | spike (old → new) |
|---|---|---|---|
| 128 MiB | 78 → **108** | 62 → **86** | 15 → **21** |
| 256 MiB | 206 → **217** | 164 → **173** | 41 → **43** |
| 384 MiB | 334 (unchanged) | 267 (unchanged) | 66 (unchanged) |
| 512 MiB (default) | 462 (unchanged) | 369 (unchanged) | 92 (unchanged) |
| 1024 MiB | 974 (unchanged) | 779 (unchanged) | 194 (unchanged) |

Because the `spike` (20%) and `gomemlimit` (80%) values are derived off the hard limit, fixing the hard limit automatically improves both.

### Files

- `scheduler/controllers/nodecollectorsgroup/common.go` — new `calculateMemoryLimiterHardLimitMiB` helper, new `defaultMemoryLimiterLimitMinPercentage = 85.0` constant.
- `scheduler/controllers/clustercollectorsgroup/resource_config.go` — same helper and constant. Kept the existing quirk of computing the gateway hard limit off `memoryRequestMiB` (not `memoryLimitMiB`) to minimize blast radius.
- `scheduler/controllers/nodecollectorsgroup/common_test.go` — new.
- `scheduler/controllers/clustercollectorsgroup/resource_config_test.go` — new.

### Out of scope

- **Raising the customer override.** A downstream user configured `requestMemoryMiB: 64 / limitMemoryMiB: 128`. After this fix their ratios become sane (108/86/21), but 128 MiB is still very tight for a Go otelcol with k8s informers. The real guidance is to bump the container limit to ≥256 MiB.
- **Odiglet OOMs.** A separate issue observed in recent diagnostics shows the odiglet (768 MiB limit) OOMing on nodes with many instrumented processes — that is an eBPF-map-growth question, not a ratio question, and belongs in its own investigation.
- **The gateway-base quirk.** The gateway computes hard limit off `memoryRequestMiB` instead of `memoryLimitMiB`. Arguably a bug but changing the base would alter default derived values. Left for a follow-up.

## Test plan

- [x] `go test -v ./scheduler/controllers/nodecollectorsgroup/...` — 18 subtests pass
- [x] `go test -v ./scheduler/controllers/clustercollectorsgroup/...` — 11 subtests pass
- [x] `go build ./scheduler/...` — clean
- [ ] CI green
- [ ] Manual: roll the node collector in a cluster with `limitMemoryMiB: 128` and verify `GOMEMLIMIT=86MiB` on the data-collection container and `limit_mib: 108` in the memory_limiter config
- [ ] Manual: verify default sizing (no override) still produces `GOMEMLIMIT=369MiB` on the node collector

### Test coverage added

**Node collector (`common_test.go`)**
- `TestCalculateMemoryLimiterHardLimitMiB` — 12 container sizes from 64 MiB to 2048 MiB, including the 333/334 MiB crossover, with headroom invariant `headroom >= min(50, 15% of container)`.
- `TestGetResourceSettings_NodeCollector_Defaults` — no config → Odigos defaults (256/512) produce 462/92/369.
- `TestGetResourceSettings_NodeCollector_Sizes` — 4 sizes (64/128, 128/256, 256/512, 512/1024) verifying the full chain plus invariants `gomemlimit < hard < container limit`.
- `TestGetResourceSettings_NodeCollector_UserOverrides` — all memory/CPU knobs set by the user are passed through verbatim, not recomputed.

**Cluster gateway (`resource_config_test.go`)**
- `TestCalculateMemoryLimiterHardLimitMiB_Gateway` — 7 sizes including 500 MiB default (unchanged at 450) and 128 MiB override (78 → 108).
- `TestGetGatewayResourceSettings_Defaults` — default sizing unchanged.
- `TestGetGatewayResourceSettings_SmallOverride` — `requestMemoryMiB: 128` override now produces 108/86/21.

emergency-ticket id: EMR-1447
