### PR TITLE
fix(instrumentation): defer instrumentation until FileOpen trigger fires

### DIFF
--- a/instrumentation/manager.go
+++ b/instrumentation/manager.go
@@ -434,21 +434,23 @@ func (m *manager[ProcessGroup, ConfigGroup, ProcessDetails]) tryInstrumentFromPr
 		return errors.Join(err, errFailedToGetDetails)
 	}
 
-	// Skip Exec/Fork events for distros that declare FileOpenTriggers — wait
-	// for the FileOpen event instead. The trigger declaration means the agent
-	// is only usable after that file is opened (e.g. java-ebpf-instrumentations
-	// only works once tracing_probes.so is mapped into the JVM via
-	// System.load). Running tryInstrument on the bare exec event would race
-	// with the agent's own startup — most visibly when a third-party javaagent
-	// is chained ahead of Odigos' agent in JAVA_TOOL_OPTIONS, which delays the
-	// open by however long the earlier agent's premain takes.
+	// For distros that declare FileOpenTriggers, the agent is only usable once
+	// the target opens the trigger file (e.g. java-ebpf-instrumentations only
+	// works after tracing_probes.so is mapped into the JVM via System.load).
+	// Defer Exec/Fork events for these distros until the trigger file shows
+	// up — either because the FileOpen event fires later (the typical case
+	// for fresh exec) or because /proc/<pid>/maps already shows it (running
+	// processes seen during initial scan, fork-without-exec workers like
+	// gunicorn preload mode that inherit the parent's mapping, etc.).
 	if e.EventType == detector.ProcessExecEvent || e.EventType == detector.ProcessForkEvent {
 		if otelDistro, derr := pd.Distribution(ctx); derr == nil &&
 			otelDistro != nil && otelDistro.RuntimeAgent != nil &&
 			len(otelDistro.RuntimeAgent.FileOpenTriggers) > 0 {
-			m.logger.Debug("waiting for FileOpen trigger before instrumenting",
-				"pid", e.PID, "triggers", otelDistro.RuntimeAgent.FileOpenTriggers)
-			return nil
+			if !anyTriggerFileAlreadyMapped(e.PID, otelDistro.RuntimeAgent.FileOpenTriggers) {
+				m.logger.Debug("waiting for FileOpen trigger before instrumenting",
+					"pid", e.PID, "triggers", otelDistro.RuntimeAgent.FileOpenTriggers)
+				return nil
+			}
 		}
 	}
 

--- a/instrumentation/manager.go
+++ b/instrumentation/manager.go
@@ -434,6 +434,24 @@ func (m *manager[ProcessGroup, ConfigGroup, ProcessDetails]) tryInstrumentFromPr
 		return errors.Join(err, errFailedToGetDetails)
 	}
 
+	// Skip Exec/Fork events for distros that declare FileOpenTriggers — wait
+	// for the FileOpen event instead. The trigger declaration means the agent
+	// is only usable after that file is opened (e.g. java-ebpf-instrumentations
+	// only works once tracing_probes.so is mapped into the JVM via
+	// System.load). Running tryInstrument on the bare exec event would race
+	// with the agent's own startup — most visibly when a third-party javaagent
+	// is chained ahead of Odigos' agent in JAVA_TOOL_OPTIONS, which delays the
+	// open by however long the earlier agent's premain takes.
+	if e.EventType == detector.ProcessExecEvent || e.EventType == detector.ProcessForkEvent {
+		if otelDistro, derr := pd.Distribution(ctx); derr == nil &&
+			otelDistro != nil && otelDistro.RuntimeAgent != nil &&
+			len(otelDistro.RuntimeAgent.FileOpenTriggers) > 0 {
+			m.logger.Debug("waiting for FileOpen trigger before instrumenting",
+				"pid", e.PID, "triggers", otelDistro.RuntimeAgent.FileOpenTriggers)
+			return nil
+		}
+	}
+
 	return m.tryInstrument(ctx, pd, e.PID)
 }
 

--- a/instrumentation/manager.go
+++ b/instrumentation/manager.go
@@ -434,23 +434,16 @@ func (m *manager[ProcessGroup, ConfigGroup, ProcessDetails]) tryInstrumentFromPr
 		return errors.Join(err, errFailedToGetDetails)
 	}
 
-	// For distros that declare FileOpenTriggers, the agent is only usable once
-	// the target opens the trigger file (e.g. java-ebpf-instrumentations only
-	// works after tracing_probes.so is mapped into the JVM via System.load).
-	// Defer Exec/Fork events for these distros until the trigger file shows
-	// up — either because the FileOpen event fires later (the typical case
-	// for fresh exec) or because /proc/<pid>/maps already shows it (running
-	// processes seen during initial scan, fork-without-exec workers like
-	// gunicorn preload mode that inherit the parent's mapping, etc.).
+	// Defer Exec/Fork when the distro declares FileOpenTriggers and the
+	// trigger file isn't yet mapped — the FileOpen event will retry later.
 	if e.EventType == detector.ProcessExecEvent || e.EventType == detector.ProcessForkEvent {
 		if otelDistro, derr := pd.Distribution(ctx); derr == nil &&
 			otelDistro != nil && otelDistro.RuntimeAgent != nil &&
-			len(otelDistro.RuntimeAgent.FileOpenTriggers) > 0 {
-			if !anyTriggerFileAlreadyMapped(e.PID, otelDistro.RuntimeAgent.FileOpenTriggers) {
-				m.logger.Debug("waiting for FileOpen trigger before instrumenting",
-					"pid", e.PID, "triggers", otelDistro.RuntimeAgent.FileOpenTriggers)
-				return nil
-			}
+			len(otelDistro.RuntimeAgent.FileOpenTriggers) > 0 &&
+			!anyTriggerFileAlreadyMapped(e.PID, otelDistro.RuntimeAgent.FileOpenTriggers) {
+			m.logger.Debug("waiting for FileOpen trigger before instrumenting",
+				"pid", e.PID, "triggers", otelDistro.RuntimeAgent.FileOpenTriggers)
+			return nil
 		}
 	}
 

--- a/instrumentation/proc_maps.go
+++ b/instrumentation/proc_maps.go
@@ -1,0 +1,52 @@
+package instrumentation
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// anyTriggerFileAlreadyMapped reports whether any of the given absolute paths
+// is already present in /proc/<pid>/maps. Used to short-circuit the
+// FileOpen-trigger wait for processes that already have the trigger file
+// loaded — typically (a) processes running before odiglet started (the
+// runtime-detector's initial scan reports them as exec events even though
+// the actual open() syscall happened long ago) and (b) workers forked from
+// a parent that already opened the file (e.g. Python gunicorn in preload
+// mode: the master loads the .so once, forked workers inherit the mapping
+// and never call open() themselves, so no FileOpen event will ever fire
+// for them).
+//
+// Returns false on any error (process gone, /proc not readable, no match)
+// so that the caller falls back to waiting for a FileOpen event — that's
+// the safe default; the worst that happens is a small delay.
+func anyTriggerFileAlreadyMapped(pid int, paths []string) bool {
+	if pid <= 0 || len(paths) == 0 {
+		return false
+	}
+	procDir := os.Getenv("ODIGOS_PROC_DIR")
+	if procDir == "" {
+		procDir = "/proc"
+	}
+	f, err := os.Open(filepath.Join(procDir, strconv.Itoa(pid), "maps"))
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// /proc/<pid>/maps lines end with the pathname column; matching on
+		// " "+path avoids false positives from substrings appearing earlier
+		// in the line (offsets, inodes, etc.).
+		for _, p := range paths {
+			if p != "" && strings.HasSuffix(line, " "+p) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/instrumentation/proc_maps.go
+++ b/instrumentation/proc_maps.go
@@ -1,51 +1,43 @@
 package instrumentation
 
 import (
-	"bufio"
+	"bytes"
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 )
 
+var procDir = func() string {
+	if d := os.Getenv("ODIGOS_PROC_DIR"); d != "" {
+		return d
+	}
+	return "/proc"
+}()
+
 // anyTriggerFileAlreadyMapped reports whether any of the given absolute paths
-// is already present in /proc/<pid>/maps. Used to short-circuit the
-// FileOpen-trigger wait for processes that already have the trigger file
-// loaded — typically (a) processes running before odiglet started (the
-// runtime-detector's initial scan reports them as exec events even though
-// the actual open() syscall happened long ago) and (b) workers forked from
-// a parent that already opened the file (e.g. Python gunicorn in preload
-// mode: the master loads the .so once, forked workers inherit the mapping
-// and never call open() themselves, so no FileOpen event will ever fire
-// for them).
-//
-// Returns false on any error (process gone, /proc not readable, no match)
-// so that the caller falls back to waiting for a FileOpen event — that's
-// the safe default; the worst that happens is a small delay.
+// is already present in /proc/<pid>/maps. False on any error (process gone,
+// permission denied, no match) — caller falls back to waiting for FileOpen.
 func anyTriggerFileAlreadyMapped(pid int, paths []string) bool {
 	if pid <= 0 || len(paths) == 0 {
 		return false
 	}
-	procDir := os.Getenv("ODIGOS_PROC_DIR")
-	if procDir == "" {
-		procDir = "/proc"
-	}
-	f, err := os.Open(filepath.Join(procDir, strconv.Itoa(pid), "maps"))
+	data, err := os.ReadFile(filepath.Join(procDir, strconv.Itoa(pid), "maps"))
 	if err != nil {
 		return false
 	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := scanner.Text()
-		// /proc/<pid>/maps lines end with the pathname column; matching on
-		// " "+path avoids false positives from substrings appearing earlier
-		// in the line (offsets, inodes, etc.).
-		for _, p := range paths {
-			if p != "" && strings.HasSuffix(line, " "+p) {
-				return true
-			}
+	// Each maps entry ends in " <pathname>\n"; matching that exact byte
+	// sequence avoids false positives from offsets/inodes earlier in the
+	// line and resolves to a single SIMD-accelerated bytes.Index per path.
+	needle := make([]byte, 0, 256)
+	for _, p := range paths {
+		if p == "" {
+			continue
+		}
+		needle = append(needle[:0], ' ')
+		needle = append(needle, p...)
+		needle = append(needle, '\n')
+		if bytes.Contains(data, needle) {
+			return true
 		}
 	}
 	return false


### PR DESCRIPTION
## Problem

Distros can declare \`RuntimeAgent.FileOpenTriggers\` to express \"this agent is only usable once the target opens this file.\" \`java-ebpf-instrumentations\` declares \`tracing_probes.so\` for exactly this reason — the Odigos Java agent calls \`System.load(\"tracing_probes.so\")\` inside its \`premain()\`, and nothing about the manager works until that file is mapped into the JVM.

The runtime-detector already emits \`ProcessFileOpenEvent\` whenever a target opens one of the configured trigger files, but \`instrumentation/manager.go\` treats \`Exec\`, \`Fork\`, and \`FileOpen\` identically — all three call \`tryInstrumentFromProcessEvent\` → \`tryInstrument\`. The exec event always arrives first (the kernel's \`do_execve\` hook fires at process start, before any javaagent has run), so \`tryInstrument\` runs racing with the agent's own startup. By the time the FileOpen event arrives, the pid is already in \`detailsByPid\` and the FileOpen path is a no-op.

This race surfaces in production when a third-party javaagent is chained ahead of Odigos' agent in \`JAVA_TOOL_OPTIONS\` — the earlier agent's \`premain()\` delays \`System.load(\"tracing_probes.so\")\` by however long it takes (we've seen multi-second delays), and Odigos' Java instrumentor falls into a non-lazy fallback because \`tracing_probes.so\` isn't yet visible at instrumentation-Load time. The trigger declaration was supposed to gate this, but the gating wasn't actually wired up.

## Fix

Eighteen lines in \`tryInstrumentFromProcessEvent\`. When an \`Exec\` or \`Fork\` event arrives for a distro that declares \`FileOpenTriggers\`, return early without instrumenting. The subsequent \`FileOpen\` event for that pid lands here too and proceeds to \`tryInstrument\` because the \`if\` only short-circuits Exec/Fork.

Distros that don't declare \`FileOpenTriggers\` (most of them) are unaffected — they keep instrumenting on Exec.

## Edge cases

- **Process started before odiglet:** runtime-detector's initial scan reports it as Exec. With this change, that pid would wait for FileOpen, which won't arrive again — the file is already open. Mitigation in this PR: none yet, but it's not a regression because today these pids hit the racy non-lazy path anyway. A follow-up could check \`/proc/<pid>/maps\` synchronously and skip the wait if the trigger file is already mapped.
- **FileOpenTriggers configured but agent never opens the file:** pid stays uninstrumented forever. Same as above — needs a deadline-based fallback eventually. Not addressing here to keep the change small and focused.

## Why this is the right primary fix

We have a companion PR in [\`ebpf-java-instrumentation\` #402](https://github.com/odigos-io/ebpf-java-instrumentation/pull/402) that adds retries inside \`ProbeExists\` to handle the same race at a lower layer. That fix covers cases where the trigger machinery isn't configured (custom distros, configuration drift) and is safer to deploy first. This PR is the architectural fix that makes the trigger mechanism actually do what its name promises; with it landed, the retry in \`ProbeExists\` becomes belt-and-suspenders rather than load-bearing.

## Test plan

- [x] gofmt clean
- [ ] CI build (BPF generation lives in odiglet's build, not in this module's vet/build directly)
- [ ] e2e: existing slow-agent test in \`ebpf-java-instrumentation/e2e\` indirectly covers this — but the test asserts on the \"Loading with lazy loading enabled\" log emitted by the runner, which uses this manager. With this change, the trigger gates the exec event so ProbeExists no longer needs to retry. Will be added in a follow-up against this repo's e2e suite.

emergency-ticket id: EMR-1578
