### PR TITLE
ci: use the git config user for cherry pick

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -219,6 +219,9 @@ jobs:
 
           git fetch origin main
 
+          git config user.name "$(git log -1 --format='%an' "$MERGE_COMMIT")"
+          git config user.email "$(git log -1 --format='%ae' "$MERGE_COMMIT")"
+
           PARENT_COUNT=$(git rev-list --parents -n 1 "$MERGE_COMMIT" 2>/dev/null | awk '{print NF-1}' || echo 0)
           if [[ "$PARENT_COUNT" -gt 1 ]]; then
             echo "Merge commit detected; using cherry-pick -m 1"


### PR DESCRIPTION
#### What this PR does / why we need it:

resolve:

```
Committer identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
```

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```

cherry-pick: v1.24

emergency-ticket id: EMR-1503
