### PR TITLE
cherry-pick: fix Redis tcp-keepalive to prevent Central proxy disconnections (v1.24)

### DIFF
--- a/helm/odigos-central/templates/redis/redis.yaml
+++ b/helm/odigos-central/templates/redis/redis.yaml
@@ -43,6 +43,10 @@ spec:
             - "--maxmemory-policy"
             - "{{ .Values.redis.maxmemoryPolicy }}"
             {{- end }}
+            {{- if .Values.redis.tcpKeepalive }}
+            - "--tcp-keepalive"
+            - "{{ .Values.redis.tcpKeepalive }}"
+            {{- end }}
           ports:
             - containerPort: {{ .Values.redis.port }}
               name: {{ .Values.redis.portName }}

--- a/helm/odigos-central/values.yaml
+++ b/helm/odigos-central/values.yaml
@@ -81,6 +81,9 @@ redis:
   # Eviction policy when maxmemory is reached
   # allkeys-lru: evict least recently used keys (good default for mixed use)
   maxmemoryPolicy: allkeys-lru
+  # TCP keepalive interval in seconds. Sends probe packets on idle connections to prevent
+  # network infrastructure (NAT/firewall) from closing them due to idle timeouts.
+  tcpKeepalive: 30
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
Cherry-pick of #4801 to releases/v1.24.0

#### What this PR does / why we need it:
Cherry-picks the Redis tcp-keepalive fix to the v1.24 release branch. This prevents Central proxy disconnections caused by idle Redis connections being dropped.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
fix: add Redis tcp-keepalive to prevent Central proxy disconnections
```

Made with [Cursor](https://cursor.com)

emergency-ticket id: EMR-1660
