### PR TITLE
CORE-919: CLI will not assume flag --onprem-token is provided for any pro command and will exit gracefully without go panic

### DIFF
--- a/cli/cmd/pro.go
+++ b/cli/cmd/pro.go
@@ -51,7 +51,6 @@ var proCmd = &cobra.Command{
 		client := cmdcontext.KubeClientFromContextOrExit(ctx)
 
 		onPremToken := cmd.Flag("onprem-token").Value.String()
-
 		ns, err := resources.GetOdigosNamespace(client, ctx)
 		if resources.IsErrNoOdigosNamespaceFound(err) {
 			fmt.Println("\033[31mERROR\033[0m no odigos installation found in the current cluster")
@@ -391,6 +390,8 @@ func init() {
 	rootCmd.AddCommand(proCmd)
 
 	proCmd.AddCommand(offsetsCmd)
+	proCmd.Flags().String("onprem-token", "", "On-prem token for Odigos")
+	proCmd.MarkFlagRequired("onprem-token")
 	offsetsCmd.Flags().BoolVar(&useDefault, "default", false, "revert to using the default offsets data shipped with the current version of Odigos")
 	offsetsCmd.Flags().StringVar(&downloadFile, "download-file", "", "download the offsets file to the specified location without updating the cluster")
 	offsetsCmd.Flags().StringVar(&fromFile, "from-file", "", "use the offsets file from the specified location instead of downloading it")

--- a/docs/snippets/shared/cli/odigos_pro.mdx
+++ b/docs/snippets/shared/cli/odigos_pro.mdx
@@ -28,7 +28,8 @@ odigos pro --onprem-token <token>
 ### Options
 
 ```
-  -h, --help   help for pro
+  -h, --help                  help for pro
+      --onprem-token string   On-prem token for Odigos
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
… pro command

#### What this PR does / why we need it:
<!--
This PR fixes the panic when running odigos pro command running without --onprem-token required flag.
Instead of panic, the user will get an error with the pro command help output.
-->

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```

cherry-pick: v1.24
