### PR TITLE
Update PHP community agent version to v0.3.2 in Dockerfiles

### DIFF
--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -54,7 +54,7 @@ COPY --from=public.ecr.aws/odigos/agents/nodejs-community-14:v0.0.17 /instrument
 COPY --from=dotnet-builder /dotnet-instrumentation /instrumentations/dotnet
 
 # php-community
-COPY --from=public.ecr.aws/odigos/agents/php-community:v0.3.0 /instrumentations/php /instrumentations/php
+COPY --from=public.ecr.aws/odigos/agents/php-community:v0.3.2 /instrumentations/php /instrumentations/php
 
 # ruby-community
 COPY --from=public.ecr.aws/odigos/agents/ruby-community:v0.0.8 /instrumentations/ruby /instrumentations/ruby

--- a/odiglet/debug.Dockerfile
+++ b/odiglet/debug.Dockerfile
@@ -76,7 +76,7 @@ COPY --from=public.ecr.aws/odigos/agents/nodejs-community-14:v0.0.17 /instrument
 COPY --from=dotnet-builder /dotnet-instrumentation /instrumentations/dotnet
 
 # php-community
-COPY --from=public.ecr.aws/odigos/agents/php-community:v0.3.0 /instrumentations/php /instrumentations/php
+COPY --from=public.ecr.aws/odigos/agents/php-community:v0.3.2 /instrumentations/php /instrumentations/php
 
 # ruby-community
 COPY --from=public.ecr.aws/odigos/agents/ruby-community:v0.0.8 /instrumentations/ruby /instrumentations/ruby


### PR DESCRIPTION
```release-note
Update PHP community agent version to v0.3.2 in Dockerfiles
```

cherry-pick: v1.23, v1.24

emergency-ticket id: EMR-1555
