### PR TITLE
CORE-887 | fix: deterministic gateway config creation

### DIFF
--- a/autoscaler/controllers/clustercollector/configmap.go
+++ b/autoscaler/controllers/clustercollector/configmap.go
@@ -411,6 +411,13 @@ func calculateDataStreams(
 		return strings.Compare(a.Name, b.Name)
 	})
 
+	// Sort destinations within each data stream for stable pipeline output
+	for i := range dataStreamDetailsList {
+		slices.SortFunc(dataStreamDetailsList[i].Destinations, func(a, b pipelinegen.Destination) int {
+			return strings.Compare(a.DestinationName, b.DestinationName)
+		})
+	}
+
 	return dataStreamDetailsList, nil
 }
 

--- a/autoscaler/controllers/clustercollector/sync.go
+++ b/autoscaler/controllers/clustercollector/sync.go
@@ -2,6 +2,8 @@ package clustercollector
 
 import (
 	"context"
+	"slices"
+	"strings"
 
 	"github.com/odigos-io/odigos/api/k8sconsts"
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
@@ -71,6 +73,11 @@ func syncGateway(dests *odigosv1.DestinationList, processors *odigosv1.Processor
 		}
 		enabledDests.Items = append(enabledDests.Items, dest)
 	}
+
+	// Kubernetes list order is unspecified; sort once so downstream config is stable.
+	slices.SortFunc(enabledDests.Items, func(a, b odigosv1.Destination) int {
+		return strings.Compare(a.Name, b.Name)
+	})
 
 	signals, err := syncConfigMap(enabledDests, processors, gateway, ctx, c, scheme)
 	if err != nil {

--- a/common/pipelinegen/config_builder.go
+++ b/common/pipelinegen/config_builder.go
@@ -201,6 +201,9 @@ func CalculateGatewayConfig(
 		currentConfig.Extensions[*gatewayOptions.OdigosConfigExtensionName] = config.GenericMap{}
 	}
 
+	// Sort extensions for deterministic YAML output
+	slices.Sort(currentConfig.Service.Extensions)
+
 	// Final marshal to YAML
 	data, err := yaml.Marshal(currentConfig)
 	if err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
We want to ensure that any non-deterministic behavior in gateway configuration updates becomes deterministic, in order to prevent unnecessary reloads on gateway.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
fix periodic config reload in gateway without real config change. this improve the collector memory stability and availability 
```
