### PR TITLE
feat: support dryrun in head sampling

### DIFF
--- a/api/config/crd/bases/odigos.io_instrumentationconfigs.yaml
+++ b/api/config/crd/bases/odigos.io_instrumentationconfigs.yaml
@@ -212,6 +212,15 @@ spec:
                             This config currently only applies to root spans.
                             In the Future we might add another level of configuration base on the parent span (ParentBased Sampling)
                           properties:
+                            dryRun:
+                              description: |-
+                                If true, the sampling decision will be made in dry-run mode.
+                                When dry-run is enabled, the sampling decision will be made but the trace will not be dropped.
+                                This is useful to evaluate the sampling decision before actually committing to it.
+                                2 additional attributes will be set on the spans:
+                                - odigos.sampling.dry_run: true
+                                - odigos.sampling.dry_run.kept: true if the trace would have been kept, false if it would have been dropped.
+                              type: boolean
                             fallbackFraction:
                               default: 1
                               description: |-

--- a/api/generated/odigos/applyconfiguration/odigos/v1alpha1/headsamplingconfig.go
+++ b/api/generated/odigos/applyconfiguration/odigos/v1alpha1/headsamplingconfig.go
@@ -24,6 +24,13 @@ import (
 // HeadSamplingConfigApplyConfiguration represents a declarative configuration of the HeadSamplingConfig type for use
 // with apply.
 type HeadSamplingConfigApplyConfiguration struct {
+	// If true, the sampling decision will be made in dry-run mode.
+	// When dry-run is enabled, the sampling decision will be made but the trace will not be dropped.
+	// This is useful to evaluate the sampling decision before actually committing to it.
+	// 2 additional attributes will be set on the spans:
+	// - odigos.sampling.dry_run: true
+	// - odigos.sampling.dry_run.kept: true if the trace would have been kept, false if it would have been dropped.
+	DryRun *bool `json:"dryRun,omitempty"`
 	// Noisy operations are categories of matchers that are used on the root span.
 	// If match, the fraction is used to determine the sampling decision for the entire trace.
 	// If multiple noisy operations match, the lowest fraction is used.
@@ -37,6 +44,14 @@ type HeadSamplingConfigApplyConfiguration struct {
 // apply.
 func HeadSamplingConfig() *HeadSamplingConfigApplyConfiguration {
 	return &HeadSamplingConfigApplyConfiguration{}
+}
+
+// WithDryRun sets the DryRun field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the DryRun field is set to the value of the last call.
+func (b *HeadSamplingConfigApplyConfiguration) WithDryRun(value bool) *HeadSamplingConfigApplyConfiguration {
+	b.DryRun = &value
+	return b
 }
 
 // WithNoisyOperations adds the given value to the NoisyOperations field in the declarative configuration

--- a/api/odigos/v1alpha1/instrumentationconfig_types.go
+++ b/api/odigos/v1alpha1/instrumentationconfig_types.go
@@ -535,6 +535,14 @@ type SdkConfig struct {
 
 type HeadSamplingConfig struct {
 
+	// If true, the sampling decision will be made in dry-run mode.
+	// When dry-run is enabled, the sampling decision will be made but the trace will not be dropped.
+	// This is useful to evaluate the sampling decision before actually committing to it.
+	// 2 additional attributes will be set on the spans:
+	// - odigos.sampling.dry_run: true
+	// - odigos.sampling.dry_run.kept: true if the trace would have been kept, false if it would have been dropped.
+	DryRun bool `json:"dryRun,omitempty"`
+
 	// Noisy operations are categories of matchers that are used on the root span.
 	// If match, the fraction is used to determine the sampling decision for the entire trace.
 	// If multiple noisy operations match, the lowest fraction is used.

--- a/collector/processors/odigostracestateprocessor/README.md
+++ b/collector/processors/odigostracestateprocessor/README.md
@@ -35,13 +35,14 @@ Each field is `key:value`. The gateway processor understands these keys (see `pr
 | `c` | Sampling **category** shorthand | `n` → noisy operation category | `odigos.sampling.category` = `"noise"` |
 | `dr.p` | **Trace deciding rule** — configured keep percentage | floating-point string | `odigos.sampling.trace.deciding_rule.keep_percentage` |
 | `dr.id` | **Trace deciding rule** — stable rule id | opaque id string | `odigos.sampling.trace.deciding_rule.id` |
+| `dry` | **Dry-run sampling decision** — set when tracing dry-run is enabled | `t` → trace kept, `f` → trace dropped | `odigos.sampling.dry_run` = `true`, `odigos.sampling.trace.kept` = `true`/`false` |
 
-Attribute names match `github.com/odigos-io/odigos/common/odigosattributes` (`SamplingCategory`, `SamplingTraceDecidingRuleKeepPercentage`, `SamplingTraceDecidingRuleId`, etc.).
+Attribute names match `github.com/odigos-io/odigos/common/odigosattributes` (`SamplingCategory`, `SamplingTraceDecidingRuleKeepPercentage`, `SamplingTraceDecidingRuleId`, `SamplingDryRun`, `SamplingTraceKept`, etc.).
 
 **Example** (illustrative):
 
 ```text
-tracestate: odigos=c:n;dr.p:12.5;dr.id=abc123,othervendor=1
+tracestate: odigos=c:n;dr.p:12.5;dr.id:abc123;dry:t,othervendor=1
 ```
 
 Only the `odigos=...` segment is parsed here; other vendors’ entries are ignored by this processor.

--- a/collector/processors/odigostracestateprocessor/processor.go
+++ b/collector/processors/odigostracestateprocessor/processor.go
@@ -68,6 +68,15 @@ func (p *traceStateProcessor) processSpanTraceState(span ptrace.Span) {
 			if p.traceDecidingRuleEnabled {
 				span.Attributes().PutStr(odigosattributes.SamplingTraceDecidingRuleId, value)
 			}
+		case "dry":
+			span.Attributes().PutBool(odigosattributes.SamplingDryRun, true)
+
+			switch value {
+			case "t":
+				span.Attributes().PutBool(odigosattributes.SamplingTraceKept, true)
+			case "f":
+				span.Attributes().PutBool(odigosattributes.SamplingTraceKept, false)
+			}
 		}
 	}
 }

--- a/collector/processors/odigostracestateprocessor/processor_test.go
+++ b/collector/processors/odigostracestateprocessor/processor_test.go
@@ -1,0 +1,62 @@
+package odigostracestateprocessor
+
+import (
+	"testing"
+
+	"github.com/odigos-io/odigos/common/odigosattributes"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+)
+
+func TestProcessSpanTraceStateDryRun(t *testing.T) {
+	tests := []struct {
+		name         string
+		traceState   string
+		expectedKept *bool
+	}{
+		{
+			name:         "kept",
+			traceState:   "odigos=dry:t",
+			expectedKept: boolPtr(true),
+		},
+		{
+			name:         "dropped",
+			traceState:   "odigos=dry:f",
+			expectedKept: boolPtr(false),
+		},
+		{
+			name:         "unknown decision",
+			traceState:   "odigos=dry:x",
+			expectedKept: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			span := ptrace.NewSpan()
+			span.TraceState().FromRaw(tt.traceState)
+
+			processor := traceStateProcessor{
+				logger: zap.NewNop(),
+			}
+			processor.processSpanTraceState(span)
+
+			dryRun, ok := span.Attributes().Get(odigosattributes.SamplingDryRun)
+			require.True(t, ok)
+			require.True(t, dryRun.Bool())
+
+			traceKept, ok := span.Attributes().Get(odigosattributes.SamplingTraceKept)
+			if tt.expectedKept == nil {
+				require.False(t, ok)
+				return
+			}
+			require.True(t, ok)
+			require.Equal(t, *tt.expectedKept, traceKept.Bool())
+		})
+	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}

--- a/collector/processors/odigostracestateprocessor/processor_test.go
+++ b/collector/processors/odigostracestateprocessor/processor_test.go
@@ -3,10 +3,11 @@ package odigostracestateprocessor
 import (
 	"testing"
 
-	"github.com/odigos-io/odigos/common/odigosattributes"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
+
+	"github.com/odigos-io/odigos/common/odigosattributes"
 )
 
 func TestProcessSpanTraceStateDryRun(t *testing.T) {

--- a/docs/snippets/shared/api-reference/odigos.io.v1alpha1.mdx
+++ b/docs/snippets/shared/api-reference/odigos.io.v1alpha1.mdx
@@ -1978,6 +1978,24 @@ If not specified, defaults to &quot;all&quot;.</p>
 
 <tr>
 <td>
+<code>dryRun</code> <B>[Required]</B>
+</td>
+<td>
+<code>bool</code>
+</td>
+<td>
+   <p>If true, the sampling decision will be made in dry-run mode.
+When dry-run is enabled, the sampling decision will be made but the trace will not be dropped.
+This is useful to evaluate the sampling decision before actually committing to it.
+2 additional attributes will be set on the spans:</p>
+<ul>
+<li>odigos.sampling.dry_run: true</li>
+<li>odigos.sampling.dry_run.kept: true if the trace would have been kept, false if it would have been dropped.</li>
+</ul>
+</td>
+</tr>
+<tr>
+<td>
 <code>noisyOperations</code> <B>[Required]</B>
 </td>
 <td>

--- a/helm/odigos/templates/crds/odigos.io_instrumentationconfigs.yaml
+++ b/helm/odigos/templates/crds/odigos.io_instrumentationconfigs.yaml
@@ -212,6 +212,15 @@ spec:
                             This config currently only applies to root spans.
                             In the Future we might add another level of configuration base on the parent span (ParentBased Sampling)
                           properties:
+                            dryRun:
+                              description: |-
+                                If true, the sampling decision will be made in dry-run mode.
+                                When dry-run is enabled, the sampling decision will be made but the trace will not be dropped.
+                                This is useful to evaluate the sampling decision before actually committing to it.
+                                2 additional attributes will be set on the spans:
+                                - odigos.sampling.dry_run: true
+                                - odigos.sampling.dry_run.kept: true if the trace would have been kept, false if it would have been dropped.
+                              type: boolean
                             fallbackFraction:
                               default: 1
                               description: |-

--- a/instrumentor/controllers/agentenabled/dynamicconfig/config.go
+++ b/instrumentor/controllers/agentenabled/dynamicconfig/config.go
@@ -65,7 +65,12 @@ func calculateTracesConfig(
 	// use head/tail sampling based on the distro support.
 	if len(noisyOps) > 0 {
 		if traces.DistroSupportsHeadSampling(d) {
+			dryRun := false
+			if effectiveConfig.Sampling != nil && effectiveConfig.Sampling.DryRun != nil {
+				dryRun = *effectiveConfig.Sampling.DryRun
+			}
 			agentConfig.HeadSampling = &odigosv1.HeadSamplingConfig{
+				DryRun:          dryRun,
 				NoisyOperations: noisyOps,
 			}
 		} else {


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: CORE-939

This PR bridges the dryrun sampling config from effective config, so it ends up in the agent container config for traces, so agents can use it and apply it if supported.

It also extracts this property from the trace state if set by the agent, and populate it as span attributes.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

Still not implemented by agents.

```release-note
NONE
```
