### PR TITLE
fix: broken autoscaler tests

### DIFF
--- a/autoscaler/controllers/nodecollector/testdata/logs_included.yaml
+++ b/autoscaler/controllers/nodecollector/testdata/logs_included.yaml
@@ -169,7 +169,7 @@ service:
       - filelog
     metrics:
       exporters:
-        - otlp_grpc/out-cluster-collector-metrics
+      - otlp_grpc/out-cluster-collector-metrics
       processors:
       - batch
       - memory_limiter
@@ -184,7 +184,7 @@ service:
       - hostmetrics
     metrics/own-metrics-ui:
       exporters:
-        - otlp_grpc/odigos-own-telemetry-ui
+      - otlp_grpc/odigos-own-telemetry-ui
       processors:
       - resource/pod-name
       - resource/odigos-collector-role

--- a/autoscaler/controllers/nodecollector/testdata/traces_only_no_loadbalancing.yaml
+++ b/autoscaler/controllers/nodecollector/testdata/traces_only_no_loadbalancing.yaml
@@ -101,7 +101,7 @@ service:
   pipelines:
     metrics/own-metrics-ui:
       exporters:
-        - otlp_grpc/odigos-own-telemetry-ui
+      - otlp_grpc/odigos-own-telemetry-ui
       processors:
       - resource/pod-name
       - resource/odigos-collector-role
@@ -109,7 +109,7 @@ service:
       - prometheus/self-metrics-ui
     traces:
       exporters:
-        - otlp_grpc/out-cluster-collector-traces
+      - otlp_grpc/out-cluster-collector-traces
       processors:
       - batch
       - memory_limiter


### PR DESCRIPTION
#### What this PR does / why we need it:
https://github.com/odigos-io/odigos/pull/4640 added some extra spaces in the yaml fixtures, which broke build-and-test-autoscaler (see https://github.com/odigos-io/odigos/actions/runs/24509895534/job/71666942008?pr=4637 example)

will also push to https://github.com/odigos-io/odigos/pull/4645

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```

emergency-ticket id: EMR-1502
