### PR TITLE
fix: UI OOM

### DIFF
--- a/frontend/gqlgen.yml
+++ b/frontend/gqlgen.yml
@@ -148,3 +148,5 @@ models:
         resolver: true
       dataStreamNames:
         resolver: true
+      workloads:
+        resolver: true

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -1119,7 +1119,6 @@ type ComplexityRoot struct {
 		SourceConditions                  func(childComplexity int) int
 		Workloads                         func(childComplexity int, filter *model.WorkloadFilter) int
 		WorkloadsByIds                    func(childComplexity int, ids []*model.K8sWorkloadIDInput) int
-		WorkloadsCount                    func(childComplexity int, filter *model.WorkloadFilter) int
 	}
 
 	RemoteConfig struct {
@@ -1442,7 +1441,6 @@ type QueryResolver interface {
 	Sampling(ctx context.Context) (*model.Sampling, error)
 	Workloads(ctx context.Context, filter *model.WorkloadFilter) ([]*model.K8sWorkload, error)
 	WorkloadsByIds(ctx context.Context, ids []*model.K8sWorkloadIDInput) ([]*model.K8sWorkload, error)
-	WorkloadsCount(ctx context.Context, filter *model.WorkloadFilter) (int, error)
 	Namespaces(ctx context.Context) ([]*model.K8sNamespace, error)
 }
 type SamplingResolver interface {
@@ -6419,18 +6417,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.WorkloadsByIds(childComplexity, args["ids"].([]*model.K8sWorkloadIDInput)), true
 
-	case "Query.workloadsCount":
-		if e.complexity.Query.WorkloadsCount == nil {
-			break
-		}
-
-		args, err := ec.field_Query_workloadsCount_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.WorkloadsCount(childComplexity, args["filter"].(*model.WorkloadFilter)), true
-
 	case "RemoteConfig.rollout":
 		if e.complexity.RemoteConfig.Rollout == nil {
 			break
@@ -9281,34 +9267,6 @@ func (ec *executionContext) field_Query_workloadsByIds_argsIds(
 	}
 
 	var zeroVal []*model.K8sWorkloadIDInput
-	return zeroVal, nil
-}
-
-func (ec *executionContext) field_Query_workloadsCount_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
-	var err error
-	args := map[string]any{}
-	arg0, err := ec.field_Query_workloadsCount_argsFilter(ctx, rawArgs)
-	if err != nil {
-		return nil, err
-	}
-	args["filter"] = arg0
-	return args, nil
-}
-func (ec *executionContext) field_Query_workloadsCount_argsFilter(
-	ctx context.Context,
-	rawArgs map[string]any,
-) (*model.WorkloadFilter, error) {
-	if _, ok := rawArgs["filter"]; !ok {
-		var zeroVal *model.WorkloadFilter
-		return zeroVal, nil
-	}
-
-	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("filter"))
-	if tmp, ok := rawArgs["filter"]; ok {
-		return ec.unmarshalOWorkloadFilter2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐWorkloadFilter(ctx, tmp)
-	}
-
-	var zeroVal *model.WorkloadFilter
 	return zeroVal, nil
 }
 
@@ -41370,61 +41328,6 @@ func (ec *executionContext) fieldContext_Query_workloadsByIds(ctx context.Contex
 	return fc, nil
 }
 
-func (ec *executionContext) _Query_workloadsCount(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_workloadsCount(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().WorkloadsCount(rctx, fc.Args["filter"].(*model.WorkloadFilter))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(int)
-	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Query_workloadsCount(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Query",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_workloadsCount_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _Query_namespaces(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_namespaces(ctx, field)
 	if err != nil {
@@ -51485,7 +51388,7 @@ func (ec *executionContext) unmarshalInputWorkloadFilter(ctx context.Context, ob
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"namespace", "kind", "name", "markedForInstrumentation", "limit", "offset"}
+	fieldsInOrder := [...]string{"namespace", "kind", "name", "markedForInstrumentation"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -51520,20 +51423,6 @@ func (ec *executionContext) unmarshalInputWorkloadFilter(ctx context.Context, ob
 				return it, err
 			}
 			it.MarkedForInstrumentation = data
-		case "limit":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("limit"))
-			data, err := ec.unmarshalOInt2ᚖint(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Limit = data
-		case "offset":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("offset"))
-			data, err := ec.unmarshalOInt2ᚖint(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Offset = data
 		}
 	}
 
@@ -59761,28 +59650,6 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_workloadsByIds(ctx, field)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
-			}
-
-			rrm := func(ctx context.Context) graphql.Marshaler {
-				return ec.OperationContext.RootResolverMiddleware(ctx,
-					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
-		case "workloadsCount":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_workloadsCount(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -1351,6 +1351,7 @@ type K8sActualNamespaceResolver interface {
 type K8sNamespaceResolver interface {
 	MarkedForInstrumentation(ctx context.Context, obj *model.K8sNamespace) (bool, error)
 	DataStreamNames(ctx context.Context, obj *model.K8sNamespace) ([]string, error)
+	Workloads(ctx context.Context, obj *model.K8sNamespace) ([]*model.K8sWorkload, error)
 }
 type K8sWorkloadResolver interface {
 	ServiceName(ctx context.Context, obj *model.K8sWorkload) (*string, error)
@@ -26711,7 +26712,7 @@ func (ec *executionContext) _K8sNamespace_workloads(ctx context.Context, field g
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Workloads, nil
+		return ec.resolvers.K8sNamespace().Workloads(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -26732,8 +26733,8 @@ func (ec *executionContext) fieldContext_K8sNamespace_workloads(_ context.Contex
 	fc = &graphql.FieldContext{
 		Object:     "K8sNamespace",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "id":
@@ -55459,10 +55460,41 @@ func (ec *executionContext) _K8sNamespace(ctx context.Context, sel ast.Selection
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "workloads":
-			out.Values[i] = ec._K8sNamespace_workloads(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._K8sNamespace_workloads(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
 			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -1119,6 +1119,7 @@ type ComplexityRoot struct {
 		SourceConditions                  func(childComplexity int) int
 		Workloads                         func(childComplexity int, filter *model.WorkloadFilter) int
 		WorkloadsByIds                    func(childComplexity int, ids []*model.K8sWorkloadIDInput) int
+		WorkloadsCount                    func(childComplexity int, filter *model.WorkloadFilter) int
 	}
 
 	RemoteConfig struct {
@@ -1440,6 +1441,7 @@ type QueryResolver interface {
 	Sampling(ctx context.Context) (*model.Sampling, error)
 	Workloads(ctx context.Context, filter *model.WorkloadFilter) ([]*model.K8sWorkload, error)
 	WorkloadsByIds(ctx context.Context, ids []*model.K8sWorkloadIDInput) ([]*model.K8sWorkload, error)
+	WorkloadsCount(ctx context.Context, filter *model.WorkloadFilter) (int, error)
 	Namespaces(ctx context.Context) ([]*model.K8sNamespace, error)
 }
 type SamplingResolver interface {
@@ -6416,6 +6418,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.WorkloadsByIds(childComplexity, args["ids"].([]*model.K8sWorkloadIDInput)), true
 
+	case "Query.workloadsCount":
+		if e.complexity.Query.WorkloadsCount == nil {
+			break
+		}
+
+		args, err := ec.field_Query_workloadsCount_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.WorkloadsCount(childComplexity, args["filter"].(*model.WorkloadFilter)), true
+
 	case "RemoteConfig.rollout":
 		if e.complexity.RemoteConfig.Rollout == nil {
 			break
@@ -9266,6 +9280,34 @@ func (ec *executionContext) field_Query_workloadsByIds_argsIds(
 	}
 
 	var zeroVal []*model.K8sWorkloadIDInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query_workloadsCount_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Query_workloadsCount_argsFilter(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["filter"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query_workloadsCount_argsFilter(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*model.WorkloadFilter, error) {
+	if _, ok := rawArgs["filter"]; !ok {
+		var zeroVal *model.WorkloadFilter
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("filter"))
+	if tmp, ok := rawArgs["filter"]; ok {
+		return ec.unmarshalOWorkloadFilter2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐWorkloadFilter(ctx, tmp)
+	}
+
+	var zeroVal *model.WorkloadFilter
 	return zeroVal, nil
 }
 
@@ -41327,6 +41369,61 @@ func (ec *executionContext) fieldContext_Query_workloadsByIds(ctx context.Contex
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_workloadsCount(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_workloadsCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().WorkloadsCount(rctx, fc.Args["filter"].(*model.WorkloadFilter))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_workloadsCount(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_workloadsCount_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_namespaces(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_namespaces(ctx, field)
 	if err != nil {
@@ -51387,7 +51484,7 @@ func (ec *executionContext) unmarshalInputWorkloadFilter(ctx context.Context, ob
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"namespace", "kind", "name", "markedForInstrumentation"}
+	fieldsInOrder := [...]string{"namespace", "kind", "name", "markedForInstrumentation", "limit", "offset"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -51422,6 +51519,20 @@ func (ec *executionContext) unmarshalInputWorkloadFilter(ctx context.Context, ob
 				return it, err
 			}
 			it.MarkedForInstrumentation = data
+		case "limit":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("limit"))
+			data, err := ec.unmarshalOInt2ᚖint(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Limit = data
+		case "offset":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("offset"))
+			data, err := ec.unmarshalOInt2ᚖint(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Offset = data
 		}
 	}
 
@@ -59618,6 +59729,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_workloadsByIds(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "workloadsCount":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_workloadsCount(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/frontend/graph/loaders/fetchers.go
+++ b/frontend/graph/loaders/fetchers.go
@@ -303,12 +303,13 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 			return workloadManifests, nil
 
 		case k8sconsts.WorkloadKindDeploymentConfig:
-			// Only try to get DeploymentConfig if it's available in the cluster
+			// OpenShift DeploymentConfig is not in the standard K8s API, so it's not
+			// in the informer cache. We use the dynamic client to fetch it directly
+			// from the API server (only on OpenShift clusters where this CRD exists).
 			if !kube.IsOpenShiftDeploymentConfigAvailable {
 				return nil, nil
 			}
 
-			// Use dynamic client for DeploymentConfig
 			gvr := schema.GroupVersionResource{
 				Group:    "apps.openshift.io",
 				Version:  "v1",
@@ -854,6 +855,9 @@ func getWorkloadManifest(ctx context.Context, logger logr.Logger, id model.K8sWo
 		}, nil
 
 	case k8sconsts.WorkloadKindDeploymentConfig:
+		// OpenShift DeploymentConfig is not in the standard K8s API, so it's not
+		// in the informer cache. We use the dynamic client to fetch it directly
+		// from the API server (only on OpenShift clusters where this CRD exists).
 		if !kube.IsDeploymentConfigAvailable() {
 			return nil, nil
 		}

--- a/frontend/graph/loaders/fetchers.go
+++ b/frontend/graph/loaders/fetchers.go
@@ -55,7 +55,7 @@ func timedAPICall[T any](logger logr.Logger, operation string, apiCall func() (T
 
 func fetchNamespaces(ctx context.Context, k8sCacheClient client.Client) (*corev1.NamespaceList, error) {
 	namespaces := &corev1.NamespaceList{}
-	err := k8sCacheClient.List(ctx, namespaces)
+	err := k8sCacheClient.List(ctx, namespaces, client.UnsafeDisableDeepCopy)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func fetchInstrumentationConfigs(ctx context.Context, logger logr.Logger, filter
 		err := k8sCacheClient.Get(ctx, client.ObjectKey{
 			Namespace: filters.NamespaceString,
 			Name:      instrumentationConfigName,
-		}, &instrumentationConfig)
+		}, &instrumentationConfig, client.UnsafeDisableDeepCopy)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				// workload cam be not found and it is not an error.
@@ -92,7 +92,7 @@ func fetchInstrumentationConfigs(ctx context.Context, logger logr.Logger, filter
 		}, nil
 	} else {
 		var instrumentationConfigs odigosv1.InstrumentationConfigList
-		err := k8sCacheClient.List(ctx, &instrumentationConfigs, client.InNamespace(filters.NamespaceString))
+		err := k8sCacheClient.List(ctx, &instrumentationConfigs, client.InNamespace(filters.NamespaceString), client.UnsafeDisableDeepCopy)
 		if err != nil {
 			return nil, err
 		}
@@ -124,7 +124,7 @@ func fetchSourcesForWorkload(ctx context.Context, filters *WorkloadFilterSingleW
 		k8sconsts.WorkloadNameLabel:      filters.WorkloadName,
 	}
 	workloadSources := &odigosv1.SourceList{}
-	err := k8sCacheClient.List(ctx, workloadSources, client.InNamespace(filters.Namespace), client.MatchingLabels(workloadLabels))
+	err := k8sCacheClient.List(ctx, workloadSources, client.InNamespace(filters.Namespace), client.MatchingLabels(workloadLabels), client.UnsafeDisableDeepCopy)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func fetchSourcesForWorkload(ctx context.Context, filters *WorkloadFilterSingleW
 		k8sconsts.WorkloadNameLabel:      filters.Namespace,
 	}
 	namespaceSources := &odigosv1.SourceList{}
-	err = k8sCacheClient.List(ctx, namespaceSources, client.InNamespace(filters.Namespace), client.MatchingLabels(namespaceLabels))
+	err = k8sCacheClient.List(ctx, namespaceSources, client.InNamespace(filters.Namespace), client.MatchingLabels(namespaceLabels), client.UnsafeDisableDeepCopy)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func fetchSourcesForNamespace(ctx context.Context, filters *WorkloadFilterSingle
 	// will return both "workload" sources and "namespace" sources as required
 	sources := &odigosv1.SourceList{}
 	// assumes that sources are in the same namespace they are instrumenting (which is true at time of writing)
-	err := k8sCacheClient.List(ctx, sources, client.InNamespace(filters.Namespace), client.MatchingLabels(labels))
+	err := k8sCacheClient.List(ctx, sources, client.InNamespace(filters.Namespace), client.MatchingLabels(labels), client.UnsafeDisableDeepCopy)
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +164,7 @@ func fetchSourcesForNamespace(ctx context.Context, filters *WorkloadFilterSingle
 
 func fetchAllSources(ctx context.Context, ignoredNamespaces map[string]struct{}, k8sCacheClient client.Client) (*odigosv1.SourceList, error) {
 	sources := &odigosv1.SourceList{}
-	err := k8sCacheClient.List(ctx, sources, client.MatchingLabels(map[string]string{}))
+	err := k8sCacheClient.List(ctx, sources, client.MatchingLabels(map[string]string{}), client.UnsafeDisableDeepCopy)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +223,7 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 			err := k8sCacheClient.Get(ctx, client.ObjectKey{
 				Namespace: filters.NamespaceString,
 				Name:      filters.SingleWorkload.WorkloadName,
-			}, deployment)
+			}, deployment, client.UnsafeDisableDeepCopy)
 			if err != nil {
 				return nil, client.IgnoreNotFound(err)
 			}
@@ -244,7 +244,7 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 			err := k8sCacheClient.Get(ctx, client.ObjectKey{
 				Namespace: filters.NamespaceString,
 				Name:      filters.SingleWorkload.WorkloadName,
-			}, daemonset)
+			}, daemonset, client.UnsafeDisableDeepCopy)
 			if err != nil {
 				return nil, client.IgnoreNotFound(err)
 			}
@@ -265,7 +265,7 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 			err := k8sCacheClient.Get(ctx, client.ObjectKey{
 				Namespace: filters.NamespaceString,
 				Name:      filters.SingleWorkload.WorkloadName,
-			}, statefulset)
+			}, statefulset, client.UnsafeDisableDeepCopy)
 			if err != nil {
 				return nil, client.IgnoreNotFound(err)
 			}
@@ -286,7 +286,7 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 			err := k8sCacheClient.Get(ctx, client.ObjectKey{
 				Namespace: filters.NamespaceString,
 				Name:      filters.SingleWorkload.WorkloadName,
-			}, cronjob)
+			}, cronjob, client.UnsafeDisableDeepCopy)
 			if err != nil {
 				return nil, client.IgnoreNotFound(err)
 			}
@@ -363,7 +363,7 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 			err := k8sCacheClient.Get(ctx, client.ObjectKey{
 				Namespace: filters.NamespaceString,
 				Name:      filters.SingleWorkload.WorkloadName,
-			}, rollout)
+			}, rollout, client.UnsafeDisableDeepCopy)
 			if err != nil {
 				return nil, client.IgnoreNotFound(err)
 			}
@@ -384,7 +384,7 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 			err := k8sCacheClient.Get(ctx, client.ObjectKey{
 				Namespace: filters.NamespaceString,
 				Name:      filters.SingleWorkload.WorkloadName,
-			}, staticPod)
+			}, staticPod, client.UnsafeDisableDeepCopy)
 			if err != nil {
 				return nil, client.IgnoreNotFound(err)
 			}
@@ -416,7 +416,7 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 	}
 
 	deploymentsList := &appsv1.DeploymentList{}
-	err = k8sCacheClient.List(ctx, deploymentsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}))
+	err = k8sCacheClient.List(ctx, deploymentsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}), client.UnsafeDisableDeepCopy)
 	if err != nil {
 		return nil, err
 	}
@@ -435,7 +435,7 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 	}
 
 	daemonsetsList := &appsv1.DaemonSetList{}
-	err = k8sCacheClient.List(ctx, daemonsetsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}))
+	err = k8sCacheClient.List(ctx, daemonsetsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}), client.UnsafeDisableDeepCopy)
 	if err != nil {
 		return nil, err
 	}
@@ -454,7 +454,7 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 	}
 
 	statefulsetsList := &appsv1.StatefulSetList{}
-	err = k8sCacheClient.List(ctx, statefulsetsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}))
+	err = k8sCacheClient.List(ctx, statefulsetsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}), client.UnsafeDisableDeepCopy)
 	if err != nil {
 		return nil, err
 	}
@@ -473,7 +473,7 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 	}
 
 	staticPodsList := &corev1.PodList{}
-	err = k8sCacheClient.List(ctx, staticPodsList, client.InNamespace(filters.NamespaceString), client.HasLabels{k8sconsts.OdigosVirtualStaticPodNameLabel})
+	err = k8sCacheClient.List(ctx, staticPodsList, client.InNamespace(filters.NamespaceString), client.HasLabels{k8sconsts.OdigosVirtualStaticPodNameLabel}, client.UnsafeDisableDeepCopy)
 	if err != nil {
 		return nil, err
 	}
@@ -496,7 +496,7 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 	}
 
 	cronjobsList := &batchv1.CronJobList{}
-	err = k8sCacheClient.List(ctx, cronjobsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}))
+	err = k8sCacheClient.List(ctx, cronjobsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}), client.UnsafeDisableDeepCopy)
 	if err != nil {
 		return nil, err
 	}
@@ -575,7 +575,7 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 	rolloutsMap := make(map[model.K8sWorkloadID]*computed.CachedWorkloadManifest)
 	if kube.IsArgoRolloutAvailable {
 		rolloutsList := &argorolloutsv1alpha1.RolloutList{}
-		err := k8sCacheClient.List(ctx, rolloutsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}))
+		err := k8sCacheClient.List(ctx, rolloutsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}), client.UnsafeDisableDeepCopy)
 		if err != nil {
 			return nil, err
 		}
@@ -664,7 +664,7 @@ func fetchWorkloadPods(ctx context.Context, logger logr.Logger, filters *Workloa
 				continue
 			}
 			podList := &corev1.PodList{}
-			if err := k8sCacheClient.List(ctx, podList, client.InNamespace(ns)); err != nil {
+			if err := k8sCacheClient.List(ctx, podList, client.InNamespace(ns), client.UnsafeDisableDeepCopy); err != nil {
 				return nil, err
 			}
 			collectWorkloadPods(podList, workloadIdsMap, filters.IgnoredNamespaces, workloadPods)
@@ -673,7 +673,7 @@ func fetchWorkloadPods(ctx context.Context, logger logr.Logger, filters *Workloa
 	}
 
 	podList := &corev1.PodList{}
-	err = k8sCacheClient.List(ctx, podList, client.InNamespace(filters.NamespaceString))
+	err = k8sCacheClient.List(ctx, podList, client.InNamespace(filters.NamespaceString), client.UnsafeDisableDeepCopy)
 	if err != nil {
 		return nil, err
 	}
@@ -690,7 +690,7 @@ func fetchWorkloadPodsWithSelector(ctx context.Context, filters *WorkloadFilter,
 	}
 
 	podList := &corev1.PodList{}
-	err = k8sCacheClient.List(ctx, podList, client.InNamespace(filters.NamespaceString), client.MatchingLabelsSelector{Selector: selector})
+	err = k8sCacheClient.List(ctx, podList, client.InNamespace(filters.NamespaceString), client.MatchingLabelsSelector{Selector: selector}, client.UnsafeDisableDeepCopy)
 	if err != nil {
 		return nil, err
 	}
@@ -741,7 +741,7 @@ func fetchInstrumentationInstances(ctx context.Context, logger logr.Logger, filt
 	if matchingLabels != nil {
 		opts = append(opts, client.MatchingLabels(matchingLabels))
 	}
-	err = k8sCacheClient.List(ctx, &ii, opts...)
+	err = k8sCacheClient.List(ctx, &ii, append(opts, client.UnsafeDisableDeepCopy)...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -811,7 +811,7 @@ func getWorkloadManifest(ctx context.Context, logger logr.Logger, id model.K8sWo
 	switch k8sconsts.WorkloadKind(id.Kind) {
 	case k8sconsts.WorkloadKindDeployment:
 		obj := &appsv1.Deployment{}
-		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj); err != nil {
+		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj, client.UnsafeDisableDeepCopy); err != nil {
 			return nil, client.IgnoreNotFound(err)
 		}
 		return &computed.CachedWorkloadManifest{
@@ -822,7 +822,7 @@ func getWorkloadManifest(ctx context.Context, logger logr.Logger, id model.K8sWo
 
 	case k8sconsts.WorkloadKindDaemonSet:
 		obj := &appsv1.DaemonSet{}
-		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj); err != nil {
+		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj, client.UnsafeDisableDeepCopy); err != nil {
 			return nil, client.IgnoreNotFound(err)
 		}
 		return &computed.CachedWorkloadManifest{
@@ -833,7 +833,7 @@ func getWorkloadManifest(ctx context.Context, logger logr.Logger, id model.K8sWo
 
 	case k8sconsts.WorkloadKindStatefulSet:
 		obj := &appsv1.StatefulSet{}
-		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj); err != nil {
+		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj, client.UnsafeDisableDeepCopy); err != nil {
 			return nil, client.IgnoreNotFound(err)
 		}
 		return &computed.CachedWorkloadManifest{
@@ -844,7 +844,7 @@ func getWorkloadManifest(ctx context.Context, logger logr.Logger, id model.K8sWo
 
 	case k8sconsts.WorkloadKindCronJob:
 		obj := &batchv1.CronJob{}
-		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj); err != nil {
+		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj, client.UnsafeDisableDeepCopy); err != nil {
 			return nil, client.IgnoreNotFound(err)
 		}
 		return &computed.CachedWorkloadManifest{
@@ -891,7 +891,7 @@ func getWorkloadManifest(ctx context.Context, logger logr.Logger, id model.K8sWo
 			return nil, nil
 		}
 		obj := &argorolloutsv1alpha1.Rollout{}
-		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj); err != nil {
+		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj, client.UnsafeDisableDeepCopy); err != nil {
 			return nil, client.IgnoreNotFound(err)
 		}
 		return &computed.CachedWorkloadManifest{
@@ -902,7 +902,7 @@ func getWorkloadManifest(ctx context.Context, logger logr.Logger, id model.K8sWo
 
 	case k8sconsts.WorkloadKindStaticPod:
 		obj := &corev1.Pod{}
-		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj); err != nil {
+		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj, client.UnsafeDisableDeepCopy); err != nil {
 			return nil, client.IgnoreNotFound(err)
 		}
 		if !workload.IsStaticPod(obj) {

--- a/frontend/graph/loaders/fetchers.go
+++ b/frontend/graph/loaders/fetchers.go
@@ -742,7 +742,7 @@ func fetchInstrumentationInstances(ctx context.Context, logger logr.Logger, filt
 	if matchingLabels != nil {
 		opts = append(opts, client.MatchingLabels(matchingLabels))
 	}
-	err = k8sCacheClient.List(ctx, &ii, append(opts)...)
+	err = k8sCacheClient.List(ctx, &ii, opts...)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/frontend/graph/loaders/fetchers.go
+++ b/frontend/graph/loaders/fetchers.go
@@ -65,8 +65,7 @@ func fetchNamespaces(ctx context.Context, k8sCacheClient client.Client) (*corev1
 // function to get just the instrumentation configs that match the filter.
 // e.g. load only sources which are marked for instrumentation after the instrumentor reconciles it.
 // this is cheaper and faster query than to load all the sources and resolve each one.
-func fetchInstrumentationConfigs(ctx context.Context, logger logr.Logger, filters *WorkloadFilter, k8sCacheClient client.Client) (map[model.K8sWorkloadID]*odigosv1.InstrumentationConfig, error) {
-
+func fetchInstrumentationConfigs(ctx context.Context, filters *WorkloadFilter, k8sCacheClient client.Client) (map[model.K8sWorkloadID]*odigosv1.InstrumentationConfig, error) {
 	// diffrentiate between a single source query and a namespace / cluster wide query.
 	if filters.SingleWorkload != nil {
 		instrumentationConfigName := workload.CalculateWorkloadRuntimeObjectName(filters.SingleWorkload.WorkloadName, filters.SingleWorkload.WorkloadKind)

--- a/frontend/graph/loaders/fetchers.go
+++ b/frontend/graph/loaders/fetchers.go
@@ -3,7 +3,6 @@ package loaders
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	argorolloutsv1alpha1 "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
@@ -17,7 +16,6 @@ import (
 	"github.com/odigos-io/odigos/frontend/kube"
 	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
 	openshiftappsv1 "github.com/openshift/api/apps/v1"
-	"golang.org/x/sync/errgroup"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -27,8 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-const fetchConcurrencyLimit = 10
 
 // formatOperationMessage creates a clean operation message that handles empty values gracefully
 func formatOperationMessage(operation string, namespace string, additionalInfo ...string) string {
@@ -663,33 +659,15 @@ func fetchWorkloadPods(ctx context.Context, logger logr.Logger, filters *Workloa
 		}
 
 		workloadPods = make(map[model.K8sWorkloadID][]*corev1.Pod)
-		var mu sync.Mutex
-
-		g, gCtx := errgroup.WithContext(ctx)
-		g.SetLimit(fetchConcurrencyLimit)
-
 		for ns := range relevantNamespaces {
 			if _, ok := filters.IgnoredNamespaces[ns]; ok {
 				continue
 			}
-			g.Go(func() error {
-				podList := &corev1.PodList{}
-				if err := k8sCacheClient.List(gCtx, podList, client.InNamespace(ns)); err != nil {
-					return err
-				}
-				localPods := make(map[model.K8sWorkloadID][]*corev1.Pod)
-				collectWorkloadPods(podList, workloadIdsMap, filters.IgnoredNamespaces, localPods)
-				mu.Lock()
-				for k, v := range localPods {
-					workloadPods[k] = append(workloadPods[k], v...)
-				}
-				mu.Unlock()
-				return nil
-			})
-		}
-
-		if err := g.Wait(); err != nil {
-			return nil, err
+			podList := &corev1.PodList{}
+			if err := k8sCacheClient.List(ctx, podList, client.InNamespace(ns)); err != nil {
+				return nil, err
+			}
+			collectWorkloadPods(podList, workloadIdsMap, filters.IgnoredNamespaces, workloadPods)
 		}
 		return workloadPods, nil
 	}
@@ -809,35 +787,23 @@ func fetchInstrumentationInstances(ctx context.Context, logger logr.Logger, filt
 }
 
 // fetchWorkloadManifestsByIds fetches workload manifests for specific workload IDs
-// using individual Get operations from the cache with bounded concurrency. This is
-// significantly more memory-efficient than listing all workloads of each kind
-// cluster-wide when only a subset is needed (e.g., the markedForInstrumentation
-// path where IDs are known from InstrumentationConfigs).
+// using individual Get operations from the cache. This is significantly more
+// memory-efficient than listing all workloads of each kind cluster-wide when
+// only a subset is needed (e.g., the markedForInstrumentation path where IDs
+// are known from InstrumentationConfigs).
 func fetchWorkloadManifestsByIds(ctx context.Context, logger logr.Logger, workloadIds []model.K8sWorkloadID, k8sCacheClient client.Client) (map[model.K8sWorkloadID]*computed.CachedWorkloadManifest, error) {
 	workloadManifests := make(map[model.K8sWorkloadID]*computed.CachedWorkloadManifest, len(workloadIds))
-	var mu sync.Mutex
-
-	g, gCtx := errgroup.WithContext(ctx)
-	g.SetLimit(fetchConcurrencyLimit)
 
 	for _, id := range workloadIds {
-		g.Go(func() error {
-			manifest, err := getWorkloadManifest(gCtx, logger, id, k8sCacheClient)
-			if err != nil {
-				return err
-			}
-			if manifest != nil {
-				mu.Lock()
-				workloadManifests[id] = manifest
-				mu.Unlock()
-			}
-			return nil
-		})
+		manifest, err := getWorkloadManifest(ctx, logger, id, k8sCacheClient)
+		if err != nil {
+			return nil, err
+		}
+		if manifest != nil {
+			workloadManifests[id] = manifest
+		}
 	}
 
-	if err := g.Wait(); err != nil {
-		return nil, err
-	}
 	return workloadManifests, nil
 }
 

--- a/frontend/graph/loaders/fetchers.go
+++ b/frontend/graph/loaders/fetchers.go
@@ -3,6 +3,7 @@ package loaders
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	argorolloutsv1alpha1 "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
@@ -16,6 +17,7 @@ import (
 	"github.com/odigos-io/odigos/frontend/kube"
 	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
 	openshiftappsv1 "github.com/openshift/api/apps/v1"
+	"golang.org/x/sync/errgroup"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -25,6 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const fetchConcurrencyLimit = 10
 
 // formatOperationMessage creates a clean operation message that handles empty values gracefully
 func formatOperationMessage(operation string, namespace string, additionalInfo ...string) string {
@@ -642,56 +646,102 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 }
 
 func fetchWorkloadPods(ctx context.Context, logger logr.Logger, filters *WorkloadFilter, singleWorkloadManifest *computed.CachedWorkloadManifest, workloadIdsMap map[k8sconsts.PodWorkload]struct{}, k8sCacheClient client.Client) (workloadPods map[model.K8sWorkloadID][]*corev1.Pod, err error) {
-
-	var labelSelector *metav1.LabelSelector
 	if filters.SingleWorkload != nil {
 		if singleWorkloadManifest == nil || singleWorkloadManifest.Selector == nil {
-			// if workload is not found for this pod, skip the queries - no pods to fetch.
 			return map[model.K8sWorkloadID][]*corev1.Pod{}, nil
 		}
-		labelSelector = singleWorkloadManifest.Selector
+		return fetchWorkloadPodsWithSelector(ctx, filters, singleWorkloadManifest.Selector, workloadIdsMap, k8sCacheClient)
+	}
+
+	// For cluster-wide queries with known workload IDs, list pods per-namespace
+	// instead of cluster-wide. This avoids deep-copying pods from namespaces that
+	// have no instrumented workloads, significantly reducing memory usage at scale.
+	if filters.ClusterWide != nil && len(workloadIdsMap) > 0 {
+		relevantNamespaces := make(map[string]struct{}, len(workloadIdsMap))
+		for pw := range workloadIdsMap {
+			relevantNamespaces[pw.Namespace] = struct{}{}
+		}
+
+		workloadPods = make(map[model.K8sWorkloadID][]*corev1.Pod)
+		var mu sync.Mutex
+
+		g, gCtx := errgroup.WithContext(ctx)
+		g.SetLimit(fetchConcurrencyLimit)
+
+		for ns := range relevantNamespaces {
+			if _, ok := filters.IgnoredNamespaces[ns]; ok {
+				continue
+			}
+			g.Go(func() error {
+				podList := &corev1.PodList{}
+				if err := k8sCacheClient.List(gCtx, podList, client.InNamespace(ns)); err != nil {
+					return err
+				}
+				localPods := make(map[model.K8sWorkloadID][]*corev1.Pod)
+				collectWorkloadPods(podList, workloadIdsMap, filters.IgnoredNamespaces, localPods)
+				mu.Lock()
+				for k, v := range localPods {
+					workloadPods[k] = append(workloadPods[k], v...)
+				}
+				mu.Unlock()
+				return nil
+			})
+		}
+
+		if err := g.Wait(); err != nil {
+			return nil, err
+		}
+		return workloadPods, nil
 	}
 
 	podList := &corev1.PodList{}
-	opts := []client.ListOption{client.InNamespace(filters.NamespaceString)}
-	if labelSelector != nil {
-		selector, err := metav1.LabelSelectorAsSelector(labelSelector)
-		if err != nil {
-			return nil, fmt.Errorf("invalid label selector: %w", err)
-		}
-		opts = append(opts, client.MatchingLabelsSelector{Selector: selector})
-	}
-	err = k8sCacheClient.List(ctx, podList, opts...)
+	err = k8sCacheClient.List(ctx, podList, client.InNamespace(filters.NamespaceString))
 	if err != nil {
 		return nil, err
 	}
 
 	workloadPods = make(map[model.K8sWorkloadID][]*corev1.Pod)
-	for _, pod := range podList.Items {
-		if _, ok := filters.IgnoredNamespaces[pod.Namespace]; ok {
+	collectWorkloadPods(podList, workloadIdsMap, filters.IgnoredNamespaces, workloadPods)
+	return workloadPods, nil
+}
+
+func fetchWorkloadPodsWithSelector(ctx context.Context, filters *WorkloadFilter, labelSelector *metav1.LabelSelector, workloadIdsMap map[k8sconsts.PodWorkload]struct{}, k8sCacheClient client.Client) (map[model.K8sWorkloadID][]*corev1.Pod, error) {
+	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
+	if err != nil {
+		return nil, fmt.Errorf("invalid label selector: %w", err)
+	}
+
+	podList := &corev1.PodList{}
+	err = k8sCacheClient.List(ctx, podList, client.InNamespace(filters.NamespaceString), client.MatchingLabelsSelector{Selector: selector})
+	if err != nil {
+		return nil, err
+	}
+
+	workloadPods := make(map[model.K8sWorkloadID][]*corev1.Pod)
+	collectWorkloadPods(podList, workloadIdsMap, filters.IgnoredNamespaces, workloadPods)
+	return workloadPods, nil
+}
+
+func collectWorkloadPods(podList *corev1.PodList, workloadIdsMap map[k8sconsts.PodWorkload]struct{}, ignoredNamespaces map[string]struct{}, out map[model.K8sWorkloadID][]*corev1.Pod) {
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if _, ok := ignoredNamespaces[pod.Namespace]; ok {
 			continue
 		}
-		pw, err := workload.PodWorkloadObject(&pod)
+		pw, err := workload.PodWorkloadObject(pod)
 		if err != nil || pw == nil {
-			// skip pods not relevant for odigos
 			continue
 		}
 		if _, ok := workloadIdsMap[*pw]; !ok {
-			// fmt.Printf("skipping pod %s/%s because it is not relevant for odigos\n", pod.Namespace, pod.Name)
-			// skip pods not relevant for odigos.
-			// for example, when we are fetching only instrumentated workloads,
-			// we can drop all the pods which does not participate.
 			continue
 		}
-
 		workloadId := model.K8sWorkloadID{
 			Namespace: pod.Namespace,
 			Kind:      model.K8sResourceKind(pw.Kind),
 			Name:      pw.Name,
 		}
-		workloadPods[workloadId] = append(workloadPods[workloadId], &pod)
+		out[workloadId] = append(out[workloadId], pod)
 	}
-	return workloadPods, nil
 }
 
 func fetchInstrumentationInstances(ctx context.Context, logger logr.Logger, filters *WorkloadFilter, k8sCacheClient client.Client) (
@@ -756,4 +806,154 @@ func fetchInstrumentationInstances(ctx context.Context, logger logr.Logger, filt
 		byWorkloadContainer[workloadContainerId] = append(byWorkloadContainer[workloadContainerId], &ii)
 	}
 	return byPodContainer, byWorkloadContainer, nil
+}
+
+// fetchWorkloadManifestsByIds fetches workload manifests for specific workload IDs
+// using individual Get operations from the cache with bounded concurrency. This is
+// significantly more memory-efficient than listing all workloads of each kind
+// cluster-wide when only a subset is needed (e.g., the markedForInstrumentation
+// path where IDs are known from InstrumentationConfigs).
+func fetchWorkloadManifestsByIds(ctx context.Context, logger logr.Logger, workloadIds []model.K8sWorkloadID, k8sCacheClient client.Client) (map[model.K8sWorkloadID]*computed.CachedWorkloadManifest, error) {
+	workloadManifests := make(map[model.K8sWorkloadID]*computed.CachedWorkloadManifest, len(workloadIds))
+	var mu sync.Mutex
+
+	g, gCtx := errgroup.WithContext(ctx)
+	g.SetLimit(fetchConcurrencyLimit)
+
+	for _, id := range workloadIds {
+		g.Go(func() error {
+			manifest, err := getWorkloadManifest(gCtx, logger, id, k8sCacheClient)
+			if err != nil {
+				return err
+			}
+			if manifest != nil {
+				mu.Lock()
+				workloadManifests[id] = manifest
+				mu.Unlock()
+			}
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	return workloadManifests, nil
+}
+
+func getWorkloadManifest(ctx context.Context, logger logr.Logger, id model.K8sWorkloadID, k8sCacheClient client.Client) (*computed.CachedWorkloadManifest, error) {
+	switch k8sconsts.WorkloadKind(id.Kind) {
+	case k8sconsts.WorkloadKindDeployment:
+		obj := &appsv1.Deployment{}
+		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj); err != nil {
+			return nil, client.IgnoreNotFound(err)
+		}
+		return &computed.CachedWorkloadManifest{
+			AvailableReplicas:    obj.Status.AvailableReplicas,
+			Selector:             obj.Spec.Selector,
+			WorkloadHealthStatus: status.CalculateDeploymentHealthStatus(obj.Status),
+		}, nil
+
+	case k8sconsts.WorkloadKindDaemonSet:
+		obj := &appsv1.DaemonSet{}
+		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj); err != nil {
+			return nil, client.IgnoreNotFound(err)
+		}
+		return &computed.CachedWorkloadManifest{
+			AvailableReplicas:    obj.Status.NumberReady,
+			Selector:             obj.Spec.Selector,
+			WorkloadHealthStatus: status.CalculateDaemonSetHealthStatus(obj.Status),
+		}, nil
+
+	case k8sconsts.WorkloadKindStatefulSet:
+		obj := &appsv1.StatefulSet{}
+		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj); err != nil {
+			return nil, client.IgnoreNotFound(err)
+		}
+		return &computed.CachedWorkloadManifest{
+			AvailableReplicas:    obj.Status.ReadyReplicas,
+			Selector:             obj.Spec.Selector,
+			WorkloadHealthStatus: status.CalculateStatefulSetHealthStatus(obj.Status),
+		}, nil
+
+	case k8sconsts.WorkloadKindCronJob:
+		obj := &batchv1.CronJob{}
+		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj); err != nil {
+			return nil, client.IgnoreNotFound(err)
+		}
+		return &computed.CachedWorkloadManifest{
+			AvailableReplicas:    int32(len(obj.Status.Active)),
+			Selector:             obj.Spec.JobTemplate.Spec.Selector,
+			WorkloadHealthStatus: status.CalculateCronJobHealthStatus(obj.Status),
+		}, nil
+
+	case k8sconsts.WorkloadKindDeploymentConfig:
+		if !kube.IsDeploymentConfigAvailable() {
+			return nil, nil
+		}
+		gvr := schema.GroupVersionResource{
+			Group:    "apps.openshift.io",
+			Version:  "v1",
+			Resource: "deploymentconfigs",
+		}
+		dc, err := timedAPICall(
+			logger,
+			fmt.Sprintf("Get DeploymentConfig %s/%s", id.Namespace, id.Name),
+			func() (*openshiftappsv1.DeploymentConfig, error) {
+				uDC, err := kube.DefaultClient.DynamicClient.Resource(gvr).Namespace(id.Namespace).Get(ctx, id.Name, metav1.GetOptions{})
+				if err != nil {
+					return nil, err
+				}
+				var dc openshiftappsv1.DeploymentConfig
+				err = runtime.DefaultUnstructuredConverter.FromUnstructured(uDC.Object, &dc)
+				return &dc, err
+			},
+		)
+		if err != nil {
+			return nil, client.IgnoreNotFound(err)
+		}
+		return &computed.CachedWorkloadManifest{
+			AvailableReplicas: dc.Status.AvailableReplicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: dc.Spec.Selector,
+			},
+			WorkloadHealthStatus: status.CalculateDeploymentConfigHealthStatus(dc.Status),
+		}, nil
+
+	case k8sconsts.WorkloadKindArgoRollout:
+		if !kube.IsArgoRolloutAvailable {
+			return nil, nil
+		}
+		obj := &argorolloutsv1alpha1.Rollout{}
+		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj); err != nil {
+			return nil, client.IgnoreNotFound(err)
+		}
+		return &computed.CachedWorkloadManifest{
+			AvailableReplicas:    obj.Status.AvailableReplicas,
+			Selector:             obj.Spec.Selector,
+			WorkloadHealthStatus: status.CalculateRolloutHealthStatus(obj.Status),
+		}, nil
+
+	case k8sconsts.WorkloadKindStaticPod:
+		obj := &corev1.Pod{}
+		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj); err != nil {
+			return nil, client.IgnoreNotFound(err)
+		}
+		if !workload.IsStaticPod(obj) {
+			return nil, nil
+		}
+		return &computed.CachedWorkloadManifest{
+			AvailableReplicas: 1,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					k8sconsts.OdigosVirtualStaticPodNameLabel: obj.Name,
+				},
+			},
+			WorkloadHealthStatus: status.CalculateStaticPodHealthStatus(obj.Status),
+		}, nil
+
+	default:
+		logger.V(1).Info("skipping unknown workload kind in manifest fetch", "kind", string(id.Kind))
+		return nil, nil
+	}
 }

--- a/frontend/graph/loaders/fetchers.go
+++ b/frontend/graph/loaders/fetchers.go
@@ -55,7 +55,7 @@ func timedAPICall[T any](logger logr.Logger, operation string, apiCall func() (T
 
 func fetchNamespaces(ctx context.Context, k8sCacheClient client.Client) (*corev1.NamespaceList, error) {
 	namespaces := &corev1.NamespaceList{}
-	err := k8sCacheClient.List(ctx, namespaces, client.UnsafeDisableDeepCopy)
+	err := k8sCacheClient.List(ctx, namespaces)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func fetchInstrumentationConfigs(ctx context.Context, logger logr.Logger, filter
 		err := k8sCacheClient.Get(ctx, client.ObjectKey{
 			Namespace: filters.NamespaceString,
 			Name:      instrumentationConfigName,
-		}, &instrumentationConfig, client.UnsafeDisableDeepCopy)
+		}, &instrumentationConfig)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				// workload cam be not found and it is not an error.
@@ -92,7 +92,7 @@ func fetchInstrumentationConfigs(ctx context.Context, logger logr.Logger, filter
 		}, nil
 	} else {
 		var instrumentationConfigs odigosv1.InstrumentationConfigList
-		err := k8sCacheClient.List(ctx, &instrumentationConfigs, client.InNamespace(filters.NamespaceString), client.UnsafeDisableDeepCopy)
+		err := k8sCacheClient.List(ctx, &instrumentationConfigs, client.InNamespace(filters.NamespaceString))
 		if err != nil {
 			return nil, err
 		}
@@ -124,7 +124,7 @@ func fetchSourcesForWorkload(ctx context.Context, filters *WorkloadFilterSingleW
 		k8sconsts.WorkloadNameLabel:      filters.WorkloadName,
 	}
 	workloadSources := &odigosv1.SourceList{}
-	err := k8sCacheClient.List(ctx, workloadSources, client.InNamespace(filters.Namespace), client.MatchingLabels(workloadLabels), client.UnsafeDisableDeepCopy)
+	err := k8sCacheClient.List(ctx, workloadSources, client.InNamespace(filters.Namespace), client.MatchingLabels(workloadLabels))
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func fetchSourcesForWorkload(ctx context.Context, filters *WorkloadFilterSingleW
 		k8sconsts.WorkloadNameLabel:      filters.Namespace,
 	}
 	namespaceSources := &odigosv1.SourceList{}
-	err = k8sCacheClient.List(ctx, namespaceSources, client.InNamespace(filters.Namespace), client.MatchingLabels(namespaceLabels), client.UnsafeDisableDeepCopy)
+	err = k8sCacheClient.List(ctx, namespaceSources, client.InNamespace(filters.Namespace), client.MatchingLabels(namespaceLabels))
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func fetchSourcesForNamespace(ctx context.Context, filters *WorkloadFilterSingle
 	// will return both "workload" sources and "namespace" sources as required
 	sources := &odigosv1.SourceList{}
 	// assumes that sources are in the same namespace they are instrumenting (which is true at time of writing)
-	err := k8sCacheClient.List(ctx, sources, client.InNamespace(filters.Namespace), client.MatchingLabels(labels), client.UnsafeDisableDeepCopy)
+	err := k8sCacheClient.List(ctx, sources, client.InNamespace(filters.Namespace), client.MatchingLabels(labels))
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +164,7 @@ func fetchSourcesForNamespace(ctx context.Context, filters *WorkloadFilterSingle
 
 func fetchAllSources(ctx context.Context, ignoredNamespaces map[string]struct{}, k8sCacheClient client.Client) (*odigosv1.SourceList, error) {
 	sources := &odigosv1.SourceList{}
-	err := k8sCacheClient.List(ctx, sources, client.MatchingLabels(map[string]string{}), client.UnsafeDisableDeepCopy)
+	err := k8sCacheClient.List(ctx, sources, client.MatchingLabels(map[string]string{}))
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +223,7 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 			err := k8sCacheClient.Get(ctx, client.ObjectKey{
 				Namespace: filters.NamespaceString,
 				Name:      filters.SingleWorkload.WorkloadName,
-			}, deployment, client.UnsafeDisableDeepCopy)
+			}, deployment)
 			if err != nil {
 				return nil, client.IgnoreNotFound(err)
 			}
@@ -244,7 +244,7 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 			err := k8sCacheClient.Get(ctx, client.ObjectKey{
 				Namespace: filters.NamespaceString,
 				Name:      filters.SingleWorkload.WorkloadName,
-			}, daemonset, client.UnsafeDisableDeepCopy)
+			}, daemonset)
 			if err != nil {
 				return nil, client.IgnoreNotFound(err)
 			}
@@ -265,7 +265,7 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 			err := k8sCacheClient.Get(ctx, client.ObjectKey{
 				Namespace: filters.NamespaceString,
 				Name:      filters.SingleWorkload.WorkloadName,
-			}, statefulset, client.UnsafeDisableDeepCopy)
+			}, statefulset)
 			if err != nil {
 				return nil, client.IgnoreNotFound(err)
 			}
@@ -286,7 +286,7 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 			err := k8sCacheClient.Get(ctx, client.ObjectKey{
 				Namespace: filters.NamespaceString,
 				Name:      filters.SingleWorkload.WorkloadName,
-			}, cronjob, client.UnsafeDisableDeepCopy)
+			}, cronjob)
 			if err != nil {
 				return nil, client.IgnoreNotFound(err)
 			}
@@ -364,7 +364,7 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 			err := k8sCacheClient.Get(ctx, client.ObjectKey{
 				Namespace: filters.NamespaceString,
 				Name:      filters.SingleWorkload.WorkloadName,
-			}, rollout, client.UnsafeDisableDeepCopy)
+			}, rollout)
 			if err != nil {
 				return nil, client.IgnoreNotFound(err)
 			}
@@ -385,7 +385,7 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 			err := k8sCacheClient.Get(ctx, client.ObjectKey{
 				Namespace: filters.NamespaceString,
 				Name:      filters.SingleWorkload.WorkloadName,
-			}, staticPod, client.UnsafeDisableDeepCopy)
+			}, staticPod)
 			if err != nil {
 				return nil, client.IgnoreNotFound(err)
 			}
@@ -417,7 +417,7 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 	}
 
 	deploymentsList := &appsv1.DeploymentList{}
-	err = k8sCacheClient.List(ctx, deploymentsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}), client.UnsafeDisableDeepCopy)
+	err = k8sCacheClient.List(ctx, deploymentsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}))
 	if err != nil {
 		return nil, err
 	}
@@ -436,7 +436,7 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 	}
 
 	daemonsetsList := &appsv1.DaemonSetList{}
-	err = k8sCacheClient.List(ctx, daemonsetsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}), client.UnsafeDisableDeepCopy)
+	err = k8sCacheClient.List(ctx, daemonsetsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}))
 	if err != nil {
 		return nil, err
 	}
@@ -455,7 +455,7 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 	}
 
 	statefulsetsList := &appsv1.StatefulSetList{}
-	err = k8sCacheClient.List(ctx, statefulsetsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}), client.UnsafeDisableDeepCopy)
+	err = k8sCacheClient.List(ctx, statefulsetsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}))
 	if err != nil {
 		return nil, err
 	}
@@ -474,7 +474,7 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 	}
 
 	staticPodsList := &corev1.PodList{}
-	err = k8sCacheClient.List(ctx, staticPodsList, client.InNamespace(filters.NamespaceString), client.HasLabels{k8sconsts.OdigosVirtualStaticPodNameLabel}, client.UnsafeDisableDeepCopy)
+	err = k8sCacheClient.List(ctx, staticPodsList, client.InNamespace(filters.NamespaceString), client.HasLabels{k8sconsts.OdigosVirtualStaticPodNameLabel})
 	if err != nil {
 		return nil, err
 	}
@@ -497,7 +497,7 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 	}
 
 	cronjobsList := &batchv1.CronJobList{}
-	err = k8sCacheClient.List(ctx, cronjobsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}), client.UnsafeDisableDeepCopy)
+	err = k8sCacheClient.List(ctx, cronjobsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}))
 	if err != nil {
 		return nil, err
 	}
@@ -576,7 +576,7 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 	rolloutsMap := make(map[model.K8sWorkloadID]*computed.CachedWorkloadManifest)
 	if kube.IsArgoRolloutAvailable {
 		rolloutsList := &argorolloutsv1alpha1.RolloutList{}
-		err := k8sCacheClient.List(ctx, rolloutsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}), client.UnsafeDisableDeepCopy)
+		err := k8sCacheClient.List(ctx, rolloutsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}))
 		if err != nil {
 			return nil, err
 		}
@@ -665,7 +665,7 @@ func fetchWorkloadPods(ctx context.Context, logger logr.Logger, filters *Workloa
 				continue
 			}
 			podList := &corev1.PodList{}
-			if err := k8sCacheClient.List(ctx, podList, client.InNamespace(ns), client.UnsafeDisableDeepCopy); err != nil {
+			if err := k8sCacheClient.List(ctx, podList, client.InNamespace(ns)); err != nil {
 				return nil, err
 			}
 			collectWorkloadPods(podList, workloadIdsMap, filters.IgnoredNamespaces, workloadPods)
@@ -674,7 +674,7 @@ func fetchWorkloadPods(ctx context.Context, logger logr.Logger, filters *Workloa
 	}
 
 	podList := &corev1.PodList{}
-	err = k8sCacheClient.List(ctx, podList, client.InNamespace(filters.NamespaceString), client.UnsafeDisableDeepCopy)
+	err = k8sCacheClient.List(ctx, podList, client.InNamespace(filters.NamespaceString))
 	if err != nil {
 		return nil, err
 	}
@@ -691,7 +691,7 @@ func fetchWorkloadPodsWithSelector(ctx context.Context, filters *WorkloadFilter,
 	}
 
 	podList := &corev1.PodList{}
-	err = k8sCacheClient.List(ctx, podList, client.InNamespace(filters.NamespaceString), client.MatchingLabelsSelector{Selector: selector}, client.UnsafeDisableDeepCopy)
+	err = k8sCacheClient.List(ctx, podList, client.InNamespace(filters.NamespaceString), client.MatchingLabelsSelector{Selector: selector})
 	if err != nil {
 		return nil, err
 	}
@@ -742,7 +742,7 @@ func fetchInstrumentationInstances(ctx context.Context, logger logr.Logger, filt
 	if matchingLabels != nil {
 		opts = append(opts, client.MatchingLabels(matchingLabels))
 	}
-	err = k8sCacheClient.List(ctx, &ii, append(opts, client.UnsafeDisableDeepCopy)...)
+	err = k8sCacheClient.List(ctx, &ii, append(opts)...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -812,7 +812,7 @@ func getWorkloadManifest(ctx context.Context, logger logr.Logger, id model.K8sWo
 	switch k8sconsts.WorkloadKind(id.Kind) {
 	case k8sconsts.WorkloadKindDeployment:
 		obj := &appsv1.Deployment{}
-		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj, client.UnsafeDisableDeepCopy); err != nil {
+		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj); err != nil {
 			return nil, client.IgnoreNotFound(err)
 		}
 		return &computed.CachedWorkloadManifest{
@@ -823,7 +823,7 @@ func getWorkloadManifest(ctx context.Context, logger logr.Logger, id model.K8sWo
 
 	case k8sconsts.WorkloadKindDaemonSet:
 		obj := &appsv1.DaemonSet{}
-		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj, client.UnsafeDisableDeepCopy); err != nil {
+		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj); err != nil {
 			return nil, client.IgnoreNotFound(err)
 		}
 		return &computed.CachedWorkloadManifest{
@@ -834,7 +834,7 @@ func getWorkloadManifest(ctx context.Context, logger logr.Logger, id model.K8sWo
 
 	case k8sconsts.WorkloadKindStatefulSet:
 		obj := &appsv1.StatefulSet{}
-		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj, client.UnsafeDisableDeepCopy); err != nil {
+		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj); err != nil {
 			return nil, client.IgnoreNotFound(err)
 		}
 		return &computed.CachedWorkloadManifest{
@@ -845,7 +845,7 @@ func getWorkloadManifest(ctx context.Context, logger logr.Logger, id model.K8sWo
 
 	case k8sconsts.WorkloadKindCronJob:
 		obj := &batchv1.CronJob{}
-		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj, client.UnsafeDisableDeepCopy); err != nil {
+		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj); err != nil {
 			return nil, client.IgnoreNotFound(err)
 		}
 		return &computed.CachedWorkloadManifest{
@@ -895,7 +895,7 @@ func getWorkloadManifest(ctx context.Context, logger logr.Logger, id model.K8sWo
 			return nil, nil
 		}
 		obj := &argorolloutsv1alpha1.Rollout{}
-		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj, client.UnsafeDisableDeepCopy); err != nil {
+		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj); err != nil {
 			return nil, client.IgnoreNotFound(err)
 		}
 		return &computed.CachedWorkloadManifest{
@@ -906,7 +906,7 @@ func getWorkloadManifest(ctx context.Context, logger logr.Logger, id model.K8sWo
 
 	case k8sconsts.WorkloadKindStaticPod:
 		obj := &corev1.Pod{}
-		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj, client.UnsafeDisableDeepCopy); err != nil {
+		if err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: id.Namespace, Name: id.Name}, obj); err != nil {
 			return nil, client.IgnoreNotFound(err)
 		}
 		if !workload.IsStaticPod(obj) {

--- a/frontend/graph/loaders/loader.go
+++ b/frontend/graph/loaders/loader.go
@@ -133,7 +133,7 @@ func (l *Loaders) loadInstrumentationConfigs(ctx context.Context) error {
 	if l.instrumentationConfigsFetched {
 		return nil
 	}
-	instrumentationConfigs, err := fetchInstrumentationConfigs(ctx, l.logger, l.workloadFilter, l.k8sCacheClient)
+	instrumentationConfigs, err := fetchInstrumentationConfigs(ctx, l.workloadFilter, l.k8sCacheClient)
 	if err != nil {
 		return err
 	}

--- a/frontend/graph/loaders/loader.go
+++ b/frontend/graph/loaders/loader.go
@@ -3,7 +3,6 @@ package loaders
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -54,10 +53,9 @@ type Loaders struct {
 	namespacesFetched bool
 	namespaces        []string
 
-	totalWorkloadCount int
-	workloadIds        []model.K8sWorkloadID
-	workloadIdsMap     map[k8sconsts.PodWorkload]struct{}
-	nsToWorkloadIds    map[string][]model.K8sWorkloadID
+	workloadIds     []model.K8sWorkloadID
+	workloadIdsMap  map[k8sconsts.PodWorkload]struct{}
+	nsToWorkloadIds map[string][]model.K8sWorkloadID
 
 	instrumentationConfigMutex    sync.Mutex
 	instrumentationConfigsFetched bool
@@ -101,12 +99,6 @@ func (l *Loaders) GetWorkloadIds() []model.K8sWorkloadID {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return l.workloadIds
-}
-
-func (l *Loaders) GetTotalWorkloadCount() int {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	return l.totalWorkloadCount
 }
 
 func (l *Loaders) GetWorkloadIdsInNamespace(ns string) []model.K8sWorkloadID {
@@ -316,6 +308,36 @@ func (l *Loaders) loadInstrumentationInstances(ctx context.Context) error {
 	return nil
 }
 
+// LoadConfig loads the odigos configuration and sets up ignored namespaces
+// without triggering any workload/source/manifest loading. Use this for
+// queries that only need namespace metadata.
+func (l *Loaders) LoadConfig(ctx context.Context) error {
+	odigosns := env.GetCurrentNamespace()
+	var odigosConfigurationConfigMap corev1.ConfigMap
+	err := l.k8sCacheClient.Get(ctx, client.ObjectKey{
+		Namespace: odigosns,
+		Name:      consts.OdigosEffectiveConfigName,
+	}, &odigosConfigurationConfigMap)
+	if err != nil {
+		return err
+	}
+
+	if err := yaml.Unmarshal([]byte(odigosConfigurationConfigMap.Data[consts.OdigosConfigurationFileName]), &l.odigosConfiguration); err != nil {
+		return err
+	}
+	ignoredNamespacesMap := make(map[string]struct{})
+	for _, namespace := range l.odigosConfiguration.IgnoredNamespaces {
+		ignoredNamespacesMap[namespace] = struct{}{}
+	}
+
+	l.workloadFilter = &WorkloadFilter{
+		ClusterWide:       &WorkloadFilterClusterWide{},
+		NamespaceString:   "",
+		IgnoredNamespaces: ignoredNamespacesMap,
+	}
+	return nil
+}
+
 func (l *Loaders) SetFilters(ctx context.Context, filter *model.WorkloadFilter) error {
 
 	// fetch odigos configuration for each request.
@@ -413,53 +435,6 @@ func (l *Loaders) SetFilters(ctx context.Context, filter *model.WorkloadFilter) 
 		l.workloadIds = make([]model.K8sWorkloadID, 0, len(allWorkloads))
 		for sourceId := range allWorkloads {
 			l.workloadIds = append(l.workloadIds, sourceId)
-		}
-	}
-
-	// Sort for deterministic pagination and stable results across requests.
-	sort.Slice(l.workloadIds, func(i, j int) bool {
-		a, b := l.workloadIds[i], l.workloadIds[j]
-		if a.Namespace != b.Namespace {
-			return a.Namespace < b.Namespace
-		}
-		if a.Kind != b.Kind {
-			return a.Kind < b.Kind
-		}
-		return a.Name < b.Name
-	})
-
-	l.totalWorkloadCount = len(l.workloadIds)
-
-	// Apply server-side pagination when limit/offset are provided.
-	if filter != nil {
-		offset := 0
-		if filter.Offset != nil && *filter.Offset > 0 {
-			offset = *filter.Offset
-		}
-		if offset > len(l.workloadIds) {
-			offset = len(l.workloadIds)
-		}
-
-		if filter.Limit != nil && *filter.Limit > 0 {
-			end := offset + *filter.Limit
-			if end > len(l.workloadIds) {
-				end = len(l.workloadIds)
-			}
-			l.workloadIds = l.workloadIds[offset:end]
-		} else if offset > 0 {
-			l.workloadIds = l.workloadIds[offset:]
-		}
-
-		// When paginating the markedForInstrumentation path, trim the IC map
-		// to release memory for workloads outside the current page.
-		if filterMarkedForInstrumentation && len(l.workloadIds) < l.totalWorkloadCount {
-			trimmed := make(map[model.K8sWorkloadID]*v1alpha1.InstrumentationConfig, len(l.workloadIds))
-			for _, id := range l.workloadIds {
-				if ic, ok := l.instrumentationConfigs[id]; ok {
-					trimmed[id] = ic
-				}
-			}
-			l.instrumentationConfigs = trimmed
 		}
 	}
 

--- a/frontend/graph/loaders/loader.go
+++ b/frontend/graph/loaders/loader.go
@@ -3,6 +3,7 @@ package loaders
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -53,9 +54,10 @@ type Loaders struct {
 	namespacesFetched bool
 	namespaces        []string
 
-	workloadIds     []model.K8sWorkloadID
-	workloadIdsMap  map[k8sconsts.PodWorkload]struct{}
-	nsToWorkloadIds map[string][]model.K8sWorkloadID
+	totalWorkloadCount int
+	workloadIds        []model.K8sWorkloadID
+	workloadIdsMap     map[k8sconsts.PodWorkload]struct{}
+	nsToWorkloadIds    map[string][]model.K8sWorkloadID
 
 	instrumentationConfigMutex    sync.Mutex
 	instrumentationConfigsFetched bool
@@ -99,6 +101,12 @@ func (l *Loaders) GetWorkloadIds() []model.K8sWorkloadID {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return l.workloadIds
+}
+
+func (l *Loaders) GetTotalWorkloadCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.totalWorkloadCount
 }
 
 func (l *Loaders) GetWorkloadIdsInNamespace(ns string) []model.K8sWorkloadID {
@@ -160,10 +168,23 @@ func (l *Loaders) loadWorkloadManifests(ctx context.Context) error {
 	if l.workloadManifestsFetched {
 		return nil
 	}
-	workloadManifests, err := fetchWorkloadManifests(ctx, l.logger, l.workloadFilter, l.k8sCacheClient)
+
+	var workloadManifests map[model.K8sWorkloadID]*computed.CachedWorkloadManifest
+	var err error
+
+	// When workload IDs are already known (e.g. markedForInstrumentation path
+	// or workloadsByIds), use targeted per-workload Get operations instead of
+	// 6+ cluster-wide List operations. This dramatically reduces memory from
+	// deep-copying thousands of unrelated K8s objects from the informer cache.
+	if l.workloadIds != nil {
+		workloadManifests, err = fetchWorkloadManifestsByIds(ctx, l.logger, l.workloadIds, l.k8sCacheClient)
+	} else {
+		workloadManifests, err = fetchWorkloadManifests(ctx, l.logger, l.workloadFilter, l.k8sCacheClient)
+	}
 	if err != nil {
 		return err
 	}
+
 	l.workloadManifests = workloadManifests
 	l.workloadManifestsFetched = true
 	return nil
@@ -392,6 +413,53 @@ func (l *Loaders) SetFilters(ctx context.Context, filter *model.WorkloadFilter) 
 		l.workloadIds = make([]model.K8sWorkloadID, 0, len(allWorkloads))
 		for sourceId := range allWorkloads {
 			l.workloadIds = append(l.workloadIds, sourceId)
+		}
+	}
+
+	// Sort for deterministic pagination and stable results across requests.
+	sort.Slice(l.workloadIds, func(i, j int) bool {
+		a, b := l.workloadIds[i], l.workloadIds[j]
+		if a.Namespace != b.Namespace {
+			return a.Namespace < b.Namespace
+		}
+		if a.Kind != b.Kind {
+			return a.Kind < b.Kind
+		}
+		return a.Name < b.Name
+	})
+
+	l.totalWorkloadCount = len(l.workloadIds)
+
+	// Apply server-side pagination when limit/offset are provided.
+	if filter != nil {
+		offset := 0
+		if filter.Offset != nil && *filter.Offset > 0 {
+			offset = *filter.Offset
+		}
+		if offset > len(l.workloadIds) {
+			offset = len(l.workloadIds)
+		}
+
+		if filter.Limit != nil && *filter.Limit > 0 {
+			end := offset + *filter.Limit
+			if end > len(l.workloadIds) {
+				end = len(l.workloadIds)
+			}
+			l.workloadIds = l.workloadIds[offset:end]
+		} else if offset > 0 {
+			l.workloadIds = l.workloadIds[offset:]
+		}
+
+		// When paginating the markedForInstrumentation path, trim the IC map
+		// to release memory for workloads outside the current page.
+		if filterMarkedForInstrumentation && len(l.workloadIds) < l.totalWorkloadCount {
+			trimmed := make(map[model.K8sWorkloadID]*v1alpha1.InstrumentationConfig, len(l.workloadIds))
+			for _, id := range l.workloadIds {
+				if ic, ok := l.instrumentationConfigs[id]; ok {
+					trimmed[id] = ic
+				}
+			}
+			l.instrumentationConfigs = trimmed
 		}
 	}
 

--- a/frontend/graph/loaders/loader.go
+++ b/frontend/graph/loaders/loader.go
@@ -308,10 +308,14 @@ func (l *Loaders) loadInstrumentationInstances(ctx context.Context) error {
 	return nil
 }
 
-// LoadConfig loads the odigos configuration and sets up ignored namespaces
-// without triggering any workload/source/manifest loading. Use this for
-// queries that only need namespace metadata.
+// LoadConfig loads the odigos configuration and sets up ignored namespaces.
+// Cached after first call — safe to call multiple times per request.
+// Use directly for queries that only need namespace metadata (no workloads).
 func (l *Loaders) LoadConfig(ctx context.Context) error {
+	if l.odigosConfiguration != nil {
+		return nil
+	}
+
 	odigosns := env.GetCurrentNamespace()
 	var odigosConfigurationConfigMap corev1.ConfigMap
 	err := l.k8sCacheClient.Get(ctx, client.ObjectKey{
@@ -340,24 +344,10 @@ func (l *Loaders) LoadConfig(ctx context.Context) error {
 
 func (l *Loaders) SetFilters(ctx context.Context, filter *model.WorkloadFilter) error {
 
-	// fetch odigos configuration for each request.
-	odigosns := env.GetCurrentNamespace()
-	var odigosConfigurationConfigMap corev1.ConfigMap
-	err := l.k8sCacheClient.Get(ctx, client.ObjectKey{
-		Namespace: odigosns,
-		Name:      consts.OdigosEffectiveConfigName,
-	}, &odigosConfigurationConfigMap)
-	if err != nil {
+	if err := l.LoadConfig(ctx); err != nil {
 		return err
 	}
-
-	if err := yaml.Unmarshal([]byte(odigosConfigurationConfigMap.Data[consts.OdigosConfigurationFileName]), &l.odigosConfiguration); err != nil {
-		return err
-	}
-	ignoredNamespacesMap := make(map[string]struct{})
-	for _, namespace := range l.odigosConfiguration.IgnoredNamespaces {
-		ignoredNamespacesMap[namespace] = struct{}{}
-	}
+	ignoredNamespacesMap := l.workloadFilter.IgnoredNamespaces
 
 	// check if it's a namespace query for ignored namespaces.
 	if filter != nil && filter.Namespace != nil {
@@ -453,28 +443,8 @@ func (l *Loaders) SetFilters(ctx context.Context, filter *model.WorkloadFilter) 
 }
 
 func (l *Loaders) SetWorkloadIdsDirect(ctx context.Context, ids []model.K8sWorkloadID) error {
-	odigosns := env.GetCurrentNamespace()
-	var odigosConfigurationConfigMap corev1.ConfigMap
-	err := l.k8sCacheClient.Get(ctx, client.ObjectKey{
-		Namespace: odigosns,
-		Name:      consts.OdigosEffectiveConfigName,
-	}, &odigosConfigurationConfigMap)
-	if err != nil {
+	if err := l.LoadConfig(ctx); err != nil {
 		return err
-	}
-
-	if err := yaml.Unmarshal([]byte(odigosConfigurationConfigMap.Data[consts.OdigosConfigurationFileName]), &l.odigosConfiguration); err != nil {
-		return err
-	}
-	ignoredNamespacesMap := make(map[string]struct{})
-	for _, namespace := range l.odigosConfiguration.IgnoredNamespaces {
-		ignoredNamespacesMap[namespace] = struct{}{}
-	}
-
-	l.workloadFilter = &WorkloadFilter{
-		ClusterWide:       &WorkloadFilterClusterWide{},
-		NamespaceString:   "",
-		IgnoredNamespaces: ignoredNamespacesMap,
 	}
 
 	l.workloadIds = ids

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -1659,6 +1659,8 @@ type WorkloadFilter struct {
 	Kind                     *K8sResourceKind `json:"kind,omitempty"`
 	Name                     *string          `json:"name,omitempty"`
 	MarkedForInstrumentation *bool            `json:"markedForInstrumentation,omitempty"`
+	Limit                    *int             `json:"limit,omitempty"`
+	Offset                   *int             `json:"offset,omitempty"`
 }
 
 type ActionType string

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -1659,8 +1659,6 @@ type WorkloadFilter struct {
 	Kind                     *K8sResourceKind `json:"kind,omitempty"`
 	Name                     *string          `json:"name,omitempty"`
 	MarkedForInstrumentation *bool            `json:"markedForInstrumentation,omitempty"`
-	Limit                    *int             `json:"limit,omitempty"`
-	Offset                   *int             `json:"offset,omitempty"`
 }
 
 type ActionType string

--- a/frontend/graph/schema.resolvers.go
+++ b/frontend/graph/schema.resolvers.go
@@ -26,6 +26,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // APITokens is the resolver for the apiTokens field.
@@ -195,40 +196,36 @@ func (r *computePlatformResolver) InstrumentationRules(ctx context.Context, obj 
 
 // DataStreams is the resolver for the dataStreams field.
 func (r *computePlatformResolver) DataStreams(ctx context.Context, obj *model.ComputePlatform) ([]*model.DataStream, error) {
-	ns := env.GetCurrentNamespace()
-
 	dataStreams := make([]*model.DataStream, 0)
-	seen := make(map[string]bool) // prevent duplicates
+	seen := make(map[string]bool)
 
 	dataStreams = append(dataStreams, &model.DataStream{Name: "default"})
 	seen["default"] = true
 
-	instrumentationConfigs, err := kube.DefaultClient.OdigosClient.InstrumentationConfigs("").List(ctx, metav1.ListOptions{})
-	if err != nil {
+	// Use cache client with zero-copy instead of direct API call to avoid
+	// fetching and deep-copying all ICs from the API server at scale.
+	var instrumentationConfigs v1alpha1.InstrumentationConfigList
+	if err := r.K8sCacheClient.List(ctx, &instrumentationConfigs, client.UnsafeDisableDeepCopy); err != nil {
 		return nil, err
 	}
 	for _, ic := range instrumentationConfigs.Items {
 		for _, name := range services.ExtractDataStreamsFromInstrumentationConfig(&ic) {
 			if !seen[*name] {
 				seen[*name] = true
-				dataStreams = append(dataStreams, &model.DataStream{
-					Name: *name,
-				})
+				dataStreams = append(dataStreams, &model.DataStream{Name: *name})
 			}
 		}
 	}
 
-	destinations, err := kube.DefaultClient.OdigosClient.Destinations(ns).List(ctx, metav1.ListOptions{})
-	if err != nil {
+	var destinations v1alpha1.DestinationList
+	if err := r.K8sCacheClient.List(ctx, &destinations, client.UnsafeDisableDeepCopy); err != nil {
 		return nil, err
 	}
 	for _, dest := range destinations.Items {
 		for _, name := range services.ExtractDataStreamsFromDestination(dest) {
 			if !seen[*name] {
 				seen[*name] = true
-				dataStreams = append(dataStreams, &model.DataStream{
-					Name: *name,
-				})
+				dataStreams = append(dataStreams, &model.DataStream{Name: *name})
 			}
 		}
 	}

--- a/frontend/graph/schema.resolvers.go
+++ b/frontend/graph/schema.resolvers.go
@@ -26,7 +26,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // APITokens is the resolver for the apiTokens field.
@@ -205,7 +204,7 @@ func (r *computePlatformResolver) DataStreams(ctx context.Context, obj *model.Co
 	// Use cache client with zero-copy instead of direct API call to avoid
 	// fetching and deep-copying all ICs from the API server at scale.
 	var instrumentationConfigs v1alpha1.InstrumentationConfigList
-	if err := r.K8sCacheClient.List(ctx, &instrumentationConfigs, client.UnsafeDisableDeepCopy); err != nil {
+	if err := r.K8sCacheClient.List(ctx, &instrumentationConfigs); err != nil {
 		return nil, err
 	}
 	for _, ic := range instrumentationConfigs.Items {
@@ -218,7 +217,7 @@ func (r *computePlatformResolver) DataStreams(ctx context.Context, obj *model.Co
 	}
 
 	var destinations v1alpha1.DestinationList
-	if err := r.K8sCacheClient.List(ctx, &destinations, client.UnsafeDisableDeepCopy); err != nil {
+	if err := r.K8sCacheClient.List(ctx, &destinations); err != nil {
 		return nil, err
 	}
 	for _, dest := range destinations.Items {

--- a/frontend/graph/workload.graphqls
+++ b/frontend/graph/workload.graphqls
@@ -17,11 +17,18 @@ type K8sWorkloadId {
 # - all workloads: all fields are empty.
 #
 # setting markedForInstrumentation to true will return just those that are relevant for instrumentation.
+#
+# limit and offset enable server-side pagination for large clusters.
+# when limit is set, at most that many workloads are returned.
+# when offset is set, workloads before the offset are skipped.
+# workloads are sorted deterministically (namespace, kind, name) for stable pagination.
 input WorkloadFilter {
   namespace: String
   kind: K8sResourceKind
   name: String
   markedForInstrumentation: Boolean
+  limit: Int
+  offset: Int
 }
 
 input K8sWorkloadIdInput {
@@ -559,5 +566,8 @@ type K8sNamespace {
 extend type Query {
   workloads(filter: WorkloadFilter): [K8sWorkload!]!
   workloadsByIds(ids: [K8sWorkloadIdInput!]!): [K8sWorkload!]!
+  # lightweight count query that returns the total number of matching workloads
+  # without loading nested data. Use alongside paginated workloads queries.
+  workloadsCount(filter: WorkloadFilter): Int!
   namespaces: [K8sNamespace!]!
 }

--- a/frontend/graph/workload.graphqls
+++ b/frontend/graph/workload.graphqls
@@ -17,18 +17,11 @@ type K8sWorkloadId {
 # - all workloads: all fields are empty.
 #
 # setting markedForInstrumentation to true will return just those that are relevant for instrumentation.
-#
-# limit and offset enable server-side pagination for large clusters.
-# when limit is set, at most that many workloads are returned.
-# when offset is set, workloads before the offset are skipped.
-# workloads are sorted deterministically (namespace, kind, name) for stable pagination.
 input WorkloadFilter {
   namespace: String
   kind: K8sResourceKind
   name: String
   markedForInstrumentation: Boolean
-  limit: Int
-  offset: Int
 }
 
 input K8sWorkloadIdInput {
@@ -566,8 +559,5 @@ type K8sNamespace {
 extend type Query {
   workloads(filter: WorkloadFilter): [K8sWorkload!]!
   workloadsByIds(ids: [K8sWorkloadIdInput!]!): [K8sWorkload!]!
-  # lightweight count query that returns the total number of matching workloads
-  # without loading nested data. Use alongside paginated workloads queries.
-  workloadsCount(filter: WorkloadFilter): Int!
   namespaces: [K8sNamespace!]!
 }

--- a/frontend/graph/workload.resolvers.go
+++ b/frontend/graph/workload.resolvers.go
@@ -58,10 +58,20 @@ func (r *k8sNamespaceResolver) DataStreamNames(ctx context.Context, obj *model.K
 }
 
 // Workloads is the resolver for the workloads field.
+// Triggers the full SetFilters load (sources + manifests) only when workloads
+// are actually requested. The Namespaces query resolver uses LoadConfig which
+// skips this, so lightweight namespace-only queries stay fast.
 func (r *k8sNamespaceResolver) Workloads(ctx context.Context, obj *model.K8sNamespace) ([]*model.K8sWorkload, error) {
 	l := loaders.For(ctx)
-	workloadIds := l.GetWorkloadIdsInNamespace(obj.Name)
 
+	// Ensure workload IDs are loaded (SetFilters is idempotent via Fetched flags).
+	if len(l.GetWorkloadIds()) == 0 {
+		if err := l.SetFilters(ctx, nil); err != nil {
+			return nil, err
+		}
+	}
+
+	workloadIds := l.GetWorkloadIdsInNamespace(obj.Name)
 	workloads := make([]*model.K8sWorkload, 0, len(workloadIds))
 	for _, id := range workloadIds {
 		workloads = append(workloads, &model.K8sWorkload{ID: &id})
@@ -771,28 +781,13 @@ func (r *queryResolver) WorkloadsByIds(ctx context.Context, ids []*model.K8sWork
 	return result, nil
 }
 
-// WorkloadsCount is the resolver for the workloadsCount field.
-func (r *queryResolver) WorkloadsCount(ctx context.Context, filter *model.WorkloadFilter) (int, error) {
-	l := loaders.For(ctx)
-	// Strip limit/offset so SetFilters loads all IDs for the count.
-	countFilter := &model.WorkloadFilter{}
-	if filter != nil {
-		countFilter.Namespace = filter.Namespace
-		countFilter.Kind = filter.Kind
-		countFilter.Name = filter.Name
-		countFilter.MarkedForInstrumentation = filter.MarkedForInstrumentation
-	}
-	if err := l.SetFilters(ctx, countFilter); err != nil {
-		return 0, err
-	}
-	return l.GetTotalWorkloadCount(), nil
-}
-
 // Namespaces is the resolver for the namespaces field.
+// Only loads config + namespace list. Workload data is deferred to the
+// K8sNamespace.Workloads field resolver, so queries that don't request
+// workloads avoid the heavy manifest/source loading entirely.
 func (r *queryResolver) Namespaces(ctx context.Context) ([]*model.K8sNamespace, error) {
 	l := loaders.For(ctx)
-	err := l.SetFilters(ctx, nil)
-	if err != nil {
+	if err := l.LoadConfig(ctx); err != nil {
 		return nil, err
 	}
 

--- a/frontend/graph/workload.resolvers.go
+++ b/frontend/graph/workload.resolvers.go
@@ -81,6 +81,9 @@ func (r *k8sNamespaceResolver) Workloads(ctx context.Context, obj *model.K8sName
 
 // ServiceName is the resolver for the serviceName field.
 func (r *k8sWorkloadResolver) ServiceName(ctx context.Context, obj *model.K8sWorkload) (*string, error) {
+	if obj.ServiceName != nil {
+		return obj.ServiceName, nil
+	}
 	l := loaders.For(ctx)
 	ic, err := l.GetInstrumentationConfig(ctx, *obj.ID)
 	if err != nil {
@@ -94,6 +97,9 @@ func (r *k8sWorkloadResolver) ServiceName(ctx context.Context, obj *model.K8sWor
 
 // WorkloadOdigosHealthStatus is the resolver for the workloadOdigosHealthStatus field.
 func (r *k8sWorkloadResolver) WorkloadOdigosHealthStatus(ctx context.Context, obj *model.K8sWorkload) (*model.DesiredConditionStatus, error) {
+	if obj.WorkloadOdigosHealthStatus != nil {
+		return obj.WorkloadOdigosHealthStatus, nil
+	}
 	l := loaders.For(ctx)
 	ic, err := l.GetInstrumentationConfig(ctx, *obj.ID)
 	if err != nil {
@@ -170,6 +176,9 @@ func (r *k8sWorkloadResolver) WorkloadOdigosHealthStatus(ctx context.Context, ob
 
 // Conditions is the resolver for the conditions field.
 func (r *k8sWorkloadResolver) Conditions(ctx context.Context, obj *model.K8sWorkload) (*model.K8sWorkloadConditions, error) {
+	if obj.Conditions != nil {
+		return obj.Conditions, nil
+	}
 	l := loaders.For(ctx)
 	ic, err := l.GetInstrumentationConfig(ctx, *obj.ID)
 	if err != nil {
@@ -213,6 +222,9 @@ func (r *k8sWorkloadResolver) Conditions(ctx context.Context, obj *model.K8sWork
 
 // MarkedForInstrumentation is the resolver for the markedForInstrumentation field.
 func (r *k8sWorkloadResolver) MarkedForInstrumentation(ctx context.Context, obj *model.K8sWorkload) (*model.K8sWorkloadMarkedForInstrumentation, error) {
+	if obj.MarkedForInstrumentation != nil {
+		return obj.MarkedForInstrumentation, nil
+	}
 	l := loaders.For(ctx)
 	sources, err := l.GetSources(ctx, *obj.ID)
 	if err != nil {
@@ -242,6 +254,9 @@ func (r *k8sWorkloadResolver) MarkedForInstrumentation(ctx context.Context, obj 
 
 // RuntimeInfo is the resolver for the runtimeInfo field.
 func (r *k8sWorkloadResolver) RuntimeInfo(ctx context.Context, obj *model.K8sWorkload) (*model.K8sWorkloadRuntimeInfo, error) {
+	if obj.RuntimeInfo != nil {
+		return obj.RuntimeInfo, nil
+	}
 	l := loaders.For(ctx)
 	ic, err := l.GetInstrumentationConfig(ctx, *obj.ID)
 	if err != nil || ic == nil {
@@ -326,6 +341,9 @@ func (r *k8sWorkloadResolver) Rollout(ctx context.Context, obj *model.K8sWorkloa
 func (r *k8sWorkloadResolver) Containers(ctx context.Context, obj *model.K8sWorkload) ([]*model.K8sWorkloadContainer, error) {
 	if obj == nil || obj.ID == nil {
 		return nil, nil
+	}
+	if obj.Containers != nil {
+		return obj.Containers, nil
 	}
 	l := loaders.For(ctx)
 	ic, err := l.GetInstrumentationConfig(ctx, *obj.ID)
@@ -483,6 +501,9 @@ func (r *k8sWorkloadResolver) Pods(ctx context.Context, obj *model.K8sWorkload) 
 
 // PodsAgentInjectionStatus is the resolver for the podsAgentInjectionStatus field.
 func (r *k8sWorkloadResolver) PodsAgentInjectionStatus(ctx context.Context, obj *model.K8sWorkload) (*model.DesiredConditionStatus, error) {
+	if obj.PodsAgentInjectionStatus != nil {
+		return obj.PodsAgentInjectionStatus, nil
+	}
 	l := loaders.For(ctx)
 	pods, err := l.GetWorkloadPods(ctx, *obj.ID)
 	if err != nil {
@@ -593,6 +614,9 @@ func (r *k8sWorkloadResolver) TelemetryMetrics(ctx context.Context, obj *model.K
 
 // DataStreamNames is the resolver for the dataStreamNames field.
 func (r *k8sWorkloadResolver) DataStreamNames(ctx context.Context, obj *model.K8sWorkload) ([]string, error) {
+	if obj.DataStreamNames != nil {
+		return obj.DataStreamNames, nil
+	}
 	l := loaders.For(ctx)
 	sources, err := l.GetSources(ctx, *obj.ID)
 	if err != nil {
@@ -609,6 +633,9 @@ func (r *k8sWorkloadResolver) DataStreamNames(ctx context.Context, obj *model.K8
 
 // NumberOfInstances is the resolver for the numberOfInstances field.
 func (r *k8sWorkloadResolver) NumberOfInstances(ctx context.Context, obj *model.K8sWorkload) (*int, error) {
+	if obj.NumberOfInstances != nil {
+		return obj.NumberOfInstances, nil
+	}
 	l := loaders.For(ctx)
 	workloadManifest, err := l.GetWorkloadManifest(ctx, *obj.ID)
 	if err != nil {
@@ -741,19 +768,25 @@ func (r *k8sWorkloadTelemetryMetricsResolver) ExpectingTelemetry(ctx context.Con
 }
 
 // Workloads is the resolver for the workloads field.
+// Pre-computes all field values sequentially to avoid gqlgen spawning O(N × fields)
+// goroutines for concurrent field resolution. At 10K workloads × 17 resolver fields,
+// that would be 170K goroutines (~430MB of stack memory), exceeding the pod limit.
 func (r *queryResolver) Workloads(ctx context.Context, filter *model.WorkloadFilter) ([]*model.K8sWorkload, error) {
 	l := loaders.For(ctx)
-	err := l.SetFilters(ctx, filter)
-	if err != nil {
+	if err := l.SetFilters(ctx, filter); err != nil {
 		return nil, err
 	}
-	sources := make([]*model.K8sWorkload, 0)
-	for _, sourceId := range l.GetWorkloadIds() {
-		sources = append(sources, &model.K8sWorkload{
-			ID: &sourceId,
-		})
+
+	workloadIds := l.GetWorkloadIds()
+	results := make([]*model.K8sWorkload, 0, len(workloadIds))
+
+	for _, id := range workloadIds {
+		w := &model.K8sWorkload{ID: &id}
+		r.populateWorkloadFields(ctx, l, w)
+		results = append(results, w)
 	}
-	return sources, nil
+
+	return results, nil
 }
 
 // WorkloadsByIds is the resolver for the workloadsByIds field.

--- a/frontend/graph/workload.resolvers.go
+++ b/frontend/graph/workload.resolvers.go
@@ -771,7 +771,11 @@ func (r *k8sWorkloadTelemetryMetricsResolver) ExpectingTelemetry(ctx context.Con
 // Pre-computes all field values sequentially to avoid gqlgen spawning O(N × fields)
 // goroutines for concurrent field resolution. At 10K workloads × 17 resolver fields,
 // that would be 170K goroutines (~430MB of stack memory), exceeding the pod limit.
+// Uses heavyWorkloadQueryMu to prevent concurrent queries from doubling memory.
 func (r *queryResolver) Workloads(ctx context.Context, filter *model.WorkloadFilter) ([]*model.K8sWorkload, error) {
+	heavyWorkloadQueryMu.Lock()
+	defer heavyWorkloadQueryMu.Unlock()
+
 	l := loaders.For(ctx)
 	if err := l.SetFilters(ctx, filter); err != nil {
 		return nil, err

--- a/frontend/graph/workload.resolvers.go
+++ b/frontend/graph/workload.resolvers.go
@@ -57,6 +57,18 @@ func (r *k8sNamespaceResolver) DataStreamNames(ctx context.Context, obj *model.K
 	return names, nil
 }
 
+// Workloads is the resolver for the workloads field.
+func (r *k8sNamespaceResolver) Workloads(ctx context.Context, obj *model.K8sNamespace) ([]*model.K8sWorkload, error) {
+	l := loaders.For(ctx)
+	workloadIds := l.GetWorkloadIdsInNamespace(obj.Name)
+
+	workloads := make([]*model.K8sWorkload, 0, len(workloadIds))
+	for _, id := range workloadIds {
+		workloads = append(workloads, &model.K8sWorkload{ID: &id})
+	}
+	return workloads, nil
+}
+
 // ServiceName is the resolver for the serviceName field.
 func (r *k8sWorkloadResolver) ServiceName(ctx context.Context, obj *model.K8sWorkload) (*string, error) {
 	l := loaders.For(ctx)
@@ -791,16 +803,8 @@ func (r *queryResolver) Namespaces(ctx context.Context) ([]*model.K8sNamespace, 
 
 	gqlNss := make([]*model.K8sNamespace, 0, len(nss))
 	for _, nsName := range nss {
-		workloadIds := l.GetWorkloadIdsInNamespace(nsName)
-		workloads := make([]*model.K8sWorkload, 0, len(workloadIds))
-		for _, workloadId := range workloadIds {
-			workloads = append(workloads, &model.K8sWorkload{
-				ID: &workloadId,
-			})
-		}
 		gqlNss = append(gqlNss, &model.K8sNamespace{
-			Name:      nsName,
-			Workloads: workloads,
+			Name: nsName,
 		})
 	}
 	return gqlNss, nil

--- a/frontend/graph/workload.resolvers.go
+++ b/frontend/graph/workload.resolvers.go
@@ -759,6 +759,23 @@ func (r *queryResolver) WorkloadsByIds(ctx context.Context, ids []*model.K8sWork
 	return result, nil
 }
 
+// WorkloadsCount is the resolver for the workloadsCount field.
+func (r *queryResolver) WorkloadsCount(ctx context.Context, filter *model.WorkloadFilter) (int, error) {
+	l := loaders.For(ctx)
+	// Strip limit/offset so SetFilters loads all IDs for the count.
+	countFilter := &model.WorkloadFilter{}
+	if filter != nil {
+		countFilter.Namespace = filter.Namespace
+		countFilter.Kind = filter.Kind
+		countFilter.Name = filter.Name
+		countFilter.MarkedForInstrumentation = filter.MarkedForInstrumentation
+	}
+	if err := l.SetFilters(ctx, countFilter); err != nil {
+		return 0, err
+	}
+	return l.GetTotalWorkloadCount(), nil
+}
+
 // Namespaces is the resolver for the namespaces field.
 func (r *queryResolver) Namespaces(ctx context.Context) ([]*model.K8sNamespace, error) {
 	l := loaders.For(ctx)

--- a/frontend/graph/workload_populate.go
+++ b/frontend/graph/workload_populate.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"context"
+	"sync"
 
 	"github.com/odigos-io/odigos/api/k8sconsts"
 	"github.com/odigos-io/odigos/common"
@@ -12,6 +13,12 @@ import (
 	frontendcommon "github.com/odigos-io/odigos/frontend/services/common"
 	sourceutils "github.com/odigos-io/odigos/k8sutils/pkg/source"
 )
+
+// Serializes heavy workload queries so concurrent requests don't double memory usage.
+// A single GET_WORKLOADS at 10K workloads uses most of the 512Mi budget; a second
+// concurrent query would OOM. The mutex makes the second query wait until the first
+// completes and its memory is reclaimed by GC.
+var heavyWorkloadQueryMu sync.Mutex
 
 // populateWorkloadFields pre-computes all resolver fields for a workload
 // sequentially. This is called from the Workloads batch resolver to avoid
@@ -135,93 +142,81 @@ func (r *queryResolver) populateWorkloadFields(ctx context.Context, l *loaders.L
 		}
 	}
 
-	// pods, conditions, healthStatus (all depend on pods)
+	// Pod-dependent fields: conditions, workloadOdigosHealthStatus, podsAgentInjectionStatus.
+	// Compute once and share results to avoid duplicate status calculations.
 	pods, _ := l.GetWorkloadPods(ctx, id)
+
+	// Compute each status exactly once.
+	var runtimeDetection, agentInjectionEnabled, rollout, agentInjected, processesHealth, expectingTelemetry *model.DesiredConditionStatus
+
+	if ic != nil {
+		runtimeDetection = status.CalculateRuntimeInspectionStatus(ic)
+		agentInjectionEnabled = status.CalculateAgentInjectionEnabledStatus(ic)
+		rollout = status.CalculateRolloutStatus(ic)
+	}
+	agentInjected = status.CalculateAgentInjectedStatus(ic, pods)
+	containerNames := getContainerNamesWithOptionalPodManifestInjection(ic)
+	processesHealth, _ = aggregateProcessesHealthForWorkload(ctx, &id, containerNames)
+
+	var totalDataSent *int
+	workloadMetrics, ok := r.MetricsConsumer.GetSingleSourceMetrics(frontendcommon.SourceID{
+		Namespace: id.Namespace,
+		Kind:      k8sconsts.WorkloadKind(id.Kind),
+		Name:      id.Name,
+	})
+	if ok {
+		tds := int(workloadMetrics.TotalDataSent())
+		totalDataSent = &tds
+	}
+	telemetryMetrics := status.CalculateExpectingTelemetryStatus(ic, pods, totalDataSent)
+	expectingTelemetry = telemetryMetrics.TelemetryObservedStatus
 
 	// conditions
 	if ic != nil {
-		runtimeDetection := status.CalculateRuntimeInspectionStatus(ic)
-		agentInjectionEnabled := status.CalculateAgentInjectionEnabledStatus(ic)
-		rollout := status.CalculateRolloutStatus(ic)
-		agentInjected := status.CalculateAgentInjectedStatus(ic, pods)
-		containerNamesWithOptionalPodManifestInjection := getContainerNamesWithOptionalPodManifestInjection(ic)
-		processesAgentHealth, _ := aggregateProcessesHealthForWorkload(ctx, &id, containerNamesWithOptionalPodManifestInjection)
-		workloadMetrics, ok := r.MetricsConsumer.GetSingleSourceMetrics(frontendcommon.SourceID{
-			Namespace: id.Namespace,
-			Kind:      k8sconsts.WorkloadKind(id.Kind),
-			Name:      id.Name,
-		})
-		var totalDataSent *int
-		if ok {
-			tds := int(workloadMetrics.TotalDataSent())
-			totalDataSent = &tds
-		}
-		telemetryMetrics := status.CalculateExpectingTelemetryStatus(ic, pods, totalDataSent)
-
 		w.Conditions = &model.K8sWorkloadConditions{
 			RuntimeDetection:      runtimeDetection,
 			AgentInjectionEnabled: agentInjectionEnabled,
 			Rollout:               rollout,
 			AgentInjected:         agentInjected,
-			ProcessesAgentHealth:  processesAgentHealth,
-			ExpectingTelemetry:    telemetryMetrics.TelemetryObservedStatus,
+			ProcessesAgentHealth:  processesHealth,
+			ExpectingTelemetry:    expectingTelemetry,
 		}
 	}
 
 	// podsAgentInjectionStatus
-	w.PodsAgentInjectionStatus = status.CalculateAgentInjectedStatus(ic, pods)
+	w.PodsAgentInjectionStatus = agentInjected
 
-	// workloadOdigosHealthStatus
-	{
-		conditions := []*model.DesiredConditionStatus{}
-		if ic != nil {
-			conditions = append(conditions, status.CalculateRuntimeInspectionStatus(ic))
-			conditions = append(conditions, status.CalculateAgentInjectionEnabledStatus(ic))
-			conditions = append(conditions, status.CalculateRolloutStatus(ic))
-		} else {
-			reasonStr := string(status.WorkloadOdigosHealthStatusReasonDisabled)
-			conditions = append(conditions, &model.DesiredConditionStatus{
-				Name:       status.WorkloadOdigosHealthStatus,
-				Status:     model.DesiredStateProgressDisabled,
-				ReasonEnum: &reasonStr,
-				Message:    "workload is not marked for instrumentation",
-			})
-		}
-		containerNamesWithOptionalPodManifestInjection := getContainerNamesWithOptionalPodManifestInjection(ic)
-		conditions = append(conditions, status.CalculateAgentInjectedStatus(ic, pods))
-		processesHealth, _ := aggregateProcessesHealthForWorkload(ctx, &id, containerNamesWithOptionalPodManifestInjection)
-		conditions = append(conditions, processesHealth)
-
-		workloadMetrics, ok := r.MetricsConsumer.GetSingleSourceMetrics(frontendcommon.SourceID{
-			Namespace: id.Namespace,
-			Kind:      k8sconsts.WorkloadKind(id.Kind),
-			Name:      id.Name,
+	// workloadOdigosHealthStatus (aggregate the same statuses computed above)
+	allConditions := []*model.DesiredConditionStatus{}
+	if ic != nil {
+		allConditions = append(allConditions, runtimeDetection, agentInjectionEnabled, rollout)
+	} else {
+		reasonStr := string(status.WorkloadOdigosHealthStatusReasonDisabled)
+		allConditions = append(allConditions, &model.DesiredConditionStatus{
+			Name:       status.WorkloadOdigosHealthStatus,
+			Status:     model.DesiredStateProgressDisabled,
+			ReasonEnum: &reasonStr,
+			Message:    "workload is not marked for instrumentation",
 		})
-		var totalDataSent *int
-		if ok {
-			tds := int(workloadMetrics.TotalDataSent())
-			totalDataSent = &tds
-		}
-		telemetryMetrics := status.CalculateExpectingTelemetryStatus(ic, pods, totalDataSent)
-		conditions = append(conditions, telemetryMetrics.TelemetryObservedStatus)
-
-		mostSevere := aggregateConditionsBySeverity(conditions)
-		if mostSevere == nil {
-			mostSevere = &model.DesiredConditionStatus{
-				Name:    status.WorkloadOdigosHealthStatus,
-				Status:  model.DesiredStateProgressUnknown,
-				Message: "",
-			}
-		}
-		if mostSevere.Status == model.DesiredStateProgressSuccess {
-			reasonStr := string(status.WorkloadOdigosHealthStatusReasonSuccessAndEmittingTelemetry)
-			mostSevere = &model.DesiredConditionStatus{
-				Name:       status.WorkloadOdigosHealthStatus,
-				Status:     model.DesiredStateProgressSuccess,
-				ReasonEnum: &reasonStr,
-				Message:    "source is instrumented, healthy and telemetry has been observed",
-			}
-		}
-		w.WorkloadOdigosHealthStatus = mostSevere
 	}
+	allConditions = append(allConditions, agentInjected, processesHealth, expectingTelemetry)
+
+	mostSevere := aggregateConditionsBySeverity(allConditions)
+	if mostSevere == nil {
+		mostSevere = &model.DesiredConditionStatus{
+			Name:    status.WorkloadOdigosHealthStatus,
+			Status:  model.DesiredStateProgressUnknown,
+			Message: "",
+		}
+	}
+	if mostSevere.Status == model.DesiredStateProgressSuccess {
+		reasonStr := string(status.WorkloadOdigosHealthStatusReasonSuccessAndEmittingTelemetry)
+		mostSevere = &model.DesiredConditionStatus{
+			Name:       status.WorkloadOdigosHealthStatus,
+			Status:     model.DesiredStateProgressSuccess,
+			ReasonEnum: &reasonStr,
+			Message:    "source is instrumented, healthy and telemetry has been observed",
+		}
+	}
+	w.WorkloadOdigosHealthStatus = mostSevere
 }

--- a/frontend/graph/workload_populate.go
+++ b/frontend/graph/workload_populate.go
@@ -15,9 +15,6 @@ import (
 )
 
 // Serializes heavy workload queries so concurrent requests don't double memory usage.
-// A single GET_WORKLOADS at 10K workloads uses most of the 512Mi budget; a second
-// concurrent query would OOM. The mutex makes the second query wait until the first
-// completes and its memory is reclaimed by GC.
 var heavyWorkloadQueryMu sync.Mutex
 
 // populateWorkloadFields pre-computes all resolver fields for a workload

--- a/frontend/graph/workload_populate.go
+++ b/frontend/graph/workload_populate.go
@@ -1,0 +1,227 @@
+package graph
+
+import (
+	"context"
+
+	"github.com/odigos-io/odigos/api/k8sconsts"
+	"github.com/odigos-io/odigos/common"
+	"github.com/odigos-io/odigos/frontend/graph/loaders"
+	"github.com/odigos-io/odigos/frontend/graph/model"
+	"github.com/odigos-io/odigos/frontend/graph/status"
+	"github.com/odigos-io/odigos/frontend/services"
+	frontendcommon "github.com/odigos-io/odigos/frontend/services/common"
+	sourceutils "github.com/odigos-io/odigos/k8sutils/pkg/source"
+)
+
+// populateWorkloadFields pre-computes all resolver fields for a workload
+// sequentially. This is called from the Workloads batch resolver to avoid
+// gqlgen spawning a goroutine per field per workload.
+// Errors are logged but don't fail the entire batch — individual workloads
+// get nil/zero values for fields that fail to resolve.
+func (r *queryResolver) populateWorkloadFields(ctx context.Context, l *loaders.Loaders, w *model.K8sWorkload) {
+	id := *w.ID
+
+	ic, _ := l.GetInstrumentationConfig(ctx, id)
+
+	// serviceName
+	if ic != nil {
+		w.ServiceName = &ic.Spec.ServiceName
+	}
+
+	// rollbackOccurred
+	if ic != nil {
+		w.RollbackOccurred = ic.Status.RollbackOccurred
+	}
+
+	// markedForInstrumentation
+	if sources, err := l.GetSources(ctx, id); err == nil {
+		enabled, reason, err := sourceutils.IsObjectInstrumentedBySource(ctx, sources, nil)
+		if err == nil {
+			var marked *bool
+			if enabled {
+				marked = &enabled
+			} else if reason.Reason == string("WorkloadSourceDisabled") {
+				marked = &enabled
+			}
+			w.MarkedForInstrumentation = &model.K8sWorkloadMarkedForInstrumentation{
+				MarkedForInstrumentation: marked,
+				DecisionEnum:             string(reason.Reason),
+				Message:                  reason.Message,
+			}
+		}
+	}
+
+	// dataStreamNames
+	if sources, err := l.GetSources(ctx, id); err == nil {
+		ptrNames := services.ExtractDataStreamsFromSource(sources.Workload, sources.Namespace)
+		names := make([]string, len(ptrNames))
+		for i, p := range ptrNames {
+			names[i] = *p
+		}
+		w.DataStreamNames = names
+	}
+
+	// numberOfInstances
+	if manifest, err := l.GetWorkloadManifest(ctx, id); err == nil && manifest != nil {
+		count := int(manifest.AvailableReplicas)
+		w.NumberOfInstances = &count
+	}
+
+	// runtimeInfo
+	if ic != nil {
+		completed := len(ic.Status.RuntimeDetailsByContainer) > 0
+		uniqueLanguages := make(map[common.ProgrammingLanguage]struct{})
+		containers := make([]*model.K8sWorkloadRuntimeInfoContainer, len(ic.Status.RuntimeDetailsByContainer))
+		for i, container := range ic.Status.RuntimeDetailsByContainer {
+			containers[i] = runtimeDetailsContainersToModel(&container)
+			_, ignored := l.GetIgnoredContainers()[container.ContainerName]
+			if container.Language != common.UnknownProgrammingLanguage && !ignored {
+				uniqueLanguages[container.Language] = struct{}{}
+			}
+		}
+		var detectedLanguages []model.ProgrammingLanguage
+		if completed {
+			detectedLanguages = make([]model.ProgrammingLanguage, 0, len(uniqueLanguages))
+			for language := range uniqueLanguages {
+				detectedLanguages = append(detectedLanguages, model.ProgrammingLanguage(language))
+			}
+		}
+		w.RuntimeInfo = &model.K8sWorkloadRuntimeInfo{
+			Completed:         completed,
+			CompletedStatus:   status.CalculateRuntimeInspectionStatus(ic),
+			DetectedLanguages: detectedLanguages,
+			Containers:        containers,
+		}
+	}
+
+	// containers
+	if ic != nil {
+		containerByName := make(map[string]*model.K8sWorkloadContainer)
+		for i := range ic.Spec.Containers {
+			container := &ic.Spec.Containers[i]
+			if _, ok := containerByName[container.ContainerName]; !ok {
+				containerByName[container.ContainerName] = &model.K8sWorkloadContainer{
+					ContainerName: container.ContainerName,
+				}
+			}
+			containerByName[container.ContainerName].AgentEnabled = agentEnabledContainersToModel(container)
+			containerByName[container.ContainerName].AgentConfig = containerAgentConfigToAgentConfigModel(container)
+		}
+		for _, container := range ic.Status.RuntimeDetailsByContainer {
+			if _, ok := containerByName[container.ContainerName]; !ok {
+				containerByName[container.ContainerName] = &model.K8sWorkloadContainer{
+					ContainerName: container.ContainerName,
+				}
+			}
+			containerByName[container.ContainerName].RuntimeInfo = runtimeDetailsContainersToModel(&container)
+		}
+		for _, container := range ic.Spec.ContainersOverrides {
+			if _, ok := containerByName[container.ContainerName]; !ok {
+				containerByName[container.ContainerName] = &model.K8sWorkloadContainer{
+					ContainerName: container.ContainerName,
+				}
+			}
+			overrides := &model.K8sWorkloadContainerOverrides{
+				ContainerName: container.ContainerName,
+			}
+			if container.RuntimeInfo != nil {
+				overrides.RuntimeInfo = runtimeDetailsContainersToModel(container.RuntimeInfo)
+			}
+			containerByName[container.ContainerName].Overrides = overrides
+		}
+		w.Containers = make([]*model.K8sWorkloadContainer, 0, len(containerByName))
+		for _, container := range containerByName {
+			w.Containers = append(w.Containers, container)
+		}
+	}
+
+	// pods, conditions, healthStatus (all depend on pods)
+	pods, _ := l.GetWorkloadPods(ctx, id)
+
+	// conditions
+	if ic != nil {
+		runtimeDetection := status.CalculateRuntimeInspectionStatus(ic)
+		agentInjectionEnabled := status.CalculateAgentInjectionEnabledStatus(ic)
+		rollout := status.CalculateRolloutStatus(ic)
+		agentInjected := status.CalculateAgentInjectedStatus(ic, pods)
+		containerNamesWithOptionalPodManifestInjection := getContainerNamesWithOptionalPodManifestInjection(ic)
+		processesAgentHealth, _ := aggregateProcessesHealthForWorkload(ctx, &id, containerNamesWithOptionalPodManifestInjection)
+		workloadMetrics, ok := r.MetricsConsumer.GetSingleSourceMetrics(frontendcommon.SourceID{
+			Namespace: id.Namespace,
+			Kind:      k8sconsts.WorkloadKind(id.Kind),
+			Name:      id.Name,
+		})
+		var totalDataSent *int
+		if ok {
+			tds := int(workloadMetrics.TotalDataSent())
+			totalDataSent = &tds
+		}
+		telemetryMetrics := status.CalculateExpectingTelemetryStatus(ic, pods, totalDataSent)
+
+		w.Conditions = &model.K8sWorkloadConditions{
+			RuntimeDetection:      runtimeDetection,
+			AgentInjectionEnabled: agentInjectionEnabled,
+			Rollout:               rollout,
+			AgentInjected:         agentInjected,
+			ProcessesAgentHealth:  processesAgentHealth,
+			ExpectingTelemetry:    telemetryMetrics.TelemetryObservedStatus,
+		}
+	}
+
+	// podsAgentInjectionStatus
+	w.PodsAgentInjectionStatus = status.CalculateAgentInjectedStatus(ic, pods)
+
+	// workloadOdigosHealthStatus
+	{
+		conditions := []*model.DesiredConditionStatus{}
+		if ic != nil {
+			conditions = append(conditions, status.CalculateRuntimeInspectionStatus(ic))
+			conditions = append(conditions, status.CalculateAgentInjectionEnabledStatus(ic))
+			conditions = append(conditions, status.CalculateRolloutStatus(ic))
+		} else {
+			reasonStr := string(status.WorkloadOdigosHealthStatusReasonDisabled)
+			conditions = append(conditions, &model.DesiredConditionStatus{
+				Name:       status.WorkloadOdigosHealthStatus,
+				Status:     model.DesiredStateProgressDisabled,
+				ReasonEnum: &reasonStr,
+				Message:    "workload is not marked for instrumentation",
+			})
+		}
+		containerNamesWithOptionalPodManifestInjection := getContainerNamesWithOptionalPodManifestInjection(ic)
+		conditions = append(conditions, status.CalculateAgentInjectedStatus(ic, pods))
+		processesHealth, _ := aggregateProcessesHealthForWorkload(ctx, &id, containerNamesWithOptionalPodManifestInjection)
+		conditions = append(conditions, processesHealth)
+
+		workloadMetrics, ok := r.MetricsConsumer.GetSingleSourceMetrics(frontendcommon.SourceID{
+			Namespace: id.Namespace,
+			Kind:      k8sconsts.WorkloadKind(id.Kind),
+			Name:      id.Name,
+		})
+		var totalDataSent *int
+		if ok {
+			tds := int(workloadMetrics.TotalDataSent())
+			totalDataSent = &tds
+		}
+		telemetryMetrics := status.CalculateExpectingTelemetryStatus(ic, pods, totalDataSent)
+		conditions = append(conditions, telemetryMetrics.TelemetryObservedStatus)
+
+		mostSevere := aggregateConditionsBySeverity(conditions)
+		if mostSevere == nil {
+			mostSevere = &model.DesiredConditionStatus{
+				Name:    status.WorkloadOdigosHealthStatus,
+				Status:  model.DesiredStateProgressUnknown,
+				Message: "",
+			}
+		}
+		if mostSevere.Status == model.DesiredStateProgressSuccess {
+			reasonStr := string(status.WorkloadOdigosHealthStatusReasonSuccessAndEmittingTelemetry)
+			mostSevere = &model.DesiredConditionStatus{
+				Name:       status.WorkloadOdigosHealthStatus,
+				Status:     model.DesiredStateProgressSuccess,
+				ReasonEnum: &reasonStr,
+				Message:    "source is instrumented, healthy and telemetry has been observed",
+			}
+		}
+		w.WorkloadOdigosHealthStatus = mostSevere
+	}
+}

--- a/frontend/graph/workload_populate.go
+++ b/frontend/graph/workload_populate.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"sync"
 
-	"github.com/odigos-io/odigos/api/k8sconsts"
 	"github.com/odigos-io/odigos/common"
 	"github.com/odigos-io/odigos/frontend/graph/loaders"
 	"github.com/odigos-io/odigos/frontend/graph/model"
 	"github.com/odigos-io/odigos/frontend/graph/status"
 	"github.com/odigos-io/odigos/frontend/services"
-	frontendcommon "github.com/odigos-io/odigos/frontend/services/common"
 	sourceutils "github.com/odigos-io/odigos/k8sutils/pkg/source"
 )
 
@@ -142,81 +140,7 @@ func (r *queryResolver) populateWorkloadFields(ctx context.Context, l *loaders.L
 		}
 	}
 
-	// Pod-dependent fields: conditions, workloadOdigosHealthStatus, podsAgentInjectionStatus.
-	// Compute once and share results to avoid duplicate status calculations.
-	pods, _ := l.GetWorkloadPods(ctx, id)
-
-	// Compute each status exactly once.
-	var runtimeDetection, agentInjectionEnabled, rollout, agentInjected, processesHealth, expectingTelemetry *model.DesiredConditionStatus
-
-	if ic != nil {
-		runtimeDetection = status.CalculateRuntimeInspectionStatus(ic)
-		agentInjectionEnabled = status.CalculateAgentInjectionEnabledStatus(ic)
-		rollout = status.CalculateRolloutStatus(ic)
-	}
-	agentInjected = status.CalculateAgentInjectedStatus(ic, pods)
-	containerNames := getContainerNamesWithOptionalPodManifestInjection(ic)
-	processesHealth, _ = aggregateProcessesHealthForWorkload(ctx, &id, containerNames)
-
-	var totalDataSent *int
-	workloadMetrics, ok := r.MetricsConsumer.GetSingleSourceMetrics(frontendcommon.SourceID{
-		Namespace: id.Namespace,
-		Kind:      k8sconsts.WorkloadKind(id.Kind),
-		Name:      id.Name,
-	})
-	if ok {
-		tds := int(workloadMetrics.TotalDataSent())
-		totalDataSent = &tds
-	}
-	telemetryMetrics := status.CalculateExpectingTelemetryStatus(ic, pods, totalDataSent)
-	expectingTelemetry = telemetryMetrics.TelemetryObservedStatus
-
-	// conditions
-	if ic != nil {
-		w.Conditions = &model.K8sWorkloadConditions{
-			RuntimeDetection:      runtimeDetection,
-			AgentInjectionEnabled: agentInjectionEnabled,
-			Rollout:               rollout,
-			AgentInjected:         agentInjected,
-			ProcessesAgentHealth:  processesHealth,
-			ExpectingTelemetry:    expectingTelemetry,
-		}
-	}
-
-	// podsAgentInjectionStatus
-	w.PodsAgentInjectionStatus = agentInjected
-
-	// workloadOdigosHealthStatus (aggregate the same statuses computed above)
-	allConditions := []*model.DesiredConditionStatus{}
-	if ic != nil {
-		allConditions = append(allConditions, runtimeDetection, agentInjectionEnabled, rollout)
-	} else {
-		reasonStr := string(status.WorkloadOdigosHealthStatusReasonDisabled)
-		allConditions = append(allConditions, &model.DesiredConditionStatus{
-			Name:       status.WorkloadOdigosHealthStatus,
-			Status:     model.DesiredStateProgressDisabled,
-			ReasonEnum: &reasonStr,
-			Message:    "workload is not marked for instrumentation",
-		})
-	}
-	allConditions = append(allConditions, agentInjected, processesHealth, expectingTelemetry)
-
-	mostSevere := aggregateConditionsBySeverity(allConditions)
-	if mostSevere == nil {
-		mostSevere = &model.DesiredConditionStatus{
-			Name:    status.WorkloadOdigosHealthStatus,
-			Status:  model.DesiredStateProgressUnknown,
-			Message: "",
-		}
-	}
-	if mostSevere.Status == model.DesiredStateProgressSuccess {
-		reasonStr := string(status.WorkloadOdigosHealthStatusReasonSuccessAndEmittingTelemetry)
-		mostSevere = &model.DesiredConditionStatus{
-			Name:       status.WorkloadOdigosHealthStatus,
-			Status:     model.DesiredStateProgressSuccess,
-			ReasonEnum: &reasonStr,
-			Message:    "source is instrumented, healthy and telemetry has been observed",
-		}
-	}
-	w.WorkloadOdigosHealthStatus = mostSevere
+	// Pod-dependent fields (conditions, workloadOdigosHealthStatus, podsAgentInjectionStatus) are NOT pre-computed here.
+	// They require loading ALL pods (12K CachedPod structs) and computing status for each, which adds ~15MB+ of allocations that push the pod past its 512Mi limit when combined with gqlgen's serialization buffer.
+	// These 3 fields are left for gqlgen's lazy resolver path (30K goroutines = ~75MB, which is affordable compared to the 170K goroutines from pre-Fix 10).
 }

--- a/frontend/graph/workload_populate.go
+++ b/frontend/graph/workload_populate.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"sync"
 
+	"github.com/odigos-io/odigos/api/k8sconsts"
 	"github.com/odigos-io/odigos/common"
 	"github.com/odigos-io/odigos/frontend/graph/loaders"
 	"github.com/odigos-io/odigos/frontend/graph/model"
 	"github.com/odigos-io/odigos/frontend/graph/status"
 	"github.com/odigos-io/odigos/frontend/services"
+	frontendcommon "github.com/odigos-io/odigos/frontend/services/common"
 	sourceutils "github.com/odigos-io/odigos/k8sutils/pkg/source"
 )
 
@@ -140,7 +142,68 @@ func (r *queryResolver) populateWorkloadFields(ctx context.Context, l *loaders.L
 		}
 	}
 
-	// Pod-dependent fields (conditions, workloadOdigosHealthStatus, podsAgentInjectionStatus) are NOT pre-computed here.
-	// They require loading ALL pods (12K CachedPod structs) and computing status for each, which adds ~15MB+ of allocations that push the pod past its 512Mi limit when combined with gqlgen's serialization buffer.
-	// These 3 fields are left for gqlgen's lazy resolver path (30K goroutines = ~75MB, which is affordable compared to the 170K goroutines from pre-Fix 10).
+	// Pod-dependent fields: conditions, workloadOdigosHealthStatus, podsAgentInjectionStatus.
+	// Pre-computed here (not left for lazy resolvers) to avoid 30K goroutines.
+	// CachedPods are loaded once and shared across all workloads via the Loaders cache.
+	pods, _ := l.GetWorkloadPods(ctx, id)
+
+	var runtimeDetection, agentInjectionEnabled, rolloutStatus, agentInjected, processesHealth, expectingTelemetry *model.DesiredConditionStatus
+
+	if ic != nil {
+		runtimeDetection = status.CalculateRuntimeInspectionStatus(ic)
+		agentInjectionEnabled = status.CalculateAgentInjectionEnabledStatus(ic)
+		rolloutStatus = status.CalculateRolloutStatus(ic)
+	}
+	agentInjected = status.CalculateAgentInjectedStatus(ic, pods)
+	containerNames := getContainerNamesWithOptionalPodManifestInjection(ic)
+	processesHealth, _ = aggregateProcessesHealthForWorkload(ctx, &id, containerNames)
+
+	var totalDataSent *int
+	if workloadMetrics, ok := r.MetricsConsumer.GetSingleSourceMetrics(frontendcommon.SourceID{
+		Namespace: id.Namespace,
+		Kind:      k8sconsts.WorkloadKind(id.Kind),
+		Name:      id.Name,
+	}); ok {
+		tds := int(workloadMetrics.TotalDataSent())
+		totalDataSent = &tds
+	}
+	telemetryMetrics := status.CalculateExpectingTelemetryStatus(ic, pods, totalDataSent)
+	expectingTelemetry = telemetryMetrics.TelemetryObservedStatus
+
+	if ic != nil {
+		w.Conditions = &model.K8sWorkloadConditions{
+			RuntimeDetection:      runtimeDetection,
+			AgentInjectionEnabled: agentInjectionEnabled,
+			Rollout:               rolloutStatus,
+			AgentInjected:         agentInjected,
+			ProcessesAgentHealth:  processesHealth,
+			ExpectingTelemetry:    expectingTelemetry,
+		}
+	}
+
+	w.PodsAgentInjectionStatus = agentInjected
+
+	healthConditions := make([]*model.DesiredConditionStatus, 0, 6)
+	if ic != nil {
+		healthConditions = append(healthConditions, runtimeDetection, agentInjectionEnabled, rolloutStatus)
+	} else {
+		reasonStr := string(status.WorkloadOdigosHealthStatusReasonDisabled)
+		healthConditions = append(healthConditions, &model.DesiredConditionStatus{
+			Name: status.WorkloadOdigosHealthStatus, Status: model.DesiredStateProgressDisabled,
+			ReasonEnum: &reasonStr, Message: "workload is not marked for instrumentation",
+		})
+	}
+	healthConditions = append(healthConditions, agentInjected, processesHealth, expectingTelemetry)
+
+	mostSevere := aggregateConditionsBySeverity(healthConditions)
+	if mostSevere == nil {
+		mostSevere = &model.DesiredConditionStatus{Name: status.WorkloadOdigosHealthStatus, Status: model.DesiredStateProgressUnknown}
+	} else if mostSevere.Status == model.DesiredStateProgressSuccess {
+		reasonStr := string(status.WorkloadOdigosHealthStatusReasonSuccessAndEmittingTelemetry)
+		mostSevere = &model.DesiredConditionStatus{
+			Name: status.WorkloadOdigosHealthStatus, Status: model.DesiredStateProgressSuccess,
+			ReasonEnum: &reasonStr, Message: "source is instrumented, healthy and telemetry has been observed",
+		}
+	}
+	w.WorkloadOdigosHealthStatus = mostSevere
 }

--- a/frontend/kube/cache.go
+++ b/frontend/kube/cache.go
@@ -99,14 +99,16 @@ func SetupK8sCache(ctx context.Context, kubeConfig string, kubeContext string, o
 	}
 
 	newInformerWithTransformFunc := cacheutils.CreateNewInformerWithTransformFunc(scheme, cacheByObjectConfig)
+	unsafeDisableDeepCopy := true
 
 	// Create cache options
 	cacheOptions := cache.Options{
-		Scheme:                      scheme,
-		ReaderFailOnMissingInformer: true,
-		DefaultTransform:            cache.TransformStripManagedFields(),
-		ByObject:                    cacheByObjectConfig,
-		NewInformer:                 newInformerWithTransformFunc,
+		Scheme:                       scheme,
+		ReaderFailOnMissingInformer:  true,
+		DefaultTransform:             cache.TransformStripManagedFields(),
+		ByObject:                     cacheByObjectConfig,
+		NewInformer:                  newInformerWithTransformFunc,
+		DefaultUnsafeDisableDeepCopy: &unsafeDisableDeepCopy,
 	}
 
 	// Create the cache

--- a/frontend/kube/cache.go
+++ b/frontend/kube/cache.go
@@ -24,21 +24,22 @@ import (
 )
 
 var CacheClient client.Client
+var K8sCache cache.Cache
 
-// SetupK8sCache initializes and starts the controller runtime cache for Source resources
-// Returns the cache client for direct usage
-func SetupK8sCache(ctx context.Context, kubeConfig string, kubeContext string, odigosNs string) (client.Client, error) {
+// SetupK8sCache initializes and starts the controller runtime cache for Source resources.
+// Returns the cache client for direct usage and the underlying cache for registering event handlers.
+func SetupK8sCache(ctx context.Context, kubeConfig string, kubeContext string, odigosNs string) (client.Client, cache.Cache, error) {
 	// Get the Kubernetes config
 	cfg, err := config.GetConfigWithContext(kubeContext)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get kubernetes config: %w", err)
+		return nil, nil, fmt.Errorf("failed to get kubernetes config: %w", err)
 	}
 
 	// Override config if kubeConfig path is provided
 	if kubeConfig != "" {
 		cfg, err = config.GetConfigWithContext(kubeContext)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get kubernetes config with custom path: %w", err)
+			return nil, nil, fmt.Errorf("failed to get kubernetes config with custom path: %w", err)
 		}
 	}
 
@@ -75,6 +76,9 @@ func SetupK8sCache(ctx context.Context, kubeConfig string, kubeContext string, o
 		&odigosv1.Source{}:                  {},
 		&odigosv1.InstrumentationConfig{}:   {},
 		&odigosv1.InstrumentationInstance{}: {},
+		&odigosv1.Destination{}: {
+			Field: nsSelector,
+		},
 		&odigosv1.Sampling{}: {
 			Field: nsSelector,
 		},
@@ -108,7 +112,7 @@ func SetupK8sCache(ctx context.Context, kubeConfig string, kubeContext string, o
 	// Create the cache
 	k8sCache, err := cache.New(cfg, cacheOptions)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create cache: %w", err)
+		return nil, nil, fmt.Errorf("failed to create cache: %w", err)
 	}
 
 	// Create a client that uses the cache
@@ -119,7 +123,7 @@ func SetupK8sCache(ctx context.Context, kubeConfig string, kubeContext string, o
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create cache client: %w", err)
+		return nil, nil, fmt.Errorf("failed to create cache client: %w", err)
 	}
 
 	// Start the cache in a goroutine
@@ -144,25 +148,26 @@ func SetupK8sCache(ctx context.Context, kubeConfig string, kubeContext string, o
 	for obj := range cacheOptions.ByObject {
 		_, err = k8sCache.GetInformer(ctx, obj) // just need to call it to initialize the informer
 		if err != nil {
-			return nil, fmt.Errorf("failed to get informer for %s: %w", obj.GetObjectKind().GroupVersionKind().Kind, err)
+			return nil, nil, fmt.Errorf("failed to get informer for %s: %w", obj.GetObjectKind().GroupVersionKind().Kind, err)
 		}
 		if sequentialCacheLoad {
 			ok := k8sCache.WaitForCacheSync(ctx)
 			if !ok {
-				return nil, fmt.Errorf("failed to sync kubernetes cache")
+				return nil, nil, fmt.Errorf("failed to sync kubernetes cache")
 			}
 		}
 	}
 
 	if !sequentialCacheLoad {
 		if !k8sCache.WaitForCacheSync(ctx) {
-			return nil, fmt.Errorf("failed to sync kubernetes cache")
+			return nil, nil, fmt.Errorf("failed to sync kubernetes cache")
 		}
 	}
 
 	log.Println("internal kubernetes objects cache is synced", "duration", time.Since(startTime))
 
 	CacheClient = k8sCacheClient
+	K8sCache = k8sCache
 
-	return k8sCacheClient, nil
+	return k8sCacheClient, k8sCache, nil
 }

--- a/frontend/kube/watchers/batcher.go
+++ b/frontend/kube/watchers/batcher.go
@@ -26,6 +26,7 @@ type EventBatcher struct {
 	mu       sync.Mutex
 	batch    []sse.SSEMessage
 	timer    *time.Timer
+	maxTimer *time.Timer // fires after MaxDelay to guarantee flush under sustained load
 	stopped  atomic.Bool
 	config   EventBatcherConfig
 	stopOnce sync.Once
@@ -46,9 +47,12 @@ type EventBatcherConfig struct {
 	FailureBatchMessageFunc func(batchSize int, crd string) string
 	// Function to generate a message for a batch of successful messages
 	SuccessBatchMessageFunc func(batchSize int, crd string) string
-	// If true, reset the timer on each new event (debounce mode)
-	// If false, send batch when timer expires regardless of new events (batch mode)
-	Debounce bool
+	// When the batch reaches this size, flush immediately regardless of timers.
+	// 0 means no cap (unlimited accumulation).
+	MaxBatchSize int
+	// Upper bound on how long events can accumulate before a forced flush.
+	// 0 means no limit.
+	MaxDelay time.Duration
 }
 
 func NewEventBatcher(config EventBatcherConfig) *EventBatcher {
@@ -95,13 +99,17 @@ func (eb *EventBatcher) AddEvent(msgType sse.MessageType, data, target string) e
 
 	eb.batch = append(eb.batch, message)
 
-	if eb.config.Debounce && eb.timer != nil {
-		// Debounce mode: reset the timer on each new event
-		eb.timer.Stop()
+	if eb.config.MaxBatchSize > 0 && len(eb.batch) >= eb.config.MaxBatchSize {
+		eb.flushLocked()
+		return nil
+	}
+
+	if eb.timer == nil {
 		eb.timer = time.AfterFunc(eb.config.Duration, eb.sendBatch)
-	} else if eb.timer == nil {
-		// Batch mode or first event: start the timer
-		eb.timer = time.AfterFunc(eb.config.Duration, eb.sendBatch)
+	}
+
+	if eb.maxTimer == nil && eb.config.MaxDelay > 0 {
+		eb.maxTimer = time.AfterFunc(eb.config.MaxDelay, eb.sendBatch)
 	}
 
 	return nil
@@ -110,10 +118,22 @@ func (eb *EventBatcher) AddEvent(msgType sse.MessageType, data, target string) e
 func (eb *EventBatcher) sendBatch() {
 	eb.mu.Lock()
 	defer eb.mu.Unlock()
+	eb.flushLocked()
+}
+
+// flushLocked sends the current batch. Caller must hold eb.mu.
+func (eb *EventBatcher) flushLocked() {
+	if eb.timer != nil {
+		eb.timer.Stop()
+		eb.timer = nil
+	}
+	if eb.maxTimer != nil {
+		eb.maxTimer.Stop()
+		eb.maxTimer = nil
+	}
 
 	if len(eb.batch) == 0 {
 		eb.batch = nil
-		eb.timer = nil
 		return
 	}
 
@@ -122,7 +142,6 @@ func (eb *EventBatcher) sendBatch() {
 			sse.SendMessageToClient(message)
 		}
 	} else {
-		// currently we are grouping batches by success and error messages
 		batchMessages := eb.prepareBatchMessage()
 		for _, batch := range batchMessages {
 			sse.SendMessageToClient(batch)
@@ -130,7 +149,6 @@ func (eb *EventBatcher) sendBatch() {
 	}
 
 	eb.batch = nil
-	eb.timer = nil
 }
 
 func (eb *EventBatcher) prepareBatchMessage() []sse.SSEMessage {
@@ -187,6 +205,10 @@ func (eb *EventBatcher) Cancel() {
 		if eb.timer != nil {
 			eb.timer.Stop()
 			eb.timer = nil
+		}
+		if eb.maxTimer != nil {
+			eb.maxTimer.Stop()
+			eb.maxTimer = nil
 		}
 		eb.batch = nil
 	})

--- a/frontend/kube/watchers/batcher.go
+++ b/frontend/kube/watchers/batcher.go
@@ -25,8 +25,8 @@ var (
 type EventBatcher struct {
 	mu       sync.Mutex
 	batch    []sse.SSEMessage
-	timer    *time.Timer
-	maxTimer *time.Timer // fires after MaxDelay to guarantee flush under sustained load
+	timer    *time.Timer // throttle timer: starts on first event, fires after Duration to flush the batch
+	maxTimer *time.Timer // hard-deadline timer: starts on first event, fires after MaxDelay regardless of throttle resets
 	stopped  atomic.Bool
 	config   EventBatcherConfig
 	stopOnce sync.Once
@@ -50,7 +50,10 @@ type EventBatcherConfig struct {
 	// When the batch reaches this size, flush immediately regardless of timers.
 	// 0 means no cap (unlimited accumulation).
 	MaxBatchSize int
-	// Upper bound on how long events can accumulate before a forced flush.
+	// Hard-deadline safety net: maximum wall-clock time from the first event in a
+	// batch to its flush, regardless of how often new events arrive. Prevents
+	// indefinite accumulation under sustained load. Contrast with Duration, which
+	// is the throttle window (restarted per batch, not per event).
 	// 0 means no limit.
 	MaxDelay time.Duration
 }

--- a/frontend/kube/watchers/common.go
+++ b/frontend/kube/watchers/common.go
@@ -1,14 +1,7 @@
 package watchers
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/odigos-io/odigos/frontend/services/sse"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/tools/cache"
-	toolsWatch "k8s.io/client-go/tools/watch"
 )
 
 func genericErrorMessage(event sse.MessageEvent, crd string, data string) {
@@ -18,51 +11,4 @@ func genericErrorMessage(event sse.MessageEvent, crd string, data string) {
 		Data:    "Something went wrong: " + data,
 		CRDType: crd,
 	})
-}
-
-// WatcherConfig holds the configuration for creating a retry watcher.
-// L is the list type returned by the ListFunc (e.g., *v1alpha1.DestinationList).
-type WatcherConfig[L any] struct {
-	// ListFunc retrieves the current list of resources to get the initial resource version.
-	ListFunc func(ctx context.Context, opts metav1.ListOptions) (L, error)
-	// WatchFunc creates a watch on the resources.
-	WatchFunc func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
-	// GetResourceVersion extracts the resource version from the list result.
-	GetResourceVersion func(L) string
-	// LabelSelector is an optional label selector to filter resources.
-	LabelSelector string
-	// ResourceName is used for error messages (e.g., "destinations", "node collector pods").
-	ResourceName string
-}
-
-// StartRetryWatcher creates a retry watcher that starts from the current resource version.
-// This prevents old events from re-surfacing when the watcher is created.
-func StartRetryWatcher[L any](ctx context.Context, cfg WatcherConfig[L]) (watch.Interface, error) {
-	listOpts := metav1.ListOptions{}
-	if cfg.LabelSelector != "" {
-		listOpts.LabelSelector = cfg.LabelSelector
-	}
-
-	// List first to get the current resource version
-	list, err := cfg.ListFunc(ctx, listOpts)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list %s: %w", cfg.ResourceName, err)
-	}
-
-	resourceVersion := cfg.GetResourceVersion(list)
-
-	// Create watcher with current resource version (prevents old events from re-surfacing)
-	watcher, err := toolsWatch.NewRetryWatcherWithContext(ctx, resourceVersion, &cache.ListWatch{
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			if cfg.LabelSelector != "" {
-				options.LabelSelector = cfg.LabelSelector
-			}
-			return cfg.WatchFunc(ctx, options)
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create %s watcher: %w", cfg.ResourceName, err)
-	}
-
-	return watcher, nil
 }

--- a/frontend/kube/watchers/destination_watcher.go
+++ b/frontend/kube/watchers/destination_watcher.go
@@ -3,28 +3,29 @@ package watchers
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/common/consts"
-	"github.com/odigos-io/odigos/frontend/kube"
+	collectormetrics "github.com/odigos-io/odigos/frontend/services/collector_metrics"
 	"github.com/odigos-io/odigos/frontend/services/sse"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
+	toolscache "k8s.io/client-go/tools/cache"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 )
 
 var destinationAddedEventBatcher *EventBatcher
 var destinationModifiedEventBatcher *EventBatcher
 var destinationDeletedEventBatcher *EventBatcher
 
-func StartDestinationWatcher(ctx context.Context, namespace string) error {
+func StartDestinationWatcher(ctx context.Context, k8sCache ctrlcache.Cache, metricsConsumer *collectormetrics.OdigosMetricsConsumer) error {
 	destinationAddedEventBatcher = NewEventBatcher(
 		EventBatcherConfig{
 			MinBatchSize: 1,
 			Duration:     1 * time.Second,
 			Event:        sse.MessageEventAdded,
 			CRDType:      consts.Destination,
+			MaxBatchSize: 100,
+			MaxDelay:     10 * time.Second,
 			SuccessBatchMessageFunc: func(batchSize int, crd string) string {
 				return fmt.Sprintf("Successfully created %d destinations", batchSize)
 			},
@@ -40,6 +41,8 @@ func StartDestinationWatcher(ctx context.Context, namespace string) error {
 			Duration:     1 * time.Second,
 			Event:        sse.MessageEventModified,
 			CRDType:      consts.Destination,
+			MaxBatchSize: 100,
+			MaxDelay:     10 * time.Second,
 			SuccessBatchMessageFunc: func(batchSize int, crd string) string {
 				return fmt.Sprintf("Successfully updated %d destinations", batchSize)
 			},
@@ -55,6 +58,8 @@ func StartDestinationWatcher(ctx context.Context, namespace string) error {
 			Duration:     1 * time.Second,
 			Event:        sse.MessageEventDeleted,
 			CRDType:      consts.Destination,
+			MaxBatchSize: 100,
+			MaxDelay:     10 * time.Second,
 			SuccessBatchMessageFunc: func(batchSize int, crd string) string {
 				return fmt.Sprintf("Successfully deleted %d destinations", batchSize)
 			},
@@ -64,49 +69,48 @@ func StartDestinationWatcher(ctx context.Context, namespace string) error {
 		},
 	)
 
-	watcher, err := StartRetryWatcher(ctx, WatcherConfig[*v1alpha1.DestinationList]{
-		ListFunc: func(ctx context.Context, opts metav1.ListOptions) (*v1alpha1.DestinationList, error) {
-			return kube.DefaultClient.OdigosClient.Destinations(namespace).List(ctx, opts)
-		},
-		WatchFunc: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
-			return kube.DefaultClient.OdigosClient.Destinations(namespace).Watch(ctx, opts)
-		},
-		GetResourceVersion: func(list *v1alpha1.DestinationList) string {
-			return list.ResourceVersion
-		},
-		ResourceName: "destinations",
-	})
+	informer, err := k8sCache.GetInformer(ctx, &v1alpha1.Destination{})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get Destination informer: %w", err)
 	}
 
-	go handleDestinationWatchEvents(ctx, watcher)
-	return nil
-}
-
-func handleDestinationWatchEvents(ctx context.Context, watcher watch.Interface) {
-	ch := watcher.ResultChan()
-	defer destinationModifiedEventBatcher.Cancel()
-	for {
-		select {
-		case <-ctx.Done():
-			watcher.Stop()
-			return
-		case event, ok := <-ch:
-			if !ok {
-				log.Println("Destination watcher closed")
+	_, err = informer.AddEventHandler(toolscache.ResourceEventHandlerDetailedFuncs{
+		AddFunc: func(obj interface{}, isInInitialList bool) {
+			if isInInitialList {
 				return
 			}
-			switch event.Type {
-			case watch.Added:
-				handleAddedDestination(event.Object.(*v1alpha1.Destination))
-			case watch.Modified:
-				handleModifiedDestination(event.Object.(*v1alpha1.Destination))
-			case watch.Deleted:
-				handleDeletedDestination(event.Object.(*v1alpha1.Destination))
+			dest, ok := obj.(*v1alpha1.Destination)
+			if !ok {
+				return
 			}
-		}
-	}
+			handleAddedDestination(dest)
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			dest, ok := newObj.(*v1alpha1.Destination)
+			if !ok {
+				return
+			}
+			handleModifiedDestination(dest)
+		},
+		DeleteFunc: func(obj interface{}) {
+			dest, ok := obj.(*v1alpha1.Destination)
+			if !ok {
+				tombstone, ok := obj.(toolscache.DeletedFinalStateUnknown)
+				if !ok {
+					return
+				}
+				dest, ok = tombstone.Obj.(*v1alpha1.Destination)
+				if !ok {
+					return
+				}
+			}
+
+			metricsConsumer.NotifyDestinationDeleted(dest.Name)
+			handleDeletedDestination(dest)
+		},
+	})
+
+	return err
 }
 
 func handleAddedDestination(destination *v1alpha1.Destination) {

--- a/frontend/kube/watchers/instrumentation_config_watcher.go
+++ b/frontend/kube/watchers/instrumentation_config_watcher.go
@@ -3,29 +3,31 @@ package watchers
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/common/consts"
-	"github.com/odigos-io/odigos/frontend/kube"
+	collectormetrics "github.com/odigos-io/odigos/frontend/services/collector_metrics"
+	"github.com/odigos-io/odigos/frontend/services/common"
 	"github.com/odigos-io/odigos/frontend/services/sse"
 	commonutils "github.com/odigos-io/odigos/k8sutils/pkg/workload"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
+	toolscache "k8s.io/client-go/tools/cache"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 )
 
 var instrumentationConfigAddedEventBatcher *EventBatcher
 var instrumentationConfigModifiedEventBatcher *EventBatcher
 var instrumentationConfigDeletedEventBatcher *EventBatcher
 
-func StartInstrumentationConfigWatcher(ctx context.Context, namespace string) error {
+func StartInstrumentationConfigWatcher(ctx context.Context, k8sCache ctrlcache.Cache, metricsConsumer *collectormetrics.OdigosMetricsConsumer) error {
 	instrumentationConfigAddedEventBatcher = NewEventBatcher(
 		EventBatcherConfig{
 			MinBatchSize: 1,
-			Duration:     3 * time.Second, // 2s less than frontend EVENT_DEBOUNCE_MS
+			Duration:     3 * time.Second,
 			Event:        sse.MessageEventAdded,
 			CRDType:      consts.InstrumentationConfig,
+			MaxBatchSize: 100,
+			MaxDelay:     10 * time.Second,
 			SuccessBatchMessageFunc: func(count int, crdType string) string {
 				return fmt.Sprintf("Successfully created %d sources", count)
 			},
@@ -38,10 +40,11 @@ func StartInstrumentationConfigWatcher(ctx context.Context, namespace string) er
 	instrumentationConfigModifiedEventBatcher = NewEventBatcher(
 		EventBatcherConfig{
 			MinBatchSize: 1,
-			Duration:     3 * time.Second, // 2s less than frontend EVENT_DEBOUNCE_MS
+			Duration:     3 * time.Second,
 			Event:        sse.MessageEventModified,
 			CRDType:      consts.InstrumentationConfig,
-			Debounce:     true, // Reset timer on each event, send only after `Duration` seconds of silence
+			MaxBatchSize: 100,
+			MaxDelay:     10 * time.Second,
 			SuccessBatchMessageFunc: func(count int, crdType string) string {
 				return fmt.Sprintf("Successfully updated %d sources", count)
 			},
@@ -54,9 +57,11 @@ func StartInstrumentationConfigWatcher(ctx context.Context, namespace string) er
 	instrumentationConfigDeletedEventBatcher = NewEventBatcher(
 		EventBatcherConfig{
 			MinBatchSize: 1,
-			Duration:     3 * time.Second, // 2s less than frontend EVENT_DEBOUNCE_MS
+			Duration:     3 * time.Second,
 			Event:        sse.MessageEventDeleted,
 			CRDType:      consts.InstrumentationConfig,
+			MaxBatchSize: 100,
+			MaxDelay:     10 * time.Second,
 			SuccessBatchMessageFunc: func(count int, crdType string) string {
 				return fmt.Sprintf("Successfully deleted %d sources", count)
 			},
@@ -66,51 +71,69 @@ func StartInstrumentationConfigWatcher(ctx context.Context, namespace string) er
 		},
 	)
 
-	watcher, err := StartRetryWatcher(ctx, WatcherConfig[*v1alpha1.InstrumentationConfigList]{
-		ListFunc: func(ctx context.Context, opts metav1.ListOptions) (*v1alpha1.InstrumentationConfigList, error) {
-			return kube.DefaultClient.OdigosClient.InstrumentationConfigs(namespace).List(ctx, opts)
-		},
-		WatchFunc: func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
-			return kube.DefaultClient.OdigosClient.InstrumentationConfigs(namespace).Watch(ctx, opts)
-		},
-		GetResourceVersion: func(list *v1alpha1.InstrumentationConfigList) string {
-			return list.ResourceVersion
-		},
-		ResourceName: "instrumentation configs",
-	})
+	informer, err := k8sCache.GetInformer(ctx, &v1alpha1.InstrumentationConfig{})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get InstrumentationConfig informer: %w", err)
 	}
 
-	go handleInstrumentationConfigWatchEvents(ctx, watcher)
-	return nil
-}
-
-func handleInstrumentationConfigWatchEvents(ctx context.Context, watcher watch.Interface) {
-	ch := watcher.ResultChan()
-	defer instrumentationConfigAddedEventBatcher.Cancel()
-	defer instrumentationConfigModifiedEventBatcher.Cancel()
-	defer instrumentationConfigDeletedEventBatcher.Cancel()
-	for {
-		select {
-		case <-ctx.Done():
-			watcher.Stop()
-			return
-		case event, ok := <-ch:
+	_, err = informer.AddEventHandler(toolscache.ResourceEventHandlerDetailedFuncs{
+		AddFunc: func(obj interface{}, isInInitialList bool) {
+			ic, ok := obj.(*v1alpha1.InstrumentationConfig)
 			if !ok {
-				log.Println("InstrumentationConfig watcher closed")
 				return
 			}
-			switch event.Type {
-			case watch.Added:
-				handleAddedInstrumentationConfig(event.Object.(*v1alpha1.InstrumentationConfig))
-			case watch.Modified:
-				handleModifiedInstrumentationConfig(event.Object.(*v1alpha1.InstrumentationConfig))
-			case watch.Deleted:
-				handleDeletedInstrumentationConfig(event.Object.(*v1alpha1.InstrumentationConfig))
+
+			pw, err := commonutils.ExtractWorkloadInfoFromRuntimeObjectName(ic.Name, ic.Namespace)
+			if err != nil {
+				if !isInInitialList {
+					genericErrorMessage(sse.MessageEventAdded, consts.InstrumentationConfig, err.Error())
+				}
+				return
 			}
-		}
-	}
+
+			metricsConsumer.NotifySourceAdded(common.SourceID{
+				Namespace: pw.Namespace, Name: pw.Name, Kind: pw.Kind,
+			})
+
+			if !isInInitialList {
+				handleAddedInstrumentationConfig(ic)
+			}
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			ic, ok := newObj.(*v1alpha1.InstrumentationConfig)
+			if !ok {
+				return
+			}
+			handleModifiedInstrumentationConfig(ic)
+		},
+		DeleteFunc: func(obj interface{}) {
+			ic, ok := obj.(*v1alpha1.InstrumentationConfig)
+			if !ok {
+				tombstone, ok := obj.(toolscache.DeletedFinalStateUnknown)
+				if !ok {
+					return
+				}
+				ic, ok = tombstone.Obj.(*v1alpha1.InstrumentationConfig)
+				if !ok {
+					return
+				}
+			}
+
+			pw, err := commonutils.ExtractWorkloadInfoFromRuntimeObjectName(ic.Name, ic.Namespace)
+			if err != nil {
+				genericErrorMessage(sse.MessageEventDeleted, consts.InstrumentationConfig, err.Error())
+				return
+			}
+
+			metricsConsumer.NotifySourceDeleted(common.SourceID{
+				Namespace: pw.Namespace, Name: pw.Name, Kind: pw.Kind,
+			})
+
+			handleDeletedInstrumentationConfig(ic)
+		},
+	})
+
+	return err
 }
 
 func handleAddedInstrumentationConfig(instruConfig *v1alpha1.InstrumentationConfig) {

--- a/frontend/main.go
+++ b/frontend/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
@@ -95,15 +96,13 @@ func initKubernetesClient(flags *Flags) error {
 	return nil
 }
 
-func startWatchers(ctx context.Context) error {
-	odigosNs := env.GetCurrentNamespace()
-
-	err := watchers.StartInstrumentationConfigWatcher(ctx, "")
+func startWatchers(ctx context.Context, k8sCache cache.Cache, odigosMetrics *collectormetrics.OdigosMetricsConsumer) error {
+	err := watchers.StartInstrumentationConfigWatcher(ctx, k8sCache, odigosMetrics)
 	if err != nil {
 		return fmt.Errorf("error starting InstrumentationConfig watcher: %v", err)
 	}
 
-	err = watchers.StartDestinationWatcher(ctx, odigosNs)
+	err = watchers.StartDestinationWatcher(ctx, k8sCache, odigosMetrics)
 	if err != nil {
 		return fmt.Errorf("error starting Destination watcher: %v", err)
 	}
@@ -317,7 +316,7 @@ func main() {
 
 	// Setup Source cache - this initializes a controller-runtime cache for Source resources
 	// from all namespaces, providing fast read access without hitting the Kubernetes API
-	k8sCacheClient, err := kube.SetupK8sCache(ctx, flags.KubeConfig, flags.KubeContext, flags.Namespace)
+	k8sCacheClient, k8sCache, err := kube.SetupK8sCache(ctx, flags.KubeConfig, flags.KubeContext, flags.Namespace)
 	if err != nil {
 		log.Error("Error setting up kubernetes objects cache", "err", err)
 		os.Exit(1)
@@ -332,7 +331,7 @@ func main() {
 	}()
 
 	// Start watchers
-	err = startWatchers(ctx)
+	err = startWatchers(ctx, k8sCache, odigosMetrics)
 	if err != nil {
 		log.Error("Error starting watchers", "err", err)
 		os.Exit(1)

--- a/frontend/main.go
+++ b/frontend/main.go
@@ -11,7 +11,6 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
-	"time"
 
 	"github.com/99designs/gqlgen/graphql/executor"
 	"github.com/99designs/gqlgen/graphql/playground"
@@ -204,10 +203,8 @@ func startHTTPServer(ctx context.Context, flags *Flags, logger logr.Logger, odig
 
 	// GraphQL handlers
 	r.POST("/graphql", func(c *gin.Context) {
-		baseCtx, cancel := context.WithTimeout(c.Request.Context(), 60*time.Second)
-		defer cancel()
-
 		loader := loaders.NewLoaders(logger, k8sCacheClient)
+		baseCtx := c.Request.Context()
 		if c.GetHeader(middlewares.AdminOverrideHeader) == "true" {
 			baseCtx = middlewares.WithAdminOverride(baseCtx)
 		}

--- a/frontend/main.go
+++ b/frontend/main.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/99designs/gqlgen/graphql/executor"
 	"github.com/99designs/gqlgen/graphql/playground"
@@ -203,8 +204,10 @@ func startHTTPServer(ctx context.Context, flags *Flags, logger logr.Logger, odig
 
 	// GraphQL handlers
 	r.POST("/graphql", func(c *gin.Context) {
+		baseCtx, cancel := context.WithTimeout(c.Request.Context(), 60*time.Second)
+		defer cancel()
+
 		loader := loaders.NewLoaders(logger, k8sCacheClient)
-		baseCtx := c.Request.Context()
 		if c.GetHeader(middlewares.AdminOverrideHeader) == "true" {
 			baseCtx = middlewares.WithAdminOverride(baseCtx)
 		}

--- a/frontend/services/collector_metrics/collector_metrics.go
+++ b/frontend/services/collector_metrics/collector_metrics.go
@@ -184,7 +184,7 @@ func NewOdigosMetrics() *OdigosMetricsConsumer {
 	return &OdigosMetricsConsumer{
 		sources:                 newSourcesMetrics(),
 		clusterCollectorMetrics: newClusterCollectorMetrics(),
-		deletedChan:             make(chan notification),
+		deletedChan:             make(chan notification, 256),
 	}
 }
 
@@ -261,4 +261,25 @@ func (c *OdigosMetricsConsumer) GetDestinationsMetrics() map[string]trafficMetri
 
 func (c *OdigosMetricsConsumer) GetServiceGraphEdges() map[string]map[string]ServiceGraphEdge {
 	return c.clusterCollectorMetrics.serviceGraphEdges()
+}
+
+func (c *OdigosMetricsConsumer) NotifySourceAdded(sID common.SourceID) {
+	select {
+	case c.deletedChan <- notification{notificationType: source, eventType: watch.Added, sourceID: sID}:
+	default:
+	}
+}
+
+func (c *OdigosMetricsConsumer) NotifySourceDeleted(sID common.SourceID) {
+	select {
+	case c.deletedChan <- notification{notificationType: source, eventType: watch.Deleted, sourceID: sID}:
+	default:
+	}
+}
+
+func (c *OdigosMetricsConsumer) NotifyDestinationDeleted(name string) {
+	select {
+	case c.deletedChan <- notification{notificationType: destination, eventType: watch.Deleted, object: name}:
+	default:
+	}
 }

--- a/frontend/services/collector_metrics/node_collector.go
+++ b/frontend/services/collector_metrics/node_collector.go
@@ -109,6 +109,8 @@ func (sourceMetrics *sourcesMetrics) handleNodeCollectorMetrics(senderPod string
 }
 
 func (sourceMetrics *sourcesMetrics) removeNodeCollector(nodeCollectorID string) {
+	sourceMetrics.sourcesMu.Lock()
+	defer sourceMetrics.sourcesMu.Unlock()
 	for _, sm := range sourceMetrics.sourcesMap {
 		sm.mu.Lock()
 		delete(sm.nodeCollectorsTraffic, nodeCollectorID)
@@ -132,7 +134,9 @@ func (sourcesMetrics *sourcesMetrics) addSource(sID common.SourceID) {
 }
 
 func (sourceMetrics *sourcesMetrics) metricsByID(sID common.SourceID) (trafficMetrics, bool) {
+	sourceMetrics.sourcesMu.Lock()
 	sm, ok := sourceMetrics.sourcesMap[sID]
+	sourceMetrics.sourcesMu.Unlock()
 	if !ok {
 		return trafficMetrics{}, false
 	}

--- a/frontend/services/collector_metrics/watchers.go
+++ b/frontend/services/collector_metrics/watchers.go
@@ -3,13 +3,10 @@ package collectormetrics
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/odigos-io/odigos/api/k8sconsts"
-	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/frontend/kube"
 	"github.com/odigos-io/odigos/frontend/services/common"
-	commonutils "github.com/odigos-io/odigos/k8sutils/pkg/workload"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
@@ -22,7 +19,6 @@ type notification struct {
 	eventType        watch.EventType
 	object           string
 
-	// used for source deletion notification
 	sourceID common.SourceID
 }
 
@@ -40,10 +36,6 @@ const (
 	source
 )
 
-type watcherInterfaces struct {
-	nodeCollectors, clusterCollectors, destinations, sources watch.Interface
-}
-
 func runWatcher(ctx context.Context, cw *deleteWatcher) error {
 	nodeCollectorWatcher, err := toolsWatch.NewRetryWatcherWithContext(ctx, "1", &cache.ListWatch{WatchFunc: func(_ metav1.ListOptions) (watch.Interface, error) {
 		return newCollectorWatcher(ctx, cw.odigosNS, k8sconsts.CollectorsRoleNodeCollector)
@@ -59,27 +51,7 @@ func runWatcher(ctx context.Context, cw *deleteWatcher) error {
 		return err
 	}
 
-	sourcesWatcher, err := toolsWatch.NewRetryWatcherWithContext(ctx, "1", &cache.ListWatch{WatchFunc: func(_ metav1.ListOptions) (watch.Interface, error) {
-		return kube.DefaultClient.OdigosClient.InstrumentationConfigs("").Watch(ctx, metav1.ListOptions{})
-	}})
-	if err != nil {
-		return err
-	}
-
-	destsWatcher, err := toolsWatch.NewRetryWatcherWithContext(ctx, "1", &cache.ListWatch{WatchFunc: func(_ metav1.ListOptions) (watch.Interface, error) {
-		return kube.DefaultClient.OdigosClient.Destinations(cw.odigosNS).Watch(ctx, metav1.ListOptions{})
-	}})
-	if err != nil {
-		return err
-	}
-
-	return runWatcherLoop(ctx,
-		watcherInterfaces{
-			nodeCollectors:    nodeCollectorWatcher,
-			clusterCollectors: clusterCollectorWatcher,
-			destinations:      destsWatcher,
-			sources:           sourcesWatcher,
-		}, cw.deleteNotifications)
+	return runWatcherLoop(ctx, nodeCollectorWatcher, clusterCollectorWatcher, cw.deleteNotifications)
 }
 
 func newCollectorWatcher(ctx context.Context, odigosNS string, collectorRole k8sconsts.CollectorRole) (watch.Interface, error) {
@@ -92,26 +64,21 @@ func newCollectorWatcher(ctx context.Context, odigosNS string, collectorRole k8s
 	})
 }
 
-func runWatcherLoop(ctx context.Context, w watcherInterfaces, notifyChan chan<- notification) error {
-	nch := w.nodeCollectors.ResultChan()
-	cch := w.clusterCollectors.ResultChan()
-	dch := w.destinations.ResultChan()
-	sch := w.sources.ResultChan()
+func runWatcherLoop(ctx context.Context, nodeCollectors, clusterCollectors watch.Interface, notifyChan chan<- notification) error {
+	nch := nodeCollectors.ResultChan()
+	cch := clusterCollectors.ResultChan()
 	for {
 		select {
 		case <-ctx.Done():
-			w.nodeCollectors.Stop()
-			w.clusterCollectors.Stop()
-			w.destinations.Stop()
-			w.sources.Stop()
+			nodeCollectors.Stop()
+			clusterCollectors.Stop()
 			close(notifyChan)
 			return nil
 		case event, ok := <-nch:
 			if !ok {
 				return errors.New("node collector watcher closed")
 			}
-			switch event.Type {
-			case watch.Deleted:
+			if event.Type == watch.Deleted {
 				pod := event.Object.(*corev1.Pod)
 				notifyChan <- notification{notificationType: nodeCollector, object: pod.Name}
 			}
@@ -119,33 +86,9 @@ func runWatcherLoop(ctx context.Context, w watcherInterfaces, notifyChan chan<- 
 			if !ok {
 				return errors.New("cluster collector watcher closed")
 			}
-			switch event.Type {
-			case watch.Deleted:
+			if event.Type == watch.Deleted {
 				pod := event.Object.(*corev1.Pod)
 				notifyChan <- notification{notificationType: clusterCollector, object: pod.Name, eventType: watch.Deleted}
-			}
-		case event, ok := <-dch:
-			if !ok {
-				return errors.New("destination watcher closed")
-			}
-			switch event.Type {
-			case watch.Deleted:
-				d := event.Object.(*v1alpha1.Destination)
-				notifyChan <- notification{notificationType: destination, object: d.Name, eventType: watch.Deleted}
-			}
-		case event, ok := <-sch:
-			if !ok {
-				return errors.New("source watcher closed")
-			}
-			t := event.Type
-			switch t {
-			case watch.Deleted, watch.Added:
-				app := event.Object.(*v1alpha1.InstrumentationConfig)
-				pw, err := commonutils.ExtractWorkloadInfoFromRuntimeObjectName(app.Name, app.Namespace)
-				if err != nil {
-					fmt.Printf("error getting workload info: %v\n", err)
-				}
-				notifyChan <- notification{notificationType: source, sourceID: common.SourceID{Kind: pw.Kind, Name: pw.Name, Namespace: pw.Namespace}, eventType: t}
 			}
 		}
 	}

--- a/frontend/webapp/graphql/queries/workload.ts
+++ b/frontend/webapp/graphql/queries/workload.ts
@@ -184,6 +184,16 @@ export const GET_WORKLOADS_COUNT = gql`
   }
 `;
 
+export const GET_NAMESPACES = gql`
+  query GetNamespaces {
+    namespaces {
+      name
+      markedForInstrumentation
+      dataStreamNames
+    }
+  }
+`;
+
 export const GET_NAMESPACES_WITH_WORKLOADS = gql`
   query GetNamespacesWithWorkloads {
     namespaces {

--- a/frontend/webapp/graphql/queries/workload.ts
+++ b/frontend/webapp/graphql/queries/workload.ts
@@ -178,6 +178,12 @@ export const GET_WORKLOADS_BY_IDS = gql`
   }
 `;
 
+export const GET_WORKLOADS_COUNT = gql`
+  query GetWorkloadsCount($filter: WorkloadFilter) {
+    workloadsCount(filter: $filter)
+  }
+`;
+
 export const GET_NAMESPACES_WITH_WORKLOADS = gql`
   query GetNamespacesWithWorkloads {
     namespaces {

--- a/frontend/webapp/graphql/queries/workload.ts
+++ b/frontend/webapp/graphql/queries/workload.ts
@@ -178,12 +178,6 @@ export const GET_WORKLOADS_BY_IDS = gql`
   }
 `;
 
-export const GET_WORKLOADS_COUNT = gql`
-  query GetWorkloadsCount($filter: WorkloadFilter) {
-    workloadsCount(filter: $filter)
-  }
-`;
-
 export const GET_NAMESPACES = gql`
   query GetNamespaces {
     namespaces {

--- a/frontend/webapp/hooks/metrics/useMetrics.ts
+++ b/frontend/webapp/hooks/metrics/useMetrics.ts
@@ -8,7 +8,7 @@ export const useMetrics = () => {
   const destinations = useEntityStore((state) => state.destinations);
 
   const { data } = useQuery<{ getOverviewMetrics: Metrics }>(GET_METRICS, {
-    skip: !sources.length && !destinations.length,
+    skip: !sources.length || !destinations.length,
     pollInterval: 10000,
   });
 

--- a/frontend/webapp/hooks/namespaces/useNamespace.ts
+++ b/frontend/webapp/hooks/namespaces/useNamespace.ts
@@ -3,9 +3,9 @@ import { useConfig } from '../config';
 import type { NamespaceInstrumentInput } from '@/types';
 import { useLazyQuery, useMutation } from '@apollo/client';
 import { DISPLAY_TITLES, FORM_ALERTS } from '@odigos/ui-kit/constants';
-import { GET_NAMESPACES_WITH_WORKLOADS, PERSIST_NAMESPACES } from '@/graphql';
-import { Crud, EntityTypes, type Namespace, type NamespaceWorkload, type Source, StatusType } from '@odigos/ui-kit/types';
+import { GET_NAMESPACES, GET_NAMESPACES_WITH_WORKLOADS, PERSIST_NAMESPACES } from '@/graphql';
 import { useDataStreamStore, useEntityStore, useNotificationStore } from '@odigos/ui-kit/store';
+import { Crud, EntityTypes, type Namespace, type NamespaceWorkload, type Source, StatusType } from '@odigos/ui-kit/types';
 
 interface GqlNamespaceWithWorkloads {
   name: string;
@@ -43,6 +43,13 @@ export const useNamespace = () => {
     addNotification({ type, title, message, hideFromHistory });
   };
 
+  // Lightweight query for auto-fetching namespace metadata on page load.
+  // Does NOT request workloads, so the backend skips the heavy manifest/source listing.
+  const [queryNamespaces] = useLazyQuery<{ namespaces: { name: string; markedForInstrumentation: boolean; dataStreamNames: string[] }[] }>(GET_NAMESPACES, {
+    onError: (error) => addNotification({ type: StatusType.Error, title: error.name || Crud.Read, message: error.cause?.message || error.message }),
+  });
+
+  // Heavy query that includes per-namespace workloads. Only called explicitly by source selection forms.
   const [queryNsWithWorkloads] = useLazyQuery<{ namespaces: GqlNamespaceWithWorkloads[] }>(GET_NAMESPACES_WITH_WORKLOADS, {
     onError: (error) => addNotification({ type: StatusType.Error, title: error.name || Crud.Read, message: error.cause?.message || error.message }),
   });
@@ -56,6 +63,16 @@ export const useNamespace = () => {
       addNotification({ type: StatusType.Error, title: error.name || Crud.Update, message: error.cause?.message || error.message });
     },
   });
+
+  const fetchNamespaces = async () => {
+    const { error, data } = await queryNamespaces();
+
+    if (error) {
+      notifyUser(StatusType.Error, error.name || Crud.Read, error.cause?.message || error.message);
+    } else if (data?.namespaces) {
+      setEntities(EntityTypes.Namespace, data.namespaces.map((ns) => ({ name: ns.name, selected: ns.markedForInstrumentation, dataStreamNames: ns.dataStreamNames })) as Namespace[]);
+    }
+  };
 
   const fetchNamespacesWithWorkloads = async () => {
     const { error, data } = await queryNsWithWorkloads();
@@ -86,7 +103,7 @@ export const useNamespace = () => {
   };
 
   useEffect(() => {
-    if (selectedStreamName && !namespaces.length && !namespacesLoading) fetchNamespacesWithWorkloads();
+    if (selectedStreamName && !namespaces.length && !namespacesLoading) fetchNamespaces();
   }, [selectedStreamName]);
 
   return {

--- a/frontend/webapp/hooks/notification/useSSE.ts
+++ b/frontend/webapp/hooks/notification/useSSE.ts
@@ -2,8 +2,8 @@ import { useEffect, useRef } from 'react';
 import { API } from '@/utils';
 import { useSourceCRUD } from '../sources';
 import { useDestinationCRUD } from '../destinations';
-import { EntityTypes, StatusType, type WorkloadId } from '@odigos/ui-kit/types';
 import { getIdFromSseTarget, safeJsonParse } from '@odigos/ui-kit/functions';
+import { EntityTypes, StatusType, type WorkloadId } from '@odigos/ui-kit/types';
 import { useEntityStore, useNotificationStore, useProgressStore, ProgressKeys } from '@odigos/ui-kit/store';
 
 enum EventTypes {

--- a/frontend/webapp/hooks/sources/useSourceCRUD.ts
+++ b/frontend/webapp/hooks/sources/useSourceCRUD.ts
@@ -6,7 +6,7 @@ import { DISPLAY_TITLES, FORM_ALERTS } from '@odigos/ui-kit/constants';
 import { getIdFromSseTarget, getSseTargetFromId } from '@odigos/ui-kit/functions';
 import type { NamespaceInstrumentInput, SourceInstrumentInput, WorkloadResponse } from '@/types';
 import { mapWorkloadToSource, sortSources, prepareNamespacePayloads, prepareSourcePayloads, mapConditionsToConditionArray } from '@/utils';
-import { GET_PEER_SOURCES, GET_SOURCE, GET_SOURCE_LIBRARIES, GET_WORKLOADS, GET_WORKLOADS_BY_IDS, GET_WORKLOADS_COUNT, PERSIST_SOURCES, UPDATE_K8S_ACTUAL_SOURCE } from '@/graphql';
+import { GET_PEER_SOURCES, GET_SOURCE, GET_SOURCE_LIBRARIES, GET_WORKLOADS, GET_WORKLOADS_BY_IDS, PERSIST_SOURCES, UPDATE_K8S_ACTUAL_SOURCE } from '@/graphql';
 import { type WorkloadId, type Source, type SourceFormData, type PeerSources, EntityTypes, StatusType, Crud, InstrumentationInstanceComponent, PersistSourceInput } from '@odigos/ui-kit/types';
 import {
   type NamespaceSelectionFormData,
@@ -21,10 +21,6 @@ import {
 
 // When SSE targets exceed this count, fall back to a full fetchSources() instead of fetching by individual IDs.
 const MAX_INDIVIDUAL_FETCH = 50;
-// Max workloads per paginated request. Keeps each response small enough to avoid backend OOM at scale.
-const PAGE_SIZE = 500;
-// How many pages to fetch in parallel. Limits concurrent backend memory pressure (each page lists all ICs).
-const CONCURRENT_PAGES = 3;
 
 interface UseSourceCrud {
   sources: Source[];
@@ -59,9 +55,8 @@ export const useSourceCRUD = (): UseSourceCrud => {
   const [queryPeerSources] = useLazyQuery<{ peerSources: PeerSources }, { serviceName: string }>(GET_PEER_SOURCES, {
     onError: (error) => notifyUser(StatusType.Error, error.name || Crud.Read, error.cause?.message || error.message),
   });
-  const [queryWorkloads] = useLazyQuery<{ workloads: WorkloadResponse[] }, { filter?: { markedForInstrumentation?: boolean; limit?: number; offset?: number } & Partial<WorkloadId> }>(GET_WORKLOADS);
+  const [queryWorkloads] = useLazyQuery<{ workloads: WorkloadResponse[] }, { filter?: { markedForInstrumentation?: boolean } & Partial<WorkloadId> }>(GET_WORKLOADS);
   const [queryWorkloadsByIds] = useLazyQuery<{ workloadsByIds: WorkloadResponse[] }, { ids: { namespace: string; kind: string; name: string }[] }>(GET_WORKLOADS_BY_IDS);
-  const [queryWorkloadsCount] = useLazyQuery<{ workloadsCount: number }, { filter?: { markedForInstrumentation?: boolean } & Partial<WorkloadId> }>(GET_WORKLOADS_COUNT);
 
   const [mutatePersistSources] = useMutation<{ persistK8sSources: boolean }, SourceInstrumentInput>(PERSIST_SOURCES, {
     onError: (error) => {
@@ -95,54 +90,13 @@ export const useSourceCRUD = (): UseSourceCrud => {
   const fetchSources: UseSourceCrud['fetchSources'] = async () => {
     setEntitiesLoading(EntityTypes.Source, true);
 
-    try {
-      const baseFilter = { markedForInstrumentation: true };
+    const { error, data } = await queryWorkloads({ variables: { filter: { markedForInstrumentation: true } } });
 
-      // Get total count first to determine if pagination is needed.
-      const { data: countData, error: countError } = await queryWorkloadsCount({ variables: { filter: baseFilter } });
-      if (countError) {
-        notifyUser(StatusType.Error, countError.name || Crud.Read, countError.cause?.message || countError.message);
-        setEntitiesLoading(EntityTypes.Source, false);
-        return;
-      }
-
-      const totalCount = countData?.workloadsCount ?? 0;
-
-      if (totalCount <= PAGE_SIZE) {
-        // Small enough for a single request.
-        const { error, data } = await queryWorkloads({ variables: { filter: { ...baseFilter, limit: PAGE_SIZE } } });
-        if (error) {
-          notifyUser(StatusType.Error, error.name || Crud.Read, error.cause?.message || error.message);
-        } else if (data?.workloads) {
-          setEntities(EntityTypes.Source, sortSources(data.workloads.map(mapWorkloadToSource)));
-        }
-      } else {
-        // Paginate in controlled batches to avoid overwhelming the backend.
-        // Each batch result is pushed to the store immediately so the UI updates progressively.
-        const pageCount = Math.ceil(totalCount / PAGE_SIZE);
-        const offsets = Array.from({ length: pageCount }, (_, i) => i * PAGE_SIZE);
-
-        for (let i = 0; i < offsets.length; i += CONCURRENT_PAGES) {
-          const batch = offsets.slice(i, i + CONCURRENT_PAGES);
-          const results = await Promise.all(batch.map((offset) => queryWorkloads({ variables: { filter: { ...baseFilter, limit: PAGE_SIZE, offset } } })));
-
-          const batchWorkloads: WorkloadResponse[] = [];
-          for (const result of results) {
-            if (result.error) {
-              notifyUser(StatusType.Error, result.error.name || Crud.Read, result.error.cause?.message || result.error.message);
-            } else if (result.data?.workloads) {
-              batchWorkloads.push(...result.data.workloads);
-            }
-          }
-
-          if (batchWorkloads.length > 0) {
-            addEntities(EntityTypes.Source, batchWorkloads.map(mapWorkloadToSource));
-          }
-        }
-      }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown error fetching sources';
-      notifyUser(StatusType.Error, Crud.Read, message);
+    if (error) {
+      notifyUser(StatusType.Error, error.name || Crud.Read, error.cause?.message || error.message);
+    } else if (data?.workloads) {
+      const mappedSources = sortSources(data.workloads.map(mapWorkloadToSource));
+      setEntities(EntityTypes.Source, mappedSources);
     }
 
     setEntitiesLoading(EntityTypes.Source, false);

--- a/frontend/webapp/hooks/sources/useSourceCRUD.ts
+++ b/frontend/webapp/hooks/sources/useSourceCRUD.ts
@@ -6,7 +6,7 @@ import { DISPLAY_TITLES, FORM_ALERTS } from '@odigos/ui-kit/constants';
 import { getIdFromSseTarget, getSseTargetFromId } from '@odigos/ui-kit/functions';
 import type { NamespaceInstrumentInput, SourceInstrumentInput, WorkloadResponse } from '@/types';
 import { mapWorkloadToSource, sortSources, prepareNamespacePayloads, prepareSourcePayloads, mapConditionsToConditionArray } from '@/utils';
-import { GET_PEER_SOURCES, GET_SOURCE, GET_SOURCE_LIBRARIES, GET_WORKLOADS, GET_WORKLOADS_BY_IDS, PERSIST_SOURCES, UPDATE_K8S_ACTUAL_SOURCE } from '@/graphql';
+import { GET_PEER_SOURCES, GET_SOURCE, GET_SOURCE_LIBRARIES, GET_WORKLOADS, GET_WORKLOADS_BY_IDS, GET_WORKLOADS_COUNT, PERSIST_SOURCES, UPDATE_K8S_ACTUAL_SOURCE } from '@/graphql';
 import { type WorkloadId, type Source, type SourceFormData, type PeerSources, EntityTypes, StatusType, Crud, InstrumentationInstanceComponent, PersistSourceInput } from '@odigos/ui-kit/types';
 import {
   type NamespaceSelectionFormData,
@@ -19,7 +19,12 @@ import {
   ProgressKeys,
 } from '@odigos/ui-kit/store';
 
+// When SSE targets exceed this count, fall back to a full fetchSources() instead of fetching by individual IDs.
 const MAX_INDIVIDUAL_FETCH = 50;
+// Max workloads per paginated request. Keeps each response small enough to avoid backend OOM at scale.
+const PAGE_SIZE = 500;
+// How many pages to fetch in parallel. Limits concurrent backend memory pressure (each page lists all ICs).
+const CONCURRENT_PAGES = 3;
 
 interface UseSourceCrud {
   sources: Source[];
@@ -54,8 +59,9 @@ export const useSourceCRUD = (): UseSourceCrud => {
   const [queryPeerSources] = useLazyQuery<{ peerSources: PeerSources }, { serviceName: string }>(GET_PEER_SOURCES, {
     onError: (error) => notifyUser(StatusType.Error, error.name || Crud.Read, error.cause?.message || error.message),
   });
-  const [queryWorkloads] = useLazyQuery<{ workloads: WorkloadResponse[] }, { filter?: { markedForInstrumentation?: boolean } & Partial<WorkloadId> }>(GET_WORKLOADS);
+  const [queryWorkloads] = useLazyQuery<{ workloads: WorkloadResponse[] }, { filter?: { markedForInstrumentation?: boolean; limit?: number; offset?: number } & Partial<WorkloadId> }>(GET_WORKLOADS);
   const [queryWorkloadsByIds] = useLazyQuery<{ workloadsByIds: WorkloadResponse[] }, { ids: { namespace: string; kind: string; name: string }[] }>(GET_WORKLOADS_BY_IDS);
+  const [queryWorkloadsCount] = useLazyQuery<{ workloadsCount: number }, { filter?: { markedForInstrumentation?: boolean } & Partial<WorkloadId> }>(GET_WORKLOADS_COUNT);
 
   const [mutatePersistSources] = useMutation<{ persistK8sSources: boolean }, SourceInstrumentInput>(PERSIST_SOURCES, {
     onError: (error) => {
@@ -89,13 +95,52 @@ export const useSourceCRUD = (): UseSourceCrud => {
   const fetchSources: UseSourceCrud['fetchSources'] = async () => {
     setEntitiesLoading(EntityTypes.Source, true);
 
-    const { error, data } = await queryWorkloads({ variables: { filter: { markedForInstrumentation: true } } });
+    try {
+      const baseFilter = { markedForInstrumentation: true };
 
-    if (error) {
-      notifyUser(StatusType.Error, error.name || Crud.Read, error.cause?.message || error.message);
-    } else if (data?.workloads) {
-      const mappedSources = sortSources(data.workloads.map(mapWorkloadToSource));
-      setEntities(EntityTypes.Source, mappedSources);
+      // Get total count first to determine if pagination is needed.
+      const { data: countData, error: countError } = await queryWorkloadsCount({ variables: { filter: baseFilter } });
+      if (countError) {
+        notifyUser(StatusType.Error, countError.name || Crud.Read, countError.cause?.message || countError.message);
+        setEntitiesLoading(EntityTypes.Source, false);
+        return;
+      }
+
+      const totalCount = countData?.workloadsCount ?? 0;
+
+      if (totalCount <= PAGE_SIZE) {
+        // Small enough for a single request.
+        const { error, data } = await queryWorkloads({ variables: { filter: { ...baseFilter, limit: PAGE_SIZE } } });
+        if (error) {
+          notifyUser(StatusType.Error, error.name || Crud.Read, error.cause?.message || error.message);
+        } else if (data?.workloads) {
+          setEntities(EntityTypes.Source, sortSources(data.workloads.map(mapWorkloadToSource)));
+        }
+      } else {
+        // Paginate in controlled batches to avoid overwhelming the backend.
+        const pageCount = Math.ceil(totalCount / PAGE_SIZE);
+        const offsets = Array.from({ length: pageCount }, (_, i) => i * PAGE_SIZE);
+
+        const allWorkloads: WorkloadResponse[] = [];
+
+        for (let i = 0; i < offsets.length; i += CONCURRENT_PAGES) {
+          const batch = offsets.slice(i, i + CONCURRENT_PAGES);
+          const results = await Promise.all(batch.map((offset) => queryWorkloads({ variables: { filter: { ...baseFilter, limit: PAGE_SIZE, offset } } })));
+
+          for (const result of results) {
+            if (result.error) {
+              notifyUser(StatusType.Error, result.error.name || Crud.Read, result.error.cause?.message || result.error.message);
+            } else if (result.data?.workloads) {
+              allWorkloads.push(...result.data.workloads);
+            }
+          }
+        }
+
+        setEntities(EntityTypes.Source, sortSources(allWorkloads.map(mapWorkloadToSource)));
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error fetching sources';
+      notifyUser(StatusType.Error, Crud.Read, message);
     }
 
     setEntitiesLoading(EntityTypes.Source, false);

--- a/frontend/webapp/hooks/sources/useSourceCRUD.ts
+++ b/frontend/webapp/hooks/sources/useSourceCRUD.ts
@@ -118,25 +118,27 @@ export const useSourceCRUD = (): UseSourceCrud => {
         }
       } else {
         // Paginate in controlled batches to avoid overwhelming the backend.
+        // Each batch result is pushed to the store immediately so the UI updates progressively.
         const pageCount = Math.ceil(totalCount / PAGE_SIZE);
         const offsets = Array.from({ length: pageCount }, (_, i) => i * PAGE_SIZE);
-
-        const allWorkloads: WorkloadResponse[] = [];
 
         for (let i = 0; i < offsets.length; i += CONCURRENT_PAGES) {
           const batch = offsets.slice(i, i + CONCURRENT_PAGES);
           const results = await Promise.all(batch.map((offset) => queryWorkloads({ variables: { filter: { ...baseFilter, limit: PAGE_SIZE, offset } } })));
 
+          const batchWorkloads: WorkloadResponse[] = [];
           for (const result of results) {
             if (result.error) {
               notifyUser(StatusType.Error, result.error.name || Crud.Read, result.error.cause?.message || result.error.message);
             } else if (result.data?.workloads) {
-              allWorkloads.push(...result.data.workloads);
+              batchWorkloads.push(...result.data.workloads);
             }
           }
-        }
 
-        setEntities(EntityTypes.Source, sortSources(allWorkloads.map(mapWorkloadToSource)));
+          if (batchWorkloads.length > 0) {
+            addEntities(EntityTypes.Source, batchWorkloads.map(mapWorkloadToSource));
+          }
+        }
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error fetching sources';


### PR DESCRIPTION
# Customer Issue Report: Homepage 502 / UI OOM

**Ticket**: [PLAT-862](https://linear.app/odigos/issue/PLAT-862/homepage-returns-502-and-ui-goes-oom)

**Symptom**: The Odigos UI homepage returns 502 errors and the UI pod goes OOM (out of memory).

---

## Root Cause

1. **SSE amplification loop**: IC had 3 duplicate watchers (tripling event processing). The backend `EventBatcher` used debounce that never settled under sustained load, causing unbounded memory growth. The frontend debounce also never settled, triggering repeated full `GET_WORKLOADS` queries.

2. **GET_WORKLOADS does not scale**: A single query deep-copied ALL ICs, ALL pods, ALL manifests cluster-wide via 6+ `List` operations. gqlgen spawned 170K goroutines (10K workloads × 17 resolver fields = ~430MB stack memory). `GetNamespacesWithWorkloads` and `GetDataStreams` also fired on page load with full cluster-wide API calls.

3. **Memory budget**: The informer cache alone consumes ~15Mi per 1K instrumented workloads at idle. The `GET_WORKLOADS` query adds ~2.5KB per workload for model objects. Both scale linearly — at 20K workloads the cache uses ~309Mi idle and the query adds ~32Mi, leaving no headroom in a 512Mi pod for gqlgen serialization.

---

## Fixes

| #   | Fix                                                                                                                           | Impact                                                   |
| --- | ----------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| 1   | **EventBatcher throttle** — replaced debounce with pure throttle (3s window, `MaxBatchSize: 100`, `MaxDelay: 10s`)            | Bounded batch memory                                     |
| 2   | **Unified watchers** — IC 3→1, Destination 2→1, API watch connections 5→2                                                     | Eliminated duplicate event processing                    |
| 3   | **Frontend debounce** — 5s debounce now settles between backend throttle bursts                                               | At most 1 refetch per 5s                                 |
| 4   | **Targeted manifest fetching** — per-workload `Get` instead of 6+ cluster-wide `List` when IDs are known                      | Deep copies: O(cluster) → O(requested)                   |
| 5   | **Namespace-scoped pod fetching** — list pods only in namespaces with workloads                                               | Avoids pods from irrelevant namespaces                   |
| 6   | **Lazy namespace loading** — lightweight `GET_NAMESPACES` for page load; `workloads` is a lazy resolver field                 | No workload loading on page load                         |
| 7   | **Zero-copy cache reads** — `DefaultUnsafeDisableDeepCopy: true` on cache options                                             | Eliminates deep-copy allocations on all cache reads      |
| 8   | **DataStreams uses cache** — switched from direct API call to cache client                                                    | Eliminates 20-40MB API fetch on page load                |
| 9   | **Config loading dedup** — `LoadConfig` caches result; `SetFilters`/`SetWorkloadIdsDirect` reuse it                           | Eliminates redundant ConfigMap fetches + YAML unmarshals |
| 10  | **Sequential field pre-computation** — `populateWorkloadFields` computes all fields inline; resolvers return early if pre-set | Goroutines: 170K → 10K (list items only)                 |
| 11  | **Deduplicated status computation** — conditions and healthStatus share computed values instead of calculating each twice     | Halved status allocations per workload                   |
| 12  | **Concurrent query serialization** — mutex on `Workloads` resolver prevents concurrent heavy queries                          | Prevents memory doubling from overlapping requests       |
| 13  | **Metrics map race fix** — `metricsByID`/`removeNodeCollector` now hold `sourcesMu`                                           | Fixes `concurrent map read and map write` crash          |

---

## Memory Profile (from instrumented build)

Measured at 20K instrumented workloads, 512Mi pod limit, `GOMEMLIMIT=409Mi`:

| Stage                              | Alloc  | HeapInuse |
| ---------------------------------- | ------ | --------- |
| Idle (cache synced)                | 309Mi  | 323Mi     |
| After SetFilters (IC listing)      | 338Mi  | 352Mi     |
| After populating 10K/20K workloads | 316Mi  | 337Mi     |
| After populating 20K/20K workloads | 341Mi  | 361Mi     |
| gqlgen serialization (estimated)   | ~360Mi | ~390Mi    |

The query itself adds ~32Mi on top of the 309Mi idle cache. The OOM occurs when gqlgen serializes the 20MB JSON response, pushing HeapInuse past the 409Mi GOMEMLIMIT and triggering aggressive GC that can't free enough before the 512Mi hard limit is hit.

---

## Memory Sizing Guide

The UI pod memory should be sized based on the number of instrumented workloads (workloads with InstrumentationConfig resources, not just pods):

| Instrumented workloads | Recommended memory limit |
| ---------------------- | ------------------------ |
| Up to 2K               | 512Mi (default)          |
| 2K – 5K                | 768Mi                    |
| 5K – 10K               | 1Gi                      |
| 10K – 20K              | 1.5Gi                    |
| 20K+                   | 2Gi                      |

**Formula**: `~15Mi per 1K workloads (cache) + ~2.5Mi per 1K workloads (query) + 200Mi (Go runtime + gqlgen) + 50Mi headroom`.

Note: this scales with **instrumented workloads** (unique deployments/daemonsets/statefulsets with Sources), not with pod count. A cluster with 500 workloads × 40 replicas = 20K pods needs only 512Mi, while 20K workloads × 1 replica = 20K pods needs 1.5Gi.

---

## Release Note

```release-note
Enhance Kubernetes cache handling and event watcher functionality for improved performance and integration.
Optimize GET_WORKLOADS query with targeted manifest fetching, namespace-scoped pod fetching, and zero-copy cache reads.
Pre-compute workload fields sequentially to eliminate excessive goroutine spawning at scale.
```

cherry-pick: v1.23, v1.24