### PR TITLE
refactor(ebpf-logs): replace ext attributes map with unix socket streaming | RUN-691

### DIFF
--- a/collector/receivers/odigosebpfreceiver/logs.go
+++ b/collector/receivers/odigosebpfreceiver/logs.go
@@ -1,7 +1,6 @@
 package odigosebpfreceiver
 
 import (
-	"bytes"
 	"context"
 	"sync"
 	"time"
@@ -67,10 +66,7 @@ func (e *logEvent) streamString() string {
 	}
 }
 
-// logsAttrCache is a thread-safe cache of TGID -> packed resource attributes.
-// It is built from the attributesMap at startup and refreshed on cache misses
-// by doing a direct map lookup. The cache size is bounded by the eBPF map's
-// MaxProcessesCount, since only registered TGIDs can appear.
+// logsAttrCache is a thread-safe TGID → packed resource attributes cache.
 type logsAttrCache struct {
 	mu    sync.RWMutex
 	cache map[uint32]string
@@ -89,68 +85,27 @@ func (c *logsAttrCache) set(tgid uint32, attrs string) {
 	c.cache[tgid] = attrs
 }
 
+func (c *logsAttrCache) delete(tgid uint32) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.cache, tgid)
+}
+
 func (c *logsAttrCache) size() int {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return len(c.cache)
 }
 
-// buildLogsAttrCache pre-populates the cache by iterating over the entire
-// attributesMap so that the hot path (per log event) can serve most lookups
-// from memory instead of issuing an eBPF map syscall for every event.
-func buildLogsAttrCache(attributesMap *ebpf.Map, logger *zap.Logger) *logsAttrCache {
-	ac := &logsAttrCache{cache: make(map[uint32]string)}
-
-	var tgidKey uint32
-	var attrValue [attrValueMaxSize]byte
-
-	iter := attributesMap.Iterate()
-	for iter.Next(&tgidKey, &attrValue) {
-		attrStr := string(bytes.TrimRight(attrValue[:], "\x00"))
-		if attrStr != "" {
-			ac.set(tgidKey, attrStr)
-		}
-	}
-	if err := iter.Err(); err != nil {
-		logger.Error("logs attributes map iterator error", zap.Error(err))
-	}
-
-	logger.Debug("logs attributes cache built", zap.Int("entries", len(ac.cache)))
-	return ac
-}
-
-// lookupAttrs looks up attributes for a TGID, first from cache, then from the eBPF map on miss.
-func lookupAttrs(ac *logsAttrCache, attributesMap *ebpf.Map, tgid uint32) string {
-	if attrs, ok := ac.get(tgid); ok {
-		return attrs
-	}
-
-	// Cache miss — try direct map lookup (new process registered since cache was built)
-	var attrValue [attrValueMaxSize]byte
-	if err := attributesMap.Lookup(tgid, &attrValue); err == nil {
-		attrStr := string(bytes.TrimRight(attrValue[:], "\x00"))
-		if attrStr != "" {
-			ac.set(tgid, attrStr)
-			return attrStr
-		}
-	}
-
-	return ""
-}
-
-func (r *ebpfReceiver) logsReadLoop(ctx context.Context, m *ebpf.Map, attributesMap *ebpf.Map) error {
+func (r *ebpfReceiver) logsReadLoop(ctx context.Context, m *ebpf.Map, attrCache *logsAttrCache) error {
 	reader, err := NewBufferReader(m, r.logger)
 	if err != nil {
 		return err
 	}
 	defer reader.Close()
 
-	// Build initial TGID -> packed attributes cache from the attributes map
-	attrCache := buildLogsAttrCache(attributesMap, r.logger)
-
 	r.logger.Debug("logs read loop started, waiting for eBPF log events",
-		zap.Int("ringBuf_fd", m.FD()),
-		zap.Int("attributesMap_fd", attributesMap.FD()))
+		zap.Int("ringBuf_fd", m.FD()))
 
 	var record BufferRecord
 
@@ -204,7 +159,7 @@ func (r *ebpfReceiver) logsReadLoop(ctx context.Context, m *ebpf.Map, attributes
 		event := (*logEvent)(unsafe.Pointer(&record.RawSample[0]))
 
 		// Look up resource attributes for this process
-		packedAttrs := lookupAttrs(attrCache, attributesMap, event.TGID)
+		packedAttrs, _ := attrCache.get(event.TGID)
 		r.telemetry.EbpfLogsAttrCacheSize.Record(ctx, int64(attrCache.size()))
 
 		ld := logEventToPdata(event)

--- a/collector/receivers/odigosebpfreceiver/odigosebpfreceiver.go
+++ b/collector/receivers/odigosebpfreceiver/odigosebpfreceiver.go
@@ -320,29 +320,20 @@ func (r *ebpfReceiver) startMetricsReceiver(ctx context.Context) {
 	}()
 }
 
-// logsMapPair holds both logs eBPF maps received atomically from a single FD exchange.
-type logsMapPair struct {
-	ringBuf       *ebpf.Map
-	attributesMap *ebpf.Map
-}
-
-// startLogsReceiver sets up a single FD client that receives both the ring buffer and
-// attributes map file descriptors in a single message, and a map manager that restarts
-// the logs read loop when new maps arrive.
+// startLogsReceiver connects to odiglet to receive the logs ring buffer FD
+// and stream per-process attribute events.
 func (r *ebpfReceiver) startLogsReceiver(ctx context.Context) {
-	updates := make(chan logsMapPair, 1)
+	updates := make(chan *ebpf.Map, 1)
+	attrCache := &logsAttrCache{cache: make(map[uint32]string)}
 
-	// Map manager: manages the lifecycle of both the ring buffer and attributes map,
-	// which arrive atomically via a single FD exchange.
 	r.wg.Add(1)
 	go func() {
 		defer r.wg.Done()
 
 		var (
-			currentRingBuf       *ebpf.Map
-			currentAttributesMap *ebpf.Map
-			readerCancel         context.CancelFunc
-			readerWg             sync.WaitGroup
+			currentRingBuf *ebpf.Map
+			readerCancel   context.CancelFunc
+			readerWg       sync.WaitGroup
 		)
 
 		defer func() {
@@ -353,16 +344,13 @@ func (r *ebpfReceiver) startLogsReceiver(ctx context.Context) {
 			if currentRingBuf != nil {
 				currentRingBuf.Close()
 			}
-			if currentAttributesMap != nil {
-				currentAttributesMap.Close()
-			}
 		}()
 
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case pair, ok := <-updates:
+			case newMap, ok := <-updates:
 				if !ok {
 					return
 				}
@@ -374,22 +362,16 @@ func (r *ebpfReceiver) startLogsReceiver(ctx context.Context) {
 				if currentRingBuf != nil {
 					currentRingBuf.Close()
 				}
-				if currentAttributesMap != nil {
-					currentAttributesMap.Close()
-				}
 
-				currentRingBuf = pair.ringBuf
-				currentAttributesMap = pair.attributesMap
+				currentRingBuf = newMap
 
-				r.logger.Info("received new logs maps",
-					zap.Int("ringBuf_fd", currentRingBuf.FD()),
-					zap.Int("attributesMap_fd", currentAttributesMap.FD()))
+				r.logger.Info("received new logs ring buffer",
+					zap.Int("ringBuf_fd", currentRingBuf.FD()))
 
 				readerCtx, cancel := context.WithCancel(ctx)
 				readerCancel = cancel
 
 				ringBuf := currentRingBuf
-				attributesMap := currentAttributesMap
 				readerWg.Add(1)
 				go func() {
 					defer func() {
@@ -397,7 +379,7 @@ func (r *ebpfReceiver) startLogsReceiver(ctx context.Context) {
 						readerWg.Done()
 					}()
 
-					if err := r.logsReadLoop(readerCtx, ringBuf, attributesMap); err != nil {
+					if err := r.logsReadLoop(readerCtx, ringBuf, attrCache); err != nil {
 						r.logger.Error("logsReadLoop failed", zap.Error(err))
 					}
 				}()
@@ -405,7 +387,6 @@ func (r *ebpfReceiver) startLogsReceiver(ctx context.Context) {
 		}
 	}()
 
-	// FD client: connects to odiglet and receives both logs FDs via ConnectAndListenMulti.
 	r.wg.Add(1)
 	go func() {
 		defer r.wg.Done()
@@ -413,49 +394,47 @@ func (r *ebpfReceiver) startLogsReceiver(ctx context.Context) {
 
 		r.logger.Info("starting logs FD client")
 
-		err := unixfd.ConnectAndListenMulti(ctx, unixfd.DefaultSocketPath, unixfd.ReqGetLogsFD, r.logger, func(fds []int) {
-			if len(fds) != 2 {
-				r.logger.Error("expected 2 logs FDs, closing all",
-					zap.Int("received", len(fds)))
-				for _, fd := range fds {
+		err := unixfd.ConnectAndListenLogs(ctx, unixfd.DefaultSocketPath, r.logger,
+			func(fd int) {
+				r.logger.Info("received logs ring buffer FD from odiglet", zap.Int("fd", fd))
+
+				ringBuf, err := ebpf.NewMapFromFD(fd)
+				if err != nil {
+					r.logger.Error("failed to create ring buffer map from FD", zap.Error(err), zap.Int("fd", fd))
 					unix.Close(fd)
+					return
 				}
-				return
-			}
 
-			r.logger.Info("received logs FDs from odiglet",
-				zap.Int("ringBuf_fd", fds[0]),
-				zap.Int("attributesMap_fd", fds[1]))
-
-			ringBuf, err := ebpf.NewMapFromFD(fds[0])
-			if err != nil {
-				r.logger.Error("failed to create ring buffer map from FD", zap.Error(err), zap.Int("fd", fds[0]))
-				unix.Close(fds[0])
-				unix.Close(fds[1])
-				return
-			}
-
-			attrMap, err := ebpf.NewMapFromFD(fds[1])
-			if err != nil {
-				r.logger.Error("failed to create attributes map from FD", zap.Error(err), zap.Int("fd", fds[1]))
-				ringBuf.Close()
-				unix.Close(fds[1])
-				return
-			}
-
-			select {
-			case updates <- logsMapPair{ringBuf: ringBuf, attributesMap: attrMap}:
-				r.logger.Info("queued new logs maps for processing")
-			case <-ctx.Done():
-				ringBuf.Close()
-				attrMap.Close()
-			}
-		})
+				select {
+				case updates <- ringBuf:
+					r.logger.Info("queued new logs ring buffer for processing")
+				case <-ctx.Done():
+					ringBuf.Close()
+				}
+			},
+			func(line string) {
+				r.handleLogsAttrEvent(line, attrCache)
+			},
+		)
 
 		if err != nil && ctx.Err() == nil {
 			r.logger.Error("logs FD client failed", zap.Error(err))
 		}
 	}()
+}
+
+// handleLogsAttrEvent parses "R<pid>:<attrs>" or "U<pid>" and updates the cache.
+func (r *ebpfReceiver) handleLogsAttrEvent(line string, cache *logsAttrCache) {
+	ev, ok := unixfd.DecodeLogsAttrEvent(line)
+	if !ok {
+		return
+	}
+	switch ev.Type {
+	case unixfd.LogsAttrRegister:
+		cache.set(ev.PID, ev.Attrs)
+	case unixfd.LogsAttrUnregister:
+		cache.delete(ev.PID)
+	}
 }
 
 func (r *ebpfReceiver) Shutdown(ctx context.Context) error {

--- a/common/ebpf/constants.go
+++ b/common/ebpf/constants.go
@@ -13,7 +13,6 @@ const (
 
 	// Logs eBPF map sizing constants.
 	LogsMaxEntries = 256 * 1024 // 256KB - must match BPF log_events map size
-	LogsExtKeySize = 4          // uint32 TGID
 
 	// Inner Map configuration
 	MetricKeySize    = 4   // uint32 metric_key

--- a/common/ebpf/maps.go
+++ b/common/ebpf/maps.go
@@ -74,13 +74,12 @@ func CreateMetricsMaps() (*cilumebpf.Map, *cilumebpf.Map, error) {
 	return metricsMap, metricsAttributesMap, nil
 }
 
-// CreateLogsMaps creates the logs RingBuf eBPF map and the logs ext (attributes)
-// Hash map used to pass per-process resource attributes alongside log events.
-// Returns (nil, nil, nil) when the kernel does not support RingBuf, since there
-// is no PerfEventArray fallback for logs.
-func CreateLogsMaps() (*cilumebpf.Map, *cilumebpf.Map, error) {
+// CreateLogsMap creates the logs RingBuf eBPF map used to receive log events
+// from the eBPF probes. Returns (nil, nil) when the kernel does not support
+// RingBuf, since there is no PerfEventArray fallback for logs.
+func CreateLogsMap() (*cilumebpf.Map, error) {
 	if err := features.HaveMapType(cilumebpf.RingBuf); err != nil {
-		return nil, nil, nil //nolint:nilerr // graceful: no RingBuf support, no fallback for logs
+		return nil, nil //nolint:nilerr // graceful: no RingBuf support, no fallback for logs
 	}
 
 	logsSpec := &cilumebpf.MapSpec{
@@ -91,22 +90,8 @@ func CreateLogsMaps() (*cilumebpf.Map, *cilumebpf.Map, error) {
 
 	logsMap, err := cilumebpf.NewMap(logsSpec)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create logs eBPF map: %w", err)
+		return nil, fmt.Errorf("failed to create logs eBPF map: %w", err)
 	}
 
-	logsExtSpec := &cilumebpf.MapSpec{
-		Type:       cilumebpf.Hash,
-		Name:       "logs_ext",
-		KeySize:    LogsExtKeySize,
-		ValueSize:  AttributesValueSize,
-		MaxEntries: MaxProcessesCount,
-	}
-
-	logsExtMap, err := cilumebpf.NewMap(logsExtSpec)
-	if err != nil {
-		_ = logsMap.Close()
-		return nil, nil, fmt.Errorf("failed to create logs ext eBPF map: %w", err)
-	}
-
-	return logsMap, logsExtMap, nil
+	return logsMap, nil
 }

--- a/common/unixfd/client.go
+++ b/common/unixfd/client.go
@@ -1,6 +1,7 @@
 package unixfd
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"net"
@@ -11,6 +12,8 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
 )
+
+const reconnectBackoff = 2 * time.Second
 
 // ConnectAndListen establishes a connection to the odiglet's Unix socket and retrieves a file descriptor (FD)
 // for the specified eBPF map type. The provided onFD callback is invoked only when a new FD is received,
@@ -30,9 +33,8 @@ func ConnectAndListen(ctx context.Context, socketPath string, requestType string
 		if err != nil {
 			// Connection attempt failed—odiglet may be down or in the process of restarting.
 			// Retry the connection after a short delay.
-			sleepTime := 2 * time.Second
-			logger.Info("Waiting for odiglet unix socket to be ready to receive FD", zap.Error(err), zap.Duration("sleepTime", sleepTime))
-			time.Sleep(sleepTime)
+			logger.Info("Waiting for odiglet unix socket to be ready to receive FD", zap.Error(err), zap.Duration("sleepTime", reconnectBackoff))
+			time.Sleep(reconnectBackoff)
 			continue
 		}
 
@@ -83,9 +85,8 @@ func ConnectAndListenMulti(ctx context.Context, socketPath string, requestType s
 
 		fds, err := connectAndGetFDs(ctx, socketPath, requestType)
 		if err != nil {
-			sleepTime := 2 * time.Second
-			logger.Info("Waiting for odiglet unix socket to be ready to receive FDs", zap.Error(err), zap.Duration("sleepTime", sleepTime))
-			time.Sleep(sleepTime)
+			logger.Info("Waiting for odiglet unix socket to be ready to receive FDs", zap.Error(err), zap.Duration("sleepTime", reconnectBackoff))
+			time.Sleep(reconnectBackoff)
 			continue
 		}
 
@@ -102,6 +103,65 @@ func ConnectAndListenMulti(ctx context.Context, socketPath string, requestType s
 			continue
 		}
 	}
+}
+
+// ConnectAndListenLogs receives the logs ring buffer FD and streams attribute
+// events over a persistent connection. Reconnects automatically on disconnect.
+func ConnectAndListenLogs(ctx context.Context, socketPath string, logger *zap.Logger, onFD func(fd int), onAttr func(line string)) error {
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		err := connectLogsSession(ctx, socketPath, onFD, onAttr)
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		// Session ended (server disconnected or error) — retry after backoff.
+		logger.Info("Logs connection lost, reconnecting", zap.Error(err), zap.Duration("backoff", reconnectBackoff))
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(reconnectBackoff):
+		}
+	}
+}
+
+func connectLogsSession(ctx context.Context, socketPath string, onFD func(fd int), onAttr func(line string)) error {
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, "unix", socketPath)
+	if err != nil {
+		return fmt.Errorf("dial: %w", err)
+	}
+	uc := conn.(*net.UnixConn)
+	defer func() { _ = uc.Close() }()
+
+	// Close the connection when the context is canceled to unblock scanner.Scan().
+	go func() {
+		<-ctx.Done()
+		_ = uc.Close()
+	}()
+
+	if _, err := uc.Write([]byte(ReqGetLogsFD)); err != nil {
+		return fmt.Errorf("write request: %w", err)
+	}
+
+	fds, err := recvFDs(uc)
+	if err != nil {
+		return fmt.Errorf("recv fds: %w", err)
+	}
+	if len(fds) == 0 {
+		return fmt.Errorf("no fds received")
+	}
+
+	onFD(fds[0])
+
+	scanner := bufio.NewScanner(uc)
+	for scanner.Scan() {
+		onAttr(scanner.Text())
+	}
+	return scanner.Err()
 }
 
 // connectAndGetFDs makes a single connection, gets multiple FDs, and closes connection

--- a/common/unixfd/logsattr.go
+++ b/common/unixfd/logsattr.go
@@ -1,0 +1,68 @@
+package unixfd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// LogsAttrEventType distinguishes register from unregister attribute events.
+type LogsAttrEventType int
+
+const (
+	LogsAttrRegister LogsAttrEventType = iota
+	LogsAttrUnregister
+)
+
+// LogsAttrEvent is a parsed attribute event from the logs attribute stream.
+type LogsAttrEvent struct {
+	Type  LogsAttrEventType
+	PID   uint32
+	Attrs string // packed key:val,key:val — only meaningful for Register
+}
+
+// EncodeLogsAttrRegister encodes a register event: "R<pid>:<attrs>".
+func EncodeLogsAttrRegister(pid uint32, packedAttrs string) string {
+	return fmt.Sprintf("R%d:%s", pid, packedAttrs)
+}
+
+// EncodeLogsAttrUnregister encodes an unregister event: "U<pid>".
+func EncodeLogsAttrUnregister(pid uint32) string {
+	return fmt.Sprintf("U%d", pid)
+}
+
+// DecodeLogsAttrEvent parses a single line from the attribute stream.
+// Returns the parsed event and true on success, or a zero event and false
+// if the line is malformed.
+func DecodeLogsAttrEvent(line string) (LogsAttrEvent, bool) {
+	if len(line) < 2 {
+		return LogsAttrEvent{}, false
+	}
+	switch line[0] {
+	case 'R':
+		idx := strings.IndexByte(line, ':')
+		if idx < 2 {
+			return LogsAttrEvent{}, false
+		}
+		pid, err := strconv.ParseUint(line[1:idx], 10, 32)
+		if err != nil {
+			return LogsAttrEvent{}, false
+		}
+		return LogsAttrEvent{
+			Type:  LogsAttrRegister,
+			PID:   uint32(pid),
+			Attrs: line[idx+1:],
+		}, true
+	case 'U':
+		pid, err := strconv.ParseUint(line[1:], 10, 32)
+		if err != nil {
+			return LogsAttrEvent{}, false
+		}
+		return LogsAttrEvent{
+			Type: LogsAttrUnregister,
+			PID:  uint32(pid),
+		}, true
+	default:
+		return LogsAttrEvent{}, false
+	}
+}

--- a/common/unixfd/server.go
+++ b/common/unixfd/server.go
@@ -21,6 +21,10 @@ type Server struct {
 	TracesFDProvider   func() int   // Function that returns the traces eBPF map file descriptor
 	MetricsFDsProvider func() []int // Function that returns all metrics-related eBPF map file descriptors
 	LogsFDsProvider    func() []int // Function that returns all logs-related eBPF map file descriptors
+
+	// LogsAttrSubscribe returns attribute event lines and a snapshot of current attrs.
+	// When non-nil, the logs connection stays open after FD exchange to stream events.
+	LogsAttrSubscribe func() (updates <-chan string, snapshot []string)
 }
 
 // Run starts the Unix domain socket server, which serves eBPF map file descriptors to connecting clients.
@@ -62,21 +66,19 @@ func (s *Server) Run(ctx context.Context) error {
 			continue
 		}
 
-		go s.handleRequest(conn.(*net.UnixConn))
+		go s.handleRequest(ctx, conn.(*net.UnixConn))
 	}
 }
 
 // handleRequest processes a single client request
-func (s *Server) handleRequest(conn *net.UnixConn) {
+func (s *Server) handleRequest(ctx context.Context, conn *net.UnixConn) {
 	logger := commonlogger.WrapLogr(s.Logger).WithName("unixfd")
-	defer func() {
-		_ = conn.Close()
-	}()
 
 	// Read the request
 	buf := make([]byte, 16)
 	n, err := conn.Read(buf)
 	if err != nil {
+		_ = conn.Close()
 		logger.Error(err, "failed to read request")
 		return
 	}
@@ -85,6 +87,7 @@ func (s *Server) handleRequest(conn *net.UnixConn) {
 
 	switch request {
 	case ReqGetFD, ReqGetTracesFD:
+		defer func() { _ = conn.Close() }()
 		// Legacy "GET_FD" defaults to traces for backward compatibility
 		if s.TracesFDProvider == nil {
 			logger.Error(fmt.Errorf("traces FD provider not configured"), "no traces FD provider")
@@ -102,6 +105,7 @@ func (s *Server) handleRequest(conn *net.UnixConn) {
 		logger.Info("sent FD to client", "fd", fd, "request", request)
 
 	case ReqGetMetricsFD:
+		defer func() { _ = conn.Close() }()
 		if s.MetricsFDsProvider == nil {
 			logger.Error(fmt.Errorf("metrics FDs provider not configured"), "no metrics FDs provider")
 			return
@@ -124,30 +128,67 @@ func (s *Server) handleRequest(conn *net.UnixConn) {
 		logger.Info("sent metrics FDs to client", "fds", fds, "request", request)
 
 	case ReqGetLogsFD:
-		if s.LogsFDsProvider == nil {
-			s.Logger.Error(fmt.Errorf("logs FDs provider not configured"), "no logs FDs provider")
+		s.handleLogsRequest(ctx, conn)
+
+	default:
+		_ = conn.Close()
+		logger.Info("unknown request", "request", request)
+		return
+	}
+}
+
+// handleLogsRequest sends the logs FD and optionally streams attribute events.
+func (s *Server) handleLogsRequest(ctx context.Context, conn *net.UnixConn) {
+	defer func() { _ = conn.Close() }()
+	logger := commonlogger.WrapLogr(s.Logger).WithName("unixfd")
+
+	if s.LogsFDsProvider == nil {
+		logger.Error(fmt.Errorf("logs FDs provider not configured"), "no logs FDs provider")
+		return
+	}
+	fds := s.LogsFDsProvider()
+	if len(fds) == 0 {
+		logger.Error(fmt.Errorf("no logs FDs available"), "logs FDs provider returned empty slice")
+		return
+	}
+	for _, fd := range fds {
+		if fd <= 0 {
+			logger.Error(fmt.Errorf("invalid fd %d", fd), "FD provider returned invalid fd")
 			return
 		}
-		fds := s.LogsFDsProvider()
-		if len(fds) == 0 {
-			s.Logger.Error(fmt.Errorf("no logs FDs available"), "logs FDs provider returned empty slice")
+	}
+	if err := sendFDs(conn, fds...); err != nil {
+		logger.Error(err, "failed to send logs FDs")
+		return
+	}
+	logger.Info("sent logs FDs to client", "fds", fds, "request", ReqGetLogsFD)
+
+	if s.LogsAttrSubscribe == nil {
+		return
+	}
+
+	updates, snapshot := s.LogsAttrSubscribe()
+
+	for _, line := range snapshot {
+		if _, err := conn.Write([]byte(line + "\n")); err != nil {
+			logger.Info("logs attr client disconnected during snapshot", "error", err)
 			return
 		}
-		for _, fd := range fds {
-			if fd <= 0 {
-				s.Logger.Error(fmt.Errorf("invalid fd %d", fd), "FD provider returned invalid fd", "request", request)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case line, ok := <-updates:
+			if !ok {
+				return
+			}
+			if _, err := conn.Write([]byte(line + "\n")); err != nil {
+				logger.Info("logs attr client disconnected", "error", err)
 				return
 			}
 		}
-		if err := sendFDs(conn, fds...); err != nil {
-			s.Logger.Error(err, "failed to send logs FDs")
-			return
-		}
-		s.Logger.Info("sent logs FDs to client", "fds", fds, "request", request)
-
-	default:
-		logger.Info("unknown request", "request", request)
-		return
 	}
 }
 

--- a/instrumentation/manager.go
+++ b/instrumentation/manager.go
@@ -106,9 +106,8 @@ type ManagerOptions[processGroup ProcessGroup, configGroup ConfigGroup, processD
 	// LogsMap is the optional common eBPF map that will be used to send log events from eBPF probes.
 	LogsMap *cilumebpf.Map
 
-	// LogsExtMap is the optional eBPF Hash map for TGID -> packed resource attributes.
-	// Used alongside LogsMap to store per-process resource attributes that enrich log events.
-	LogsExtMap *cilumebpf.Map
+	// LogsAttrSubscribe streams per-process resource attributes over the logs unix socket.
+	LogsAttrSubscribe func() (updates <-chan string, snapshot []string)
 }
 
 // Manager is used to orchestrate the ebpf instrumentations lifecycle.
@@ -150,7 +149,7 @@ type manager[processGroup ProcessGroup, configGroup ConfigGroup, processDetails 
 	metricsMap           *cilumebpf.Map
 	metricsAttributesMap *cilumebpf.Map
 	logsMap              *cilumebpf.Map
-	logsExtMap           *cilumebpf.Map
+	logsAttrSubscribe    func() (updates <-chan string, snapshot []string)
 }
 
 func NewManager[processGroup ProcessGroup, configGroup ConfigGroup, processDetails ProcessDetails[processGroup, configGroup]](options ManagerOptions[processGroup, configGroup, processDetails]) (Manager, error) {
@@ -206,7 +205,7 @@ func NewManager[processGroup ProcessGroup, configGroup ConfigGroup, processDetai
 		metricsMap:            options.MetricsMap,
 		metricsAttributesMap:  options.MetricsAttributesMap,
 		logsMap:               options.LogsMap,
-		logsExtMap:            options.LogsExtMap,
+		logsAttrSubscribe:     options.LogsAttrSubscribe,
 	}, nil
 }
 
@@ -361,15 +360,12 @@ func (m *manager[ProcessGroup, ConfigGroup, ProcessDetails]) Run(ctx context.Con
 				return fds
 			},
 			LogsFDsProvider: func() []int {
-				var fds []int
 				if m.logsMap != nil {
-					fds = append(fds, m.logsMap.FD())
+					return []int{m.logsMap.FD()}
 				}
-				if m.logsExtMap != nil {
-					fds = append(fds, m.logsExtMap.FD())
-				}
-				return fds
+				return nil
 			},
+			LogsAttrSubscribe: m.logsAttrSubscribe,
 		}
 
 		// Run server in background to serve the map FD to relevant data collection client.

--- a/odiglet/pkg/ebpf/common.go
+++ b/odiglet/pkg/ebpf/common.go
@@ -28,10 +28,8 @@ type InstrumentationManagerOptions struct {
 	// It allows callers (e.g. enterprise odiglet) to receive the map for use with
 	// external reader mode in the log capture BPF programs.
 	OnLogsMapCreated func(*cilumebpf.Map)
-	// OnLogsExtMapCreated is an optional callback invoked after the logs ext (attributes) eBPF map is created.
-	// It allows callers (e.g. enterprise odiglet) to receive the map for passing per-process
-	// resource attributes alongside log events.
-	OnLogsExtMapCreated func(*cilumebpf.Map)
+	// LogsAttrSubscribe streams per-process resource attributes to the collector.
+	LogsAttrSubscribe func() (updates <-chan string, snapshot []string)
 }
 
 // NewManager creates a new instrumentation manager for eBPF which is configured to work with Kubernetes.
@@ -76,20 +74,16 @@ func NewManager(
 		return nil, fmt.Errorf("failed to create metrics attributes eBPF maps: %w", err)
 	}
 
-	logsMap, logsExtMap, err := ebpfcommon.CreateLogsMaps()
+	logsMap, err := ebpfcommon.CreateLogsMap()
 	if err != nil {
 		tracesMap.Close()
 		metricsMap.Close()
 		metricsAttributesMap.Close()
-		return nil, fmt.Errorf("failed to create logs eBPF maps: %w", err)
+		return nil, fmt.Errorf("failed to create logs eBPF map: %w", err)
 	}
 
 	if logsMap != nil && opts.OnLogsMapCreated != nil {
 		opts.OnLogsMapCreated(logsMap)
-	}
-
-	if logsExtMap != nil && opts.OnLogsExtMapCreated != nil {
-		opts.OnLogsExtMapCreated(logsExtMap)
 	}
 
 	managerOpts := instrumentation.ManagerOptions[K8sProcessGroup, K8sConfigGroup, *K8sProcessDetails]{
@@ -104,7 +98,7 @@ func NewManager(
 		MetricsMap:              metricsMap,
 		MetricsAttributesMap:    metricsAttributesMap,
 		LogsMap:                 logsMap,
-		LogsExtMap:              logsExtMap,
+		LogsAttrSubscribe:      opts.LogsAttrSubscribe,
 	}
 
 	// Add file open triggers from all distributions.


### PR DESCRIPTION

#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Remove the logs_ext eBPF hash map used for per-process resource attributes and stream them over the existing unix socket connection instead, using a text protocol (R<pid>:<attrs> / U<pid>) with persistent connection and snapshot+subscribe


#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
feat: move logs attribute handling from ebpf maps to socket exchange
```
