### PR TITLE
fix: propgate auto-detected kubelet health probes to tail sampling

### DIFF
--- a/instrumentor/controllers/agentenabled/sampling/headsampling.go
+++ b/instrumentor/controllers/agentenabled/sampling/headsampling.go
@@ -136,14 +136,8 @@ func calculateKubeletHealthProbesSamplingRules(effectiveConfig *common.OdigosCon
 	return noisyOperations
 }
 
-// givin a specific container in a workload, matched to a distro, calculate it's head sampling based on odigos config and sampling rules.
-func CalculateHeadSamplingConfig(distro *distro.OtelDistro, workloadObj workload.Workload, containerName string, effectiveConfig *common.OdigosConfiguration, samplingRules *[]odigosv1.Sampling, pw k8sconsts.PodWorkload) *odigosv1.HeadSamplingConfig {
-
-	// only calculate head sampling config if the distro supports it
-	if distro.Traces == nil || distro.Traces.HeadSampling == nil || !distro.Traces.HeadSampling.Supported {
-		return nil
-	}
-
+// given a specific container in a workload, matched to a distro, calculate it's head sampling based on odigos config and sampling rules.
+func CalculateNoisyOperationsForContainer(distro *distro.OtelDistro, workloadObj workload.Workload, containerName string, effectiveConfig *common.OdigosConfiguration, samplingRules *[]odigosv1.Sampling, pw k8sconsts.PodWorkload) []commonapisampling.NoisyOperation {
 	kubeletHealthProbesRules := calculateKubeletHealthProbesSamplingRules(effectiveConfig, workloadObj, containerName)
 	customSamplingRules := getRelevantNoisyOperations(samplingRules, pw, containerName, distro)
 
@@ -165,6 +159,23 @@ func CalculateHeadSamplingConfig(distro *distro.OtelDistro, workloadObj workload
 		}
 		return strings.Compare(a.Id, b.Id)
 	})
+
+	return noisyOperations
+}
+
+// givin a specific container in a workload, matched to a distro, calculate it's head sampling based on odigos config and sampling rules.
+func CalculateHeadSamplingConfig(distro *distro.OtelDistro, workloadObj workload.Workload, containerName string, effectiveConfig *common.OdigosConfiguration, samplingRules *[]odigosv1.Sampling, pw k8sconsts.PodWorkload) *odigosv1.HeadSamplingConfig {
+
+	// only calculate head sampling config if the distro supports it
+	if distro.Traces == nil || distro.Traces.HeadSampling == nil || !distro.Traces.HeadSampling.Supported {
+		return nil
+	}
+
+	noisyOperations := CalculateNoisyOperationsForContainer(distro, workloadObj, containerName, effectiveConfig, samplingRules, pw)
+
+	if len(noisyOperations) == 0 {
+		return nil
+	}
 
 	return &odigosv1.HeadSamplingConfig{
 		NoisyOperations: noisyOperations,

--- a/instrumentor/controllers/agentenabled/sampling/tailsampling.go
+++ b/instrumentor/controllers/agentenabled/sampling/tailsampling.go
@@ -6,10 +6,11 @@ import (
 	"github.com/odigos-io/odigos/common"
 	apisampling "github.com/odigos-io/odigos/common/api/sampling"
 	"github.com/odigos-io/odigos/distros/distro"
+	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
 )
 
 func FilterTailSamplingRulesForContainer(samplingRules *[]odigosv1.Sampling, language common.ProgrammingLanguage,
-	pw k8sconsts.PodWorkload, containerName string, distro *distro.OtelDistro) ([]apisampling.NoisyOperation, []apisampling.HighlyRelevantOperation, []apisampling.CostReductionRule) {
+	pw k8sconsts.PodWorkload, containerName string, distro *distro.OtelDistro, workloadObj workload.Workload, effectiveConfig *common.OdigosConfiguration) ([]apisampling.NoisyOperation, []apisampling.HighlyRelevantOperation, []apisampling.CostReductionRule) {
 
 	var filteredNoisyOps []apisampling.NoisyOperation
 	var filteredRelevantOps []apisampling.HighlyRelevantOperation
@@ -21,17 +22,7 @@ func FilterTailSamplingRulesForContainer(samplingRules *[]odigosv1.Sampling, lan
 
 		// If the distro not supports head sampling, we need the NoisyOperations to be applied at the collector level (tailsampling).
 		if distro.Traces == nil || distro.Traces.HeadSampling == nil || !distro.Traces.HeadSampling.Supported {
-			for _, noisyOp := range samplingRule.Spec.NoisyOperations {
-				if IsServiceInRuleScope(noisyOp.SourceScopes, pw, containerName, language) {
-					filteredNoisyOps = append(filteredNoisyOps, apisampling.NoisyOperation{
-						Id:               odigosv1.ComputeNoisyOperationHash(&noisyOp),
-						Name:             noisyOp.Name,
-						Disabled:         noisyOp.Disabled,
-						Operation:        noisyOp.Operation,
-						PercentageAtMost: noisyOp.PercentageAtMost,
-					})
-				}
-			}
+			filteredNoisyOps = CalculateNoisyOperationsForContainer(distro, workloadObj, containerName, effectiveConfig, samplingRules, pw)
 		}
 
 		// Filter and convert HighlyRelevantOperations - exclude SourceScopes and Notes

--- a/instrumentor/controllers/agentenabled/sync.go
+++ b/instrumentor/controllers/agentenabled/sync.go
@@ -235,7 +235,7 @@ func updateInstrumentationConfigSpec(ctx context.Context, c client.Client, pw k8
 			podManifestInjectionOptional = false
 		}
 		// calculate the relevant collector configurations for the container.
-		currentContainerCollectorConfig := calculateContainerCollectorConfig(containerName, effectiveConfig, containerRuntimeDetails, distroPerLanguage, distroProvider.Getter, containerOverride, urlTemplatizationConfig, samplingRules, pw)
+		currentContainerCollectorConfig := calculateContainerCollectorConfig(containerName, effectiveConfig, containerRuntimeDetails, distroPerLanguage, distroProvider.Getter, containerOverride, urlTemplatizationConfig, samplingRules, pw, workloadObj)
 		if currentContainerCollectorConfig != nil {
 			collectorConfig = append(collectorConfig, *currentContainerCollectorConfig)
 		}
@@ -477,6 +477,7 @@ func calculateContainerCollectorConfig(containerName string,
 	urlTemplatizationConfig *commonapi.UrlTemplatizationConfig,
 	samplingRules *[]odigosv1.Sampling,
 	pw k8sconsts.PodWorkload,
+	workloadObj workload.Workload,
 ) *commonapi.ContainerCollectorConfig {
 
 	// If this container is ignored, runtime details are unavailable, or language is not supported,
@@ -500,7 +501,7 @@ func calculateContainerCollectorConfig(containerName string,
 		return nil
 	}
 
-	noisyOps, relevantOps, costRules := sampling.FilterTailSamplingRulesForContainer(samplingRules, runtimeDetails.Language, pw, containerName, containerDistro)
+	noisyOps, relevantOps, costRules := sampling.FilterTailSamplingRulesForContainer(samplingRules, runtimeDetails.Language, pw, containerName, containerDistro, workloadObj, effectiveConfig)
 
 	return &commonapi.ContainerCollectorConfig{
 		ContainerName: containerName,


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: CORE-925

When we have kubelet health probe enabled, and tail sampling enabled, we want to apply the health-check sampling in tail-sampler for distros that do not support head sampling.

Current config only took the manual noisy-operations rules, but did not use the health-probes for the collector config (tail sampling)

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
sample kubelet health-probe endpoints in tail sampler for languages that do not support head-sampling
```
