### PR TITLE
ci(sts): fix for homebrew repos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,7 +220,7 @@ jobs:
       - uses: odigos-io/ci-core/sts@main
         id: sts-goreleaser
         with:
-          scope: ${{ env.HOMEBREW_REPO }}
+          scope: odigos-io/${{ env.HOMEBREW_REPO }}
           identity: releaser
           output-git-config: "false"
 


### PR DESCRIPTION

#### What this PR does / why we need it:
STS didn't mention the odigos-io/% prefix in the scope;
```release-note
NONE
```

emergency-ticket id: EMR-1462
