### PR TITLE
fix: GQL schemas for profiling

### DIFF
--- a/frontend/graph/configs.graphqls
+++ b/frontend/graph/configs.graphqls
@@ -145,6 +145,10 @@ type WaspConfig {
   enabled: Boolean
 }
 
+type ProfilingConfig {
+  enabled: Boolean
+}
+
 type KarpenterConfig {
   enabled: Boolean
 }
@@ -264,6 +268,7 @@ type EffectiveConfig {
   imagePullSecrets: [String!]
   componentLogLevels: ComponentLogLevelsConfig
   sampling: SamplingConfig
+  profiling: ProfilingConfig
   provenance: [ProvenanceEntry!]
   manifestYAML: String
 }

--- a/frontend/graph/conversions.go
+++ b/frontend/graph/conversions.go
@@ -441,6 +441,15 @@ func setEffectiveConfigNestedStructs(result *model.EffectiveConfig, config *comm
 		recordSamplingProvenance(config.Sampling, pc)
 	}
 
+	if config.Profiling != nil {
+		result.Profiling = &model.ProfilingConfig{
+			Enabled: config.Profiling.Enabled,
+		}
+		if config.Profiling.Enabled != nil {
+			pc.record("profiling.enabled")
+		}
+	}
+
 	return nil
 }
 

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -438,6 +438,7 @@ type ComplexityRoot struct {
 		Oidc                             func(childComplexity int) int
 		OpenshiftEnabled                 func(childComplexity int) int
 		Profiles                         func(childComplexity int) int
+		Profiling                        func(childComplexity int) int
 		Provenance                       func(childComplexity int) int
 		Psp                              func(childComplexity int) int
 		ResourceSizePreset               func(childComplexity int) int
@@ -1110,6 +1111,10 @@ type ComplexityRoot struct {
 		Kind      func(childComplexity int) int
 		Name      func(childComplexity int) int
 		Namespace func(childComplexity int) int
+	}
+
+	ProfilingConfig struct {
+		Enabled func(childComplexity int) int
 	}
 
 	ProfilingSlots struct {
@@ -3342,6 +3347,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.EffectiveConfig.Profiles(childComplexity), true
+
+	case "EffectiveConfig.profiling":
+		if e.complexity.EffectiveConfig.Profiling == nil {
+			break
+		}
+
+		return e.complexity.EffectiveConfig.Profiling(childComplexity), true
 
 	case "EffectiveConfig.provenance":
 		if e.complexity.EffectiveConfig.Provenance == nil {
@@ -6352,6 +6364,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.PodWorkload.Namespace(childComplexity), true
+
+	case "ProfilingConfig.enabled":
+		if e.complexity.ProfilingConfig.Enabled == nil {
+			break
+		}
+
+		return e.complexity.ProfilingConfig.Enabled(childComplexity), true
 
 	case "ProfilingSlots.activeKeys":
 		if e.complexity.ProfilingSlots.ActiveKeys == nil {
@@ -22124,6 +22143,51 @@ func (ec *executionContext) fieldContext_EffectiveConfig_sampling(_ context.Cont
 				return ec.fieldContext_SamplingConfig_k8sHealthProbesSampling(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type SamplingConfig", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _EffectiveConfig_profiling(ctx context.Context, field graphql.CollectedField, obj *model.EffectiveConfig) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_EffectiveConfig_profiling(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Profiling, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.ProfilingConfig)
+	fc.Result = res
+	return ec.marshalOProfilingConfig2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐProfilingConfig(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_EffectiveConfig_profiling(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "EffectiveConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "enabled":
+				return ec.fieldContext_ProfilingConfig_enabled(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ProfilingConfig", field.Name)
 		},
 	}
 	return fc, nil
@@ -40879,6 +40943,47 @@ func (ec *executionContext) fieldContext_PodWorkload_kind(_ context.Context, fie
 	return fc, nil
 }
 
+func (ec *executionContext) _ProfilingConfig_enabled(ctx context.Context, field graphql.CollectedField, obj *model.ProfilingConfig) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ProfilingConfig_enabled(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Enabled, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*bool)
+	fc.Result = res
+	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ProfilingConfig_enabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ProfilingConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _ProfilingSlots_activeKeys(ctx context.Context, field graphql.CollectedField, obj *model.ProfilingSlots) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_ProfilingSlots_activeKeys(ctx, field)
 	if err != nil {
@@ -42517,6 +42622,8 @@ func (ec *executionContext) fieldContext_Query_effectiveConfig(_ context.Context
 				return ec.fieldContext_EffectiveConfig_componentLogLevels(ctx, field)
 			case "sampling":
 				return ec.fieldContext_EffectiveConfig_sampling(ctx, field)
+			case "profiling":
+				return ec.fieldContext_EffectiveConfig_profiling(ctx, field)
 			case "provenance":
 				return ec.fieldContext_EffectiveConfig_provenance(ctx, field)
 			case "manifestYAML":
@@ -55997,6 +56104,8 @@ func (ec *executionContext) _EffectiveConfig(ctx context.Context, sel ast.Select
 			out.Values[i] = ec._EffectiveConfig_componentLogLevels(ctx, field, obj)
 		case "sampling":
 			out.Values[i] = ec._EffectiveConfig_sampling(ctx, field, obj)
+		case "profiling":
+			out.Values[i] = ec._EffectiveConfig_profiling(ctx, field, obj)
 		case "provenance":
 			out.Values[i] = ec._EffectiveConfig_provenance(ctx, field, obj)
 		case "manifestYAML":
@@ -61220,6 +61329,42 @@ func (ec *executionContext) _PodWorkload(ctx context.Context, sel ast.SelectionS
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var profilingConfigImplementors = []string{"ProfilingConfig"}
+
+func (ec *executionContext) _ProfilingConfig(ctx context.Context, sel ast.SelectionSet, obj *model.ProfilingConfig) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, profilingConfigImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ProfilingConfig")
+		case "enabled":
+			out.Values[i] = ec._ProfilingConfig_enabled(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -69946,6 +70091,13 @@ func (ec *executionContext) unmarshalOPodWorkloadInput2ᚕᚖgithubᚗcomᚋodig
 		}
 	}
 	return res, nil
+}
+
+func (ec *executionContext) marshalOProfilingConfig2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐProfilingConfig(ctx context.Context, sel ast.SelectionSet, v *model.ProfilingConfig) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._ProfilingConfig(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOProfilingSlots2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐProfilingSlots(ctx context.Context, sel ast.SelectionSet, v *model.ProfilingSlots) graphql.Marshaler {

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -1119,7 +1119,7 @@ type ComplexityRoot struct {
 		MaxTotalBytesBudget func(childComplexity int) int
 		SlotMaxBytes        func(childComplexity int) int
 		SlotTTLSeconds      func(childComplexity int) int
-		TotalBytesInUse     func(childComplexity int) int
+		TotalBytesUsed      func(childComplexity int) int
 	}
 
 	ProvenanceEntry struct {
@@ -6395,12 +6395,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ProfilingSlots.SlotTTLSeconds(childComplexity), true
 
-	case "ProfilingSlots.totalBytesInUse":
-		if e.complexity.ProfilingSlots.TotalBytesInUse == nil {
+	case "ProfilingSlots.totalBytesUsed":
+		if e.complexity.ProfilingSlots.TotalBytesUsed == nil {
 			break
 		}
 
-		return e.complexity.ProfilingSlots.TotalBytesInUse(childComplexity), true
+		return e.complexity.ProfilingSlots.TotalBytesUsed(childComplexity), true
 
 	case "ProvenanceEntry.helmPath":
 		if e.complexity.ProvenanceEntry.HelmPath == nil {
@@ -40967,8 +40967,8 @@ func (ec *executionContext) fieldContext_ProfilingSlots_keysWithData(_ context.C
 	return fc, nil
 }
 
-func (ec *executionContext) _ProfilingSlots_totalBytesInUse(ctx context.Context, field graphql.CollectedField, obj *model.ProfilingSlots) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_ProfilingSlots_totalBytesInUse(ctx, field)
+func (ec *executionContext) _ProfilingSlots_totalBytesUsed(ctx context.Context, field graphql.CollectedField, obj *model.ProfilingSlots) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ProfilingSlots_totalBytesUsed(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -40981,7 +40981,7 @@ func (ec *executionContext) _ProfilingSlots_totalBytesInUse(ctx context.Context,
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.TotalBytesInUse, nil
+		return obj.TotalBytesUsed, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -40998,7 +40998,7 @@ func (ec *executionContext) _ProfilingSlots_totalBytesInUse(ctx context.Context,
 	return ec.marshalNInt2int(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_ProfilingSlots_totalBytesInUse(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_ProfilingSlots_totalBytesUsed(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "ProfilingSlots",
 		Field:      field,
@@ -42689,8 +42689,8 @@ func (ec *executionContext) fieldContext_Query_profilingSlots(_ context.Context,
 				return ec.fieldContext_ProfilingSlots_activeKeys(ctx, field)
 			case "keysWithData":
 				return ec.fieldContext_ProfilingSlots_keysWithData(ctx, field)
-			case "totalBytesInUse":
-				return ec.fieldContext_ProfilingSlots_totalBytesInUse(ctx, field)
+			case "totalBytesUsed":
+				return ec.fieldContext_ProfilingSlots_totalBytesUsed(ctx, field)
 			case "slotMaxBytes":
 				return ec.fieldContext_ProfilingSlots_slotMaxBytes(ctx, field)
 			case "maxSlots":
@@ -61264,8 +61264,8 @@ func (ec *executionContext) _ProfilingSlots(ctx context.Context, sel ast.Selecti
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "totalBytesInUse":
-			out.Values[i] = ec._ProfilingSlots_totalBytesInUse(ctx, field, obj)
+		case "totalBytesUsed":
+			out.Values[i] = ec._ProfilingSlots_totalBytesUsed(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -496,6 +496,7 @@ type EffectiveConfig struct {
 	ImagePullSecrets                 []string                            `json:"imagePullSecrets,omitempty"`
 	ComponentLogLevels               *ComponentLogLevelsConfig           `json:"componentLogLevels,omitempty"`
 	Sampling                         *SamplingConfig                     `json:"sampling,omitempty"`
+	Profiling                        *ProfilingConfig                    `json:"profiling,omitempty"`
 	Provenance                       []*ProvenanceEntry                  `json:"provenance,omitempty"`
 	ManifestYaml                     *string                             `json:"manifestYAML,omitempty"`
 }
@@ -1378,6 +1379,10 @@ type PodWorkloadInput struct {
 	Namespace string          `json:"namespace"`
 	Kind      K8sResourceKind `json:"kind"`
 	Name      string          `json:"name"`
+}
+
+type ProfilingConfig struct {
+	Enabled *bool `json:"enabled,omitempty"`
 }
 
 // In-memory profiling buffer stats

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -1384,7 +1384,7 @@ type PodWorkloadInput struct {
 type ProfilingSlots struct {
 	ActiveKeys          []string `json:"activeKeys"`
 	KeysWithData        []string `json:"keysWithData"`
-	TotalBytesInUse     int      `json:"totalBytesInUse"`
+	TotalBytesUsed      int      `json:"totalBytesUsed"`
 	SlotMaxBytes        int      `json:"slotMaxBytes"`
 	MaxSlots            int      `json:"maxSlots"`
 	MaxTotalBytesBudget int      `json:"maxTotalBytesBudget"`

--- a/frontend/graph/profiling.graphqls
+++ b/frontend/graph/profiling.graphqls
@@ -1,18 +1,22 @@
 # Continuous profiling: OTLP profiles buffered per workload slot (UI backend).
 # Schema and resolvers live here (follow-schema → profiling.resolvers.go), not in schema.graphqls.
 
-"""In-memory profiling buffer stats"""
+"""
+In-memory profiling buffer stats
+"""
 type ProfilingSlots {
   activeKeys: [String!]!
   keysWithData: [String!]!
-  totalBytesInUse: Int!
+  totalBytesUsed: Int!
   slotMaxBytes: Int!
   maxSlots: Int!
   maxTotalBytesBudget: Int!
   slotTtlSeconds: Int!
 }
 
-"""Enabling profiling slot for a workload"""
+"""
+Enabling profiling slot for a workload
+"""
 type EnableProfilingResult {
   status: String!
   sourceKey: String!
@@ -20,51 +24,67 @@ type EnableProfilingResult {
   activeSlots: Int!
 }
 
-"""Disable profiling slot for a workload."""
+"""
+Disable profiling slot for a workload.
+"""
 type DisableProfilingResult {
   status: String!
   sourceKey: String!
   activeSlots: Int!
 }
 
-"""Clearing buffered OTLP data for a workload slot"""
+"""
+Clearing buffered OTLP data for a workload slot
+"""
 type ClearProfilingBufferResult {
   status: String!
   sourceKey: String!
   activeSlots: Int!
 }
 
-"""Pyroscope-style flame profile for one source (JSON string)."""
+"""
+Pyroscope-style flame profile for one source (JSON string).
+"""
 type SourceProfilingResult {
   profileJson: String!
 }
 
 extend type K8sActualSource {
-  """Buffered CPU profile for this source"""
+  """
+  Buffered CPU profile for this source
+  """
   profiling: SourceProfilingResult
 }
 
 extend type Query {
-  """Diagnostics: active keys, keys with data, and memory limits for the profiling buffer"""
+  """
+  Diagnostics: active keys, keys with data, and memory limits for the profiling buffer
+  """
   profilingSlots: ProfilingSlots
 }
 
 extend type Mutation {
-  """Open or refresh the in-memory profiling slot for this workload"""
+  """
+  Open or refresh the in-memory profiling slot for this workload
+  """
   enableSourceProfiling(
     namespace: String!
     kind: String!
     name: String!
   ): EnableProfilingResult!
 
-  """Close the profiling slot and free buffered chunks for this workload"""
+  """
+  Close the profiling slot and free buffered chunks for this workload
+  """
   disableSourceProfiling(
     namespace: String!
     kind: String!
     name: String!
   ): DisableProfilingResult!
 
-  """Drop buffered OTLP chunks for this slot while leaving the slot open if policy allows"""
+  """
+  Drop buffered OTLP chunks for this slot while leaving the slot open if policy allows
+  """
   clearSourceProfilingBuffer(
     namespace: String!
     kind: String!

--- a/frontend/graph/profiling.resolvers.go
+++ b/frontend/graph/profiling.resolvers.go
@@ -88,7 +88,7 @@ func (r *queryResolver) ProfilingSlots(ctx context.Context) (*model.ProfilingSlo
 	return &model.ProfilingSlots{
 		ActiveKeys:          activeKeys,
 		KeysWithData:        keysWithData,
-		TotalBytesInUse:     stats.TotalBytes,
+		TotalBytesUsed:      stats.TotalBytes,
 		SlotMaxBytes:        stats.SlotMaxBytes,
 		MaxSlots:            stats.MaxSlots,
 		MaxTotalBytesBudget: stats.MaxTotalBytesBudget,

--- a/frontend/webapp/components/lib-imports/overview-modals-and-drawers.tsx
+++ b/frontend/webapp/components/lib-imports/overview-modals-and-drawers.tsx
@@ -108,7 +108,7 @@ const OverviewModalsAndDrawers = () => {
           fetchSourceDescribe={fetchDescribeSource}
           fetchSourceLibraries={fetchSourceLibraries}
           fetchPeerSources={fetchPeerSources}
-          profilingEnabled={effectiveConfig?.profiling?.enabled}
+          profilingEnabled={effectiveConfig?.profiling?.enabled || false}
           enableProfiling={enableProfiling}
           releaseProfiling={releaseProfiling}
           fetchSourceProfiling={fetchSourceProfiling}

--- a/frontend/webapp/components/lib-imports/overview-modals-and-drawers.tsx
+++ b/frontend/webapp/components/lib-imports/overview-modals-and-drawers.tsx
@@ -31,8 +31,8 @@ const OverviewModalsAndDrawers = () => {
   const { getPotentialDestinations } = usePotentialDestinations();
   const { createActionV2, updateAction, deleteAction } = useActionCRUD();
   const { restartWorkloads, restartPod, recoverFromRollback } = useWorkloadUtils();
+  const { fetchProfilingSlots, enableProfiling, fetchSourceProfiling } = useProfiling();
   const { createDestination, updateDestination, deleteDestination } = useDestinationCRUD();
-  const { fetchProfilingSlots, enableProfiling, releaseProfiling, fetchSourceProfiling } = useProfiling();
   const { createInstrumentationRuleV2, updateInstrumentationRule, deleteInstrumentationRule } = useInstrumentationRuleCRUD();
   const { persistSources, persistSourcesV2, updateSource, fetchSourceById, fetchSourceLibraries, fetchPeerSources } = useSourceCRUD();
 
@@ -91,9 +91,8 @@ const OverviewModalsAndDrawers = () => {
         //     fetchSourceDescribe={fetchDescribeSource}
         //     fetchSourceLibraries={fetchSourceLibraries}
         //     fetchPeerSources={fetchPeerSources}
-        //     profilingEnabled={effectiveConfig?.profiling?.enabled}
+        //     profilingEnabled={effectiveConfig?.profiling?.enabled || false}
         //     enableProfiling={enableProfiling}
-        //     releaseProfiling={releaseProfiling}
         //     fetchSourceProfiling={fetchSourceProfiling}
         //     fetchProfilingSlots={fetchProfilingSlots}
         //   />
@@ -110,7 +109,6 @@ const OverviewModalsAndDrawers = () => {
           fetchPeerSources={fetchPeerSources}
           profilingEnabled={effectiveConfig?.profiling?.enabled || false}
           enableProfiling={enableProfiling}
-          releaseProfiling={releaseProfiling}
           fetchSourceProfiling={fetchSourceProfiling}
           fetchProfilingSlots={fetchProfilingSlots}
         />

--- a/frontend/webapp/components/lib-imports/overview-modals-and-drawers.tsx
+++ b/frontend/webapp/components/lib-imports/overview-modals-and-drawers.tsx
@@ -15,6 +15,7 @@ import {
   useProfiling,
   useTestConnection,
   useWorkloadUtils,
+  useEffectiveConfig,
 } from '@/hooks';
 import { SourceDrawer } from '@odigos/ui-kit/containers';
 
@@ -24,6 +25,7 @@ const OverviewModalsAndDrawers = () => {
 
   const { fetchDescribeSource } = useDescribe();
   const { testConnection } = useTestConnection();
+  const { effectiveConfig } = useEffectiveConfig();
   const { fetchNamespacesWithWorkloads } = useNamespace();
   const { getDestinationCategories } = useDestinationCategories();
   const { getPotentialDestinations } = usePotentialDestinations();
@@ -89,6 +91,7 @@ const OverviewModalsAndDrawers = () => {
         //     fetchSourceDescribe={fetchDescribeSource}
         //     fetchSourceLibraries={fetchSourceLibraries}
         //     fetchPeerSources={fetchPeerSources}
+        //     profilingEnabled={effectiveConfig?.profiling?.enabled}
         //     enableProfiling={enableProfiling}
         //     releaseProfiling={releaseProfiling}
         //     fetchSourceProfiling={fetchSourceProfiling}
@@ -105,6 +108,7 @@ const OverviewModalsAndDrawers = () => {
           fetchSourceDescribe={fetchDescribeSource}
           fetchSourceLibraries={fetchSourceLibraries}
           fetchPeerSources={fetchPeerSources}
+          profilingEnabled={effectiveConfig?.profiling?.enabled}
           enableProfiling={enableProfiling}
           releaseProfiling={releaseProfiling}
           fetchSourceProfiling={fetchSourceProfiling}

--- a/frontend/webapp/graphql/mutations/profiling.ts
+++ b/frontend/webapp/graphql/mutations/profiling.ts
@@ -10,13 +10,3 @@ export const ENABLE_SOURCE_PROFILING = gql`
     }
   }
 `;
-
-export const DISABLE_SOURCE_PROFILING = gql`
-  mutation DisableSourceProfiling($namespace: String!, $kind: String!, $name: String!) {
-    disableSourceProfiling(namespace: $namespace, kind: $kind, name: $name) {
-      status
-      sourceKey
-      activeSlots
-    }
-  }
-`;

--- a/frontend/webapp/graphql/mutations/profiling.ts
+++ b/frontend/webapp/graphql/mutations/profiling.ts
@@ -11,9 +11,9 @@ export const ENABLE_SOURCE_PROFILING = gql`
   }
 `;
 
-export const RELEASE_SOURCE_PROFILING = gql`
-  mutation ReleaseSourceProfiling($namespace: String!, $kind: String!, $name: String!) {
-    releaseSourceProfiling(namespace: $namespace, kind: $kind, name: $name) {
+export const DISABLE_SOURCE_PROFILING = gql`
+  mutation DisableSourceProfiling($namespace: String!, $kind: String!, $name: String!) {
+    disableSourceProfiling(namespace: $namespace, kind: $kind, name: $name) {
       status
       sourceKey
       activeSlots

--- a/frontend/webapp/graphql/queries/config.ts
+++ b/frontend/webapp/graphql/queries/config.ts
@@ -185,6 +185,9 @@ export const GET_EFFECTIVE_CONFIG = gql`
           keepPercentage
         }
       }
+      profiling {
+        enabled
+      }
       provenance {
         helmPath
         reconciledFrom

--- a/frontend/webapp/graphql/queries/profiling.ts
+++ b/frontend/webapp/graphql/queries/profiling.ts
@@ -15,9 +15,13 @@ export const GET_PROFILING_SLOTS = gql`
 `;
 
 export const GET_SOURCE_PROFILING = gql`
-  query GetSourceProfiling($namespace: String!, $kind: String!, $name: String!) {
-    sourceProfiling(namespace: $namespace, kind: $kind, name: $name) {
-      profileJson
+  query GetSourceProfiling($sourceId: K8sSourceId!) {
+    computePlatform {
+      source(sourceId: $sourceId) {
+        profiling {
+          profileJson
+        }
+      }
     }
   }
 `;

--- a/frontend/webapp/hooks/profiling/useProfiling.ts
+++ b/frontend/webapp/hooks/profiling/useProfiling.ts
@@ -1,12 +1,7 @@
 import { useCallback } from 'react';
+import type { WorkloadId } from '@odigos/ui-kit/types';
 import { useLazyQuery, useMutation } from '@apollo/client';
 import { GET_PROFILING_SLOTS, GET_SOURCE_PROFILING, ENABLE_SOURCE_PROFILING, DISABLE_SOURCE_PROFILING } from '@/graphql';
-
-interface SourceIdentifier {
-  namespace: string;
-  kind: string;
-  name: string;
-}
 
 interface ProfilingSlots {
   activeKeys: string[];
@@ -37,9 +32,9 @@ interface SourceProfilingResult {
 
 interface UseProfiling {
   fetchProfilingSlots: () => Promise<ProfilingSlots | undefined>;
-  enableProfiling: (source: SourceIdentifier) => Promise<EnableProfilingResult | undefined>;
-  releaseProfiling: (source: SourceIdentifier) => Promise<DisableProfilingResult | undefined>;
-  fetchSourceProfiling: (source: SourceIdentifier) => Promise<SourceProfilingResult | undefined>;
+  enableProfiling: (source: WorkloadId) => Promise<EnableProfilingResult | undefined>;
+  releaseProfiling: (source: WorkloadId) => Promise<DisableProfilingResult | undefined>;
+  fetchSourceProfiling: (source: WorkloadId) => Promise<SourceProfilingResult | undefined>;
 }
 
 export const useProfiling = (): UseProfiling => {
@@ -47,12 +42,12 @@ export const useProfiling = (): UseProfiling => {
     fetchPolicy: 'network-only',
   });
 
-  const [querySourceProfiling] = useLazyQuery<{ source: { profiling: SourceProfilingResult } }, SourceIdentifier>(GET_SOURCE_PROFILING, {
+  const [querySourceProfiling] = useLazyQuery<{ computePlatform?: { source?: { profiling: SourceProfilingResult } } }, { sourceId: WorkloadId }>(GET_SOURCE_PROFILING, {
     fetchPolicy: 'network-only',
   });
 
-  const [mutateEnable] = useMutation<{ enableSourceProfiling: EnableProfilingResult }, SourceIdentifier>(ENABLE_SOURCE_PROFILING);
-  const [mutateRelease] = useMutation<{ disableSourceProfiling: DisableProfilingResult }, SourceIdentifier>(DISABLE_SOURCE_PROFILING);
+  const [mutateEnable] = useMutation<{ enableSourceProfiling: EnableProfilingResult }, WorkloadId>(ENABLE_SOURCE_PROFILING);
+  const [mutateRelease] = useMutation<{ disableSourceProfiling: DisableProfilingResult }, WorkloadId>(DISABLE_SOURCE_PROFILING);
 
   // Returns buffer/slot diagnostics: which workloads have active slots, which have buffered data, and memory usage.
   // Example response: { activeKeys: ["default/Deployment/inventory", ...], keysWithData: [...], totalBytesUsed: 4897024, ... }
@@ -88,8 +83,8 @@ export const useProfiling = (): UseProfiling => {
   //       => { profileJson: '{"version":1,"flamebearer":{"names":[...],"levels":[...],...},...}' }
   const fetchSourceProfiling: UseProfiling['fetchSourceProfiling'] = useCallback(
     async (source) => {
-      const { data } = await querySourceProfiling({ variables: source });
-      return data?.source.profiling;
+      const { data } = await querySourceProfiling({ variables: { sourceId: source } });
+      return data?.computePlatform?.source?.profiling;
     },
     [querySourceProfiling],
   );

--- a/frontend/webapp/hooks/profiling/useProfiling.ts
+++ b/frontend/webapp/hooks/profiling/useProfiling.ts
@@ -47,7 +47,7 @@ export const useProfiling = (): UseProfiling => {
     fetchPolicy: 'network-only',
   });
 
-  const [querySourceProfiling] = useLazyQuery<{ sourceProfiling: SourceProfilingResult }, SourceIdentifier>(GET_SOURCE_PROFILING, {
+  const [querySourceProfiling] = useLazyQuery<{ source: { profiling: SourceProfilingResult } }, SourceIdentifier>(GET_SOURCE_PROFILING, {
     fetchPolicy: 'network-only',
   });
 
@@ -89,7 +89,7 @@ export const useProfiling = (): UseProfiling => {
   const fetchSourceProfiling: UseProfiling['fetchSourceProfiling'] = useCallback(
     async (source) => {
       const { data } = await querySourceProfiling({ variables: source });
-      return data?.sourceProfiling;
+      return data?.source.profiling;
     },
     [querySourceProfiling],
   );

--- a/frontend/webapp/hooks/profiling/useProfiling.ts
+++ b/frontend/webapp/hooks/profiling/useProfiling.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { useLazyQuery, useMutation } from '@apollo/client';
-import { GET_PROFILING_SLOTS, GET_SOURCE_PROFILING, ENABLE_SOURCE_PROFILING, RELEASE_SOURCE_PROFILING } from '@/graphql';
+import { GET_PROFILING_SLOTS, GET_SOURCE_PROFILING, ENABLE_SOURCE_PROFILING, DISABLE_SOURCE_PROFILING } from '@/graphql';
 
 interface SourceIdentifier {
   namespace: string;
@@ -25,7 +25,7 @@ interface EnableProfilingResult {
   activeSlots: number;
 }
 
-interface ReleaseProfilingResult {
+interface DisableProfilingResult {
   status: string;
   sourceKey: string;
   activeSlots: number;
@@ -38,7 +38,7 @@ interface SourceProfilingResult {
 interface UseProfiling {
   fetchProfilingSlots: () => Promise<ProfilingSlots | undefined>;
   enableProfiling: (source: SourceIdentifier) => Promise<EnableProfilingResult | undefined>;
-  releaseProfiling: (source: SourceIdentifier) => Promise<ReleaseProfilingResult | undefined>;
+  releaseProfiling: (source: SourceIdentifier) => Promise<DisableProfilingResult | undefined>;
   fetchSourceProfiling: (source: SourceIdentifier) => Promise<SourceProfilingResult | undefined>;
 }
 
@@ -52,7 +52,7 @@ export const useProfiling = (): UseProfiling => {
   });
 
   const [mutateEnable] = useMutation<{ enableSourceProfiling: EnableProfilingResult }, SourceIdentifier>(ENABLE_SOURCE_PROFILING);
-  const [mutateRelease] = useMutation<{ releaseSourceProfiling: ReleaseProfilingResult }, SourceIdentifier>(RELEASE_SOURCE_PROFILING);
+  const [mutateRelease] = useMutation<{ disableSourceProfiling: DisableProfilingResult }, SourceIdentifier>(DISABLE_SOURCE_PROFILING);
 
   // Returns buffer/slot diagnostics: which workloads have active slots, which have buffered data, and memory usage.
   // Example response: { activeKeys: ["default/Deployment/inventory", ...], keysWithData: [...], totalBytesUsed: 4897024, ... }
@@ -78,7 +78,7 @@ export const useProfiling = (): UseProfiling => {
   const releaseProfiling: UseProfiling['releaseProfiling'] = useCallback(
     async (source) => {
       const { data } = await mutateRelease({ variables: source });
-      return data?.releaseSourceProfiling;
+      return data?.disableSourceProfiling;
     },
     [mutateRelease],
   );

--- a/frontend/webapp/hooks/profiling/useProfiling.ts
+++ b/frontend/webapp/hooks/profiling/useProfiling.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import type { WorkloadId } from '@odigos/ui-kit/types';
 import { useLazyQuery, useMutation } from '@apollo/client';
-import { GET_PROFILING_SLOTS, GET_SOURCE_PROFILING, ENABLE_SOURCE_PROFILING, DISABLE_SOURCE_PROFILING } from '@/graphql';
+import { GET_PROFILING_SLOTS, GET_SOURCE_PROFILING, ENABLE_SOURCE_PROFILING } from '@/graphql';
 
 interface ProfilingSlots {
   activeKeys: string[];
@@ -20,34 +20,24 @@ interface EnableProfilingResult {
   activeSlots: number;
 }
 
-interface DisableProfilingResult {
-  status: string;
-  sourceKey: string;
-  activeSlots: number;
-}
-
 interface SourceProfilingResult {
   profileJson: string;
 }
 
 interface UseProfiling {
-  fetchProfilingSlots: () => Promise<ProfilingSlots | undefined>;
   enableProfiling: (source: WorkloadId) => Promise<EnableProfilingResult | undefined>;
-  releaseProfiling: (source: WorkloadId) => Promise<DisableProfilingResult | undefined>;
+  fetchProfilingSlots: () => Promise<ProfilingSlots | undefined>;
   fetchSourceProfiling: (source: WorkloadId) => Promise<SourceProfilingResult | undefined>;
 }
 
 export const useProfiling = (): UseProfiling => {
+  const [mutateEnable] = useMutation<{ enableSourceProfiling: EnableProfilingResult }, WorkloadId>(ENABLE_SOURCE_PROFILING);
   const [querySlots] = useLazyQuery<{ profilingSlots: ProfilingSlots }>(GET_PROFILING_SLOTS, {
     fetchPolicy: 'network-only',
   });
-
   const [querySourceProfiling] = useLazyQuery<{ computePlatform?: { source?: { profiling: SourceProfilingResult } } }, { sourceId: WorkloadId }>(GET_SOURCE_PROFILING, {
     fetchPolicy: 'network-only',
   });
-
-  const [mutateEnable] = useMutation<{ enableSourceProfiling: EnableProfilingResult }, WorkloadId>(ENABLE_SOURCE_PROFILING);
-  const [mutateRelease] = useMutation<{ disableSourceProfiling: DisableProfilingResult }, WorkloadId>(DISABLE_SOURCE_PROFILING);
 
   // Returns buffer/slot diagnostics: which workloads have active slots, which have buffered data, and memory usage.
   // Example response: { activeKeys: ["default/Deployment/inventory", ...], keysWithData: [...], totalBytesUsed: 4897024, ... }
@@ -67,17 +57,6 @@ export const useProfiling = (): UseProfiling => {
     [mutateEnable],
   );
 
-  // Drops the profiling slot and frees buffered OTLP data for a workload (e.g. user closed the profiling panel).
-  // Example: await releaseProfiling({ namespace: "default", kind: "Deployment", name: "inventory" })
-  //       => { status: "ok", sourceKey: "default/Deployment/inventory", activeSlots: 5 }
-  const releaseProfiling: UseProfiling['releaseProfiling'] = useCallback(
-    async (source) => {
-      const { data } = await mutateRelease({ variables: source });
-      return data?.disableSourceProfiling;
-    },
-    [mutateRelease],
-  );
-
   // Fetches the aggregated Pyroscope-shaped flame graph for a workload. Returns a JSON-encoded FlamebearerProfile.
   // Example: await fetchSourceProfiling({ namespace: "default", kind: "Deployment", name: "inventory" })
   //       => { profileJson: '{"version":1,"flamebearer":{"names":[...],"levels":[...],...},...}' }
@@ -92,7 +71,6 @@ export const useProfiling = (): UseProfiling => {
   return {
     fetchProfilingSlots,
     enableProfiling,
-    releaseProfiling,
     fetchSourceProfiling,
   };
 };

--- a/frontend/webapp/package.json
+++ b/frontend/webapp/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@apollo/client": "^3.13.9",
     "@apollo/experimental-nextjs-app-support": "^0.12.3",
-    "@odigos/ui-kit": "0.0.229",
+    "@odigos/ui-kit": "0.0.230",
     "graphql": "^16.13.2",
     "next": "15.5.14",
     "react": "19.2.5",

--- a/frontend/webapp/package.json
+++ b/frontend/webapp/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@apollo/client": "^3.13.9",
     "@apollo/experimental-nextjs-app-support": "^0.12.3",
-    "@odigos/ui-kit": "0.0.228",
+    "@odigos/ui-kit": "0.0.229",
     "graphql": "^16.13.2",
     "next": "15.5.14",
     "react": "19.2.5",

--- a/frontend/webapp/package.json
+++ b/frontend/webapp/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@apollo/client": "^3.13.9",
     "@apollo/experimental-nextjs-app-support": "^0.12.3",
-    "@odigos/ui-kit": "0.0.227",
+    "@odigos/ui-kit": "0.0.228",
     "graphql": "^16.13.2",
     "next": "15.5.14",
     "react": "19.2.5",

--- a/frontend/webapp/yarn.lock
+++ b/frontend/webapp/yarn.lock
@@ -635,10 +635,10 @@
   resolved "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
-"@odigos/ui-kit@0.0.229":
-  version "0.0.229"
-  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.229.tgz#9973df2cdde66a143fd4710cffe4ca38bd4a99a1"
-  integrity sha512-WS+HU5h2UHLsgcyYnQoUoQ5SvIdjmI4pyC5EjDIOCQwc/PjU/bpWJiRpb2WFESNjtQl436HDSvV93Wcu/8izTA==
+"@odigos/ui-kit@0.0.230":
+  version "0.0.230"
+  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.230.tgz#b1e0cf8341ee54690f1aeb7e23ee5be339fc2c1f"
+  integrity sha512-sTSac+/kkCazcjS+mTddQlPVIlhkIE25OfGZlW9+dDTIL5z/I28c6dFFIHCyC5tl5b6xeY1ZV7nal/qgzL1zJA==
   dependencies:
     "@xyflow/react" "^12.10.2"
     elkjs "^0.11.1"

--- a/frontend/webapp/yarn.lock
+++ b/frontend/webapp/yarn.lock
@@ -635,10 +635,10 @@
   resolved "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
-"@odigos/ui-kit@0.0.228":
-  version "0.0.228"
-  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.228.tgz#bb2ce75f95c17042a748ec5f5c38563f6457d48a"
-  integrity sha512-4Pre6SWR/lyoHNPg2JCSFse1IGTfNTR1Z/LWy7oLWsh6iFXrBda4BGn+YCmb36kRXFr4iwJ4PJXHOPlFGEIkGA==
+"@odigos/ui-kit@0.0.229":
+  version "0.0.229"
+  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.229.tgz#9973df2cdde66a143fd4710cffe4ca38bd4a99a1"
+  integrity sha512-WS+HU5h2UHLsgcyYnQoUoQ5SvIdjmI4pyC5EjDIOCQwc/PjU/bpWJiRpb2WFESNjtQl436HDSvV93Wcu/8izTA==
   dependencies:
     "@xyflow/react" "^12.10.2"
     elkjs "^0.11.1"

--- a/frontend/webapp/yarn.lock
+++ b/frontend/webapp/yarn.lock
@@ -635,10 +635,10 @@
   resolved "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
-"@odigos/ui-kit@0.0.227":
-  version "0.0.227"
-  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.227.tgz#a57928e49518f7b74e3d8e133cf7444314efbddf"
-  integrity sha512-5D5ADajROnJhbmM9te1IUx05ueaYCM5J0RpVC52RFGSMXxgjxxjP3H6ZfhU6U+eImX9aCljXrqWQv1F5Xd91Gg==
+"@odigos/ui-kit@0.0.228":
+  version "0.0.228"
+  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.228.tgz#bb2ce75f95c17042a748ec5f5c38563f6457d48a"
+  integrity sha512-4Pre6SWR/lyoHNPg2JCSFse1IGTfNTR1Z/LWy7oLWsh6iFXrBda4BGn+YCmb36kRXFr4iwJ4PJXHOPlFGEIkGA==
   dependencies:
     "@xyflow/react" "^12.10.2"
     elkjs "^0.11.1"


### PR DESCRIPTION
Updated the GraphQL schema and corresponding resolvers to rename the field `TotalBytesInUse` to `TotalBytesUsed` for clarity and consistency. Adjusted related queries and mutations to reflect this change.

```release-note
fix: GQL schemas for profiling
```

cherry-pick: v1.25

emergency-ticket id: EMR-1635
