### PR TITLE
chore: improve collector build command to run faster

### DIFF
--- a/collector/Dockerfile
+++ b/collector/Dockerfile
@@ -4,6 +4,11 @@ COPY ./collector/ /go/src/collector
 COPY ./common/ /go/src/common
 WORKDIR /go/src/collector
 
+# download dependencies before branching out to cross-compile for better caching
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    cd odigosotelcol && go mod download
+
 ARG TARGETARCH
 ARG RHEL=false
 RUN --mount=type=cache,target=/go/pkg/mod \

--- a/collector/Dockerfile
+++ b/collector/Dockerfile
@@ -9,6 +9,7 @@ ARG RHEL=false
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     GOOS=linux GOARCH=$TARGETARCH make build-odigoscol
+
 RUN if [ "$RHEL" = "true" ] ; then \
       make licenses ; \
     fi

--- a/collector/Makefile
+++ b/collector/Makefile
@@ -47,7 +47,11 @@ test-odigostailsamplingprocessor:
 
 .PHONY: build-odigoscol
 build-odigoscol: download_builder test-odigossamplingprocessor test-odigostailsamplingprocessor
-	$(BUILDER) --ldflags="-checklinkname=0" --config builder-config.yaml --skip-generate --skip-get-modules
+	$(BUILDER) \
+	--ldflags="-s -w -checklinkname=0" \
+	--config builder-config.yaml \
+	--skip-generate \
+	--skip-get-modules
 
 .PHONY: install-tools
 install-tools:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->

Since we are using custom `ldflags` to build the collector, ocb didn't add the strip flags while building, resulting in a large and slow build.

https://github.com/open-telemetry/opentelemetry-collector/blob/main/cmd/builder/internal/builder/main.go#L129-L132

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
