### PR TITLE
fix(sdk/go): shutdown gRPC exporter on failed Go instrumentation to prevent goroutine leak

### DIFF
--- a/odiglet/pkg/ebpf/sdks/go.go
+++ b/odiglet/pkg/ebpf/sdks/go.go
@@ -46,6 +46,9 @@ func (g *GoInstrumentationFactory) CreateInstrumentation(ctx context.Context, pi
 
 	initialConfig, err := convertToGoInstrumentationConfig(settings.InitialConfig)
 	if err != nil {
+		if shutdownErr := defaultExporter.Shutdown(ctx); shutdownErr != nil {
+			log.Error("failed to shutdown exporter after config error", "error", shutdownErr)
+		}
 		return nil, fmt.Errorf("invalid initial config type, expected *odigosv1.SdkConfig, got %T", settings.InitialConfig)
 	}
 
@@ -63,6 +66,9 @@ func (g *GoInstrumentationFactory) CreateInstrumentation(ctx context.Context, pi
 	)
 	if err != nil {
 		log.Error("instrumentation setup failed", "err", err)
+		if shutdownErr := defaultExporter.Shutdown(ctx); shutdownErr != nil {
+			log.Error("failed to shutdown exporter after instrumentation setup failure", "error", shutdownErr)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION


#### What this PR does / why we need it:
Related https://linear.app/odigos/issue/RUN-747/goroutine-leaks-in-go-instrumentation
#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
fix(sdk/go): shutdown gRPC exporter on failed Go instrumentation to prevent goroutine leak
```
