### PR TITLE
CORE-000 | fix(helm): propagate per-component logLevel to effective config ConfigMap

### DIFF
--- a/helm/odigos/templates/odigos-configuration-cm.yaml
+++ b/helm/odigos/templates/odigos-configuration-cm.yaml
@@ -15,6 +15,21 @@ data:
     configVersion: 1
     componentLogLevels:
       default: {{ .Values.logLevel | default "info" }}
+      {{- if .Values.autoscaler.logLevel }}
+      autoscaler: {{ .Values.autoscaler.logLevel }}
+      {{- end }}
+      {{- if .Values.scheduler.logLevel }}
+      scheduler: {{ .Values.scheduler.logLevel }}
+      {{- end }}
+      {{- if .Values.instrumentor.logLevel }}
+      instrumentor: {{ .Values.instrumentor.logLevel }}
+      {{- end }}
+      {{- if .Values.odiglet.logLevel }}
+      odiglet: {{ .Values.odiglet.logLevel }}
+      {{- end }}
+      {{- if .Values.ui.logLevel }}
+      ui: {{ .Values.ui.logLevel }}
+      {{- end }}
     {{- if .Values.clusterName }}
     clusterName: {{ .Values.clusterName }}
     {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
The LogLevelReconciler watches the odigos-configuration ConfigMap and calls SetLevel with the resolved component log level. Previously only the global default was written, so per-component overrides like autoscaler.logLevel=debug were set via `ODIGOS_LOG_LEVEL` at startup but immediately reset to info by the reconciler.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below. If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```