### PR TITLE
fix(baseimg): upgrade base image to 1.26.2

### DIFF
--- a/odiglet/base.Dockerfile
+++ b/odiglet/base.Dockerfile
@@ -22,7 +22,7 @@ RUN wget https://download.samba.org/pub/rsync/src/rsync-${RSYNC_VERSION}.tar.gz 
     && cd .. \
     && rm -rf rsync-${RSYNC_VERSION}*
 
-FROM golang:1.26.1-trixie
+FROM golang:1.26.2-trixie
 
 # goreleaser is used to build vmagent
 RUN echo "deb [trusted=yes] https://repo.goreleaser.com/apt/ /" > /etc/apt/sources.list.d/goreleaser.list


### PR DESCRIPTION
#### What this PR does / why we need it:
1.26.1 has vulns; upgrde to 1.26.2
#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
```release-note
Update golang to 1.26.2 on base image to resolve CVE-2026-32280[HIGH]
```
Fixes RUN-694
