### PR TITLE
chore: add enterprise-ro STS identity for enterprise builds

### DIFF
--- a/.github/chainguard/enterprise-ro.sts.yaml
+++ b/.github/chainguard/enterprise-ro.sts.yaml
@@ -1,0 +1,5 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: '^repo:odigos-io/odigos-enterprise:(pull_request|ref:.*)$'
+
+permissions:
+  contents: read


### PR DESCRIPTION
#### What this PR does / why we need it:

Add `.github/chainguard/enterprise-ro.sts.yaml` identity to allow the odigos-enterprise repo to read odigos source via STS tokens during Docker builds.

The existing `ro` identity only allows requests from the odigos repo itself. Enterprise CI needs to `go mod download` private deps from odigos during Docker builds.

Follows the same pattern as ebpf-core, ebpf-java-instrumentation, etc.

**Blocks:** odigos-io/odigos-enterprise#2580 (retire RELEASE_BOT_TOKEN)

Fixes RUN-676

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
NONE
```