### PR TITLE
chore: reduce logging of opamp

### DIFF
--- a/k8sutils/pkg/instrumentation_instance/status.go
+++ b/k8sutils/pkg/instrumentation_instance/status.go
@@ -13,7 +13,6 @@ import (
 
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/common/consts"
-	commonlogger "github.com/odigos-io/odigos/common/logger"
 )
 
 const (
@@ -91,9 +90,7 @@ func UpdateInstrumentationInstanceStatus(ctx context.Context, owner client.Objec
 
 		// check if we can create a new instance
 		if instrumentationInstancesCountReachedLimit(ctx, owner, kubeClient) {
-			commonlogger.LoggerCompat().Debug("instrumentation instances count per pod reached limit, skipping creation",
-				"owner", owner.GetName(), "namespace", owner.GetNamespace(), "limit", maxInstrumentationInstancesPerPod)
-			return nil
+			return fmt.Errorf("instrumentation instances count per pod is over the limit of %d", maxInstrumentationInstancesPerPod)
 		}
 
 		// create new instance

--- a/k8sutils/pkg/instrumentation_instance/status.go
+++ b/k8sutils/pkg/instrumentation_instance/status.go
@@ -13,6 +13,7 @@ import (
 
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/common/consts"
+	commonlogger "github.com/odigos-io/odigos/common/logger"
 )
 
 const (
@@ -90,7 +91,9 @@ func UpdateInstrumentationInstanceStatus(ctx context.Context, owner client.Objec
 
 		// check if we can create a new instance
 		if instrumentationInstancesCountReachedLimit(ctx, owner, kubeClient) {
-			return fmt.Errorf("instrumentation instances count per pod is over the limit of %d", maxInstrumentationInstancesPerPod)
+			commonlogger.LoggerCompat().Debug("instrumentation instances count per pod reached limit, skipping creation",
+				"owner", owner.GetName(), "namespace", owner.GetNamespace(), "limit", maxInstrumentationInstancesPerPod)
+			return nil
 		}
 
 		// create new instance

--- a/opampserver/pkg/server/handlers.go
+++ b/opampserver/pkg/server/handlers.go
@@ -46,7 +46,7 @@ func (c *ConnectionHandlers) OnNewConnection(ctx context.Context, firstMessage *
 		// first message must be agent description.
 		// it is, however, possible that the OpAMP server restarted, and the agent is trying to reconnect.
 		// in which case we send back flag and request full status update.
-		c.logger.Info("Agent description is missing in the first OpAMP message, requesting full state update")
+		c.logger.Debug("Agent description is missing in the first OpAMP message, requesting full state update")
 		serverToAgent := &protobufs.ServerToAgent{
 			Flags: uint64(protobufs.ServerToAgentFlags_ServerToAgentFlags_ReportFullState),
 		}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
In some environments, OpAMP server logs are too verbose at the info level, making it harder to focus on important events.
This PR lowers specific OpAMP logs from info to debug, and changes the instrumentation instances count per pod reached limit path to log at debug and return nil instead of an error, after verifying this error was only used for logging.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Reduce OpAMP server log verbosity
```

emergency-ticket id: EMR-1568
