### PR TITLE
fix: add Redis tcp-keepalive to prevent Central proxy disconnections

### DIFF
--- a/helm/odigos-central/templates/redis/redis.yaml
+++ b/helm/odigos-central/templates/redis/redis.yaml
@@ -43,6 +43,10 @@ spec:
             - "--maxmemory-policy"
             - "{{ .Values.redis.maxmemoryPolicy }}"
             {{- end }}
+            {{- if .Values.redis.tcpKeepalive }}
+            - "--tcp-keepalive"
+            - "{{ .Values.redis.tcpKeepalive }}"
+            {{- end }}
           ports:
             - containerPort: {{ .Values.redis.port }}
               name: {{ .Values.redis.portName }}

--- a/helm/odigos-central/values.yaml
+++ b/helm/odigos-central/values.yaml
@@ -81,6 +81,9 @@ redis:
   # Eviction policy when maxmemory is reached
   # allkeys-lru: evict least recently used keys (good default for mixed use)
   maxmemoryPolicy: allkeys-lru
+  # TCP keepalive interval in seconds. Sends probe packets on idle connections to prevent
+  # network infrastructure (NAT/firewall) from closing them due to idle timeouts.
+  tcpKeepalive: 30
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
**What this PR does / why we need it:**
Network infrastructure (NAT gateways, firewalls) in some environments closes idle TCP connections after 60 seconds. Redis PubSub connections used by Central are idle by nature — they sit open waiting for traffic — making them vulnerable to being silently killed. When this happens, all cluster proxy subscriptions drop simultaneously, causing clusters to appear disconnected in the Central UI.

This adds --tcp-keepalive 30 to the Redis deployment, which sends small TCP probe packets every 30 seconds on idle connections, keeping them alive through network infrastructure timeouts. The value is configurable via redis.tcpKeepalive in values.yaml.

```release-note
Fixed an issue where Central proxy clusters could intermittently appear as "Connection lost" in environments where network infrastructure closes idle TCP connections (e.g. NAT gateways with 60s idle timeout).
```

emergency-ticket id: EMR-1648
