### PR TITLE
chore: retire RELEASE_BOT_TOKEN in favor of STS (RUN-672..675)

### DIFF
--- a/.github/chainguard/publish-helm.sts.yaml
+++ b/.github/chainguard/publish-helm.sts.yaml
@@ -1,0 +1,5 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: repo:odigos-io/odigos:ref:refs/(tags/.*|heads/main)
+
+permissions:
+  contents: write

--- a/.github/chainguard/trigger-release.sts.yaml
+++ b/.github/chainguard/trigger-release.sts.yaml
@@ -1,5 +1,5 @@
 issuer: https://token.actions.githubusercontent.com
-subject_pattern: repo:odigos-io/(odigos|odigos-enterprise):ref:(refs/heads/.*|refs/tags/.*)$
+subject_pattern: repo:odigos-io/(odigos|odigos-enterprise):ref:refs/(heads/main|tags/.*)$
 
 permissions:
   contents: write # to trigger the release workflow

--- a/.github/workflows/promote-rc-to-stable.yml
+++ b/.github/workflows/promote-rc-to-stable.yml
@@ -10,7 +10,7 @@ on:
 permissions:
   contents: write
   packages: write
-  id-token: 'write'
+  id-token: write
 
 env:
   DOCKERHUB_REPO: "keyval"

--- a/.github/workflows/publish-modules-rhel.yml
+++ b/.github/workflows/publish-modules-rhel.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on: ${{ matrix.runner }}
         permissions:
           contents: 'read'
-          id-token: 'write'
+          id-token: write
           packages: 'write'
         strategy:
           matrix:
@@ -127,7 +127,7 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
           contents: 'read'
-          id-token: 'write'
+          id-token: write
         steps:
           - name: Checkout repository
             uses: actions/checkout@v5
@@ -205,11 +205,19 @@ jobs:
     trigger-enterprise-publish:
         needs: publish-cli-rhel
         runs-on: ubuntu-latest
+        permissions:
+          id-token: write
         steps:
+          - uses: odigos-io/ci-core/sts@main
+            id: sts
+            with:
+              scope: odigos-io/odigos-enterprise
+              identity: trigger-release
+
           - name: Trigger Enterprise Publish job
             run: |
               curl -X POST \
                 -H "Accept: application/vnd.github.v3+json" \
-                -H "Authorization: token ${{ secrets.RELEASE_BOT_TOKEN }}" \
+                -H "Authorization: token ${{ steps.sts.outputs.GH_TOKEN }}" \
                 https://api.github.com/repos/odigos-io/odigos-enterprise/dispatches \
                 -d '{"event_type": "publish_images_rhel", "client_payload": {"tag": "${{ inputs.tag }}"}}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,7 +339,7 @@ jobs:
       - uses: odigos-io/ci-core/sts@main
         id: sts
         with:
-          identity: push-tags
+          identity: publish-helm
 
       - name: Publish Helm charts
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,6 +299,9 @@ jobs:
   publish-helm:
     needs: [build-cli]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Determine Tag Value
         run: |
@@ -333,9 +336,14 @@ jobs:
           name: odigos-chart
           path: helm/
 
+      - uses: odigos-io/ci-core/sts@main
+        id: sts
+        with:
+          identity: push-tags
+
       - name: Publish Helm charts
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+          GH_TOKEN: ${{ steps.sts.outputs.GH_TOKEN }}
         run: bash ./scripts/publish-charts.sh
 
       - name: Notify Slack

--- a/.github/workflows/test-release-pr.yml
+++ b/.github/workflows/test-release-pr.yml
@@ -24,16 +24,23 @@ jobs:
     needs: decide
     if: ${{ needs.decide.outputs.skip != 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     strategy:
       matrix:
         repo: ['enterprise-go-instrumentation']
     steps:
+      - uses: odigos-io/ci-core/sts@main
+        id: sts
+        with:
+          identity: cherry-pick-decision
+
       - name: Verify no open offsets PRs
         id: verify
         run: |
           # Fetch open PRs and filter by "offsets" label
           result=$(curl -s -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.RELEASE_BOT_TOKEN }}" \
+            -H "Authorization: Bearer ${{ steps.sts.outputs.GH_TOKEN }}" \
             "https://api.github.com/repos/odigos-io/${{ matrix.repo }}/pulls?state=open&per_page=100&base=main")
 
           pr_links=$(echo "$result" \
@@ -57,16 +64,23 @@ jobs:
     if: ${{ needs.decide.outputs.skip != 'true' }}
     needs: decide
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     strategy:
       matrix:
         repo: ['odigos-enterprise']
     steps:
+      - uses: odigos-io/ci-core/sts@main
+        id: sts
+        with:
+          identity: cherry-pick-decision
+
       - name: Verify no open dependencies-syncer-bot PRs
         id: verify
         run: |
           # Fetch open PRs and filter by "dependencies-syncer-bot" label
           result=$(curl -s -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.RELEASE_BOT_TOKEN }}" \
+            -H "Authorization: Bearer ${{ steps.sts.outputs.GH_TOKEN }}" \
             "https://api.github.com/repos/odigos-io/${{ matrix.repo }}/pulls?state=open&per_page=100&base=${{ github.base_ref }}")
 
           pr_links=$(echo "$result" \
@@ -90,16 +104,23 @@ jobs:
     if: ${{ needs.decide.outputs.skip != 'true' }}
     needs: decide
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     strategy:
       matrix:
         repo: ['odigos', 'odigos-enterprise']
     steps:
+      - uses: odigos-io/ci-core/sts@main
+        id: sts
+        with:
+          identity: cherry-pick-decision
+
       - name: Verify no open release-blocker PRs
         id: verify
         run: |
           # Fetch open PRs and filter by "release-blocker" label
           result=$(curl -s -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.RELEASE_BOT_TOKEN }}" \
+            -H "Authorization: Bearer ${{ steps.sts.outputs.GH_TOKEN }}" \
             "https://api.github.com/repos/odigos-io/${{ matrix.repo }}/pulls?state=open&per_page=100&base=${{ github.base_ref }}")
 
           pr_links=$(echo "$result" \

--- a/.github/workflows/trigger-dependency-sync.yaml
+++ b/.github/workflows/trigger-dependency-sync.yaml
@@ -17,6 +17,8 @@ on:
 jobs:
   trigger-odigos-enterprise:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - name: Fetch Associated PR
         env:
@@ -36,11 +38,18 @@ jobs:
           # Extract PR URL
           echo "PR_URL=$(echo "$RESPONSE" | jq -r '.[0].html_url')" >> "$GITHUB_ENV"
 
+      - uses: odigos-io/ci-core/sts@main
+        id: sts
+        with:
+          pairs: |
+            odigos-io/odigos-enterprise:trigger-release
+            odigos-io/vm-agent:dep-sync-trigger
+
       - name: Trigger process PR in Odigos Enterprise
         run: |
           curl -X POST \
           -H "Accept: application/vnd.github.v3+json" \
-          -H "Authorization: token ${{ secrets.RELEASE_BOT_TOKEN }}" \
+          -H "Authorization: token ${{ steps.sts.outputs.GH_TOKEN }}" \
           https://api.github.com/repos/odigos-io/odigos-enterprise/dispatches \
           -d '{"event_type": "process_update_dependencies_pr", "client_payload": {"pr_creator": "${{ github.event.pusher.name }}", "source_pr_url": "${{ env.PR_URL }}" }}'
 
@@ -48,6 +57,6 @@ jobs:
         run: |
           curl -X POST \
           -H "Accept: application/vnd.github.v3+json" \
-          -H "Authorization: token ${{ secrets.RELEASE_BOT_TOKEN }}" \
+          -H "Authorization: token ${{ steps.sts.outputs.GH_TOKEN }}" \
           https://api.github.com/repos/odigos-io/vm-agent/dispatches \
           -d '{"event_type": "process_update_dependencies_pr", "client_payload": {"pr_creator": "${{ github.event.pusher.name }}", "source_pr_url": "${{ env.PR_URL }}" }}'

--- a/.github/workflows/trigger-dependency-sync.yaml
+++ b/.github/workflows/trigger-dependency-sync.yaml
@@ -39,17 +39,22 @@ jobs:
           echo "PR_URL=$(echo "$RESPONSE" | jq -r '.[0].html_url')" >> "$GITHUB_ENV"
 
       - uses: odigos-io/ci-core/sts@main
-        id: sts
+        id: sts-enterprise
         with:
-          pairs: |
-            odigos-io/odigos-enterprise:trigger-release
-            odigos-io/vm-agent:dep-sync-trigger
+          scope: odigos-io/odigos-enterprise
+          identity: trigger-release
+
+      - uses: odigos-io/ci-core/sts@main
+        id: sts-vm-agent
+        with:
+          scope: odigos-io/vm-agent
+          identity: dep-sync-trigger
 
       - name: Trigger process PR in Odigos Enterprise
         run: |
           curl -X POST \
           -H "Accept: application/vnd.github.v3+json" \
-          -H "Authorization: token ${{ steps.sts.outputs.GH_TOKEN }}" \
+          -H "Authorization: token ${{ steps.sts-enterprise.outputs.GH_TOKEN }}" \
           https://api.github.com/repos/odigos-io/odigos-enterprise/dispatches \
           -d '{"event_type": "process_update_dependencies_pr", "client_payload": {"pr_creator": "${{ github.event.pusher.name }}", "source_pr_url": "${{ env.PR_URL }}" }}'
 
@@ -57,6 +62,6 @@ jobs:
         run: |
           curl -X POST \
           -H "Accept: application/vnd.github.v3+json" \
-          -H "Authorization: token ${{ steps.sts.outputs.GH_TOKEN }}" \
+          -H "Authorization: token ${{ steps.sts-vm-agent.outputs.GH_TOKEN }}" \
           https://api.github.com/repos/odigos-io/vm-agent/dispatches \
           -d '{"event_type": "process_update_dependencies_pr", "client_payload": {"pr_creator": "${{ github.event.pusher.name }}", "source_pr_url": "${{ env.PR_URL }}" }}'


### PR DESCRIPTION
#### What this PR does / why we need it:

Replace `secrets.RELEASE_BOT_TOKEN` with STS (octo-sts.dev) short-lived tokens in 4 workflow files, using existing STS identities. This eliminates long-lived PATs in favor of OIDC-based ephemeral tokens.

- `publish-modules-rhel.yml` — uses `trigger-release` identity
- `release.yml` — uses `push-tags` identity
- `test-release-pr.yml` — uses `cherry-pick-decision` identity
- `trigger-dependency-sync.yaml` — uses `trigger-release` identity for enterprise, keeps RELEASE_BOT_TOKEN for vm-agent pending identity creation

Fixes RUN-672
Fixes RUN-673
Fixes RUN-674
Fixes RUN-675

#### Optimization notes (from STS audit):

- `agent-version-updater` identity has `actions:write` which is unnecessary — auto-merge only needs `contents:write` + `pull_requests:write`. Tracked in RUN-690.
- `create-pr` identity allows any ref (`ref:.*`) — should be tightened to `refs/heads/(main|release-.*)`. Tracked in RUN-690.
- `trigger-dependency-sync.yaml` uses `pairs` mode correctly for multi-repo token exchange.

#### Changelog entry:

```release-note
NONE
```

#### Test plan

- [ ] Verify STS identities exist in target repos
- [ ] Test publish-modules-rhel workflow dispatch
- [ ] Test release Helm chart publishing
- [ ] Test release PR verification
- [ ] Test dependency sync trigger