### PR TITLE
fix: performance for querying all namespaces with all workloads

### DIFF
--- a/frontend/graph/loaders/loader.go
+++ b/frontend/graph/loaders/loader.go
@@ -78,6 +78,12 @@ type Loaders struct {
 	instrumentationInstancesFetched             bool
 	instrumentationInstancesByPodContainer      map[PodContainerId][]*v1alpha1.InstrumentationInstance
 	instrumentationInstancesByWorkloadContainer map[WorkloadContainerId][]*v1alpha1.InstrumentationInstance
+
+	// heavyWorkloadsOnce guards the first call to SetFilters(nil) for the
+	// K8sNamespace.Workloads resolver path. Subsequent namespaces in the same
+	// request fast-path without re-acquiring the global heavy-query mutex.
+	heavyWorkloadsOnce sync.Once
+	heavyWorkloadsErr  error
 }
 
 func WithLoaders(ctx context.Context, loaders *Loaders) context.Context {
@@ -440,6 +446,21 @@ func (l *Loaders) SetFilters(ctx context.Context, filter *model.WorkloadFilter) 
 	}
 
 	return nil
+}
+
+// EnsureHeavyWorkloadsLoaded runs SetFilters(nil) at most once per request,
+// guarded by the caller-provided global heavy-query mutex. It is intended for
+// the K8sNamespace.Workloads resolver path, which is invoked concurrently from
+// gqlgen once per namespace in the selection set — all callers block on the
+// sync.Once, only the first acquires the global mutex, and subsequent
+// invocations return the cached error without lock contention.
+func (l *Loaders) EnsureHeavyWorkloadsLoaded(ctx context.Context, heavyMu *sync.Mutex) error {
+	l.heavyWorkloadsOnce.Do(func() {
+		heavyMu.Lock()
+		defer heavyMu.Unlock()
+		l.heavyWorkloadsErr = l.SetFilters(ctx, nil)
+	})
+	return l.heavyWorkloadsErr
 }
 
 func (l *Loaders) SetWorkloadIdsDirect(ctx context.Context, ids []model.K8sWorkloadID) error {

--- a/frontend/graph/loaders/loader.go
+++ b/frontend/graph/loaders/loader.go
@@ -79,9 +79,7 @@ type Loaders struct {
 	instrumentationInstancesByPodContainer      map[PodContainerId][]*v1alpha1.InstrumentationInstance
 	instrumentationInstancesByWorkloadContainer map[WorkloadContainerId][]*v1alpha1.InstrumentationInstance
 
-	// heavyWorkloadsOnce guards the first call to SetFilters(nil) for the
-	// K8sNamespace.Workloads resolver path. Subsequent namespaces in the same
-	// request fast-path without re-acquiring the global heavy-query mutex.
+	// heavyWorkloadsOnce guards the first call to LoadWorkloadsWithFilter(nil) for the K8sNamespace.Workloads resolver path. Subsequent namespaces in the same request fast-path without re-acquiring the global heavy-query mutex.
 	heavyWorkloadsOnce sync.Once
 	heavyWorkloadsErr  error
 }
@@ -348,7 +346,9 @@ func (l *Loaders) LoadConfig(ctx context.Context) error {
 	return nil
 }
 
-func (l *Loaders) SetFilters(ctx context.Context, filter *model.WorkloadFilter) error {
+// LoadWorkloadsWithFilter resolves the set of workload IDs that match the given filter and primes the loader caches needed by downstream resolvers.
+// This is the heaviest operation in the request — for cluster-wide filters it lists all Source CRs plus 6+ cluster-wide workload-manifest kinds.
+func (l *Loaders) LoadWorkloadsWithFilter(ctx context.Context, filter *model.WorkloadFilter) error {
 
 	if err := l.LoadConfig(ctx); err != nil {
 		return err
@@ -448,17 +448,13 @@ func (l *Loaders) SetFilters(ctx context.Context, filter *model.WorkloadFilter) 
 	return nil
 }
 
-// EnsureHeavyWorkloadsLoaded runs SetFilters(nil) at most once per request,
-// guarded by the caller-provided global heavy-query mutex. It is intended for
-// the K8sNamespace.Workloads resolver path, which is invoked concurrently from
-// gqlgen once per namespace in the selection set — all callers block on the
-// sync.Once, only the first acquires the global mutex, and subsequent
-// invocations return the cached error without lock contention.
+// EnsureHeavyWorkloadsLoaded runs LoadWorkloadsWithFilter(nil) at most once per request, guarded by the caller-provided global heavy-query mutex.
+// It is intended for the K8sNamespace.Workloads resolver path, which is invoked concurrently from gqlgen once per namespace in the selection set — all callers block on the sync.Once, only the first acquires the global mutex, and subsequent invocations return the cached error without lock contention.
 func (l *Loaders) EnsureHeavyWorkloadsLoaded(ctx context.Context, heavyMu *sync.Mutex) error {
 	l.heavyWorkloadsOnce.Do(func() {
 		heavyMu.Lock()
 		defer heavyMu.Unlock()
-		l.heavyWorkloadsErr = l.SetFilters(ctx, nil)
+		l.heavyWorkloadsErr = l.LoadWorkloadsWithFilter(ctx, nil)
 	})
 	return l.heavyWorkloadsErr
 }

--- a/frontend/graph/workload.resolvers.go
+++ b/frontend/graph/workload.resolvers.go
@@ -58,17 +58,10 @@ func (r *k8sNamespaceResolver) DataStreamNames(ctx context.Context, obj *model.K
 }
 
 // Workloads is the resolver for the workloads field.
-// Triggers the full SetFilters load (sources + manifests) only when workloads
-// are actually requested. The Namespaces query resolver uses LoadConfig which
-// skips this, so lightweight namespace-only queries stay fast.
+// Triggers the full LoadWorkloadsWithFilter load (sources + manifests) only when workloads are actually requested. The Namespaces query resolver uses LoadConfig which skips this, so lightweight namespace-only queries stay fast.
 //
-// The initial SetFilters call is guarded by the global heavyWorkloadQueryMu
-// (via Loaders.EnsureHeavyWorkloadsLoaded) so concurrent
-// GetNamespacesWithWorkloads / GetWorkloads requests don't double memory. Each
-// workload's lightweight fields (markedForInstrumentation, dataStreamNames,
-// numberOfInstances) are pre-populated inline so gqlgen's per-field goroutines
-// short-circuit instead of doing real work — without this, 20K workloads × 3
-// fields = ~60K work-doing goroutines push the UI pod past GOMEMLIMIT.
+// The initial LoadWorkloadsWithFilter call is guarded by the global heavyWorkloadQueryMu (via Loaders.EnsureHeavyWorkloadsLoaded) so concurrent GetNamespacesWithWorkloads / GetWorkloads requests don't double memory.
+// Each workload's lightweight fields (markedForInstrumentation, dataStreamNames, numberOfInstances) are pre-populated inline so gqlgen's per-field goroutines short-circuit instead of doing real work — without this, 20K workloads × 3 fields = ~60K work-doing goroutines push the UI pod past GOMEMLIMIT.
 func (r *k8sNamespaceResolver) Workloads(ctx context.Context, obj *model.K8sNamespace) ([]*model.K8sWorkload, error) {
 	l := loaders.For(ctx)
 
@@ -784,7 +777,7 @@ func (r *queryResolver) Workloads(ctx context.Context, filter *model.WorkloadFil
 	defer heavyWorkloadQueryMu.Unlock()
 
 	l := loaders.For(ctx)
-	if err := l.SetFilters(ctx, filter); err != nil {
+	if err := l.LoadWorkloadsWithFilter(ctx, filter); err != nil {
 		return nil, err
 	}
 

--- a/frontend/graph/workload.resolvers.go
+++ b/frontend/graph/workload.resolvers.go
@@ -61,20 +61,27 @@ func (r *k8sNamespaceResolver) DataStreamNames(ctx context.Context, obj *model.K
 // Triggers the full SetFilters load (sources + manifests) only when workloads
 // are actually requested. The Namespaces query resolver uses LoadConfig which
 // skips this, so lightweight namespace-only queries stay fast.
+//
+// The initial SetFilters call is guarded by the global heavyWorkloadQueryMu
+// (via Loaders.EnsureHeavyWorkloadsLoaded) so concurrent
+// GetNamespacesWithWorkloads / GetWorkloads requests don't double memory. Each
+// workload's lightweight fields (markedForInstrumentation, dataStreamNames,
+// numberOfInstances) are pre-populated inline so gqlgen's per-field goroutines
+// short-circuit instead of doing real work — without this, 20K workloads × 3
+// fields = ~60K work-doing goroutines push the UI pod past GOMEMLIMIT.
 func (r *k8sNamespaceResolver) Workloads(ctx context.Context, obj *model.K8sNamespace) ([]*model.K8sWorkload, error) {
 	l := loaders.For(ctx)
 
-	// Ensure workload IDs are loaded (SetFilters is idempotent via Fetched flags).
-	if len(l.GetWorkloadIds()) == 0 {
-		if err := l.SetFilters(ctx, nil); err != nil {
-			return nil, err
-		}
+	if err := l.EnsureHeavyWorkloadsLoaded(ctx, &heavyWorkloadQueryMu); err != nil {
+		return nil, err
 	}
 
 	workloadIds := l.GetWorkloadIdsInNamespace(obj.Name)
 	workloads := make([]*model.K8sWorkload, 0, len(workloadIds))
 	for _, id := range workloadIds {
-		workloads = append(workloads, &model.K8sWorkload{ID: &id})
+		w := &model.K8sWorkload{ID: &id}
+		populateNamespaceWorkloadLightFields(ctx, l, w)
+		workloads = append(workloads, w)
 	}
 	return workloads, nil
 }

--- a/frontend/graph/workload_populate.go
+++ b/frontend/graph/workload_populate.go
@@ -17,6 +17,53 @@ import (
 // Serializes heavy workload queries so concurrent requests don't double memory usage.
 var heavyWorkloadQueryMu sync.Mutex
 
+// populateNamespaceWorkloadLightFields pre-computes the three resolver fields
+// requested by GetNamespacesWithWorkloads (markedForInstrumentation,
+// dataStreamNames, numberOfInstances) directly from the already-loaded source
+// and manifest caches. This lets each field resolver short-circuit via its
+// `if obj.X != nil` guard and keeps gqlgen's per-field goroutines in the 2 KB
+// stack range — critical at 20K workloads where spawning 60K work-doing
+// goroutines otherwise pushes the UI pod past its GOMEMLIMIT.
+//
+// Unlike populateWorkloadFields, this helper intentionally does NOT touch
+// InstrumentationConfigs or Pods — both are expensive to load cluster-wide
+// and are not needed by the source-selection UI that drives this query.
+func populateNamespaceWorkloadLightFields(ctx context.Context, l *loaders.Loaders, w *model.K8sWorkload) {
+	id := *w.ID
+
+	// Share a single GetSources lookup across the two source-derived fields
+	// instead of locking l.sourcesMutex twice per workload.
+	sources, sourcesErr := l.GetSources(ctx, id)
+	if sourcesErr == nil && sources != nil {
+		enabled, reason, err := sourceutils.IsObjectInstrumentedBySource(ctx, sources, nil)
+		if err == nil {
+			var marked *bool
+			if enabled {
+				marked = &enabled
+			} else if reason.Reason == string("WorkloadSourceDisabled") {
+				marked = &enabled
+			}
+			w.MarkedForInstrumentation = &model.K8sWorkloadMarkedForInstrumentation{
+				MarkedForInstrumentation: marked,
+				DecisionEnum:             string(reason.Reason),
+				Message:                  reason.Message,
+			}
+		}
+
+		ptrNames := services.ExtractDataStreamsFromSource(sources.Workload, sources.Namespace)
+		names := make([]string, len(ptrNames))
+		for i, p := range ptrNames {
+			names[i] = *p
+		}
+		w.DataStreamNames = names
+	}
+
+	if manifest, err := l.GetWorkloadManifest(ctx, id); err == nil && manifest != nil {
+		count := int(manifest.AvailableReplicas)
+		w.NumberOfInstances = &count
+	}
+}
+
 // populateWorkloadFields pre-computes all resolver fields for a workload
 // sequentially. This is called from the Workloads batch resolver to avoid
 // gqlgen spawning a goroutine per field per workload.


### PR DESCRIPTION
- UI pod still OOMs/timeouts when running `GetNamespacesWithWorkloads` despite earlier fixes.
- Root issue: this query path bypasses optimizations (no mutex + no precomputed fields).
- It triggers full cluster-wide workload + manifest loading, doubling memory under concurrency.
- gqlgen spawns ~60K goroutines (for ~20K workloads), causing ~150–250Mi transient memory spike.
- Additional inefficiency: duplicate `GetSources` calls per workload add lock contention + allocations.

**Fixes:**
- Precompute required workload fields to avoid heavy resolver execution.
- Serialize heavy queries using a mutex + `sync.Once`.
- Reduce redundant `GetSources` calls to one per workload.

**Result:**
- Peak memory drops ~470–570Mi → ~420–440Mi (within limits).
- Eliminates OOM spikes but not baseline memory usage.

---

### 200 namespaces with 20,000 workloads (in total), took only 3 seconds to fetch with only 512Mi allocated to the UI, zero OOMs/restarts:

<img width="179" height="108" alt="Screenshot 2026-04-23 at 17 40 01" src="https://github.com/user-attachments/assets/8e31125a-fd7b-4f91-a42a-c6e5c582e0ee" />

<img width="421" height="458" alt="Screenshot 2026-04-23 at 17 36 54" src="https://github.com/user-attachments/assets/9e7afcad-43dc-4f01-89b1-3bb858d5bdd0" />

### Release notes

```release-note
fix: performance for querying all namespaces with all workloads
```

cherry-pick: v1.23, v1.24

emergency-ticket id: EMR-1565
