### PR TITLE
chore: save only minimal pod metadata in opamp connectionCache

### DIFF
--- a/opampserver/pkg/server/handlers.go
+++ b/opampserver/pkg/server/handlers.go
@@ -106,8 +106,16 @@ func (c *ConnectionHandlers) OnNewConnection(ctx context.Context, firstMessage *
 	logger.Info("new OpAMP client connected", "namespace", k8sAttributes.Namespace, "podName", k8sAttributes.PodName, "instrumentedAppName", instrumentedAppName, "workloadKind", k8sAttributes.WorkloadKind, "workloadName", k8sAttributes.WorkloadName, "containerName", k8sAttributes.ContainerName, "otelServiceName", serviceName)
 
 	connectionInfo := &connection.ConnectionInfo{
-		Workload:                 podWorkload,
-		Pod:                      pod,
+		Workload: podWorkload,
+		// Store only the minimal pod metadata needed for owner references and identification.
+		// The full pod object (containers, volumes, etc.) is not cached to reduce memory and GC pressure.
+		Pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pod.Name,
+				Namespace: pod.Namespace,
+				UID:       pod.UID,
+			},
+		},
 		ContainerName:            k8sAttributes.ContainerName,
 		Pid:                      vpid,
 		ProgrammingLanguage:      attrs.ProgrammingLanguage,
@@ -158,7 +166,7 @@ func (c *ConnectionHandlers) UpdateInstrumentationInstanceStatus(ctx context.Con
 		}
 		// [1] - agent disconnects with healthy status, delete the instrumentation instance CR
 		if message.Health.Healthy {
-			logger.Info("Agent disconnected with healthy status, deleting instrumentation instance", "workloadNamespace", connectionInfo.Workload.Namespace, "workloadName", connectionInfo.Workload.Name, "workloadKind", connectionInfo.Workload.Kind)
+			logger.Debug("Agent disconnected with healthy status, deleting instrumentation instance", "workloadNamespace", connectionInfo.Workload.Namespace, "workloadName", connectionInfo.Workload.Name, "workloadKind", connectionInfo.Workload.Kind)
 			return instrumentation_instance.DeleteInstrumentationInstance(ctx, connectionInfo.Pod, connectionInfo.ContainerName, c.kubeclient, int(connectionInfo.Pid))
 		}
 

--- a/opampserver/pkg/server/server.go
+++ b/opampserver/pkg/server/server.go
@@ -115,7 +115,7 @@ func StartOpAmpServer(ctx context.Context, mgr ctrl.Manager, kubeClientSet *kube
 
 			// This may occurs when Odiglet restarts, and a previously connected pod sends a disconnect message right after reconnecting.
 			if connectionInfo != nil {
-				logger.Info("Agent disconnected", "workloadNamespace", connectionInfo.Workload.Namespace, "workloadName", connectionInfo.Workload.Name, "workloadKind", connectionInfo.Workload.Kind)
+				logger.Debug("Agent disconnected", "workloadNamespace", connectionInfo.Workload.Namespace, "workloadName", connectionInfo.Workload.Name, "workloadKind", connectionInfo.Workload.Kind)
 			}
 			// if agent disconnects, remove the connection from the cache
 			// as it is not expected to send additional messages


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Instead of storing the full Pod object in the OpAMP connection cache, we now keep only the minimal metadata required for the server logic. This change reduces the cache size by roughly 1MB per pod.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```

emergency-ticket id: EMR-1455
