### PR TITLE
CORE-935: use a real sts identity for RHEL trigger

### DIFF
--- a/.github/workflows/publish-modules-rhel.yml
+++ b/.github/workflows/publish-modules-rhel.yml
@@ -226,7 +226,7 @@ jobs:
             uses: odigos-io/ci-core/sts@main
             with:
               scope: odigos-io/odigos-enterprise
-              identity: trigger-publish-rhel
+              identity: trigger-release-pr
               output-git-config: "false"
 
           - name: Trigger Enterprise Publish job


### PR DESCRIPTION
#### What this PR does / why we need it:
https://github.com/odigos-io/odigos/pull/4764 used a nonexistent STS identity, this updates RHEL job to use the same identity as the main release flow to trigger enterprise

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
