### PR TITLE
fix: set span metrics mode for headsampling even when no rules

### DIFF
--- a/instrumentor/controllers/agentenabled/dynamicconfig/config.go
+++ b/instrumentor/controllers/agentenabled/dynamicconfig/config.go
@@ -65,34 +65,38 @@ func calculateTracesConfig(
 
 	// Sampling
 	noisyOps, relevantOps, costRules := traces.CalculateSamplingCategoryRulesForContainer(samplingRules, runtimeDetails.Language, pw, containerName, d, workloadObj, effectiveConfig)
-	// if we have any noisy operations, we need to add them to the traces config.
-	// use head/tail sampling based on the distro support.
-	if len(noisyOps) > 0 {
-		if traces.DistroSupportsHeadSampling(d) {
-			dryRun := false
-			spanMetricsMode := commonapisampling.SpanMetricsModeSampledSpansOnly
-			if effectiveConfig.Sampling != nil && effectiveConfig.Sampling.DryRun != nil {
-				dryRun = *effectiveConfig.Sampling.DryRun
-			}
 
-			spanMetricsEnabled := nodeCollectorsGroup != nil &&
-				nodeCollectorsGroup.Spec.Metrics != nil &&
-				(nodeCollectorsGroup.Spec.Metrics.SpanMetrics == nil ||
-					nodeCollectorsGroup.Spec.Metrics.SpanMetrics.Disabled == nil ||
-					!*nodeCollectorsGroup.Spec.Metrics.SpanMetrics.Disabled)
-			metricsSignalEnabled := nodeCollectorsGroup != nil &&
-				slices.Contains(nodeCollectorsGroup.Status.ReceiverSignals, common.MetricsObservabilitySignal)
-			configuredMode := effectiveConfig.MetricsSources != nil &&
-				effectiveConfig.MetricsSources.SpanMetrics != nil &&
-				effectiveConfig.MetricsSources.SpanMetrics.SpanMetricsMode != nil
-			if spanMetricsEnabled && metricsSignalEnabled && configuredMode {
-				spanMetricsMode = *effectiveConfig.MetricsSources.SpanMetrics.SpanMetricsMode
-			}
+	// use head/tail sampling based on the distro support.
+	// we need to set the span metrics mode even if no noisy operations are present,
+	// since the decision can be made at other service and propagate to this one.
+	distroSupportsHeadSampling := traces.DistroSupportsHeadSampling(d)
+	if distroSupportsHeadSampling {
+
+		spanMetricsMode := metrics.CalculateSpanMetricsMode(effectiveConfig, nodeCollectorsGroup)
+
+		// write the head sampling only if needed, e.g. if there are any noisy operations or non-default configuration.
+		if len(noisyOps) > 0 || spanMetricsMode != commonapisampling.SpanMetricsModeSampledSpansOnly {
+
+			dryRun := metrics.CalculateDryRun(effectiveConfig)
+
 			agentConfig.HeadSampling = &odigosv1.HeadSamplingConfig{
 				DryRun:          dryRun,
 				SpanMetricsMode: spanMetricsMode,
 				NoisyOperations: noisyOps,
 			}
+		}
+	} else if len(noisyOps) > 0 {
+		if collectorConfig == nil {
+			collectorConfig = &commonapi.ContainerCollectorConfig{}
+		}
+		collectorConfig.TailSampling = &commonapisampling.TailSamplingSourceConfig{
+			NoisyOperations: noisyOps,
+		}
+	}
+
+	if len(noisyOps) > 0 {
+		if traces.DistroSupportsHeadSampling(d) {
+
 		} else {
 			if collectorConfig == nil {
 				collectorConfig = &commonapi.ContainerCollectorConfig{}

--- a/instrumentor/controllers/agentenabled/dynamicconfig/metrics/spanmetrics.go
+++ b/instrumentor/controllers/agentenabled/dynamicconfig/metrics/spanmetrics.go
@@ -2,10 +2,12 @@ package metrics
 
 import (
 	"fmt"
+	"slices"
 	"time"
 
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/common"
+	commonapisampling "github.com/odigos-io/odigos/common/api/sampling"
 	"github.com/odigos-io/odigos/distros/distro"
 )
 
@@ -91,4 +93,38 @@ func CalculateMetricsConfig(metricsEnabled bool, effectiveConfig *common.OdigosC
 	}
 
 	return metricsConfig, nil
+}
+
+func CalculateSpanMetricsMode(effectiveConfig *common.OdigosConfiguration, nodeCollectorsGroup *odigosv1.CollectorsGroup) commonapisampling.SpanMetricsMode {
+
+	spanMetricsEnabled := nodeCollectorsGroup != nil &&
+		nodeCollectorsGroup.Spec.Metrics != nil &&
+		(nodeCollectorsGroup.Spec.Metrics.SpanMetrics == nil ||
+			nodeCollectorsGroup.Spec.Metrics.SpanMetrics.Disabled == nil ||
+			!*nodeCollectorsGroup.Spec.Metrics.SpanMetrics.Disabled)
+
+	if !spanMetricsEnabled {
+		return commonapisampling.SpanMetricsModeSampledSpansOnly
+	}
+
+	metricsSignalEnabled := nodeCollectorsGroup != nil &&
+		slices.Contains(nodeCollectorsGroup.Status.ReceiverSignals, common.MetricsObservabilitySignal)
+	if !metricsSignalEnabled {
+		return commonapisampling.SpanMetricsModeSampledSpansOnly
+	}
+
+	configuredMode := effectiveConfig.MetricsSources != nil &&
+		effectiveConfig.MetricsSources.SpanMetrics != nil &&
+		effectiveConfig.MetricsSources.SpanMetrics.SpanMetricsMode != nil
+	if !configuredMode { // not set in config, use the default
+		return commonapisampling.SpanMetricsModeSampledSpansOnly
+	}
+
+	return *effectiveConfig.MetricsSources.SpanMetrics.SpanMetricsMode
+}
+
+func CalculateDryRun(effectiveConfig *common.OdigosConfiguration) bool {
+	return effectiveConfig.Sampling != nil &&
+		effectiveConfig.Sampling.DryRun != nil &&
+		*effectiveConfig.Sampling.DryRun
 }


### PR DESCRIPTION
#### What this PR does / why we need it:


Currently, we only set the headsampling config for a distro if there are any noisy operation rules.
However, consider the following scenario:
- svc A - one rule to head sample.
- calls svc B with no rules
- svc B is not aware of the spanMetricsMode since it has no rules
- spans are dropped at svc B and not forwarded to nodecollector for spanmetrics computation.

This PR writes the spanmetricsmode even if there are no rules set for a specific container

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```

emergency-ticket id: EMR-1647
