### PR TITLE
fix: check if metrics exists to avoid panic

### DIFF
--- a/instrumentor/controllers/agentenabled/dynamicconfig/config.go
+++ b/instrumentor/controllers/agentenabled/dynamicconfig/config.go
@@ -75,8 +75,13 @@ func calculateTracesConfig(
 				dryRun = *effectiveConfig.Sampling.DryRun
 			}
 
-			spanMetricsEnabled := nodeCollectorsGroup.Spec.Metrics.SpanMetrics == nil || nodeCollectorsGroup.Spec.Metrics.SpanMetrics.Disabled == nil || !*nodeCollectorsGroup.Spec.Metrics.SpanMetrics.Disabled
-			metricsSignalEnabled := slices.Contains(nodeCollectorsGroup.Status.ReceiverSignals, common.MetricsObservabilitySignal)
+			spanMetricsEnabled := nodeCollectorsGroup != nil &&
+				(nodeCollectorsGroup.Spec.Metrics == nil ||
+					nodeCollectorsGroup.Spec.Metrics.SpanMetrics == nil ||
+					nodeCollectorsGroup.Spec.Metrics.SpanMetrics.Disabled == nil ||
+					!*nodeCollectorsGroup.Spec.Metrics.SpanMetrics.Disabled)
+			metricsSignalEnabled := nodeCollectorsGroup != nil &&
+				slices.Contains(nodeCollectorsGroup.Status.ReceiverSignals, common.MetricsObservabilitySignal)
 			configuredMode := effectiveConfig.MetricsSources != nil &&
 				effectiveConfig.MetricsSources.SpanMetrics != nil &&
 				effectiveConfig.MetricsSources.SpanMetrics.SpanMetricsMode != nil

--- a/instrumentor/controllers/agentenabled/dynamicconfig/config.go
+++ b/instrumentor/controllers/agentenabled/dynamicconfig/config.go
@@ -76,8 +76,8 @@ func calculateTracesConfig(
 			}
 
 			spanMetricsEnabled := nodeCollectorsGroup != nil &&
-				(nodeCollectorsGroup.Spec.Metrics == nil ||
-					nodeCollectorsGroup.Spec.Metrics.SpanMetrics == nil ||
+				nodeCollectorsGroup.Spec.Metrics != nil &&
+				(nodeCollectorsGroup.Spec.Metrics.SpanMetrics == nil ||
 					nodeCollectorsGroup.Spec.Metrics.SpanMetrics.Disabled == nil ||
 					!*nodeCollectorsGroup.Spec.Metrics.SpanMetrics.Disabled)
 			metricsSignalEnabled := nodeCollectorsGroup != nil &&


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Fix issue where Metrics is not exists in the collectorgroup.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
