### PR TITLE
fix: use the new otlp exporters naming and fix test connection

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -288,7 +288,7 @@ jobs:
         run: |
           make test
 
-  build-frontend:
+  build-and-test-frontend:
     name: build-frontend
     runs-on: ubuntu-latest
     steps:
@@ -362,6 +362,10 @@ jobs:
           name: vuln-scan-result-frontend-${{ github.sha }}.json
           path: /tmp/scan-results/odigos-ui.json
           retention-days: 30
+      - name: run tests
+        working-directory: ./frontend
+        run: |
+          make test
 
   build-operator:
     name: build-operator
@@ -417,7 +421,7 @@ jobs:
       - build-and-test-instrumentor
       - build-and-test-odigos-collector
       - build-and-test-odiglet
-      - build-frontend
+      - build-and-test-frontend
       - build-operator
     runs-on: ubuntu-latest
     if: always()

--- a/autoscaler/controllers/clustercollector/configmap.go
+++ b/autoscaler/controllers/clustercollector/configmap.go
@@ -99,7 +99,7 @@ func addSelfTelemetryPipeline(c *config.Config, ownTelemetryPort int32, destinat
 	// as it helps to calculate the size of the data being exported.
 	// In case of performance impact caused by this processor, we should modify this config to reduce the sampling ratio.
 	c.Processors["odigostrafficmetrics"] = struct{}{}
-	c.Exporters["otlp/odigos-own-telemetry-ui"] = config.GenericMap{
+	c.Exporters["otlp_grpc/odigos-own-telemetry-ui"] = config.GenericMap{
 		"endpoint":    fmt.Sprintf("ui.%s:%d", env.GetCurrentNamespace(), odigosconsts.OTLPPort),
 		"compression": "none",
 		"tls": config.GenericMap{
@@ -112,7 +112,7 @@ func addSelfTelemetryPipeline(c *config.Config, ownTelemetryPort int32, destinat
 	c.Service.Pipelines["metrics/otelcol"] = config.Pipeline{
 		Receivers:  []string{"prometheus/self-metrics"},
 		Processors: []string{"resource/pod-name", "resource/odigos-collector-role"},
-		Exporters:  []string{"otlp/odigos-own-telemetry-ui"},
+		Exporters:  []string{"otlp_grpc/odigos-own-telemetry-ui"},
 	}
 
 	podNameFromEnv := "${POD_NAME}"

--- a/autoscaler/controllers/clustercollector/configmap_test.go
+++ b/autoscaler/controllers/clustercollector/configmap_test.go
@@ -80,7 +80,7 @@ func TestAddSelfTelemetryPipeline(t *testing.T) {
 					},
 				},
 				Exporters: config.GenericMap{
-					"otlp/local": config.GenericMap{
+					"otlp_grpc/local": config.GenericMap{
 						"endpoint": "http://localhost:4317",
 						"tls": config.GenericMap{
 							"insecure": true,
@@ -92,7 +92,7 @@ func TestAddSelfTelemetryPipeline(t *testing.T) {
 						"traces/user-pipeline": {
 							Receivers:  []string{"otlp"},
 							Processors: []string{"memory_limiter", "resource/odigos-version"},
-							Exporters:  []string{"otlp/local"},
+							Exporters:  []string{"otlp_grpc/local"},
 						},
 					},
 				},
@@ -116,7 +116,7 @@ func TestAddSelfTelemetryPipeline(t *testing.T) {
 			assert.NotEmpty(t, c.Service.Pipelines["metrics/otelcol"])
 			assert.Equal(t, []string{"prometheus/self-metrics"}, c.Service.Pipelines["metrics/otelcol"].Receivers)
 			assert.Equal(t, []string{"resource/pod-name", "resource/odigos-collector-role"}, c.Service.Pipelines["metrics/otelcol"].Processors)
-			assert.Equal(t, []string{"otlp/odigos-own-telemetry-ui"}, c.Service.Pipelines["metrics/otelcol"].Exporters)
+			assert.Equal(t, []string{"otlp_grpc/odigos-own-telemetry-ui"}, c.Service.Pipelines["metrics/otelcol"].Exporters)
 			pullExporter := c.Service.Telemetry.Metrics.Readers[0]["pull"].(config.GenericMap)["exporter"].(config.GenericMap)
 			port := pullExporter["prometheus"].(config.GenericMap)["port"]
 			address := pullExporter["prometheus"].(config.GenericMap)["host"]
@@ -128,7 +128,6 @@ func TestAddSelfTelemetryPipeline(t *testing.T) {
 				} else {
 					assert.Equal(t, pipeline.Processors[len(pipeline.Processors)-1], "odigostrafficmetrics")
 				}
-
 			}
 		})
 	}

--- a/autoscaler/controllers/clustercollector/ownmetrics.go
+++ b/autoscaler/controllers/clustercollector/ownmetrics.go
@@ -9,10 +9,10 @@ import (
 )
 
 const (
-	odigosOwnTelemetryOtlpReceiverName = "otlp/odigos-own-metrics-in"
+	odigosOwnTelemetryOtlpReceiverName = "otlp_grpc/odigos-own-metrics-in"
 	gatewayPrometheusReceiverName      = "prometheus/gateway-own-metrics"
 	ownMetricsStorePipelineName        = "metrics/own-metrics"
-	odigosVictoriametricsExporterName  = "otlphttp/odigos-victoriametrics"
+	odigosVictoriametricsExporterName  = "otlp_http/odigos-victoriametrics"
 	defaultOwnMetricsScrapeInterval    = "10s"
 )
 

--- a/autoscaler/controllers/nodecollector/collectorconfig/common.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/common.go
@@ -23,9 +23,9 @@ const (
 	memoryLimiterProcessorName          = "memory_limiter"
 	balancerName                        = "round_robin"
 	nodeNameProcessorName               = "resource/node-name"
-	clusterCollectorTracesExporterName  = "otlp/out-cluster-collector-traces"
-	clusterCollectorMetricsExporterName = "otlp/out-cluster-collector-metrics"
-	clusterCollectorLogsExporterName    = "otlp/out-cluster-collector-logs"
+	clusterCollectorTracesExporterName  = "otlp_grpc/out-cluster-collector-traces"
+	clusterCollectorMetricsExporterName = "otlp_grpc/out-cluster-collector-metrics"
+	clusterCollectorLogsExporterName    = "otlp_grpc/out-cluster-collector-logs"
 	resourceDetectionProcessorName      = "resourcedetection"
 )
 

--- a/autoscaler/controllers/nodecollector/collectorconfig/ownmetrics-ui.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/ownmetrics-ui.go
@@ -18,7 +18,7 @@ const (
 
 	podNameProcessorName       = "resource/pod-name"
 	collectorRoleProcessorName = "resource/odigos-collector-role"
-	ownMetricsUiExporterName   = "otlp/odigos-own-telemetry-ui"
+	ownMetricsUiExporterName   = "otlp_grpc/odigos-own-telemetry-ui"
 	ownMetricsUiReceiverName   = "prometheus/self-metrics-ui"
 	ownMetricsUiPipelineName   = "metrics/own-metrics-ui"
 )

--- a/autoscaler/controllers/nodecollector/testdata/logs_included.yaml
+++ b/autoscaler/controllers/nodecollector/testdata/logs_included.yaml
@@ -8,26 +8,26 @@ exporters:
     resolver:
       k8s:
         service: odigos-gateway.odigos-system
-  otlp/odigos-own-telemetry-ui:
+  otlp_grpc/odigos-own-telemetry-ui:
     compression: none
     endpoint: ui.odigos-system:4317
     retry_on_failure:
       enabled: false
     tls:
       insecure: true
-  otlp/out-cluster-collector-logs:
+  otlp_grpc/out-cluster-collector-logs:
     balancer_name: round_robin
     compression: none
     endpoint: dns:///odigos-gateway.odigos-system:4317
     tls:
       insecure: true
-  otlp/out-cluster-collector-metrics:
+  otlp_grpc/out-cluster-collector-metrics:
     balancer_name: round_robin
     compression: none
     endpoint: dns:///odigos-gateway.odigos-system:4317
     tls:
       insecure: true
-  otlp/out-cluster-collector-traces:
+  otlp_grpc/out-cluster-collector-traces:
     balancer_name: round_robin
     compression: none
     endpoint: dns:///odigos-gateway.odigos-system:4317
@@ -157,7 +157,7 @@ service:
   pipelines:
     logs:
       exporters:
-      - otlp/out-cluster-collector-logs
+      - otlp_grpc/out-cluster-collector-logs
       processors:
       - memory_limiter
       - resource/node-name
@@ -169,7 +169,7 @@ service:
       - filelog
     metrics:
       exporters:
-      - otlp/out-cluster-collector-metrics
+        - otlp_grpc/out-cluster-collector-metrics
       processors:
       - batch
       - memory_limiter
@@ -184,7 +184,7 @@ service:
       - hostmetrics
     metrics/own-metrics-ui:
       exporters:
-      - otlp/odigos-own-telemetry-ui
+        - otlp_grpc/odigos-own-telemetry-ui
       processors:
       - resource/pod-name
       - resource/odigos-collector-role

--- a/autoscaler/controllers/nodecollector/testdata/traces_only_no_loadbalancing.yaml
+++ b/autoscaler/controllers/nodecollector/testdata/traces_only_no_loadbalancing.yaml
@@ -1,24 +1,24 @@
 exporters:
-  otlp/odigos-own-telemetry-ui:
+  otlp_grpc/odigos-own-telemetry-ui:
     compression: none
     endpoint: ui.odigos-system:4317
     retry_on_failure:
       enabled: false
     tls:
       insecure: true
-  otlp/out-cluster-collector-logs:
+  otlp_grpc/out-cluster-collector-logs:
     balancer_name: round_robin
     compression: none
     endpoint: dns:///odigos-gateway.odigos-system:4317
     tls:
       insecure: true
-  otlp/out-cluster-collector-metrics:
+  otlp_grpc/out-cluster-collector-metrics:
     balancer_name: round_robin
     compression: none
     endpoint: dns:///odigos-gateway.odigos-system:4317
     tls:
       insecure: true
-  otlp/out-cluster-collector-traces:
+  otlp_grpc/out-cluster-collector-traces:
     balancer_name: round_robin
     compression: none
     endpoint: dns:///odigos-gateway.odigos-system:4317
@@ -101,7 +101,7 @@ service:
   pipelines:
     metrics/own-metrics-ui:
       exporters:
-      - otlp/odigos-own-telemetry-ui
+        - otlp_grpc/odigos-own-telemetry-ui
       processors:
       - resource/pod-name
       - resource/odigos-collector-role
@@ -109,7 +109,7 @@ service:
       - prometheus/self-metrics-ui
     traces:
       exporters:
-      - otlp/out-cluster-collector-traces
+        - otlp_grpc/out-cluster-collector-traces
       processors:
       - batch
       - memory_limiter

--- a/collector/examples/test-config.yaml
+++ b/collector/examples/test-config.yaml
@@ -10,7 +10,7 @@ exporters:
   # NOTE: Prior to v0.86.0 use `logging` instead of `debug`.
   debug:
     verbosity: detailed
-  otlp/jaeger:
+  otlp_grpc/jaeger:
     endpoint: localhost:14317
     tls:
       insecure: true
@@ -20,7 +20,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/jaeger, debug]
+      exporters: [otlp_grpc/jaeger, debug]
   telemetry:
     logs:
       level: debug

--- a/common/config/alibabacloud.go
+++ b/common/config/alibabacloud.go
@@ -29,7 +29,7 @@ func (j *AlibabaCloud) ModifyConfig(dest ExporterConfigurer, cfg *Config) ([]str
 		return nil, err
 	}
 
-	exporterName := "otlp/" + uniqueUri
+	exporterName := "otlp_grpc/" + uniqueUri
 	cfg.Exporters[exporterName] = GenericMap{
 		"endpoint": endpoint,
 		"headers": GenericMap{

--- a/common/config/appdynamics.go
+++ b/common/config/appdynamics.go
@@ -60,7 +60,7 @@ func (m *AppDynamics) ModifyConfig(dest ExporterConfigurer, currentConfig *Confi
 	}
 	host := strings.Join(endpointParts, ".")
 
-	exporterName := "otlphttp/" + uniqueUri
+	exporterName := "otlp_http/" + uniqueUri
 	currentConfig.Exporters[exporterName] = GenericMap{
 		"endpoint": endpoint,
 		"headers": GenericMap{

--- a/common/config/axiom.go
+++ b/common/config/axiom.go
@@ -23,7 +23,7 @@ func (a *Axiom) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) ([]
 		dataset = "default"
 	}
 
-	axiomExporterName := "otlphttp/axiom-" + dest.GetID()
+	axiomExporterName := "otlp_http/axiom-" + dest.GetID()
 	currentConfig.Exporters[axiomExporterName] = GenericMap{
 		"compression": "gzip",
 		"endpoint":    "https://api.axiom.co",

--- a/common/config/betterstack.go
+++ b/common/config/betterstack.go
@@ -40,7 +40,7 @@ func (j *BetterStack) ModifyConfig(dest ExporterConfigurer, cfg *Config) ([]stri
 	}
 
 	if isLoggingEnabled(dest) {
-		exporterName := "otlp/" + uniqueUri
+		exporterName := "otlp_grpc/" + uniqueUri
 		cfg.Exporters[exporterName] = GenericMap{
 			"endpoint": "https://in-otel.logs.betterstack.com:443",
 		}

--- a/common/config/bonree.go
+++ b/common/config/bonree.go
@@ -30,7 +30,7 @@ func (j *Bonree) ModifyConfig(dest ExporterConfigurer, cfg *Config) ([]string, e
 		return nil, err
 	}
 
-	exporterName := "otlphttp/" + uniqueUri
+	exporterName := "otlp_http/" + uniqueUri
 	cfg.Exporters[exporterName] = GenericMap{
 		"endpoint": endpoint,
 		"headers": GenericMap{

--- a/common/config/causely.go
+++ b/common/config/causely.go
@@ -72,7 +72,7 @@ func (e *Causely) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) (
 		return nil, errors.Join(err, errors.New("failed to parse Causely endpoint, gateway will not be configured for Causely"))
 	}
 
-	exporterName := "otlp/causely-" + dest.GetID()
+	exporterName := "otlp_grpc/causely-" + dest.GetID()
 
 	currentConfig.Exporters[exporterName] = GenericMap{
 		"endpoint": validatedUrl,

--- a/common/config/checkly.go
+++ b/common/config/checkly.go
@@ -29,7 +29,7 @@ func (j *Checkly) ModifyConfig(dest ExporterConfigurer, cfg *Config) ([]string, 
 		return nil, err
 	}
 
-	exporterName := "otlp/" + uniqueUri
+	exporterName := "otlp_grpc/" + uniqueUri
 	cfg.Exporters[exporterName] = GenericMap{
 		"endpoint": endpoint,
 		"headers": GenericMap{

--- a/common/config/chronosphere.go
+++ b/common/config/chronosphere.go
@@ -30,7 +30,7 @@ func (c *Chronosphere) ModifyConfig(dest ExporterConfigurer, currentConfig *Conf
 
 	company := c.getCompanyNameFromURL(url)
 
-	chronosphereExporterName := "otlp/chronosphere-" + dest.GetID()
+	chronosphereExporterName := "otlp_grpc/chronosphere-" + dest.GetID()
 	currentConfig.Exporters[chronosphereExporterName] = GenericMap{
 		"endpoint": fmt.Sprintf("%s.chronosphere.io:443", company),
 		"retry_on_failure": GenericMap{

--- a/common/config/dash0.go
+++ b/common/config/dash0.go
@@ -33,7 +33,7 @@ func (j *Dash0) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) ([]
 		return nil, err
 	}
 
-	exporterName := "otlp/" + uniqueUri
+	exporterName := "otlp_grpc/" + uniqueUri
 	exporterConfig := GenericMap{
 		"endpoint": endpoint,
 		"headers": GenericMap{

--- a/common/config/dynatrace.go
+++ b/common/config/dynatrace.go
@@ -34,7 +34,7 @@ func (n *Dynatrace) ModifyConfig(dest ExporterConfigurer, currentConfig *Config)
 		return nil, errors.New("Dynatrace url is not a valid")
 	}
 
-	exporterName := "otlphttp/dynatrace-" + dest.GetID()
+	exporterName := "otlp_http/dynatrace-" + dest.GetID()
 	currentConfig.Exporters[exporterName] = GenericMap{
 		"endpoint": baseURL + "/api/v2/otlp",
 		"headers": GenericMap{

--- a/common/config/elasticapm.go
+++ b/common/config/elasticapm.go
@@ -28,7 +28,7 @@ func (e *ElasticAPM) ModifyConfig(dest ExporterConfigurer, currentConfig *Config
 
 	elasticApmEndpoint := e.parseEndpoint(dest.GetConfig()[elasticApmServerEndpoint])
 
-	exporterName := "otlp/elastic-" + dest.GetID()
+	exporterName := "otlp_grpc/elastic-" + dest.GetID()
 	currentConfig.Exporters[exporterName] = GenericMap{
 		"endpoint": elasticApmEndpoint,
 		"tls": GenericMap{

--- a/common/config/gcpotlp.go
+++ b/common/config/gcpotlp.go
@@ -13,7 +13,7 @@ func (g *GoogleCloudOTLP) DestType() common.DestinationType {
 func (g *GoogleCloudOTLP) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) ([]string, error) {
 	var pipelineNames []string
 	if isTracingEnabled(dest) {
-		exporterName := "otlphttp/gcp-" + dest.GetID()
+		exporterName := "otlp_http/gcp-" + dest.GetID()
 		extensionName := "googleclientauth/" + dest.GetID()
 		config := dest.GetConfig()
 		exporterConfig := GenericMap{

--- a/common/config/genericotlp.go
+++ b/common/config/genericotlp.go
@@ -81,7 +81,7 @@ func (g *GenericOTLP) ModifyConfig(dest ExporterConfigurer, currentConfig *Confi
 		currentConfig.Service.Extensions = append(currentConfig.Service.Extensions, oauth2ExtensionName)
 	}
 
-	genericOtlpExporterName := "otlp/generic-" + dest.GetID()
+	genericOtlpExporterName := "otlp_grpc/generic-" + dest.GetID()
 
 	// Add OAuth2 auth configuration if available
 	if oauth2ExtensionName != "" {

--- a/common/config/genericotlp_test.go
+++ b/common/config/genericotlp_test.go
@@ -105,7 +105,7 @@ func TestGrpcOAuth2AutoTLS(t *testing.T) {
 			assert.NotEmpty(t, pipelineNames)
 
 			// Check exporter configuration
-			exporterName := "otlp/generic-test-id"
+			exporterName := "otlp_grpc/generic-test-id"
 			assert.Contains(t, config.Exporters, exporterName)
 			exporterConfig := config.Exporters[exporterName].(GenericMap)
 			

--- a/common/config/grafanacloudloki.go
+++ b/common/config/grafanacloudloki.go
@@ -58,7 +58,7 @@ func (g *GrafanaCloudLoki) ModifyConfig(dest ExporterConfigurer, currentConfig *
 		},
 	}
 
-	exporterName := "otlphttp/" + uniqueUri
+	exporterName := "otlp_http/" + uniqueUri
 	currentConfig.Exporters[exporterName] = GenericMap{
 		"endpoint": lokiExporterEndpoint,
 		"auth": GenericMap{

--- a/common/config/grafanacloudtempo.go
+++ b/common/config/grafanacloudtempo.go
@@ -44,7 +44,7 @@ func (g *GrafanaCloudTempo) ModifyConfig(dest ExporterConfigurer, currentConfig 
 		},
 	}
 
-	exporterName := "otlp/grafana-" + dest.GetID()
+	exporterName := "otlp_grpc/grafana-" + dest.GetID()
 	currentConfig.Exporters[exporterName] = GenericMap{
 		"endpoint": grpcEndpointUrl,
 		"auth": GenericMap{

--- a/common/config/greptime.go
+++ b/common/config/greptime.go
@@ -49,7 +49,7 @@ func (j *Greptime) ModifyConfig(dest ExporterConfigurer, cfg *Config) ([]string,
 		},
 	}
 
-	exporterName := "otlphttp/" + uniqueUri
+	exporterName := "otlp_http/" + uniqueUri
 	cfg.Exporters[exporterName] = GenericMap{
 		"endpoint": endpoint,
 		"auth": GenericMap{

--- a/common/config/groundcover.go
+++ b/common/config/groundcover.go
@@ -38,7 +38,7 @@ func (j *Groundcover) ModifyConfig(dest ExporterConfigurer, currentConfig *Confi
 		return nil, err
 	}
 
-	exporterName := "otlp/" + uniqueUri
+	exporterName := "otlp_grpc/" + uniqueUri
 	exporterConfig := GenericMap{
 		"endpoint": endpoint,
 		"headers": GenericMap{

--- a/common/config/honeycomb.go
+++ b/common/config/honeycomb.go
@@ -29,7 +29,7 @@ func (h *Honeycomb) ModifyConfig(dest ExporterConfigurer, currentConfig *Config)
 		endpoint = "api.honeycomb.io"
 	}
 
-	exporterName := "otlp/honeycomb-" + dest.GetID()
+	exporterName := "otlp_grpc/honeycomb-" + dest.GetID()
 	currentConfig.Exporters[exporterName] = GenericMap{
 		"endpoint": fmt.Sprintf("%s:443", endpoint),
 		"headers": GenericMap{

--- a/common/config/hyperdx.go
+++ b/common/config/hyperdx.go
@@ -13,7 +13,7 @@ func (j *HyperDX) DestType() common.DestinationType {
 func (j *HyperDX) ModifyConfig(dest ExporterConfigurer, cfg *Config) ([]string, error) {
 	uniqueUri := "hdx-" + dest.GetID()
 
-	exporterName := "otlp/" + uniqueUri
+	exporterName := "otlp_grpc/" + uniqueUri
 	exporterConfig := GenericMap{
 		"endpoint": "in-otel.hyperdx.io:4317",
 		"headers": GenericMap{

--- a/common/config/instana.go
+++ b/common/config/instana.go
@@ -31,7 +31,7 @@ func (m *Instana) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) (
 	}
 
 	// Modify the exporter here
-	exporterName := "otlp/" + uniqueUri
+	exporterName := "otlp_grpc/" + uniqueUri
 	exporterConfig := GenericMap{
 		"endpoint": endpoint,
 		"headers": GenericMap{

--- a/common/config/jaeger.go
+++ b/common/config/jaeger.go
@@ -45,7 +45,7 @@ func (j *Jaeger) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) ([
 		return nil, err
 	}
 
-	exporterName := "otlp/" + uniqueUri
+	exporterName := "otlp_grpc/" + uniqueUri
 	exporterConfig := GenericMap{
 		"endpoint": endpoint,
 	}

--- a/common/config/kloudmate.go
+++ b/common/config/kloudmate.go
@@ -13,7 +13,7 @@ func (j *KloudMate) DestType() common.DestinationType {
 func (j *KloudMate) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) ([]string, error) {
 	uniqueUri := "kloudmate-" + dest.GetID()
 
-	exporterName := "otlphttp/" + uniqueUri
+	exporterName := "otlp_http/" + uniqueUri
 	exporterConfig := GenericMap{
 		"endpoint": "https://otel.kloudmate.com:4318",
 		"headers": GenericMap{

--- a/common/config/last9.go
+++ b/common/config/last9.go
@@ -26,7 +26,7 @@ func (m *Last9) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) ([]
 	}
 
 	// to make sure that the exporter name is unique, we'll ask a ID from destination
-	exporterName := "otlp/last9-" + dest.GetID()
+	exporterName := "otlp_grpc/last9-" + dest.GetID()
 	currentConfig.Exporters[exporterName] = GenericMap{
 		"endpoint": l9OtlpEndpoint,
 		"headers": GenericMap{

--- a/common/config/lightstep.go
+++ b/common/config/lightstep.go
@@ -13,7 +13,7 @@ func (l *Lightstep) DestType() common.DestinationType {
 func (l *Lightstep) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) ([]string, error) {
 	var pipelineNames []string
 	if isTracingEnabled(dest) {
-		exporterName := "otlp/lightstep-" + dest.GetID()
+		exporterName := "otlp_grpc/lightstep-" + dest.GetID()
 		currentConfig.Exporters[exporterName] = GenericMap{
 			"endpoint": "ingest.lightstep.com:443",
 			"headers": GenericMap{

--- a/common/config/loki.go
+++ b/common/config/loki.go
@@ -76,7 +76,7 @@ func (l *Loki) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) ([]s
 		addHeader(exporterConf, "X-Scope-OrgID", scopeOrgIdHeader)
 	}
 
-	lokiExporterName := "otlphttp/" + uniqueUri
+	lokiExporterName := "otlp_http/" + uniqueUri
 	currentConfig.Exporters[lokiExporterName] = exporterConf
 
 	processorNames := []string{}

--- a/common/config/lumigo.go
+++ b/common/config/lumigo.go
@@ -33,7 +33,7 @@ func (j *Lumigo) ModifyConfig(dest ExporterConfigurer, cfg *Config) ([]string, e
 		return nil, err
 	}
 
-	exporterName := "otlphttp/" + uniqueUri
+	exporterName := "otlp_http/" + uniqueUri
 	exporterConfig := GenericMap{
 		"endpoint": endpoint,
 		"headers": GenericMap{

--- a/common/config/middleware.go
+++ b/common/config/middleware.go
@@ -26,7 +26,7 @@ func (m *Middleware) ModifyConfig(dest ExporterConfigurer, currentConfig *Config
 		return nil, errors.New("Middleware target not specified, gateway will not be configured for Middleware")
 	}
 
-	exporterName := "otlp/middleware-" + dest.GetID()
+	exporterName := "otlp_grpc/middleware-" + dest.GetID()
 	currentConfig.Exporters[exporterName] = GenericMap{
 		"endpoint": "${MW_TARGET}",
 		"headers": GenericMap{

--- a/common/config/newrelic.go
+++ b/common/config/newrelic.go
@@ -23,7 +23,7 @@ func (n *NewRelic) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) 
 		return nil, errors.New("New relic endpoint not specified, gateway will not be configured for New Relic")
 	}
 
-	exporterName := "otlp/newrelic-" + dest.GetID()
+	exporterName := "otlp_grpc/newrelic-" + dest.GetID()
 	currentConfig.Exporters[exporterName] = GenericMap{
 		"endpoint": fmt.Sprintf("%s:4317", endpoint),
 		"headers": GenericMap{

--- a/common/config/observe.go
+++ b/common/config/observe.go
@@ -24,7 +24,7 @@ func (j *Observe) ModifyConfig(dest ExporterConfigurer, cfg *Config) ([]string, 
 		return nil, errorMissingKey(OBSERVE_CUSTOMER_ID)
 	}
 
-	exporterName := "otlphttp/" + uniqueUri
+	exporterName := "otlp_http/" + uniqueUri
 	cfg.Exporters[exporterName] = GenericMap{
 		"endpoint": "https://" + customerId + ".collect.observeinc.com/v2/otel",
 		"headers": GenericMap{

--- a/common/config/oneuptime.go
+++ b/common/config/oneuptime.go
@@ -17,7 +17,7 @@ func (j *OneUptime) DestType() common.DestinationType {
 func (j *OneUptime) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) ([]string, error) {
 	uniqueUri := "oneuptime-" + dest.GetID()
 
-	exporterName := "otlphttp/" + uniqueUri
+	exporterName := "otlp_http/" + uniqueUri
 	exporterConfig := GenericMap{
 		"endpoint": "https://oneuptime.com/otlp",
 		"encoding": "json",

--- a/common/config/openobserve.go
+++ b/common/config/openobserve.go
@@ -31,7 +31,7 @@ func (j *OpenObserve) ModifyConfig(dest ExporterConfigurer, currentConfig *Confi
 		return nil, errorMissingKey(OPEN_OBSERVE_STREAM_NAME)
 	}
 
-	exporterName := "otlphttp/" + uniqueUri
+	exporterName := "otlp_http/" + uniqueUri
 	currentConfig.Exporters[exporterName] = GenericMap{
 		"endpoint": endpoint,
 		"headers": GenericMap{

--- a/common/config/oracle.go
+++ b/common/config/oracle.go
@@ -32,7 +32,7 @@ func (j *Oracle) ModifyConfig(dest ExporterConfigurer, cfg *Config) ([]string, e
 		return nil, err
 	}
 
-	exporterName := "otlphttp/" + uniqueUri
+	exporterName := "otlp_http/" + uniqueUri
 	exporterConfig := GenericMap{
 		"endpoint": endpoint,
 		"headers": GenericMap{

--- a/common/config/otlphttp.go
+++ b/common/config/otlphttp.go
@@ -87,7 +87,7 @@ func (g *OTLPHttp) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) 
 		currentConfig.Service.Extensions = append(currentConfig.Service.Extensions, authExtensionName)
 	}
 
-	otlpHttpExporterName := "otlphttp/generic-" + dest.GetID()
+	otlpHttpExporterName := "otlp_http/generic-" + dest.GetID()
 	exporterConf := GenericMap{}
 	if parsedBase != "" {
 		exporterConf["endpoint"] = parsedBase

--- a/common/config/otlphttp_test.go
+++ b/common/config/otlphttp_test.go
@@ -364,7 +364,7 @@ func TestOAuth2Configuration(t *testing.T) {
 			assert.NotEmpty(t, pipelineNames)
 
 			// Check exporter configuration
-			exporterName := "otlphttp/generic-test-id"
+			exporterName := "otlp_http/generic-test-id"
 			assert.Contains(t, config.Exporters, exporterName)
 			exporterConfig := config.Exporters[exporterName].(GenericMap)
 

--- a/common/config/qryn.go
+++ b/common/config/qryn.go
@@ -76,7 +76,7 @@ func (g *Qryn) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) ([]s
 	otlpHttpExporterName := ""
 	otlpHttpExporter := GenericMap{}
 	if isTracingEnabled(dest) {
-		otlpHttpExporterName = "otlphttp/qryn-" + dest.GetID()
+		otlpHttpExporterName = "otlp_http/qryn-" + dest.GetID()
 		otlpHttpExporter["traces_endpoint"] = fmt.Sprintf("%s/v1/traces", baseURL)
 		otlpHttpExporter["encoding"] = "proto"
 		otlpHttpExporter["compression"] = "none"
@@ -96,7 +96,7 @@ func (g *Qryn) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) ([]s
 	}
 
 	if isLoggingEnabled(dest) {
-		otlpHttpExporterName = "otlphttp/qryn-" + dest.GetID()
+		otlpHttpExporterName = "otlp_http/qryn-" + dest.GetID()
 		otlpHttpExporter["logs_endpoint"] = fmt.Sprintf("%s/v1/logs", baseURL)
 		logsPipelineName := "logs/qryn-" + dest.GetID()
 		otlpHttpExporter["encoding"] = "proto"

--- a/common/config/quickwit.go
+++ b/common/config/quickwit.go
@@ -18,7 +18,7 @@ func (e *Quickwit) DestType() common.DestinationType {
 
 func (e *Quickwit) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) ([]string, error) {
 	if url, exists := dest.GetConfig()[qwUrlKey]; exists {
-		exporterName := "otlp/quickwit-" + dest.GetID()
+		exporterName := "otlp_grpc/quickwit-" + dest.GetID()
 
 		currentConfig.Exporters[exporterName] = GenericMap{
 			"endpoint": url,

--- a/common/config/root_test.go
+++ b/common/config/root_test.go
@@ -442,7 +442,7 @@ func TestCalculateDataStreamMissingDestinatin(t *testing.T) {
 					"metrics/otelcol": {
 						Receivers:  []string{"prometheus/self-metrics"},
 						Processors: []string{"resource/pod-name"},
-						Exporters:  []string{"otlp/odigos-own-telemetry-ui"},
+						Exporters:  []string{"otlp_grpc/odigos-own-telemetry-ui"},
 					},
 				},
 				Extensions: []string{},

--- a/common/config/seq.go
+++ b/common/config/seq.go
@@ -29,7 +29,7 @@ func (j *Seq) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) ([]st
 		return nil, err
 	}
 
-	exporterName := "otlphttp/" + uniqueUri
+	exporterName := "otlp_http/" + uniqueUri
 	currentConfig.Exporters[exporterName] = GenericMap{
 		"endpoint": endpoint,
 		"headers": GenericMap{

--- a/common/config/signoz.go
+++ b/common/config/signoz.go
@@ -30,7 +30,7 @@ func (s *Signoz) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) ([
 
 	url = strings.TrimPrefix(url, "http://")
 	url = strings.TrimSuffix(url, ":4317")
-	signozExporterName := "otlp/signoz-" + dest.GetID()
+	signozExporterName := "otlp_grpc/signoz-" + dest.GetID()
 	currentConfig.Exporters[signozExporterName] = GenericMap{
 		"endpoint": fmt.Sprintf("%s:4317", url),
 		"tls": GenericMap{

--- a/common/config/splunk.go
+++ b/common/config/splunk.go
@@ -78,7 +78,7 @@ func (s *SplunkOTLP) ModifyConfig(dest ExporterConfigurer, currentConfig *Config
 
 	var pipelineNames []string
 	if isTracingEnabled(dest) {
-		exporterName := "otlphttp/" + dest.GetID()
+		exporterName := "otlp_http/" + dest.GetID()
 		exporterConf := GenericMap{
 			"headers": GenericMap{
 				"X-SF-Token": "${SPLUNK_ACCESS_TOKEN}",

--- a/common/config/sumologic.go
+++ b/common/config/sumologic.go
@@ -11,7 +11,7 @@ func (s *SumoLogic) DestType() common.DestinationType {
 }
 
 func (s *SumoLogic) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) ([]string, error) {
-	exporterName := "otlphttp/sumologic-" + dest.GetID()
+	exporterName := "otlp_http/sumologic-" + dest.GetID()
 	currentConfig.Exporters[exporterName] = GenericMap{
 		"endpoint": "${SUMOLOGIC_COLLECTION_URL}",
 	}

--- a/common/config/telemetryhub.go
+++ b/common/config/telemetryhub.go
@@ -14,7 +14,7 @@ func (j *TelemetryHub) ModifyConfig(dest ExporterConfigurer, cfg *Config) ([]str
 	uniqueUri := "telemetryhub-" + dest.GetID()
 	var pipelineNames []string
 
-	exporterName := "otlp/" + uniqueUri
+	exporterName := "otlp_grpc/" + uniqueUri
 	cfg.Exporters[exporterName] = GenericMap{
 		"endpoint": "https://otlp.telemetryhub.com:4317",
 		"headers": GenericMap{

--- a/common/config/tempo.go
+++ b/common/config/tempo.go
@@ -40,7 +40,7 @@ func (t *Tempo) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) ([]
 			endpoint = fmt.Sprintf("%s:4317", url)
 		}
 
-		tempoExporterName := "otlp/tempo-" + dest.GetID()
+		tempoExporterName := "otlp_grpc/tempo-" + dest.GetID()
 		currentConfig.Exporters[tempoExporterName] = GenericMap{
 			"endpoint": endpoint,
 			"tls": GenericMap{

--- a/common/config/testdata/sourcesnodest.yaml
+++ b/common/config/testdata/sourcesnodest.yaml
@@ -18,7 +18,7 @@ service:
       processors:
       - resource/pod-name
       exporters:
-      - otlp/odigos-own-telemetry-ui
+      - otlp_grpc/odigos-own-telemetry-ui
   telemetry:
     metrics:
       level: ""

--- a/common/config/tingyun.go
+++ b/common/config/tingyun.go
@@ -29,7 +29,7 @@ func (j *Tingyun) ModifyConfig(dest ExporterConfigurer, cfg *Config) ([]string, 
 		return nil, err
 	}
 
-	exporterName := "otlphttp/" + uniqueUri
+	exporterName := "otlp_http/" + uniqueUri
 	cfg.Exporters[exporterName] = GenericMap{
 		"endpoint": endpoint,
 	}

--- a/common/config/traceloop.go
+++ b/common/config/traceloop.go
@@ -33,7 +33,7 @@ func (j *Traceloop) ModifyConfig(dest ExporterConfigurer, currentConfig *Config)
 		return nil, err
 	}
 
-	exporterName := "otlphttp/" + uniqueUri
+	exporterName := "otlp_http/" + uniqueUri
 	exporterConfig := GenericMap{
 		"endpoint": endpoint,
 		"headers": GenericMap{

--- a/common/config/uptrace.go
+++ b/common/config/uptrace.go
@@ -31,7 +31,7 @@ func (s *Uptrace) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) (
 	}
 
 	isHttpEndpoint := strings.HasPrefix(endpoint, "http://")
-	exporterName := "otlp/uptrace-" + dest.GetID()
+	exporterName := "otlp_grpc/uptrace-" + dest.GetID()
 
 	currentConfig.Exporters[exporterName] = GenericMap{
 		"endpoint": endpoint,

--- a/common/config/victoriametricscloud.go
+++ b/common/config/victoriametricscloud.go
@@ -35,7 +35,7 @@ func (j *VictoriaMetricsCloud) ModifyConfig(dest ExporterConfigurer, cfg *Config
 	}
 	cfg.Service.Extensions = append(cfg.Service.Extensions, authExtensionName)
 
-	exporterName := "otlphttp/" + uniqueUri
+	exporterName := "otlp_http/" + uniqueUri
 	cfg.Exporters[exporterName] = GenericMap{
 		"endpoint": endpoint,
 		"auth": GenericMap{

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -3,11 +3,14 @@ gqlgen:
 
 TOOLS := $(PWD)/.tools
 
-.PHONY: tools
+.PHONY: tools test
 tools:
 	@if [ ! -d "$(TOOLS)" ]; then \
 		mkdir $(TOOLS); \
 	fi
+
+test:
+	go test -v ./...
 
 .PHONY: go-licenses
 go-licenses: tools

--- a/frontend/go.mod
+++ b/frontend/go.mod
@@ -124,7 +124,7 @@ require (
 	go.opentelemetry.io/collector/config/confignet v1.54.0
 	go.opentelemetry.io/collector/config/configopaque v1.54.0 // indirect
 	go.opentelemetry.io/collector/config/configretry v1.54.0 // indirect
-	go.opentelemetry.io/collector/config/configtls v1.54.0 // indirect
+	go.opentelemetry.io/collector/config/configtls v1.54.0
 	go.opentelemetry.io/collector/consumer v1.54.0
 	go.opentelemetry.io/collector/extension v1.54.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.54.0 // indirect
@@ -183,7 +183,7 @@ require (
 	go.opentelemetry.io/collector/component/componentstatus v0.148.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.148.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.148.0 // indirect
-	go.opentelemetry.io/collector/consumer/consumertest v0.148.0 // indirect
+	go.opentelemetry.io/collector/consumer/consumertest v0.148.0
 	go.opentelemetry.io/collector/consumer/xconsumer v0.148.0 // indirect
 	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.148.0 // indirect
 	go.opentelemetry.io/collector/exporter/xexporter v0.148.0 // indirect

--- a/frontend/services/test_connection/otlp_test_connection.go
+++ b/frontend/services/test_connection/otlp_test_connection.go
@@ -32,7 +32,7 @@ func (t *otlpExporterConnectionTester) ModifyConfigForConnectionTest(cfg compone
 
 	// currently using the default timeout config of the collector - 5 seconds
 	// Avoid batching and retries (QueueBatchConfig zero value has enabled: false)
-	otlpConf.QueueConfig = configoptional.Some(exporterhelper.QueueBatchConfig{})
+	otlpConf.QueueConfig = configoptional.None[exporterhelper.QueueBatchConfig]()
 	otlpConf.RetryConfig.Enabled = false
 	return otlpConf
 }

--- a/frontend/services/test_connection/otlp_test_connection_test.go
+++ b/frontend/services/test_connection/otlp_test_connection_test.go
@@ -1,0 +1,116 @@
+package testconnection
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configgrpc"
+	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/config/configoptional"
+	"go.opentelemetry.io/collector/config/configtls"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/exporter/otlpexporter"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/receiver/otlpreceiver"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+)
+
+func freePort(t *testing.T) string {
+	t.Helper()
+	// let the port number to be assigned by the OS
+	l, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+	addr := l.Addr().String()
+	require.NoError(t, l.Close())
+	return addr
+}
+
+// startNoOpOTLPReceiver spins up an OTLP gRPC receiver backed by a no-op
+// consumer and returns the address it is listening on plus a teardown func.
+func startNoOpOTLPReceiver(t *testing.T, ctx context.Context, endpoint string) {
+	t.Helper()
+
+	f := otlpreceiver.NewFactory()
+	cfg := f.CreateDefaultConfig().(*otlpreceiver.Config)
+	cfg.GRPC = configoptional.Some(configgrpc.ServerConfig{
+		NetAddr: confignet.AddrConfig{
+			Endpoint:  endpoint,
+			Transport: confignet.TransportTypeTCP,
+		},
+	})
+	cfg.HTTP = configoptional.None[otlpreceiver.HTTPConfig]()
+
+	sink := new(consumertest.TracesSink)
+	r, err := f.CreateTraces(ctx, receivertest.NewNopSettings(f.Type()), cfg, sink)
+	require.NoError(t, err)
+
+	require.NoError(t, r.Start(ctx, componenttest.NewNopHost()))
+	t.Cleanup(func() { require.NoError(t, r.Shutdown(ctx)) })
+}
+
+func TestOTLPConnectionSuccess(t *testing.T) {
+	ctx := context.Background()
+	endpoint := freePort(t)
+
+	startNoOpOTLPReceiver(t, ctx, endpoint)
+
+	tester := NewOTLPTester()
+
+	factory := tester.Factory()
+	require.NotNil(t, factory)
+
+	defaultCfg := factory.CreateDefaultConfig()
+	modifiedCfg := tester.ModifyConfigForConnectionTest(defaultCfg)
+	require.NotNil(t, modifiedCfg)
+
+	otlpCfg, ok := modifiedCfg.(*otlpexporter.Config)
+	require.True(t, ok)
+
+	otlpCfg.ClientConfig = configgrpc.ClientConfig{
+		Endpoint: endpoint,
+		TLS: configtls.ClientConfig{
+			Insecure: true,
+		},
+	}
+
+	exp, err := factory.CreateTraces(ctx, exportertest.NewNopSettings(factory.Type()), otlpCfg)
+	require.NoError(t, err)
+
+	require.NoError(t, exp.Start(ctx, componenttest.NewNopHost()))
+	t.Cleanup(func() { require.NoError(t, exp.Shutdown(ctx)) })
+
+	require.NoError(t, exp.ConsumeTraces(ctx, ptrace.NewTraces()))
+}
+
+func TestOTLPConnectionRefused(t *testing.T) {
+	ctx := context.Background()
+	// Use a port with nothing listening on it.
+	endpoint := freePort(t)
+
+	tester := NewOTLPTester()
+
+	factory := tester.Factory()
+	defaultCfg := factory.CreateDefaultConfig()
+	modifiedCfg := tester.ModifyConfigForConnectionTest(defaultCfg)
+
+	otlpCfg := modifiedCfg.(*otlpexporter.Config)
+	otlpCfg.ClientConfig = configgrpc.ClientConfig{
+		Endpoint: endpoint,
+		TLS: configtls.ClientConfig{
+			Insecure: true,
+		},
+	}
+
+	exp, err := factory.CreateTraces(ctx, exportertest.NewNopSettings(factory.Type()), otlpCfg)
+	require.NoError(t, err)
+
+	require.NoError(t, exp.Start(ctx, componenttest.NewNopHost()))
+	t.Cleanup(func() { require.NoError(t, exp.Shutdown(ctx)) })
+
+	err = exp.ConsumeTraces(ctx, ptrace.NewTraces())
+	require.Error(t, err, "expected connection refused when no server is running")
+}

--- a/frontend/services/test_connection/otlphttp_test_connection.go
+++ b/frontend/services/test_connection/otlphttp_test_connection.go
@@ -31,8 +31,7 @@ func (t *otlphttpExporterConnectionTester) ModifyConfigForConnectionTest(cfg com
 	}
 
 	// currently using the default timeout config of the collector - 5 seconds
-	// Avoid batching and retries (QueueBatchConfig zero value has enabled: false)
-	otlpConf.QueueConfig = configoptional.Some(exporterhelper.QueueBatchConfig{})
+	otlpConf.QueueConfig = configoptional.None[exporterhelper.QueueBatchConfig]()
 	otlpConf.RetryConfig.Enabled = false
 	return otlpConf
 }

--- a/frontend/services/test_connection/otlphttp_test_connection_test.go
+++ b/frontend/services/test_connection/otlphttp_test_connection_test.go
@@ -1,0 +1,102 @@
+package testconnection
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configgrpc"
+	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/config/configoptional"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/receiver/otlpreceiver"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+)
+
+// startNoOpOTLPHTTPReceiver spins up an OTLP HTTP receiver backed by a no-op
+// consumer and returns the address it is listening on.
+func startNoOpOTLPHTTPReceiver(t *testing.T, ctx context.Context, endpoint string) {
+	t.Helper()
+
+	f := otlpreceiver.NewFactory()
+	cfg := f.CreateDefaultConfig().(*otlpreceiver.Config)
+	cfg.GRPC = configoptional.None[configgrpc.ServerConfig]()
+
+	httpCfg := cfg.HTTP.GetOrInsertDefault()
+	httpCfg.ServerConfig.NetAddr = confignet.AddrConfig{
+		Endpoint:  endpoint,
+		Transport: confignet.TransportTypeTCP,
+	}
+
+	sink := new(consumertest.TracesSink)
+	r, err := f.CreateTraces(ctx, receivertest.NewNopSettings(f.Type()), cfg, sink)
+	require.NoError(t, err)
+
+	require.NoError(t, r.Start(ctx, componenttest.NewNopHost()))
+	t.Cleanup(func() { require.NoError(t, r.Shutdown(ctx)) })
+}
+
+func TestOTLPHTTPConnectionSuccess(t *testing.T) {
+	ctx := context.Background()
+	endpoint := freePort(t)
+
+	startNoOpOTLPHTTPReceiver(t, ctx, endpoint)
+
+	tester := NewOTLPHTTPTester()
+
+	factory := tester.Factory()
+	require.NotNil(t, factory)
+
+	defaultCfg := factory.CreateDefaultConfig()
+	modifiedCfg := tester.ModifyConfigForConnectionTest(defaultCfg)
+	require.NotNil(t, modifiedCfg)
+
+	httpCfg, ok := modifiedCfg.(*otlphttpexporter.Config)
+	require.True(t, ok)
+
+	httpCfg.ClientConfig.Endpoint = fmt.Sprintf("http://%s", endpoint)
+
+	exp, err := factory.CreateTraces(ctx, exportertest.NewNopSettings(factory.Type()), httpCfg)
+	require.NoError(t, err)
+
+	require.NoError(t, exp.Start(ctx, componenttest.NewNopHost()))
+	t.Cleanup(func() { require.NoError(t, exp.Shutdown(ctx)) })
+
+	require.NoError(t, exp.ConsumeTraces(ctx, ptrace.NewTraces()))
+}
+
+func TestOTLPHTTPConnectionRefused(t *testing.T) {
+	ctx := context.Background()
+	endpoint := freePort(t)
+
+	tester := NewOTLPHTTPTester()
+
+	factory := tester.Factory()
+	defaultCfg := factory.CreateDefaultConfig()
+	modifiedCfg := tester.ModifyConfigForConnectionTest(defaultCfg)
+
+	httpCfg := modifiedCfg.(*otlphttpexporter.Config)
+	httpCfg.ClientConfig.Endpoint = fmt.Sprintf("http://%s", endpoint)
+
+	exp, err := factory.CreateTraces(ctx, exportertest.NewNopSettings(factory.Type()), httpCfg)
+	require.NoError(t, err)
+
+	require.NoError(t, exp.Start(ctx, componenttest.NewNopHost()))
+	t.Cleanup(func() { require.NoError(t, exp.Shutdown(ctx)) })
+
+	err = exp.ConsumeTraces(ctx, ptrace.NewTraces())
+	require.Error(t, err, "expected connection refused when no server is running")
+}
+
+func TestHTTPModifyConfigForConnectionTest_WrongType(t *testing.T) {
+	tester := NewOTLPHTTPTester()
+	result := tester.ModifyConfigForConnectionTest(&dummyHTTPConfig{})
+	require.Nil(t, result, "should return nil for non-otlphttp config")
+}
+
+type dummyHTTPConfig struct{}

--- a/frontend/services/test_connection/test_connection.go
+++ b/frontend/services/test_connection/test_connection.go
@@ -23,8 +23,8 @@ import (
 var (
 	configres         map[common.DestinationType]config.Configer
 	connectionTesters = []ExporterConnectionTester{
-		NewOTLPTester(),     // "otlp/" prefix
-		NewOTLPHTTPTester(), // "otlphttp/" prefix
+		NewOTLPTester(),     // "otlp_grpc/" prefix
+		NewOTLPHTTPTester(), // "otlp_http/" prefix
 	}
 )
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->

Upstream collector added https://github.com/open-telemetry/opentelemetry-collector/issues/14396 which changes the renaming of otlp exporters. This cause our test connection util to break.
* Align otlp exportes to new naming.
* Add tests for test_connection for otlp and otlphttp.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
fix: test connection for otlp and otlphttp destinations after collector upgrade
```

cherry-pick:v1.24
