### PR TITLE
CORE-971 | fix: issue if all detector disable still adding the processor to the pipeline

### DIFF
--- a/autoscaler/controllers/nodecollector/collectorconfig/common.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/common.go
@@ -3,6 +3,7 @@ package collectorconfig
 import (
 	"fmt"
 
+	"github.com/go-logr/logr"
 	"github.com/odigos-io/odigos/api/k8sconsts"
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	commonconf "github.com/odigos-io/odigos/autoscaler/controllers/common"
@@ -17,6 +18,7 @@ const (
 
 // CommonSignalConfig holds configuration fields shared across all signal pipelines (traces, metrics, logs).
 type CommonSignalConfig struct {
+	Logger                   logr.Logger
 	OdigosNamespace          string
 	ManifestProcessorNames   []string
 	ResourceDetectionEnabled bool

--- a/autoscaler/controllers/nodecollector/collectorconfig/common.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/common.go
@@ -48,11 +48,11 @@ func isDetectorEnabled(cfg *common.ResourceDetectorConfig) bool {
 	return cfg != nil && cfg.Enabled != nil && *cfg.Enabled
 }
 
-func ResourceDetectionEnabled(cfg *common.ResourceDetectorsConfiguration, runningOnGKE bool) bool {
-	return len(buildResourceDetectors(cfg, runningOnGKE)) > 0
+func ResourceDetectionEnabled(detectors []string) bool {
+	return len(detectors) > 0
 }
 
-func buildResourceDetectors(cfg *common.ResourceDetectorsConfiguration, runningOnGKE bool) []string {
+func BuildResourceDetectors(cfg *common.ResourceDetectorsConfiguration, runningOnGKE bool) []string {
 	if cfg == nil {
 		return nil
 	}
@@ -85,7 +85,7 @@ func buildResourceDetectors(cfg *common.ResourceDetectorsConfiguration, runningO
 	return detectors
 }
 
-func commonProcessors(nodeCG *odigosv1.CollectorsGroup, runningOnGKE bool) config.GenericMap {
+func commonProcessors(nodeCG *odigosv1.CollectorsGroup, runningOnGKE bool, detectors []string) config.GenericMap {
 
 	allProcessors := config.GenericMap{}
 	for k, v := range staticProcessors {
@@ -95,8 +95,7 @@ func commonProcessors(nodeCG *odigosv1.CollectorsGroup, runningOnGKE bool) confi
 	memoryLimiterConfig := commonconf.GetMemoryLimiterConfig(nodeCG.Spec.ResourcesSettings)
 	allProcessors[memoryLimiterProcessorName] = memoryLimiterConfig
 
-	detectors := buildResourceDetectors(nodeCG.Spec.ResourceDetectors, runningOnGKE)
-	if len(detectors) > 0 {
+	if ResourceDetectionEnabled(detectors) {
 		allProcessors[resourceDetectionProcessorName] = config.GenericMap{
 			"detectors": detectors,
 			"timeout":   "2s",
@@ -206,11 +205,11 @@ func init() {
 	}
 }
 
-func CommonApplicationTelemetryConfig(nodeCG *odigosv1.CollectorsGroup, onGKE bool, odigosNamespace string) config.Config {
+func CommonApplicationTelemetryConfig(nodeCG *odigosv1.CollectorsGroup, onGKE bool, odigosNamespace string, detectors []string) config.Config {
 	return config.Config{
 		Receivers:  commonReceivers,
 		Exporters:  getCommonExporters(nodeCG.Spec.OtlpExporterConfiguration, odigosNamespace),
-		Processors: commonProcessors(nodeCG, onGKE),
+		Processors: commonProcessors(nodeCG, onGKE, detectors),
 	}
 }
 

--- a/autoscaler/controllers/nodecollector/collectorconfig/common.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/common.go
@@ -15,6 +15,19 @@ const (
 	OTLPInReceiverName = "otlp/in"
 )
 
+// CommonSignalConfig holds configuration fields shared across all signal pipelines (traces, metrics, logs).
+type CommonSignalConfig struct {
+	OdigosNamespace          string
+	ManifestProcessorNames   []string
+	ResourceDetectionEnabled bool
+}
+
+// WithProcessors returns a copy of the config with the given manifest processor names set.
+func (c CommonSignalConfig) WithProcessors(names []string) CommonSignalConfig {
+	c.ManifestProcessorNames = names
+	return c
+}
+
 const (
 	healthCheckExtensionName            = "health_check"
 	odigosEbpfReceiverName              = "odigosebpf"
@@ -31,6 +44,10 @@ const (
 
 func isDetectorEnabled(cfg *common.ResourceDetectorConfig) bool {
 	return cfg != nil && cfg.Enabled != nil && *cfg.Enabled
+}
+
+func ResourceDetectionEnabled(cfg *common.ResourceDetectorsConfiguration, runningOnGKE bool) bool {
+	return len(buildResourceDetectors(cfg, runningOnGKE)) > 0
 }
 
 func buildResourceDetectors(cfg *common.ResourceDetectorsConfiguration, runningOnGKE bool) []string {

--- a/autoscaler/controllers/nodecollector/collectorconfig/logs.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/logs.go
@@ -104,7 +104,7 @@ type LogsConfigOptions struct {
 	Sources *odigosv1.InstrumentationConfigList
 }
 
-func LogsConfig(logger logr.Logger, nodeCG *odigosv1.CollectorsGroup, opts LogsConfigOptions) config.Config {
+func LogsConfig(nodeCG *odigosv1.CollectorsGroup, opts LogsConfigOptions) config.Config {
 
 	pipelineProcessors := []string{
 		memoryLimiterProcessorName,
@@ -120,7 +120,7 @@ func LogsConfig(logger logr.Logger, nodeCG *odigosv1.CollectorsGroup, opts LogsC
 	// append odigos traffic metrics processor last (after manifest processors)
 	pipelineProcessors = append(pipelineProcessors, odigosTrafficMetricsProcessorName)
 
-	receivers, pipelineReceivers := getReceivers(logger, opts.Sources, opts.OdigosNamespace)
+	receivers, pipelineReceivers := getReceivers(opts.Logger, opts.Sources, opts.OdigosNamespace)
 
 	return config.Config{
 		Receivers: receivers,

--- a/autoscaler/controllers/nodecollector/collectorconfig/logs.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/logs.go
@@ -99,18 +99,28 @@ func isEbpfLogCaptureEnabled(sources *odigosv1.InstrumentationConfigList) bool {
 	return false
 }
 
-func LogsConfig(logger logr.Logger, nodeCG *odigosv1.CollectorsGroup, odigosNamespace string, manifestProcessorNames []string, sources *odigosv1.InstrumentationConfigList) config.Config {
+type LogsConfigOptions struct {
+	CommonSignalConfig
+	Sources *odigosv1.InstrumentationConfigList
+}
 
-	pipelineProcessors := append([]string{
+func LogsConfig(logger logr.Logger, nodeCG *odigosv1.CollectorsGroup, opts LogsConfigOptions) config.Config {
+
+	pipelineProcessors := []string{
 		memoryLimiterProcessorName,
 		nodeNameProcessorName,
-		resourceDetectionProcessorName,
+	}
+	if opts.ResourceDetectionEnabled {
+		pipelineProcessors = append(pipelineProcessors, resourceDetectionProcessorName)
+	}
+	pipelineProcessors = append(pipelineProcessors,
 		odigosLogsResourceAttrsProcessorName,
-	}, manifestProcessorNames...)
+	)
+	pipelineProcessors = append(pipelineProcessors, opts.ManifestProcessorNames...)
 	// append odigos traffic metrics processor last (after manifest processors)
 	pipelineProcessors = append(pipelineProcessors, odigosTrafficMetricsProcessorName)
 
-	receivers, pipelineReceivers := getReceivers(logger, sources, odigosNamespace)
+	receivers, pipelineReceivers := getReceivers(logger, opts.Sources, opts.OdigosNamespace)
 
 	return config.Config{
 		Receivers: receivers,

--- a/autoscaler/controllers/nodecollector/collectorconfig/metrics.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/metrics.go
@@ -73,17 +73,25 @@ func metricsReceivers(metricsConfigSettings *odigosv1.CollectorsGroupMetricsColl
 	return receivers, pipelineReceiverNames
 }
 
-func MetricsConfig(nodeCG *odigosv1.CollectorsGroup, odigosNamespace string, manifestProcessorNames []string, metricsConfigSettings *odigosv1.CollectorsGroupMetricsCollectionSettings) config.Config {
+type MetricsConfigOptions struct {
+	CommonSignalConfig
+	MetricsConfigSettings *odigosv1.CollectorsGroupMetricsCollectionSettings
+}
 
-	metricsPipelineProcessors := append([]string{
+func MetricsConfig(nodeCG *odigosv1.CollectorsGroup, opts MetricsConfigOptions) config.Config {
+
+	baseProcessors := []string{
 		batchProcessorName,         // always start with batch
 		memoryLimiterProcessorName, // consider removing this for metrics, as they have footprint anyway
 		nodeNameProcessorName,
-		resourceDetectionProcessorName,
-	}, manifestProcessorNames...)
+	}
+	if opts.ResourceDetectionEnabled {
+		baseProcessors = append(baseProcessors, resourceDetectionProcessorName)
+	}
+	metricsPipelineProcessors := append(baseProcessors, opts.ManifestProcessorNames...)
 	metricsPipelineProcessors = append(metricsPipelineProcessors, odigosTrafficMetricsProcessorName) // keep traffic metrics last for most accurate tracking
 
-	receivers, pipelineReceiverNames := metricsReceivers(metricsConfigSettings)
+	receivers, pipelineReceiverNames := metricsReceivers(opts.MetricsConfigSettings)
 	if len(pipelineReceiverNames) == 0 {
 		// if all metrics sources are not enabled, skip the metrics pipeline generation as it has no receivers and will fail the collector
 		return config.Config{}

--- a/autoscaler/controllers/nodecollector/collectorconfig/traces.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/traces.go
@@ -95,20 +95,30 @@ func tracesExporters(nodeCG *odigosv1.CollectorsGroup, odigosNamespace string, t
 	return exporters, exporterNames
 }
 
-func TracesConfig(nodeCG *odigosv1.CollectorsGroup, odigosNamespace string, manifestProcessorNames []string, postSpanMetricsProcessorNames []string, additionalTraceExporters []string, tracesEnabledInClusterCollector bool,
-	loadBalancingNeeded bool) config.Config {
+type TracesConfigOptions struct {
+	CommonSignalConfig
+	PostSpanMetricsProcessorNames   []string
+	AdditionalTraceExporters        []string
+	TracesEnabledInClusterCollector bool
+	LoadBalancingNeeded             bool
+}
 
-	exporters, traceExporterNames := tracesExporters(nodeCG, odigosNamespace, tracesEnabledInClusterCollector, loadBalancingNeeded)
+func TracesConfig(nodeCG *odigosv1.CollectorsGroup, opts TracesConfigOptions) config.Config {
+
+	exporters, traceExporterNames := tracesExporters(nodeCG, opts.OdigosNamespace, opts.TracesEnabledInClusterCollector, opts.LoadBalancingNeeded)
 
 	// traces pipeline also feeds the spanmetrics connector.
 	// users may want some custom processors (manifestProcessorNames)
 
-	tracePipelineProcessors := append([]string{
+	baseProcessors := []string{
 		batchProcessorName,         // always start with batch
 		memoryLimiterProcessorName, // memory limiter is temporary, until we migrate all inputs to rtml based memory protection
 		nodeNameProcessorName,
-		resourceDetectionProcessorName,
-	}, manifestProcessorNames...)
+	}
+	if opts.ResourceDetectionEnabled {
+		baseProcessors = append(baseProcessors, resourceDetectionProcessorName)
+	}
+	tracePipelineProcessors := append(baseProcessors, opts.ManifestProcessorNames...)
 	tracePipelineProcessors = append(tracePipelineProcessors, odigosTrafficMetricsProcessorName) // keep traffic metrics last for most accurate tracking
 
 	// conditionally, create another pipeline for span exporting,
@@ -117,8 +127,8 @@ func TracesConfig(nodeCG *odigosv1.CollectorsGroup, odigosNamespace string, mani
 	connectors := config.GenericMap{}
 	tracesMainPipelineExporterNames := []string{}
 	additionalPipeline := map[string]config.Pipeline{}
-	if len(postSpanMetricsProcessorNames) == 0 {
-		tracesMainPipelineExporterNames = append(traceExporterNames, additionalTraceExporters...)
+	if len(opts.PostSpanMetricsProcessorNames) == 0 {
+		tracesMainPipelineExporterNames = append(traceExporterNames, opts.AdditionalTraceExporters...)
 	} else {
 		// if we do not have any traces destinations (traceExporterNames == []) but span metrics is enabled, we add a no-op exporter
 		if len(traceExporterNames) == 0 {
@@ -128,10 +138,10 @@ func TracesConfig(nodeCG *odigosv1.CollectorsGroup, odigosNamespace string, mani
 		connectors[odigosTracesExportingForwardConnectorName] = config.GenericMap{}
 		additionalPipeline[odigosTracesExportingPipelineName] = config.Pipeline{
 			Receivers:  []string{odigosTracesExportingForwardConnectorName},
-			Processors: postSpanMetricsProcessorNames,
+			Processors: opts.PostSpanMetricsProcessorNames,
 			Exporters:  traceExporterNames,
 		}
-		tracesMainPipelineExporterNames = append(additionalTraceExporters, odigosTracesExportingForwardConnectorName)
+		tracesMainPipelineExporterNames = append(opts.AdditionalTraceExporters, odigosTracesExportingForwardConnectorName)
 	}
 
 	tracePipeline := map[string]config.Pipeline{

--- a/autoscaler/controllers/nodecollector/configmap.go
+++ b/autoscaler/controllers/nodecollector/configmap.go
@@ -216,12 +216,14 @@ func calculateCollectorConfigDomains(
 		configDomains["odigos_config_extension"] = collectorconfig.NodeOdigosExtDomain()
 	}
 
-	configDomains["common_application_telemetry"] = collectorconfig.CommonApplicationTelemetryConfig(nodeCG, onGKE, odigosNamespace)
+	// resource detectors [ec2, eks, azure, aks, gcp] built once.
+	detectors := collectorconfig.BuildResourceDetectors(nodeCG.Spec.ResourceDetectors, onGKE)
+	configDomains["common_application_telemetry"] = collectorconfig.CommonApplicationTelemetryConfig(nodeCG, onGKE, odigosNamespace, detectors)
 
 	commonSignalConfig := collectorconfig.CommonSignalConfig{
 		Logger:                   logger.Logr(),
 		OdigosNamespace:          odigosNamespace,
-		ResourceDetectionEnabled: collectorconfig.ResourceDetectionEnabled(nodeCG.Spec.ResourceDetectors, onGKE),
+		ResourceDetectionEnabled: collectorconfig.ResourceDetectionEnabled(detectors),
 	}
 
 	// metrics

--- a/autoscaler/controllers/nodecollector/configmap.go
+++ b/autoscaler/controllers/nodecollector/configmap.go
@@ -218,6 +218,11 @@ func calculateCollectorConfigDomains(
 
 	configDomains["common_application_telemetry"] = collectorconfig.CommonApplicationTelemetryConfig(nodeCG, onGKE, odigosNamespace)
 
+	commonSignalConfig := collectorconfig.CommonSignalConfig{
+		OdigosNamespace:          odigosNamespace,
+		ResourceDetectionEnabled: collectorconfig.ResourceDetectionEnabled(nodeCG.Spec.ResourceDetectors, onGKE),
+	}
+
 	// metrics
 	metricsEnabled := slices.Contains(clusterCollectorSignals, odigoscommon.MetricsObservabilitySignal)
 	metricsConfigSettings := nodeCG.Spec.Metrics
@@ -236,7 +241,10 @@ func calculateCollectorConfigDomains(
 			configDomains["span_metrics"] = spanMetricsConfig
 		}
 
-		metricsConfig := collectorconfig.MetricsConfig(nodeCG, odigosNamespace, processorsResults.MetricsProcessors, metricsConfigSettings)
+		metricsConfig := collectorconfig.MetricsConfig(nodeCG, collectorconfig.MetricsConfigOptions{
+			CommonSignalConfig:    commonSignalConfig.WithProcessors(processorsResults.MetricsProcessors),
+			MetricsConfigSettings: metricsConfigSettings,
+		})
 		configDomains["metrics"] = metricsConfig
 	}
 
@@ -255,14 +263,23 @@ func calculateCollectorConfigDomains(
 	// - cluster collector has traces enabled (trace destination is enabled)
 	// - there are additional trace exporters (e.g. spanmetrics connector)
 	if tracesEnabledInClusterCollector || len(additionalTraceExporters) > 0 {
-		tracesConfig := collectorconfig.TracesConfig(nodeCG, odigosNamespace, processorsResults.TracesProcessors, processorsResults.TracesProcessorsPostSpanMetrics, additionalTraceExporters, tracesEnabledInClusterCollector, loadBalancingNeeded)
+		tracesConfig := collectorconfig.TracesConfig(nodeCG, collectorconfig.TracesConfigOptions{
+			CommonSignalConfig:              commonSignalConfig.WithProcessors(processorsResults.TracesProcessors),
+			PostSpanMetricsProcessorNames:   processorsResults.TracesProcessorsPostSpanMetrics,
+			AdditionalTraceExporters:        additionalTraceExporters,
+			TracesEnabledInClusterCollector: tracesEnabledInClusterCollector,
+			LoadBalancingNeeded:             loadBalancingNeeded,
+		})
 		configDomains["traces"] = tracesConfig
 	}
 
 	// logs
 	collectLogs := slices.Contains(clusterCollectorSignals, odigoscommon.LogsObservabilitySignal)
 	if collectLogs {
-		logsConfig := collectorconfig.LogsConfig(logger.Logr(), nodeCG, odigosNamespace, processorsResults.LogsProcessors, sources)
+		logsConfig := collectorconfig.LogsConfig(logger.Logr(), nodeCG, collectorconfig.LogsConfigOptions{
+			CommonSignalConfig: commonSignalConfig.WithProcessors(processorsResults.LogsProcessors),
+			Sources:            sources,
+		})
 		configDomains["logs"] = logsConfig
 	}
 

--- a/autoscaler/controllers/nodecollector/configmap.go
+++ b/autoscaler/controllers/nodecollector/configmap.go
@@ -219,6 +219,7 @@ func calculateCollectorConfigDomains(
 	configDomains["common_application_telemetry"] = collectorconfig.CommonApplicationTelemetryConfig(nodeCG, onGKE, odigosNamespace)
 
 	commonSignalConfig := collectorconfig.CommonSignalConfig{
+		Logger:                   logger.Logr(),
 		OdigosNamespace:          odigosNamespace,
 		ResourceDetectionEnabled: collectorconfig.ResourceDetectionEnabled(nodeCG.Spec.ResourceDetectors, onGKE),
 	}
@@ -276,7 +277,7 @@ func calculateCollectorConfigDomains(
 	// logs
 	collectLogs := slices.Contains(clusterCollectorSignals, odigoscommon.LogsObservabilitySignal)
 	if collectLogs {
-		logsConfig := collectorconfig.LogsConfig(logger.Logr(), nodeCG, collectorconfig.LogsConfigOptions{
+		logsConfig := collectorconfig.LogsConfig(nodeCG, collectorconfig.LogsConfigOptions{
 			CommonSignalConfig: commonSignalConfig.WithProcessors(processorsResults.LogsProcessors),
 			Sources:            sources,
 		})


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Fix a bug where the pipeline included the resourcedetection processor despite all resource detectors being disabled.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Fix: Processor incorrectly added to pipeline when no resource detectors are enabled
```
