### PR TITLE
CORE-900 | chore: store node attribute also for connection type = database

### DIFF
--- a/collector/connectors/servicegraphconnector/README.ODIGOS.md
+++ b/collector/connectors/servicegraphconnector/README.ODIGOS.md
@@ -21,17 +21,17 @@ This package is copied from [opentelemetry-collector-contrib](https://github.com
 |------|--------|
 | **Where** | `connector.go` — `aggregateMetricsForEdge` calls `buildMetricKeyFromEdge(e)` instead of `buildMetricKey(..., e.Dimensions)`. |
 | **Why** | The `server` label uses the **first** matching `virtual_node_peer_attributes` value (`getPeerHost`). Other peer fields can differ while `server` stays the same; the key must include them or series merge incorrectly. |
-| **What it does** | Starts from `buildMetricKey`. For `virtual_node` + non-empty `e.Peer`, appends sorted `peer\|<key>\|<value>`. Skips keys already in `e.Dimensions` as `client_*` / `server_*`. |
+| **What it does** | Starts from `buildMetricKey`. For `virtual_node` **or `database`** edges with non-empty `e.Peer`, appends sorted `peer\|<key>\|<value>`. Skips keys already in `e.Dimensions` as `client_*` / `server_*`. |
 
 ---
 
-## 3. `buildDimensions` virtual-node peer labels + `sortedMapKeys`
+## 3. `buildDimensions` peer labels + `sortedMapKeys`
 
 | Item | Detail |
 |------|--------|
-| **Where** | `connector.go` — `buildDimensions` (virtual-node branch) and `sortedMapKeys` |
-| **Why** | Odigos UI expects `server_*` labels for virtual-node peers (e.g. `server_db.system`). Upstream only copies `e.Dimensions` onto the datapoint. |
-| **What it does** | For `virtual_node` + non-empty `e.Peer`, adds `server_<peerKey>` unless already in `e.Dimensions`. Uses **sorted** peer keys (same order as §2). |
+| **Where** | `connector.go` — `buildDimensions` (virtual-node / database branch) and `sortedMapKeys` |
+| **Why** | Odigos UI expects `server_*` labels for virtual-node and database peers (e.g. `server_db.system`). Upstream only copies `e.Dimensions` onto the datapoint. Database edges are completed immediately during span processing (before `onExpire`), so they must be handled alongside virtual-node edges. |
+| **What it does** | For `virtual_node` **or `database`** edges with non-empty `e.Peer`, adds `server_<peerKey>` unless already in `e.Dimensions`. Uses **sorted** peer keys (same order as §2). |
 
 ---
 

--- a/collector/connectors/servicegraphconnector/connector.go
+++ b/collector/connectors/servicegraphconnector/connector.go
@@ -498,10 +498,10 @@ func buildDimensions(e *store.Edge) pcommon.Map {
 		dims.PutStr(k, v)
 	}
 
-	// Virtual-node edges: peer attributes describe the downstream from the client span. Emit as
-	// server_* for consistency with other server-side dimensions. Skip keys already in e.Dimensions
-	// to avoid duplicate label names. Sorted peer keys align with buildMetricKeyFromEdge.
-	if e.ConnectionType == store.VirtualNode && len(e.Peer) > 0 {
+	// Virtual-node and database edges: peer attributes describe the downstream from the client span.
+	// Emit as server_* for consistency with other server-side dimensions. Skip keys already in
+	// e.Dimensions to avoid duplicate label names. Sorted peer keys align with buildMetricKeyFromEdge.
+	if (e.ConnectionType == store.VirtualNode || e.ConnectionType == store.Database) && len(e.Peer) > 0 {
 		for _, key := range sortedMapKeys(e.Peer) {
 			dim := serverKind + "_" + key
 			if _, exists := e.Dimensions[dim]; exists {
@@ -735,13 +735,14 @@ func (p *serviceGraphConnector) buildMetricKey(clientName, serverName, connectio
 	return metricKey.String()
 }
 
-// For virtual-node edges the metric "server" label is only one chosen peer field; other peer
-// fields still live in e.Peer. buildMetricKey ignores those, so we append them here—otherwise two
-// edges with the same server name but different peer details would share one counter. Skip a peer
-// key if it is already part of base via e.Dimensions (client_/server_ + key) so we do not double-count.
+// For virtual-node and database edges the metric "server" label is only one chosen peer field;
+// other peer fields still live in e.Peer. buildMetricKey ignores those, so we append them
+// here—otherwise two edges with the same server name but different peer details would share one
+// counter. Skip a peer key if it is already part of base via e.Dimensions (client_/server_ + key)
+// so we do not double-count.
 func (p *serviceGraphConnector) buildMetricKeyFromEdge(e *store.Edge) string {
 	base := p.buildMetricKey(e.ClientService, e.ServerService, string(e.ConnectionType), strconv.FormatBool(e.Failed), e.Dimensions)
-	if e.ConnectionType != store.VirtualNode || len(e.Peer) == 0 {
+	if (e.ConnectionType != store.VirtualNode && e.ConnectionType != store.Database) || len(e.Peer) == 0 {
 		return base
 	}
 	var b strings.Builder


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Database edges (like PostgreSQL) were completing immediately during span processing with ConnectionType = Database, bypassing the onExpire path that sets VirtualNode -- so buildDimensions and buildMetricKeyFromEdge never added the server_* peer attributes (e.g. server_db.system) to the metrics. The fix extends both functions to treat Database edges the same as VirtualNode edges when populating peer attributes onto metric datapoints and building distinct series keys.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Fix service graph icons for virtual nodes in type database [postgres/mysql etc].
```
