### PR TITLE
fix: installation status handling in deployment_config.go

### DIFF
--- a/frontend/services/deployment_config.go
+++ b/frontend/services/deployment_config.go
@@ -125,7 +125,11 @@ func isCentralProxyRunning(ctx context.Context) (bool, error) {
 }
 
 func getInstallationStatus(ctx context.Context, deploymentData map[string]string) model.InstallationStatus {
-	if status := deploymentData[k8sconsts.OdigosDeploymentConfigMapInstallationStatusKey]; status != "" {
+	// Finished is a terminal state - once reached, it stays finished even if
+	// sources/destinations are later removed. Only short-circuit on Finished
+	// so that a "NEW" cluster is re-evaluated against live cluster state on
+	// every call (otherwise we'd cache "NEW" forever after the first request).
+	if status := deploymentData[k8sconsts.OdigosDeploymentConfigMapInstallationStatusKey]; status == string(Finished) {
 		return model.InstallationStatus(status)
 	}
 
@@ -134,8 +138,10 @@ func getInstallationStatus(ctx context.Context, deploymentData map[string]string
 		computed = string(Finished)
 	}
 
-	if err := persistInstallationStatus(ctx, computed); err != nil {
-		log.Printf("Error persisting installation status: %v\n", err)
+	if computed == string(Finished) {
+		if err := persistInstallationStatus(ctx, computed); err != nil {
+			log.Printf("Error persisting installation status: %v\n", err)
+		}
 	}
 	return model.InstallationStatus(computed)
 }


### PR DESCRIPTION
```release-note
fix: installation status handling in deployment_config.go
```

### Before:

Any persisted value (including `"NEW"`) caused an early return, so once `"NEW"` was written it was returned forever.

### After:

Only `"FINISHED"` short-circuits (it's terminal - once installed, stays installed even if all sources/destinations are deleted). For empty or `"NEW"` persisted values, we recompute from live cluster state on every call. We also only persist when transitioning to `"FINISHED"`, so we never cache `"NEW"` and pollute future reads.

### Note:

Existing clusters that already have a stale `"NEW"` written into the `odigos-deployment` configmap will now self-heal. The next call will ignore the stale value, recompute, and (if applicable) overwrite it with `"FINISHED"`. No manual cleanup needed.

---

cherry-pick: v1.25

emergency-ticket id: EMR-1650
