### PR TITLE
fix: optimize workload loading for namespaces query

### DIFF
--- a/frontend/graph/loaders/fetchers.go
+++ b/frontend/graph/loaders/fetchers.go
@@ -16,7 +16,6 @@ import (
 	"github.com/odigos-io/odigos/frontend/kube"
 	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
 	openshiftappsv1 "github.com/openshift/api/apps/v1"
-	"golang.org/x/sync/errgroup"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -416,119 +415,103 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 		}
 	}
 
-	// Cluster-wide manifest listing is the dominant latency cost for large
-	// clusters (6+ cluster-wide LIST operations). Run them in parallel via
-	// errgroup — the cache client is backed by informers and safe for
-	// concurrent reads. At large scale (10K+ workloads, PLAT-958) this turns
-	// a ~multi-second serial load into a max(single-kind) one.
-	g, gctx := errgroup.WithContext(ctx)
-
-	deploymentsMap := make(map[model.K8sWorkloadID]*computed.CachedWorkloadManifest)
-	g.Go(func() error {
-		deploymentsList := &appsv1.DeploymentList{}
-		if err := k8sCacheClient.List(gctx, deploymentsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{})); err != nil {
-			return err
-		}
-		for _, deployment := range deploymentsList.Items {
-			deploymentsMap[model.K8sWorkloadID{
-				Namespace: deployment.Namespace,
-				Kind:      model.K8sResourceKindDeployment,
-				Name:      deployment.Name,
-			}] = &computed.CachedWorkloadManifest{
-				AvailableReplicas:    deployment.Status.AvailableReplicas,
-				Selector:             deployment.Spec.Selector,
-				WorkloadHealthStatus: status.CalculateDeploymentHealthStatus(deployment.Status),
-			}
-		}
-		return nil
-	})
-
-	daemonsMap := make(map[model.K8sWorkloadID]*computed.CachedWorkloadManifest)
-	g.Go(func() error {
-		daemonsetsList := &appsv1.DaemonSetList{}
-		if err := k8sCacheClient.List(gctx, daemonsetsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{})); err != nil {
-			return err
-		}
-		for _, daemonset := range daemonsetsList.Items {
-			daemonsMap[model.K8sWorkloadID{
-				Namespace: daemonset.Namespace,
-				Kind:      model.K8sResourceKindDaemonSet,
-				Name:      daemonset.Name,
-			}] = &computed.CachedWorkloadManifest{
-				AvailableReplicas:    daemonset.Status.NumberReady,
-				Selector:             daemonset.Spec.Selector,
-				WorkloadHealthStatus: status.CalculateDaemonSetHealthStatus(daemonset.Status),
-			}
-		}
-		return nil
-	})
-
-	statefulsetsMap := make(map[model.K8sWorkloadID]*computed.CachedWorkloadManifest)
-	g.Go(func() error {
-		statefulsetsList := &appsv1.StatefulSetList{}
-		if err := k8sCacheClient.List(gctx, statefulsetsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{})); err != nil {
-			return err
-		}
-		for _, statefulset := range statefulsetsList.Items {
-			statefulsetsMap[model.K8sWorkloadID{
-				Namespace: statefulset.Namespace,
-				Kind:      model.K8sResourceKindStatefulSet,
-				Name:      statefulset.Name,
-			}] = &computed.CachedWorkloadManifest{
-				AvailableReplicas:    statefulset.Status.ReadyReplicas,
-				Selector:             statefulset.Spec.Selector,
-				WorkloadHealthStatus: status.CalculateStatefulSetHealthStatus(statefulset.Status),
-			}
-		}
-		return nil
-	})
-
-	staticPodsMap := make(map[model.K8sWorkloadID]*computed.CachedWorkloadManifest)
-	g.Go(func() error {
-		staticPodsList := &corev1.PodList{}
-		if err := k8sCacheClient.List(gctx, staticPodsList, client.InNamespace(filters.NamespaceString), client.HasLabels{k8sconsts.OdigosVirtualStaticPodNameLabel}); err != nil {
-			return err
-		}
-		for _, staticPod := range staticPodsList.Items {
-			staticPodsMap[model.K8sWorkloadID{
-				Namespace: staticPod.Namespace,
-				Kind:      model.K8sResourceKindStaticPod,
-				Name:      staticPod.Name,
-			}] = &computed.CachedWorkloadManifest{
-				AvailableReplicas: 1, // static pod always have 1 instance
-				Selector: &metav1.LabelSelector{ // use selector so it works the same way as other workloads
-					MatchLabels: map[string]string{
-						k8sconsts.OdigosVirtualStaticPodNameLabel: staticPod.Name,
-					},
-				},
-				WorkloadHealthStatus: status.CalculateStaticPodHealthStatus(staticPod.Status),
-			}
-		}
-		return nil
-	})
-
-	cronjobsMap := make(map[model.K8sWorkloadID]*computed.CachedWorkloadManifest)
-	g.Go(func() error {
-		cronjobsList := &batchv1.CronJobList{}
-		if err := k8sCacheClient.List(gctx, cronjobsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{})); err != nil {
-			return err
-		}
-		for _, cronjob := range cronjobsList.Items {
-			cronjobsMap[model.K8sWorkloadID{
-				Namespace: cronjob.Namespace,
-				Kind:      model.K8sResourceKindCronJob,
-				Name:      cronjob.Name,
-			}] = &computed.CachedWorkloadManifest{
-				AvailableReplicas:    int32(len(cronjob.Status.Active)),
-				Selector:             cronjob.Spec.JobTemplate.Spec.Selector,
-				WorkloadHealthStatus: status.CalculateCronJobHealthStatus(cronjob.Status),
-			}
-		}
-		return nil
-	})
-
-	if err := g.Wait(); err != nil {
+	deploymentsList := &appsv1.DeploymentList{}
+	err = k8sCacheClient.List(ctx, deploymentsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}))
+	if err != nil {
 		return nil, err
+	}
+	deploymentsMap := make(map[model.K8sWorkloadID]*computed.CachedWorkloadManifest)
+	for _, deployment := range deploymentsList.Items {
+		workloadHealthStatus := status.CalculateDeploymentHealthStatus(deployment.Status)
+		deploymentsMap[model.K8sWorkloadID{
+			Namespace: deployment.Namespace,
+			Kind:      model.K8sResourceKindDeployment,
+			Name:      deployment.Name,
+		}] = &computed.CachedWorkloadManifest{
+			AvailableReplicas:    deployment.Status.AvailableReplicas,
+			Selector:             deployment.Spec.Selector,
+			WorkloadHealthStatus: workloadHealthStatus,
+		}
+	}
+
+	daemonsetsList := &appsv1.DaemonSetList{}
+	err = k8sCacheClient.List(ctx, daemonsetsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}))
+	if err != nil {
+		return nil, err
+	}
+	daemonsMap := make(map[model.K8sWorkloadID]*computed.CachedWorkloadManifest)
+	for _, daemonset := range daemonsetsList.Items {
+		workloadHealthStatus := status.CalculateDaemonSetHealthStatus(daemonset.Status)
+		daemonsMap[model.K8sWorkloadID{
+			Namespace: daemonset.Namespace,
+			Kind:      model.K8sResourceKindDaemonSet,
+			Name:      daemonset.Name,
+		}] = &computed.CachedWorkloadManifest{
+			AvailableReplicas:    daemonset.Status.NumberReady,
+			Selector:             daemonset.Spec.Selector,
+			WorkloadHealthStatus: workloadHealthStatus,
+		}
+	}
+
+	statefulsetsList := &appsv1.StatefulSetList{}
+	err = k8sCacheClient.List(ctx, statefulsetsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}))
+	if err != nil {
+		return nil, err
+	}
+	statefulsetsMap := make(map[model.K8sWorkloadID]*computed.CachedWorkloadManifest)
+	for _, statefulset := range statefulsetsList.Items {
+		workloadHealthStatus := status.CalculateStatefulSetHealthStatus(statefulset.Status)
+		statefulsetsMap[model.K8sWorkloadID{
+			Namespace: statefulset.Namespace,
+			Kind:      model.K8sResourceKindStatefulSet,
+			Name:      statefulset.Name,
+		}] = &computed.CachedWorkloadManifest{
+			AvailableReplicas:    statefulset.Status.ReadyReplicas,
+			Selector:             statefulset.Spec.Selector,
+			WorkloadHealthStatus: workloadHealthStatus,
+		}
+	}
+
+	staticPodsList := &corev1.PodList{}
+	err = k8sCacheClient.List(ctx, staticPodsList, client.InNamespace(filters.NamespaceString), client.HasLabels{k8sconsts.OdigosVirtualStaticPodNameLabel})
+	if err != nil {
+		return nil, err
+	}
+	staticPodsMap := make(map[model.K8sWorkloadID]*computed.CachedWorkloadManifest)
+	for _, staticPod := range staticPodsList.Items {
+		workloadHealthStatus := status.CalculateStaticPodHealthStatus(staticPod.Status)
+		staticPodsMap[model.K8sWorkloadID{
+			Namespace: staticPod.Namespace,
+			Kind:      model.K8sResourceKindStaticPod,
+			Name:      staticPod.Name,
+		}] = &computed.CachedWorkloadManifest{
+			AvailableReplicas: 1, // static pod always have 1 instance
+			Selector: &metav1.LabelSelector{ // use selector so it works the same way as other workloads
+				MatchLabels: map[string]string{
+					k8sconsts.OdigosVirtualStaticPodNameLabel: staticPod.Name,
+				},
+			},
+			WorkloadHealthStatus: workloadHealthStatus,
+		}
+	}
+
+	cronjobsList := &batchv1.CronJobList{}
+	err = k8sCacheClient.List(ctx, cronjobsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}))
+	if err != nil {
+		return nil, err
+	}
+	cronjobsMap := make(map[model.K8sWorkloadID]*computed.CachedWorkloadManifest)
+	for _, cronjob := range cronjobsList.Items {
+		workloadHealthStatus := status.CalculateCronJobHealthStatus(cronjob.Status)
+		cronjobsMap[model.K8sWorkloadID{
+			Namespace: cronjob.Namespace,
+			Kind:      model.K8sResourceKindCronJob,
+			Name:      cronjob.Name,
+		}] = &computed.CachedWorkloadManifest{
+			AvailableReplicas:    int32(len(cronjob.Status.Active)),
+			Selector:             cronjob.Spec.JobTemplate.Spec.Selector,
+			WorkloadHealthStatus: workloadHealthStatus,
+		}
 	}
 
 	// Only try to list DeploymentConfigs if they're available in the cluster

--- a/frontend/graph/loaders/fetchers.go
+++ b/frontend/graph/loaders/fetchers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/odigos-io/odigos/frontend/kube"
 	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
 	openshiftappsv1 "github.com/openshift/api/apps/v1"
+	"golang.org/x/sync/errgroup"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -415,103 +416,119 @@ func fetchWorkloadManifests(ctx context.Context, logger logr.Logger, filters *Wo
 		}
 	}
 
-	deploymentsList := &appsv1.DeploymentList{}
-	err = k8sCacheClient.List(ctx, deploymentsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}))
-	if err != nil {
-		return nil, err
-	}
+	// Cluster-wide manifest listing is the dominant latency cost for large
+	// clusters (6+ cluster-wide LIST operations). Run them in parallel via
+	// errgroup — the cache client is backed by informers and safe for
+	// concurrent reads. At large scale (10K+ workloads, PLAT-958) this turns
+	// a ~multi-second serial load into a max(single-kind) one.
+	g, gctx := errgroup.WithContext(ctx)
+
 	deploymentsMap := make(map[model.K8sWorkloadID]*computed.CachedWorkloadManifest)
-	for _, deployment := range deploymentsList.Items {
-		workloadHealthStatus := status.CalculateDeploymentHealthStatus(deployment.Status)
-		deploymentsMap[model.K8sWorkloadID{
-			Namespace: deployment.Namespace,
-			Kind:      model.K8sResourceKindDeployment,
-			Name:      deployment.Name,
-		}] = &computed.CachedWorkloadManifest{
-			AvailableReplicas:    deployment.Status.AvailableReplicas,
-			Selector:             deployment.Spec.Selector,
-			WorkloadHealthStatus: workloadHealthStatus,
+	g.Go(func() error {
+		deploymentsList := &appsv1.DeploymentList{}
+		if err := k8sCacheClient.List(gctx, deploymentsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{})); err != nil {
+			return err
 		}
-	}
+		for _, deployment := range deploymentsList.Items {
+			deploymentsMap[model.K8sWorkloadID{
+				Namespace: deployment.Namespace,
+				Kind:      model.K8sResourceKindDeployment,
+				Name:      deployment.Name,
+			}] = &computed.CachedWorkloadManifest{
+				AvailableReplicas:    deployment.Status.AvailableReplicas,
+				Selector:             deployment.Spec.Selector,
+				WorkloadHealthStatus: status.CalculateDeploymentHealthStatus(deployment.Status),
+			}
+		}
+		return nil
+	})
 
-	daemonsetsList := &appsv1.DaemonSetList{}
-	err = k8sCacheClient.List(ctx, daemonsetsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}))
-	if err != nil {
-		return nil, err
-	}
 	daemonsMap := make(map[model.K8sWorkloadID]*computed.CachedWorkloadManifest)
-	for _, daemonset := range daemonsetsList.Items {
-		workloadHealthStatus := status.CalculateDaemonSetHealthStatus(daemonset.Status)
-		daemonsMap[model.K8sWorkloadID{
-			Namespace: daemonset.Namespace,
-			Kind:      model.K8sResourceKindDaemonSet,
-			Name:      daemonset.Name,
-		}] = &computed.CachedWorkloadManifest{
-			AvailableReplicas:    daemonset.Status.NumberReady,
-			Selector:             daemonset.Spec.Selector,
-			WorkloadHealthStatus: workloadHealthStatus,
+	g.Go(func() error {
+		daemonsetsList := &appsv1.DaemonSetList{}
+		if err := k8sCacheClient.List(gctx, daemonsetsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{})); err != nil {
+			return err
 		}
-	}
+		for _, daemonset := range daemonsetsList.Items {
+			daemonsMap[model.K8sWorkloadID{
+				Namespace: daemonset.Namespace,
+				Kind:      model.K8sResourceKindDaemonSet,
+				Name:      daemonset.Name,
+			}] = &computed.CachedWorkloadManifest{
+				AvailableReplicas:    daemonset.Status.NumberReady,
+				Selector:             daemonset.Spec.Selector,
+				WorkloadHealthStatus: status.CalculateDaemonSetHealthStatus(daemonset.Status),
+			}
+		}
+		return nil
+	})
 
-	statefulsetsList := &appsv1.StatefulSetList{}
-	err = k8sCacheClient.List(ctx, statefulsetsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}))
-	if err != nil {
-		return nil, err
-	}
 	statefulsetsMap := make(map[model.K8sWorkloadID]*computed.CachedWorkloadManifest)
-	for _, statefulset := range statefulsetsList.Items {
-		workloadHealthStatus := status.CalculateStatefulSetHealthStatus(statefulset.Status)
-		statefulsetsMap[model.K8sWorkloadID{
-			Namespace: statefulset.Namespace,
-			Kind:      model.K8sResourceKindStatefulSet,
-			Name:      statefulset.Name,
-		}] = &computed.CachedWorkloadManifest{
-			AvailableReplicas:    statefulset.Status.ReadyReplicas,
-			Selector:             statefulset.Spec.Selector,
-			WorkloadHealthStatus: workloadHealthStatus,
+	g.Go(func() error {
+		statefulsetsList := &appsv1.StatefulSetList{}
+		if err := k8sCacheClient.List(gctx, statefulsetsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{})); err != nil {
+			return err
 		}
-	}
+		for _, statefulset := range statefulsetsList.Items {
+			statefulsetsMap[model.K8sWorkloadID{
+				Namespace: statefulset.Namespace,
+				Kind:      model.K8sResourceKindStatefulSet,
+				Name:      statefulset.Name,
+			}] = &computed.CachedWorkloadManifest{
+				AvailableReplicas:    statefulset.Status.ReadyReplicas,
+				Selector:             statefulset.Spec.Selector,
+				WorkloadHealthStatus: status.CalculateStatefulSetHealthStatus(statefulset.Status),
+			}
+		}
+		return nil
+	})
 
-	staticPodsList := &corev1.PodList{}
-	err = k8sCacheClient.List(ctx, staticPodsList, client.InNamespace(filters.NamespaceString), client.HasLabels{k8sconsts.OdigosVirtualStaticPodNameLabel})
-	if err != nil {
-		return nil, err
-	}
 	staticPodsMap := make(map[model.K8sWorkloadID]*computed.CachedWorkloadManifest)
-	for _, staticPod := range staticPodsList.Items {
-		workloadHealthStatus := status.CalculateStaticPodHealthStatus(staticPod.Status)
-		staticPodsMap[model.K8sWorkloadID{
-			Namespace: staticPod.Namespace,
-			Kind:      model.K8sResourceKindStaticPod,
-			Name:      staticPod.Name,
-		}] = &computed.CachedWorkloadManifest{
-			AvailableReplicas: 1, // static pod always have 1 instance
-			Selector: &metav1.LabelSelector{ // use selector so it works the same way as other workloads
-				MatchLabels: map[string]string{
-					k8sconsts.OdigosVirtualStaticPodNameLabel: staticPod.Name,
+	g.Go(func() error {
+		staticPodsList := &corev1.PodList{}
+		if err := k8sCacheClient.List(gctx, staticPodsList, client.InNamespace(filters.NamespaceString), client.HasLabels{k8sconsts.OdigosVirtualStaticPodNameLabel}); err != nil {
+			return err
+		}
+		for _, staticPod := range staticPodsList.Items {
+			staticPodsMap[model.K8sWorkloadID{
+				Namespace: staticPod.Namespace,
+				Kind:      model.K8sResourceKindStaticPod,
+				Name:      staticPod.Name,
+			}] = &computed.CachedWorkloadManifest{
+				AvailableReplicas: 1, // static pod always have 1 instance
+				Selector: &metav1.LabelSelector{ // use selector so it works the same way as other workloads
+					MatchLabels: map[string]string{
+						k8sconsts.OdigosVirtualStaticPodNameLabel: staticPod.Name,
+					},
 				},
-			},
-			WorkloadHealthStatus: workloadHealthStatus,
+				WorkloadHealthStatus: status.CalculateStaticPodHealthStatus(staticPod.Status),
+			}
 		}
-	}
+		return nil
+	})
 
-	cronjobsList := &batchv1.CronJobList{}
-	err = k8sCacheClient.List(ctx, cronjobsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{}))
-	if err != nil {
-		return nil, err
-	}
 	cronjobsMap := make(map[model.K8sWorkloadID]*computed.CachedWorkloadManifest)
-	for _, cronjob := range cronjobsList.Items {
-		workloadHealthStatus := status.CalculateCronJobHealthStatus(cronjob.Status)
-		cronjobsMap[model.K8sWorkloadID{
-			Namespace: cronjob.Namespace,
-			Kind:      model.K8sResourceKindCronJob,
-			Name:      cronjob.Name,
-		}] = &computed.CachedWorkloadManifest{
-			AvailableReplicas:    int32(len(cronjob.Status.Active)),
-			Selector:             cronjob.Spec.JobTemplate.Spec.Selector,
-			WorkloadHealthStatus: workloadHealthStatus,
+	g.Go(func() error {
+		cronjobsList := &batchv1.CronJobList{}
+		if err := k8sCacheClient.List(gctx, cronjobsList, client.InNamespace(filters.NamespaceString), client.MatchingLabels(map[string]string{})); err != nil {
+			return err
 		}
+		for _, cronjob := range cronjobsList.Items {
+			cronjobsMap[model.K8sWorkloadID{
+				Namespace: cronjob.Namespace,
+				Kind:      model.K8sResourceKindCronJob,
+				Name:      cronjob.Name,
+			}] = &computed.CachedWorkloadManifest{
+				AvailableReplicas:    int32(len(cronjob.Status.Active)),
+				Selector:             cronjob.Spec.JobTemplate.Spec.Selector,
+				WorkloadHealthStatus: status.CalculateCronJobHealthStatus(cronjob.Status),
+			}
+		}
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
 
 	// Only try to list DeploymentConfigs if they're available in the cluster

--- a/frontend/graph/workload.resolvers.go
+++ b/frontend/graph/workload.resolvers.go
@@ -80,7 +80,6 @@ func (r *k8sNamespaceResolver) Workloads(ctx context.Context, obj *model.K8sName
 	workloadIds := l.GetWorkloadIdsInNamespace(obj.Name)
 	workloads := make([]*model.K8sWorkload, 0, len(workloadIds))
 	for _, id := range workloadIds {
-		id := id
 		workloads = append(workloads, &model.K8sWorkload{ID: &id})
 	}
 	return workloads, nil

--- a/frontend/graph/workload.resolvers.go
+++ b/frontend/graph/workload.resolvers.go
@@ -58,13 +58,19 @@ func (r *k8sNamespaceResolver) DataStreamNames(ctx context.Context, obj *model.K
 }
 
 // Workloads is the resolver for the workloads field.
-// Triggers the full SetFilters load (sources + manifests) only when workloads
-// are actually requested. The Namespaces query resolver uses LoadConfig which
-// skips this, so lightweight namespace-only queries stay fast.
+// Normally pre-populated by queryResolver.Namespaces when the caller asked for
+// `workloads` (see that resolver's comment on why eager population is needed
+// at scale). We short-circuit on the pre-populated slice to avoid concurrent
+// SetFilters fan-out across namespace resolvers.
 func (r *k8sNamespaceResolver) Workloads(ctx context.Context, obj *model.K8sNamespace) ([]*model.K8sWorkload, error) {
-	l := loaders.For(ctx)
+	if obj.Workloads != nil {
+		return obj.Workloads, nil
+	}
 
-	// Ensure workload IDs are loaded (SetFilters is idempotent via Fetched flags).
+	// Fallback path — should not be hit from the standard Namespaces query
+	// path, but kept for safety in case this resolver is invoked directly
+	// (e.g. via a fragment spread we don't detect as `workloads`).
+	l := loaders.For(ctx)
 	if len(l.GetWorkloadIds()) == 0 {
 		if err := l.SetFilters(ctx, nil); err != nil {
 			return nil, err
@@ -74,6 +80,7 @@ func (r *k8sNamespaceResolver) Workloads(ctx context.Context, obj *model.K8sName
 	workloadIds := l.GetWorkloadIdsInNamespace(obj.Name)
 	workloads := make([]*model.K8sWorkload, 0, len(workloadIds))
 	for _, id := range workloadIds {
+		id := id
 		workloads = append(workloads, &model.K8sWorkload{ID: &id})
 	}
 	return workloads, nil
@@ -819,9 +826,14 @@ func (r *queryResolver) WorkloadsByIds(ctx context.Context, ids []*model.K8sWork
 }
 
 // Namespaces is the resolver for the namespaces field.
-// Only loads config + namespace list. Workload data is deferred to the
-// K8sNamespace.Workloads field resolver, so queries that don't request
-// workloads avoid the heavy manifest/source loading entirely.
+// Only loads config + namespace list when workloads are not requested.
+// When the caller asks for `workloads`, we acquire heavyWorkloadQueryMu and
+// eagerly pre-populate every K8sWorkload object here (sequentially) so gqlgen's
+// per-field goroutine fan-out across N namespaces × M workloads × K fields
+// short-circuits on the pre-computed values. On large clusters (100s of
+// namespaces, 10K+ workloads) the old per-field resolver path could spawn
+// hundreds of thousands of goroutines — each acquiring loader mutexes —
+// causing the UI pod to stall (request timeout) or OOM (PLAT-958).
 func (r *queryResolver) Namespaces(ctx context.Context) ([]*model.K8sNamespace, error) {
 	l := loaders.For(ctx)
 	if err := l.LoadConfig(ctx); err != nil {
@@ -834,11 +846,48 @@ func (r *queryResolver) Namespaces(ctx context.Context) ([]*model.K8sNamespace, 
 	}
 
 	gqlNss := make([]*model.K8sNamespace, 0, len(nss))
+	nsByName := make(map[string]*model.K8sNamespace, len(nss))
 	for _, nsName := range nss {
-		gqlNss = append(gqlNss, &model.K8sNamespace{
-			Name: nsName,
-		})
+		ns := &model.K8sNamespace{Name: nsName}
+		gqlNss = append(gqlNss, ns)
+		nsByName[nsName] = ns
 	}
+
+	// Fast path: the caller didn't ask for workloads (e.g. the GET_NAMESPACES
+	// query). Skip the heavy cluster-wide source+manifest load entirely.
+	if !isNamespacesWorkloadsSelected(ctx) {
+		return gqlNss, nil
+	}
+
+	// Heavy path: serialize concurrent GetNamespacesWithWorkloads requests so
+	// the UI pod can't be hit by N simultaneous 10K-workload loads.
+	heavyWorkloadQueryMu.Lock()
+	defer heavyWorkloadQueryMu.Unlock()
+
+	if err := l.SetFilters(ctx, nil); err != nil {
+		return nil, err
+	}
+
+	for _, id := range l.GetWorkloadIds() {
+		id := id
+		ns, ok := nsByName[id.Namespace]
+		if !ok {
+			// workload belongs to an ignored/unknown namespace, skip.
+			continue
+		}
+		w := &model.K8sWorkload{ID: &id}
+		populateNamespaceQueryWorkloadFields(ctx, l, w)
+		ns.Workloads = append(ns.Workloads, w)
+	}
+
+	// Ensure a non-nil slice so k8sNamespaceResolver.Workloads short-circuits
+	// uniformly even for namespaces that have no workloads.
+	for _, ns := range gqlNss {
+		if ns.Workloads == nil {
+			ns.Workloads = []*model.K8sWorkload{}
+		}
+	}
+
 	return gqlNss, nil
 }
 

--- a/frontend/graph/workload_populate.go
+++ b/frontend/graph/workload_populate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/99designs/gqlgen/graphql"
 	"github.com/odigos-io/odigos/api/k8sconsts"
 	"github.com/odigos-io/odigos/common"
 	"github.com/odigos-io/odigos/frontend/graph/loaders"
@@ -16,6 +17,63 @@ import (
 
 // Serializes heavy workload queries so concurrent requests don't double memory usage.
 var heavyWorkloadQueryMu sync.Mutex
+
+// isNamespacesWorkloadsSelected inspects the current query selection and returns
+// true if the caller requested the `workloads` sub-field under `namespaces`.
+// Used to gate the expensive cluster-wide workload load for the lightweight
+// `GET_NAMESPACES` query which only needs namespace metadata.
+func isNamespacesWorkloadsSelected(ctx context.Context) bool {
+	for _, field := range graphql.CollectFieldsCtx(ctx, nil) {
+		if field.Name == "workloads" {
+			return true
+		}
+	}
+	return false
+}
+
+// populateNamespaceQueryWorkloadFields pre-computes the subset of K8sWorkload
+// fields needed by the `namespaces { workloads { ... } }` query path:
+// markedForInstrumentation, dataStreamNames, and numberOfInstances.
+//
+// This is called sequentially from queryResolver.Namespaces (under
+// heavyWorkloadQueryMu) so gqlgen's per-field goroutine fan-out across
+// 10K+ workloads short-circuits on pre-populated values instead of each
+// spawning mutex-acquiring resolver goroutines.
+//
+// Intentionally slim: does NOT trigger loadInstrumentationConfigs or
+// loadWorkloadPods, keeping this path much cheaper than populateWorkloadFields.
+func populateNamespaceQueryWorkloadFields(ctx context.Context, l *loaders.Loaders, w *model.K8sWorkload) {
+	id := *w.ID
+
+	if sources, err := l.GetSources(ctx, id); err == nil && sources != nil {
+		enabled, reason, rerr := sourceutils.IsObjectInstrumentedBySource(ctx, sources, nil)
+		if rerr == nil {
+			var marked *bool
+			if enabled {
+				marked = &enabled
+			} else if reason.Reason == string("WorkloadSourceDisabled") {
+				marked = &enabled
+			}
+			w.MarkedForInstrumentation = &model.K8sWorkloadMarkedForInstrumentation{
+				MarkedForInstrumentation: marked,
+				DecisionEnum:             string(reason.Reason),
+				Message:                  reason.Message,
+			}
+		}
+
+		ptrNames := services.ExtractDataStreamsFromSource(sources.Workload, sources.Namespace)
+		names := make([]string, len(ptrNames))
+		for i, p := range ptrNames {
+			names[i] = *p
+		}
+		w.DataStreamNames = names
+	}
+
+	if manifest, err := l.GetWorkloadManifest(ctx, id); err == nil && manifest != nil {
+		count := int(manifest.AvailableReplicas)
+		w.NumberOfInstances = &count
+	}
+}
 
 // populateWorkloadFields pre-computes all resolver fields for a workload
 // sequentially. This is called from the Workloads batch resolver to avoid


### PR DESCRIPTION
## Issue

On large clusters (100s of namespaces, 10K+ workloads) the query stalled and could OOM the UI pod.

gqlgen resolved `K8sNamespace.Workloads` concurrently per namespace (each calling `SetFilters`) and then spawned a goroutine per requested workload field → ~30K concurrent goroutines grabbing loader mutexes. Concurrent requests weren't serialized, so a second tab doubled memory.

## Fix

Resolver-level only:

- **`queryResolver.Namespaces`**: if the caller requested `workloads` (detected via `graphql.CollectFieldsCtx`), acquire `heavyWorkloadQueryMu`, call `SetFilters` once, and eagerly pre-populate every `K8sWorkload` in a single sequential loop.
- **`k8sNamespaceResolver.Workloads`**: short-circuits on the pre-populated slice.
- **`populateNamespaceQueryWorkloadFields`**: slim populator for the 3 fields this query actually uses (`markedForInstrumentation`, `dataStreamNames`, `numberOfInstances`). Skips InstrumentationConfig/Pod loads.

`GET_NAMESPACES` (no workloads) keeps the unchanged lightweight path.

---

```release-note
feat: optimize workload loading for namespaces query to enhance performance in large clusters
```

cherry-pick: v1.23, v1.24

emergency-ticket id: EMR-1566
