### PR TITLE
chore: bump runtime-detector to v0.0.25

### DIFF
--- a/instrumentation/go.mod
+++ b/instrumentation/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/odigos-io/odigos/common v0.0.0
 	github.com/odigos-io/odigos/distros v0.0.0
-	github.com/odigos-io/runtime-detector v0.0.24
+	github.com/odigos-io/runtime-detector v0.0.25
 	go.opentelemetry.io/otel v1.42.0
 	go.opentelemetry.io/otel/metric v1.42.0
 	golang.org/x/sync v0.20.0

--- a/instrumentation/go.sum
+++ b/instrumentation/go.sum
@@ -35,8 +35,8 @@ github.com/mdlayher/netlink v1.7.2 h1:/UtM3ofJap7Vl4QWCPDGXY8d3GIY2UGSDbK+QWmY8/
 github.com/mdlayher/netlink v1.7.2/go.mod h1:xraEF7uJbxLhc5fpHL4cPe221LI2bdttWlU+ZGLfQSw=
 github.com/mdlayher/socket v0.4.1 h1:eM9y2/jlbs1M615oshPQOHZzj6R6wMT7bX5NPiQvn2U=
 github.com/mdlayher/socket v0.4.1/go.mod h1:cAqeGjoufqdxWkD7DkpyS+wcefOtmu5OQ8KuoJGIReA=
-github.com/odigos-io/runtime-detector v0.0.24 h1:5CZqP8JDajoubW0HumGllJdoYK99Jwuq3M28ATmrvrM=
-github.com/odigos-io/runtime-detector v0.0.24/go.mod h1:Iww/+1F0b1mk8/BDsV9kmAOPVotiqgGhDr2vBP6wwgU=
+github.com/odigos-io/runtime-detector v0.0.25 h1:/pYFIK/oEIYiLECHUmD9Z8r3+hYNzHDZkwfwLEcwWhE=
+github.com/odigos-io/runtime-detector v0.0.25/go.mod h1:Iww/+1F0b1mk8/BDsV9kmAOPVotiqgGhDr2vBP6wwgU=
 github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns=
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=

--- a/odiglet/go.mod
+++ b/odiglet/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/odigos-io/odigos/k8sutils v0.0.0
 	github.com/odigos-io/odigos/opampserver v0.0.0-00010101000000-000000000000
 	github.com/odigos-io/odigos/procdiscovery v0.0.0-00010101000000-000000000000
-	github.com/odigos-io/runtime-detector v0.0.24
+	github.com/odigos-io/runtime-detector v0.0.25
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/auto v0.21.0
 	go.opentelemetry.io/otel v1.42.0

--- a/odiglet/go.sum
+++ b/odiglet/go.sum
@@ -120,8 +120,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/odigos-io/runtime-detector v0.0.24 h1:5CZqP8JDajoubW0HumGllJdoYK99Jwuq3M28ATmrvrM=
-github.com/odigos-io/runtime-detector v0.0.24/go.mod h1:Iww/+1F0b1mk8/BDsV9kmAOPVotiqgGhDr2vBP6wwgU=
+github.com/odigos-io/runtime-detector v0.0.25 h1:/pYFIK/oEIYiLECHUmD9Z8r3+hYNzHDZkwfwLEcwWhE=
+github.com/odigos-io/runtime-detector v0.0.25/go.mod h1:Iww/+1F0b1mk8/BDsV9kmAOPVotiqgGhDr2vBP6wwgU=
 github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns=
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

CORE-930

```release-note
chore: bump runtime-detector to v0.0.25. fixing race condition in detector start up that can cause a panic.
```
