### PR TITLE
CORE-935: Fix RHEL publish jobs

### DIFF
--- a/.github/workflows/publish-modules-rhel.yml
+++ b/.github/workflows/publish-modules-rhel.yml
@@ -109,6 +109,10 @@ jobs:
             env:
               ODIGOS_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || steps.extract_tag.outputs.tag}}
             with:
+              # Use the checked-out files (at inputs.tag) instead of build-push-action's
+              # default Git context, which would otherwise build from the workflow's
+              # triggering ref (e.g. main) and ignore the actions/checkout above.
+              context: .
               push: true
               provenance: false
               tags: |

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -24,4 +24,4 @@ licenses: go-licenses
 	@if [ -d "$(PWD)/licenses" ]; then \
 		rm -rf $(PWD)/licenses; \
 	fi
-	$(TOOLS)/go-licenses save . --save_path=licenses --ignore=modernc.org/mathutil
+	$(TOOLS)/go-licenses save . --save_path=licenses --ignore=modernc.org/mathutil,github.com/grafana/pyroscope/pkg


### PR DESCRIPTION
#### What this PR does / why we need it:
This ignores `github.com/grafana/pyroscope/pkg` for the ui `make licenses` (it failed with `one or more libraries have an incompatible/unknown license: map["FORBIDDEN":["github.com/grafana/pyroscope/pkg"]]` due to pyroscope using AGPL3.0, see https://github.com/odigos-io/odigos/actions/runs/25320100651/job/74232381261#step:11:6145)

It also updates `publish-modules-rhel` to use the local build context. You are supposed to be able to trigger this job from `main` and provide a tag to build/push like `v1.24.2`. However, without the explicit context in the build step, the docker build was running from the triggered branch (eg, `main`) instead of the provided checkout ref

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
