### PR TITLE
feat: add reset functionality for local UI configuration to factory defaults

### DIFF
--- a/frontend/graph/configs.graphqls
+++ b/frontend/graph/configs.graphqls
@@ -382,4 +382,5 @@ extend type Mutation {
     level: OdigosLogLevel!
   ): Boolean!
   updateLocalUiConfig(config: LocalUiConfigInput!): Boolean!
+  resetLocalUiConfigToFactoryDefaults: Boolean!
 }

--- a/frontend/graph/configs.resolvers.go
+++ b/frontend/graph/configs.resolvers.go
@@ -46,6 +46,12 @@ func (r *mutationResolver) UpdateLocalUIConfig(ctx context.Context, config model
 	return err == nil, err
 }
 
+// ResetLocalUIConfigToFactoryDefaults is the resolver for the resetLocalUiConfigToFactoryDefaults field.
+func (r *mutationResolver) ResetLocalUIConfigToFactoryDefaults(ctx context.Context) (bool, error) {
+	err := services.ResetLocalUiConfigToFactoryDefaults(ctx, r.K8sCacheClient)
+	return err == nil, err
+}
+
 // Config is the resolver for the config field.
 func (r *queryResolver) Config(ctx context.Context) (*model.Config, error) {
 	config := services.GetConfig(ctx)

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -902,41 +902,42 @@ type ComplexityRoot struct {
 	}
 
 	Mutation struct {
-		CreateAction                      func(childComplexity int, action model.ActionInput) int
-		CreateCostReductionRule           func(childComplexity int, samplingID string, rule model.CostReductionRuleInput) int
-		CreateHighlyRelevantOperationRule func(childComplexity int, samplingID string, rule model.HighlyRelevantOperationRuleInput) int
-		CreateInstrumentationRule         func(childComplexity int, instrumentationRule model.InstrumentationRuleInput) int
-		CreateNewDestination              func(childComplexity int, destination model.DestinationInput) int
-		CreateNoisyOperationRule          func(childComplexity int, samplingID string, rule model.NoisyOperationRuleInput) int
-		DeleteAction                      func(childComplexity int, id string, actionType string) int
-		DeleteCentralProxy                func(childComplexity int) int
-		DeleteCostReductionRule           func(childComplexity int, samplingID string, ruleID string) int
-		DeleteDataStream                  func(childComplexity int, id string) int
-		DeleteDestination                 func(childComplexity int, id string, currentStreamName string) int
-		DeleteHighlyRelevantOperationRule func(childComplexity int, samplingID string, ruleID string) int
-		DeleteInstrumentationRule         func(childComplexity int, ruleID string) int
-		DeleteNoisyOperationRule          func(childComplexity int, samplingID string, ruleID string) int
-		PauseOdigos                       func(childComplexity int) int
-		PersistK8sNamespaces              func(childComplexity int, namespaces []*model.PersistNamespaceItemInput) int
-		PersistK8sSources                 func(childComplexity int, sources []*model.PersistNamespaceSourceInput) int
-		RecoverFromRollbackForWorkload    func(childComplexity int, sourceID model.K8sSourceID) int
-		RestartPod                        func(childComplexity int, namespace string, name string) int
-		RestartWorkloads                  func(childComplexity int, sourceIds []*model.K8sSourceID) int
-		SetComponentLogLevel              func(childComplexity int, component *model.OdigosComponent, level model.OdigosLogLevel) int
-		TestConnectionForDestination      func(childComplexity int, destination model.DestinationInput) int
-		UninstrumentCluster               func(childComplexity int) int
-		UpdateAPIToken                    func(childComplexity int, token string) int
-		UpdateAction                      func(childComplexity int, id string, action model.ActionInput) int
-		UpdateCostReductionRule           func(childComplexity int, samplingID string, ruleID string, rule model.CostReductionRuleInput) int
-		UpdateDataStream                  func(childComplexity int, id string, dataStream model.DataStreamInput) int
-		UpdateDestination                 func(childComplexity int, id string, destination model.DestinationInput) int
-		UpdateHighlyRelevantOperationRule func(childComplexity int, samplingID string, ruleID string, rule model.HighlyRelevantOperationRuleInput) int
-		UpdateInstrumentationRule         func(childComplexity int, ruleID string, instrumentationRule model.InstrumentationRuleInput) int
-		UpdateK8sActualSource             func(childComplexity int, sourceID model.K8sSourceID, patchSourceRequest model.PatchSourceRequestInput) int
-		UpdateLocalUIConfig               func(childComplexity int, config model.LocalUIConfigInput) int
-		UpdateLocalUISamplingConfig       func(childComplexity int, config *model.SamplingConfigInput) int
-		UpdateNoisyOperationRule          func(childComplexity int, samplingID string, ruleID string, rule model.NoisyOperationRuleInput) int
-		UpdateRemoteConfig                func(childComplexity int, config model.RemoteConfigInput) int
+		CreateAction                        func(childComplexity int, action model.ActionInput) int
+		CreateCostReductionRule             func(childComplexity int, samplingID string, rule model.CostReductionRuleInput) int
+		CreateHighlyRelevantOperationRule   func(childComplexity int, samplingID string, rule model.HighlyRelevantOperationRuleInput) int
+		CreateInstrumentationRule           func(childComplexity int, instrumentationRule model.InstrumentationRuleInput) int
+		CreateNewDestination                func(childComplexity int, destination model.DestinationInput) int
+		CreateNoisyOperationRule            func(childComplexity int, samplingID string, rule model.NoisyOperationRuleInput) int
+		DeleteAction                        func(childComplexity int, id string, actionType string) int
+		DeleteCentralProxy                  func(childComplexity int) int
+		DeleteCostReductionRule             func(childComplexity int, samplingID string, ruleID string) int
+		DeleteDataStream                    func(childComplexity int, id string) int
+		DeleteDestination                   func(childComplexity int, id string, currentStreamName string) int
+		DeleteHighlyRelevantOperationRule   func(childComplexity int, samplingID string, ruleID string) int
+		DeleteInstrumentationRule           func(childComplexity int, ruleID string) int
+		DeleteNoisyOperationRule            func(childComplexity int, samplingID string, ruleID string) int
+		PauseOdigos                         func(childComplexity int) int
+		PersistK8sNamespaces                func(childComplexity int, namespaces []*model.PersistNamespaceItemInput) int
+		PersistK8sSources                   func(childComplexity int, sources []*model.PersistNamespaceSourceInput) int
+		RecoverFromRollbackForWorkload      func(childComplexity int, sourceID model.K8sSourceID) int
+		ResetLocalUIConfigToFactoryDefaults func(childComplexity int) int
+		RestartPod                          func(childComplexity int, namespace string, name string) int
+		RestartWorkloads                    func(childComplexity int, sourceIds []*model.K8sSourceID) int
+		SetComponentLogLevel                func(childComplexity int, component *model.OdigosComponent, level model.OdigosLogLevel) int
+		TestConnectionForDestination        func(childComplexity int, destination model.DestinationInput) int
+		UninstrumentCluster                 func(childComplexity int) int
+		UpdateAPIToken                      func(childComplexity int, token string) int
+		UpdateAction                        func(childComplexity int, id string, action model.ActionInput) int
+		UpdateCostReductionRule             func(childComplexity int, samplingID string, ruleID string, rule model.CostReductionRuleInput) int
+		UpdateDataStream                    func(childComplexity int, id string, dataStream model.DataStreamInput) int
+		UpdateDestination                   func(childComplexity int, id string, destination model.DestinationInput) int
+		UpdateHighlyRelevantOperationRule   func(childComplexity int, samplingID string, ruleID string, rule model.HighlyRelevantOperationRuleInput) int
+		UpdateInstrumentationRule           func(childComplexity int, ruleID string, instrumentationRule model.InstrumentationRuleInput) int
+		UpdateK8sActualSource               func(childComplexity int, sourceID model.K8sSourceID, patchSourceRequest model.PatchSourceRequestInput) int
+		UpdateLocalUIConfig                 func(childComplexity int, config model.LocalUIConfigInput) int
+		UpdateLocalUISamplingConfig         func(childComplexity int, config *model.SamplingConfigInput) int
+		UpdateNoisyOperationRule            func(childComplexity int, samplingID string, ruleID string, rule model.NoisyOperationRuleInput) int
+		UpdateRemoteConfig                  func(childComplexity int, config model.RemoteConfigInput) int
 	}
 
 	NodeCollectorAnalyze struct {
@@ -1399,6 +1400,7 @@ type MutationResolver interface {
 	UpdateRemoteConfig(ctx context.Context, config model.RemoteConfigInput) (bool, error)
 	SetComponentLogLevel(ctx context.Context, component *model.OdigosComponent, level model.OdigosLogLevel) (bool, error)
 	UpdateLocalUIConfig(ctx context.Context, config model.LocalUIConfigInput) (bool, error)
+	ResetLocalUIConfigToFactoryDefaults(ctx context.Context) (bool, error)
 	RestartPod(ctx context.Context, namespace string, name string) (bool, error)
 	UpdateLocalUISamplingConfig(ctx context.Context, config *model.SamplingConfigInput) (bool, error)
 	CreateNoisyOperationRule(ctx context.Context, samplingID string, rule model.NoisyOperationRuleInput) (*model.NoisyOperationRule, error)
@@ -5356,6 +5358,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.RecoverFromRollbackForWorkload(childComplexity, args["sourceId"].(model.K8sSourceID)), true
+
+	case "Mutation.resetLocalUiConfigToFactoryDefaults":
+		if e.complexity.Mutation.ResetLocalUIConfigToFactoryDefaults == nil {
+			break
+		}
+
+		return e.complexity.Mutation.ResetLocalUIConfigToFactoryDefaults(childComplexity), true
 
 	case "Mutation.restartPod":
 		if e.complexity.Mutation.RestartPod == nil {
@@ -34677,6 +34686,50 @@ func (ec *executionContext) fieldContext_Mutation_updateLocalUiConfig(ctx contex
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_resetLocalUiConfigToFactoryDefaults(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_resetLocalUiConfigToFactoryDefaults(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().ResetLocalUIConfigToFactoryDefaults(rctx)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_resetLocalUiConfigToFactoryDefaults(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation_restartPod(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation_restartPod(ctx, field)
 	if err != nil {
@@ -57807,6 +57860,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "updateLocalUiConfig":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_updateLocalUiConfig(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "resetLocalUiConfigToFactoryDefaults":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_resetLocalUiConfigToFactoryDefaults(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++

--- a/frontend/services/local_ui_config.go
+++ b/frontend/services/local_ui_config.go
@@ -82,6 +82,32 @@ func createLocalUiConfigMap(ctx context.Context, c client.Client, ns string, inp
 	return c.Create(ctx, &newCm)
 }
 
+func ResetLocalUiConfigToFactoryDefaults(ctx context.Context, c client.Client) error {
+	ns := env.GetCurrentNamespace()
+
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		var cm v1.ConfigMap
+		err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: consts.OdigosLocalUiConfigName}, &cm)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+
+		emptyCfg := common.OdigosConfiguration{}
+		data, err := yaml.Marshal(emptyCfg)
+		if err != nil {
+			return err
+		}
+		if cm.Data == nil {
+			cm.Data = make(map[string]string)
+		}
+		cm.Data[consts.OdigosConfigurationFileName] = string(data)
+		return c.Update(ctx, &cm)
+	})
+}
+
 func applyLocalUiConfigInput(cfg *common.OdigosConfiguration, input model.LocalUIConfigInput) {
 	if input.TelemetryEnabled != nil {
 		cfg.TelemetryEnabled = *input.TelemetryEnabled

--- a/frontend/webapp/graphql/mutations/config.ts
+++ b/frontend/webapp/graphql/mutations/config.ts
@@ -5,3 +5,9 @@ export const UPDATE_LOCAL_UI_CONFIG = gql`
     updateLocalUiConfig(config: $config)
   }
 `;
+
+export const RESET_LOCAL_UI_CONFIG_TO_FACTORY_DEFAULTS = gql`
+  mutation ResetLocalUiConfigToFactoryDefaults {
+    resetLocalUiConfigToFactoryDefaults
+  }
+`;

--- a/frontend/webapp/hooks/config/useUpdateLocalUiConfig.ts
+++ b/frontend/webapp/hooks/config/useUpdateLocalUiConfig.ts
@@ -1,7 +1,7 @@
 import { useMutation } from '@apollo/client';
 import { useNotificationStore } from '@odigos/ui-kit/store';
-import { UPDATE_LOCAL_UI_CONFIG } from '@/graphql/mutations';
 import { Crud, StatusType, type LocalUiConfigInput } from '@odigos/ui-kit/types';
+import { UPDATE_LOCAL_UI_CONFIG, RESET_LOCAL_UI_CONFIG_TO_FACTORY_DEFAULTS } from '@/graphql/mutations';
 
 export const useUpdateLocalUiConfig = () => {
   const { addNotification } = useNotificationStore();
@@ -23,12 +23,34 @@ export const useUpdateLocalUiConfig = () => {
     },
   });
 
+  const [resetMutate, { loading: resetLoading }] = useMutation<{ resetLocalUiConfigToFactoryDefaults: boolean }>(RESET_LOCAL_UI_CONFIG_TO_FACTORY_DEFAULTS, {
+    onError: (error) => {
+      addNotification({
+        type: StatusType.Error,
+        title: Crud.Update,
+        message: error.message,
+      });
+    },
+    onCompleted: () => {
+      addNotification({
+        type: StatusType.Success,
+        title: Crud.Update,
+        message: 'Local UI configuration reset to factory defaults',
+      });
+    },
+  });
+
   const updateLocalUiConfig = (config: LocalUiConfigInput) => {
     return mutate({ variables: { config } });
   };
 
+  const resetLocalUiConfigToFactoryDefaults = () => {
+    return resetMutate();
+  };
+
   return {
     updateLocalUiConfig,
-    loading,
+    resetLocalUiConfigToFactoryDefaults,
+    loading: loading || resetLoading,
   };
 };


### PR DESCRIPTION
This commit introduces a new mutation `resetLocalUiConfigToFactoryDefaults` to reset the local UI configuration to factory defaults. The corresponding resolver and service function have been implemented to handle this functionality. Additionally, the GraphQL schema and frontend hooks have been updated to support this new mutation.

```release-note
[Add mutation to reset local UI configuration to factory defaults](feat: add reset functionality for local UI configuration to factory defaults)
```

emergency-ticket id: EMR-1463
