### PR TITLE
CORE-826: Bump grpc-health-probe to v0.4.48

### DIFF
--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -131,7 +131,7 @@ RUN if [ "$RHEL" = "true" ] ; then \
 
 
 # Download grpc_health_probe this is used by the deviceplugin container to check if the deviceplugin is healthy
-ARG GRPC_HEALTH_PROBE_VERSION=v0.4.47
+ARG GRPC_HEALTH_PROBE_VERSION=v0.4.48
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
         GRPC_ARCH="arm64"; \
     else \


### PR DESCRIPTION
#### What this PR does / why we need it:
Bump the odiglet's [grpc-health-probe to v0.4.48](https://github.com/grpc-ecosystem/grpc-health-probe/tree/v0.4.48) to address https://pkg.go.dev/vuln/GO-2026-4868

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
