### PR TITLE
chore: pr policy to not run for releases PRs

### DIFF
--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -10,11 +10,13 @@ permissions:
 
 jobs:
   require-linear:
+    if: ${{ !startsWith(github.head_ref, 'pre-releases') }}
     runs-on: ubuntu-latest
     steps: 
       - uses: odigos-io/ci-core/require-linear@main
 
   release-note:
+    if: ${{ !startsWith(github.head_ref, 'pre-releases') }}
     runs-on: ubuntu-latest
     steps: 
       - uses: odigos-io/ci-core/require-release-note@main


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Pre-release PRs are automated and don't require linear tickets or release notes. GitHub Actions' pull_request trigger only filters by target branch, not source branch, so we use job-level if conditions on github.head_ref instead.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
