### PR TITLE
feat: add profiles observability signal to destinations

### DIFF
--- a/common/signals.go
+++ b/common/signals.go
@@ -4,7 +4,8 @@ package common
 type ObservabilitySignal string
 
 const (
-	LogsObservabilitySignal    ObservabilitySignal = "LOGS"
-	TracesObservabilitySignal  ObservabilitySignal = "TRACES"
-	MetricsObservabilitySignal ObservabilitySignal = "METRICS"
+	LogsObservabilitySignal     ObservabilitySignal = "LOGS"
+	TracesObservabilitySignal   ObservabilitySignal = "TRACES"
+	MetricsObservabilitySignal  ObservabilitySignal = "METRICS"
+	ProfilesObservabilitySignal ObservabilitySignal = "PROFILES"
 )

--- a/destinations/data/alibabacloud.yaml
+++ b/destinations/data/alibabacloud.yaml
@@ -13,6 +13,8 @@ spec:
       supported: false
     logs:
       supported: false
+    profiles:
+      supported: false
   fields:
     - name: ALIBABA_ENDPOINT
       displayName: OTLP gRPC Endpoint

--- a/destinations/data/appdynamics.yaml
+++ b/destinations/data/appdynamics.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: APPDYNAMICS_APPLICATION_NAME
       displayName: Application Name
@@ -20,7 +22,7 @@ spec:
       componentProps:
         type: text
         required: false
-        tooltip: 'Will define a namespace in AppDynamics'
+        tooltip: "Will define a namespace in AppDynamics"
     - name: APPDYNAMICS_ACCOUNT_NAME
       displayName: Account Name
       componentType: input

--- a/destinations/data/awscloudwatch.yaml
+++ b/destinations/data/awscloudwatch.yaml
@@ -13,25 +13,27 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: AWS_CLOUDWATCH_LOG_GROUP_NAME
       displayName: Log Group Name
       componentType: input
       componentProps:
         required: true
-        tooltip: 'The group name of the CloudWatch Logs. If it does not exist it will be created automatically.'
+        tooltip: "The group name of the CloudWatch Logs. If it does not exist it will be created automatically."
     - name: AWS_CLOUDWATCH_LOG_STREAM_NAME
       displayName: Log Stream Name
       componentType: input
       componentProps:
         required: true
-        tooltip: 'The stream name of the CloudWatch Logs. If it does not exist it will be created automatically.'
+        tooltip: "The stream name of the CloudWatch Logs. If it does not exist it will be created automatically."
     - name: AWS_CLOUDWATCH_REGION
       displayName: Region
       componentType: dropdown
       componentProps:
         required: false
-        tooltip: 'The AWS region where the log stream is in. Region must be specified if it is not already set in the default credential chain.'
+        tooltip: "The AWS region where the log stream is in. Region must be specified if it is not already set in the default credential chain."
         values:
           - af-south-1
           - ap-east-1
@@ -72,7 +74,7 @@ spec:
       componentType: dropdown
       componentProps:
         required: false
-        tooltip: 'The CloudWatch Logs service endpoint which the requests are forwarded to.'
+        tooltip: "The CloudWatch Logs service endpoint which the requests are forwarded to."
         values:
           - logs.af-south-1.amazonaws.com
           - logs.af-south-1.api.aws
@@ -153,60 +155,60 @@ spec:
         required: false
         tooltip: "LogRetention is the option to set the log retention policy for only newly created CloudWatch Log Groups. The value is in days, 0 = Never Expire. This value can also be changed later-on via the AWS console (UI) or AWS API, it's not a permanent decision once set. Also, the value here might not reflect the actual retention value in the destination if it was modified or some automatic policy is applied."
         values:
-          - '0'
-          - '1'
-          - '3'
-          - '5'
-          - '7'
-          - '14'
-          - '30'
-          - '60'
-          - '90'
-          - '120'
-          - '150'
-          - '180'
-          - '365'
-          - '400'
-          - '545'
-          - '731'
-          - '1827'
-          - '2192'
-          - '2557'
-          - '2922'
-          - '3288'
-          - '3653'
-      initialValue: '0'
+          - "0"
+          - "1"
+          - "3"
+          - "5"
+          - "7"
+          - "14"
+          - "30"
+          - "60"
+          - "90"
+          - "120"
+          - "150"
+          - "180"
+          - "365"
+          - "400"
+          - "545"
+          - "731"
+          - "1827"
+          - "2192"
+          - "2557"
+          - "2922"
+          - "3288"
+          - "3653"
+      initialValue: "0"
     - name: AWS_CLOUDWATCH_TAGS
       displayName: Tags
       componentType: keyValuePairs
       componentProps:
         required: false
-        tooltip: 'Tags is the option to set tags for the CloudWatch Log Group. If specified, please add at most 50 tags. Keys must be between 1-128 characters and follow the pattern: (alphanumerics, whitespace, and _.:/=+-!). Values must be between 1-256 characters and follow the pattern: (alphanumerics, whitespace, and _.:/=+-!).'
+        tooltip: "Tags is the option to set tags for the CloudWatch Log Group. If specified, please add at most 50 tags. Keys must be between 1-128 characters and follow the pattern: (alphanumerics, whitespace, and _.:/=+-!). Values must be between 1-256 characters and follow the pattern: (alphanumerics, whitespace, and _.:/=+-!)."
     - name: AWS_CLOUDWATCH_RAW_LOG
       displayName: Raw Log
       componentType: checkbox
       componentProps:
         required: false
-        tooltip: 'If set to true, only the log message will be exported to CloudWatch Logs. This needs to be set to true for EMF logs.'
+        tooltip: "If set to true, only the log message will be exported to CloudWatch Logs. This needs to be set to true for EMF logs."
       initialValue: false
     - name: AWS_CLOUDWATCH_METRICS_NAMESPACE
       displayName: Metrics Namespace
       componentType: input
       componentProps:
         required: false
-        tooltip: 'Customized CloudWatch metrics namespace. Metrics in different namespaces are isolated from each other. Please note this is not a cluster namespace.'
+        tooltip: "Customized CloudWatch metrics namespace. Metrics in different namespaces are isolated from each other. Please note this is not a cluster namespace."
       initialValue: Odigos
     - name: AWS_CLOUDWATCH_METRICS_DIMENSION_ROLLUP
       displayName: Metrics Dimension Rollup
       componentType: dropdown
       componentProps:
         required: false
-        tooltip: 'The option for metrics dimension rollup.'
+        tooltip: "The option for metrics dimension rollup."
         values:
-          - 'NoDimensionRollup'
-          - 'SingleDimensionRollupOnly'
-          - 'ZeroAndSingleDimensionRollup'
-      initialValue: 'NoDimensionRollup'
+          - "NoDimensionRollup"
+          - "SingleDimensionRollupOnly"
+          - "ZeroAndSingleDimensionRollup"
+      initialValue: "NoDimensionRollup"
     - name: AWS_CLOUDWATCH_METRICS_DETAILED
       displayName: Detailed Metrics
       componentType: checkbox
@@ -219,7 +221,7 @@ spec:
       componentType: checkbox
       componentProps:
         required: false
-        tooltip: 'This option specifies how the first value of a metric is handled. AWS EMF expects metric values to only contain deltas to the previous value. In the default case the first received value is therefor not sent to AWS but only used as a baseline for follow up changes to this metric. This is fine for high throughput metrics with stable labels. In this case it does not matter if the first value of this metric is discarded. However when your metric describes infrequent events or events with high label cardinality, then the exporter in default configuration would still drop the first occurrence of this metric. With this configuration value set to true the first value of all metrics will instead be send to AWS.'
+        tooltip: "This option specifies how the first value of a metric is handled. AWS EMF expects metric values to only contain deltas to the previous value. In the default case the first received value is therefor not sent to AWS but only used as a baseline for follow up changes to this metric. This is fine for high throughput metrics with stable labels. In this case it does not matter if the first value of this metric is discarded. However when your metric describes infrequent events or events with high label cardinality, then the exporter in default configuration would still drop the first occurrence of this metric. With this configuration value set to true the first value of all metrics will instead be send to AWS."
       initialValue: false
   note:
     type: Note

--- a/destinations/data/awss3.yaml
+++ b/destinations/data/awss3.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: S3_BUCKET
       displayName: Bucket Name

--- a/destinations/data/awsxray.yaml
+++ b/destinations/data/awsxray.yaml
@@ -13,13 +13,15 @@ spec:
       supported: false
     logs:
       supported: false
+    profiles:
+      supported: false
   fields:
     - name: AWS_XRAY_REGION
       displayName: Region
       componentType: dropdown
       componentProps:
         required: false
-        tooltip: 'Send segments to AWS X-Ray service in a specific region.'
+        tooltip: "Send segments to AWS X-Ray service in a specific region."
         values:
           - af-south-1
           - ap-east-1
@@ -60,102 +62,102 @@ spec:
       componentType: input
       componentProps:
         required: false
-        tooltip: 'Optionally override the default X-Ray service endpoint.'
+        tooltip: "Optionally override the default X-Ray service endpoint."
     - name: AWS_XRAY_PROXY_ADDRESS
       displayName: Proxy Address
       componentType: input
       componentProps:
         required: false
-        tooltip: 'Upload segments to AWS X-Ray through a proxy.'
+        tooltip: "Upload segments to AWS X-Ray through a proxy."
     - name: AWS_XRAY_RESOURCE_ARN
       displayName: Resource ARN
       componentType: input
       componentProps:
         required: false
-        tooltip: 'Amazon Resource Name (ARN) of the AWS resource running the collector.'
+        tooltip: "Amazon Resource Name (ARN) of the AWS resource running the collector."
     - name: AWS_XRAY_ROLE_ARN
       displayName: Role ARN
       componentType: input
       componentProps:
         required: false
-        tooltip: 'IAM role to upload segments to a different account.'
+        tooltip: "IAM role to upload segments to a different account."
     - name: AWS_XRAY_EXTERNAL_ID
       displayName: External ID
       componentType: input
       componentProps:
         required: false
-        tooltip: 'Shared identitier used when assuming an IAM role in an external AWS account.'
+        tooltip: "Shared identitier used when assuming an IAM role in an external AWS account."
     - name: AWS_XRAY_LOG_GROUPS
       displayName: Log Groups
       componentType: multiInput
       componentProps:
         required: false
-        tooltip: 'List of log group names for CloudWatch.'
+        tooltip: "List of log group names for CloudWatch."
     - name: AWS_XRAY_DISABLE_SSL
       displayName: Disable SSL Verification
       componentType: checkbox
       initialValue: false
       componentProps:
         required: false
-        tooltip: 'Enable or disable TLS certificate verification.'
+        tooltip: "Enable or disable TLS certificate verification."
     - name: AWS_XRAY_LOCAL_MODE
       displayName: Local Mode
       componentType: checkbox
       initialValue: false
       componentProps:
         required: false
-        tooltip: 'Local mode to skip EC2 instance metadata check.'
+        tooltip: "Local mode to skip EC2 instance metadata check."
     - name: AWS_XRAY_TELEMETRY_ENABLED
       displayName: Telemetry - Enabled
       componentType: checkbox
       initialValue: false
       componentProps:
         required: false
-        tooltip: 'Whether telemetry collection is enabled at all.'
+        tooltip: "Whether telemetry collection is enabled at all."
     - name: AWS_XRAY_TELEMETRY_INCLUDE_METADATA
       displayName: Telemetry - Include Metadata
       componentType: checkbox
       initialValue: false
       componentProps:
         required: false
-        tooltip: 'Whether to include metadata in the telemetry (InstanceID, Hostname, ResourceARN)'
+        tooltip: "Whether to include metadata in the telemetry (InstanceID, Hostname, ResourceARN)"
     - name: AWS_XRAY_TELEMETRY_HOSTNAME
       displayName: Telemetry - Hostname
       componentType: input
       componentProps:
         required: false
-        tooltip: 'Sets the Hostname included in the telemetry.'
+        tooltip: "Sets the Hostname included in the telemetry."
     - name: AWS_XRAY_TELEMETRY_INSTANCE_ID
       displayName: Telemetry - Instance ID
       componentType: input
       componentProps:
         required: false
-        tooltip: 'Sets the InstanceID included in the telemetry.'
+        tooltip: "Sets the InstanceID included in the telemetry."
     - name: AWS_XRAY_TELEMETRY_RESOURCE_ARN
       displayName: Telemetry - Resource ARN
       componentType: input
       componentProps:
         required: false
-        tooltip: 'Sets the Amazon Resource Name (ARN) included in the telemetry.'
+        tooltip: "Sets the Amazon Resource Name (ARN) included in the telemetry."
     - name: AWS_XRAY_TELEMETRY_CONTRIBUTORS
       displayName: Telemetry - Contributors
       componentType: multiInput
       componentProps:
         required: false
-        tooltip: 'List of X-Ray component IDs contributing to the telemetry (ex. for multiple X-Ray receivers: awsxray/1, awsxray/2)'
+        tooltip: "List of X-Ray component IDs contributing to the telemetry (ex. for multiple X-Ray receivers: awsxray/1, awsxray/2)"
     - name: AWS_XRAY_INDEX_ALL_ATTRIBUTES
       displayName: Index All Attributes
       componentType: checkbox
       initialValue: false
       componentProps:
         required: false
-        tooltip: 'Enable or disable conversion of all OpenTelemetry attributes to X-Ray annotations.'
+        tooltip: "Enable or disable conversion of all OpenTelemetry attributes to X-Ray annotations."
     - name: AWS_XRAY_INDEXED_ATTRIBUTES
       displayName: Indexed Attributes
       componentType: multiInput
       componentProps:
         required: false
-        tooltip: 'List of attribute names to be converted to X-Ray annotations.'
+        tooltip: "List of attribute names to be converted to X-Ray annotations."
   note:
     type: Note
     content: |

--- a/destinations/data/axiom.yaml
+++ b/destinations/data/axiom.yaml
@@ -13,6 +13,8 @@ spec:
       supported: false
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: AXIOM_DATASET
       displayName: Dataset

--- a/destinations/data/azureblob.yaml
+++ b/destinations/data/azureblob.yaml
@@ -13,6 +13,8 @@ spec:
       supported: false
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: AZURE_BLOB_ACCOUNT_NAME
       displayName: Account Name

--- a/destinations/data/azuremonitor.yaml
+++ b/destinations/data/azuremonitor.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: AZURE_MONITOR_CONNECTION_STRING
       displayName: Connection String

--- a/destinations/data/betterstack.yaml
+++ b/destinations/data/betterstack.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: BETTERSTACK_TOKEN
       displayName: Better Stack Source Token

--- a/destinations/data/bonree.yaml
+++ b/destinations/data/bonree.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: false
+    profiles:
+      supported: false
   fields:
     - name: BONREE_ENDPOINT
       displayName: OTLP HTTP Endpoint

--- a/destinations/data/causely.yaml
+++ b/destinations/data/causely.yaml
@@ -11,6 +11,8 @@ spec:
       supported: true
     metrics:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: CAUSELY_URL
       displayName: Endpoint
@@ -19,4 +21,4 @@ spec:
         type: text
         required: true
         placeholder: http://mediator.causely:4317
-        tooltip: 'The endpoint URL is the combined `<protocol>://<hostname>:<port>` to access your Causely Mediator service. Protocol should be `http`; using `https` or omitting it will automatically be converted to `http`. Hostname should typically follow the format: `mediator.<namespace>`. Namespace is the k8s namespace where the Causely Mediator service is deployed. Port is optional and defaults to the default OTLP gRPC port `4317`'
+        tooltip: "The endpoint URL is the combined `<protocol>://<hostname>:<port>` to access your Causely Mediator service. Protocol should be `http`; using `https` or omitting it will automatically be converted to `http`. Hostname should typically follow the format: `mediator.<namespace>`. Namespace is the k8s namespace where the Causely Mediator service is deployed. Port is optional and defaults to the default OTLP gRPC port `4317`"

--- a/destinations/data/checkly.yaml
+++ b/destinations/data/checkly.yaml
@@ -13,6 +13,8 @@ spec:
       supported: false
     logs:
       supported: false
+    profiles:
+      supported: false
   fields:
     - name: CHECKLY_ENDOINT
       displayName: OTLP gRPC Endpoint

--- a/destinations/data/chronosphere.yaml
+++ b/destinations/data/chronosphere.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: false
+    profiles:
+      supported: false
   fields:
     - name: CHRONOSPHERE_DOMAIN
       displayName: Chronosphere Company Domain
@@ -20,12 +22,12 @@ spec:
       componentProps:
         type: text
         required: true
-        tooltip: 'Company domain in Chronosphere, can be found in the URL of the Chronosphere UI. For example, if your URL is `https://demo-sandbox.chronosphere.io/`, then your company domain is `demo-sandbox`'
+        tooltip: "Company domain in Chronosphere, can be found in the URL of the Chronosphere UI. For example, if your URL is `https://demo-sandbox.chronosphere.io/`, then your company domain is `demo-sandbox`"
     - name: CHRONOSPHERE_API_TOKEN
       displayName: API Token
       componentType: input
       componentProps:
         type: password
         required: true
-        tooltip: 'API token generated from your Chronosphere service account in the Chronosphere UI, you should login to your Chronosphere admin account click the `Platform` menu on the left side of the screen, then click `Service Accounts` and create a new service account'
+        tooltip: "API token generated from your Chronosphere service account in the Chronosphere UI, you should login to your Chronosphere admin account click the `Platform` menu on the left side of the screen, then click `Service Accounts` and create a new service account"
       secret: true

--- a/destinations/data/clickhouse.yaml
+++ b/destinations/data/clickhouse.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: CLICKHOUSE_ENDPOINT
       displayName: Endpoint
@@ -59,39 +61,39 @@ spec:
       initialValue: false
       componentProps:
         required: false
-        tooltip: 'Secure connection'
+        tooltip: "Secure connection"
       customReadDataLabels:
-        - condition: 'true'
-          title: 'TLS'
-          value: 'Encrypted'
-        - condition: 'false'
-          title: 'TLS'
-          value: 'Unencrypted'
+        - condition: "true"
+          title: "TLS"
+          value: "Encrypted"
+        - condition: "false"
+          title: "TLS"
+          value: "Unencrypted"
     - name: CLICKHOUSE_INSECURE_SKIP_VERIFY
       displayName: Insecure Skip Verify
       componentType: checkbox
       initialValue: false
       componentProps:
         required: false
-        tooltip: 'Skip TLS certificate verification'
-      renderCondition: ['CLICKHOUSE_TLS_ENABLED', '==', 'true']
+        tooltip: "Skip TLS certificate verification"
+      renderCondition: ["CLICKHOUSE_TLS_ENABLED", "==", "true"]
     - name: CLICKHOUSE_USE_CUSTOM_CA
       displayName: Use Custom CA Certificate
       componentType: checkbox
       initialValue: false
       componentProps:
         required: false
-        tooltip: 'Use a custom CA certificate instead of the system root CA'
-      renderCondition: ['CLICKHOUSE_TLS_ENABLED', '==', 'true']
+        tooltip: "Use a custom CA certificate instead of the system root CA"
+      renderCondition: ["CLICKHOUSE_TLS_ENABLED", "==", "true"]
     - name: CLICKHOUSE_CA_PEM
       displayName: Certificate Authority (CA PEM)
       componentType: textarea
       componentProps:
         required: false
-        placeholder: '-----BEGIN CERTIFICATE-----'
-        tooltip: 'CA certificate in PEM format to verify the server'
-      renderCondition: ['CLICKHOUSE_USE_CUSTOM_CA', '==', 'true']
-      hideFromReadData: ['true']
+        placeholder: "-----BEGIN CERTIFICATE-----"
+        tooltip: "CA certificate in PEM format to verify the server"
+      renderCondition: ["CLICKHOUSE_USE_CUSTOM_CA", "==", "true"]
+      hideFromReadData: ["true"]
       secret: true
 
     - name: CLICKHOUSE_TRACES_TABLE
@@ -181,6 +183,6 @@ spec:
       renderCondition: ["SIGNALS", "INCLUDES", "logs"]
       hideFromReadData: ["HYPERDX_LOG_NORMALIZER", "==", "false"]
       customReadDataLabels:
-        - condition: 'true'
-          title: 'Log Normalizer'
-          value: 'Enabled'
+        - condition: "true"
+          title: "Log Normalizer"
+          value: "Enabled"

--- a/destinations/data/coralogix.yaml
+++ b/destinations/data/coralogix.yaml
@@ -14,6 +14,8 @@ spec:
       spanMetricsEnabledByDefault: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: CORALOGIX_PRIVATE_KEY
       displayName: Send-Your-Data API Key
@@ -21,7 +23,7 @@ spec:
       componentProps:
         type: password
         required: true
-        tooltip: 'The Send-Your-Data API Key is used to authenticate the data sent to Coralogix.'
+        tooltip: "The Send-Your-Data API Key is used to authenticate the data sent to Coralogix."
       secret: true
     - name: CORALOGIX_DOMAIN
       displayName: Domain
@@ -35,18 +37,18 @@ spec:
           - coralogix.in
           - coralogixsg.com
         required: true
-        tooltip: 'The Coralogix domain to which you want to send the data.'
+        tooltip: "The Coralogix domain to which you want to send the data."
     - name: CORALOGIX_APPLICATION_NAME
       displayName: Application Name
       componentType: input
       componentProps:
         type: text
         required: true
-        tooltip: 'The name of the application that sends the data to Coralogix.'
+        tooltip: "The name of the application that sends the data to Coralogix."
     - name: CORALOGIX_SUBSYSTEM_NAME
       displayName: Subsystem Name
       componentType: input
       componentProps:
         type: text
         required: true
-        tooltip: 'The name of the subsystem that sends the data to Coralogix.'
+        tooltip: "The name of the subsystem that sends the data to Coralogix."

--- a/destinations/data/dash0.yaml
+++ b/destinations/data/dash0.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: DASH0_ENDPOINT
       displayName: Dash0 OTLP gRPC Endpoint

--- a/destinations/data/datadog.yaml
+++ b/destinations/data/datadog.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: DATADOG_API_KEY
       displayName: API Key

--- a/destinations/data/dynamic.yaml
+++ b/destinations/data/dynamic.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: DYNAMIC_DESTINATION_TYPE
       displayName: Destination Type
@@ -20,7 +22,7 @@ spec:
       componentProps:
         type: text
         required: true
-        placeholder: 'otlp'
+        placeholder: "otlp"
         tooltip: The type of OpenTelemetry Collector Exporter to use for the destination.
     - name: DYNAMIC_CONFIGURATION_DATA
       displayName: Config

--- a/destinations/data/dynatrace.yaml
+++ b/destinations/data/dynatrace.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: DYNATRACE_URL
       displayName: Tenant URL

--- a/destinations/data/elasticapm.yaml
+++ b/destinations/data/elasticapm.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: ELASTIC_APM_SERVER_ENDPOINT
       displayName: elastic APM server endpoint

--- a/destinations/data/elasticsearch.yaml
+++ b/destinations/data/elasticsearch.yaml
@@ -13,6 +13,8 @@ spec:
       supported: false
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: ELASTICSEARCH_URL
       displayName: Elasticsearch URL
@@ -20,22 +22,22 @@ spec:
       componentProps:
         type: text
         required: true
-        placeholder: 'http://host:port'
-        tooltip: 'Elasticsearch endpoint. Port defaults to `9200` if not specified'
+        placeholder: "http://host:port"
+        tooltip: "Elasticsearch endpoint. Port defaults to `9200` if not specified"
     - name: ES_TRACES_INDEX
       displayName: Traces Index
       componentType: input
-      initialValue: 'trace_index'
+      initialValue: "trace_index"
       componentProps:
         type: text
-        tooltip: 'The name of the index where traces will be stored'
+        tooltip: "The name of the index where traces will be stored"
     - name: ES_LOGS_INDEX
       displayName: Logs Index
       componentType: input
-      initialValue: 'log_index'
+      initialValue: "log_index"
       componentProps:
         type: text
-        tooltip: 'The name of the index where logs will be stored.'
+        tooltip: "The name of the index where logs will be stored."
     - name: ELASTICSEARCH_BASIC_AUTH_ENABLED
       displayName: Enable HTTP Basic Authentication
       componentType: checkbox
@@ -43,52 +45,52 @@ spec:
       componentProps:
         required: false
       customReadDataLabels:
-        - condition: 'true'
-          title: 'Basic Auth'
-          value: 'Enabled'
-        - condition: 'false'
-          title: 'Basic Auth'
-          value: 'Disabled'
+        - condition: "true"
+          title: "Basic Auth"
+          value: "Enabled"
+        - condition: "false"
+          title: "Basic Auth"
+          value: "Disabled"
     - name: ELASTICSEARCH_USERNAME
       displayName: Username
       componentType: input
       componentProps:
         type: text
         required: false
-        tooltip: 'Username used for HTTP Basic Authentication'
-      renderCondition: ['ELASTICSEARCH_BASIC_AUTH_ENABLED', '==', 'true']
-      hideFromReadData: ['ELASTICSEARCH_BASIC_AUTH_ENABLED', '==', 'false']
+        tooltip: "Username used for HTTP Basic Authentication"
+      renderCondition: ["ELASTICSEARCH_BASIC_AUTH_ENABLED", "==", "true"]
+      hideFromReadData: ["ELASTICSEARCH_BASIC_AUTH_ENABLED", "==", "false"]
     - name: ELASTICSEARCH_PASSWORD
       displayName: Password
       componentType: input
       componentProps:
         type: password
         required: false
-        tooltip: 'Password used for HTTP Basic Authentication'
+        tooltip: "Password used for HTTP Basic Authentication"
       secret: true
-      renderCondition: ['ELASTICSEARCH_BASIC_AUTH_ENABLED', '==', 'true']
-      hideFromReadData: ['ELASTICSEARCH_BASIC_AUTH_ENABLED', '==', 'false']
+      renderCondition: ["ELASTICSEARCH_BASIC_AUTH_ENABLED", "==", "true"]
+      hideFromReadData: ["ELASTICSEARCH_BASIC_AUTH_ENABLED", "==", "false"]
     - name: ELASTICSEARCH_TLS_ENABLED
       displayName: Enable TLS
       componentType: checkbox
       initialValue: false
       componentProps:
         required: false
-        tooltip: 'Secure connection (Transport Layer Security)'
+        tooltip: "Secure connection (Transport Layer Security)"
       customReadDataLabels:
-        - condition: 'true'
-          title: 'TLS'
-          value: 'Encrypted'
-        - condition: 'false'
-          title: 'TLS'
-          value: 'Unencrypted'
+        - condition: "true"
+          title: "TLS"
+          value: "Encrypted"
+        - condition: "false"
+          title: "TLS"
+          value: "Unencrypted"
     - name: ELASTICSEARCH_CA_PEM
       displayName: CA Certificate
       componentType: textarea
       componentProps:
         type: text
         required: false
-        placeholder: '-----BEGIN CERTIFICATE-----'
-        tooltip: 'When using TLS, provide the CA certificate to verify the server. If empty uses system root CA'
-      renderCondition: ['ELASTICSEARCH_TLS_ENABLED', '==', 'true']
-      hideFromReadData: ['true']
+        placeholder: "-----BEGIN CERTIFICATE-----"
+        tooltip: "When using TLS, provide the CA certificate to verify the server. If empty uses system root CA"
+      renderCondition: ["ELASTICSEARCH_TLS_ENABLED", "==", "true"]
+      hideFromReadData: ["true"]

--- a/destinations/data/gigapipe.yaml
+++ b/destinations/data/gigapipe.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: QRYN_API_SECRET
       displayName: API Secret

--- a/destinations/data/googlecloudmonitoring.yaml
+++ b/destinations/data/googlecloudmonitoring.yaml
@@ -13,6 +13,8 @@ spec:
       supported: false
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: GCP_TIMEOUT
       displayName: Timeout
@@ -29,7 +31,7 @@ spec:
       componentProps:
         type: text
         required: false
-        placeholder: 'project-id'
+        placeholder: "project-id"
         tooltip: The project ID for the Google Cloud Monitoring API to send data to. Required if running Odigos outside of Google Cloud. Defaults to the detected project ID when running on GCP.
 
     - name: GCP_APPLICATION_CREDENTIALS
@@ -39,5 +41,5 @@ spec:
       componentProps:
         type: text
         required: false
-        placeholder: 'Credentials config... (optional)'
+        placeholder: "Credentials config... (optional)"
         tooltip: The JSON GCP Application Credentials file for the GCP project. Either a Workload Identity Federation config file or Service Account Key. Required if running Odigos outside of Google Cloud.

--- a/destinations/data/googlecloudotlp.yaml
+++ b/destinations/data/googlecloudotlp.yaml
@@ -13,6 +13,8 @@ spec:
       supported: false
     logs:
       supported: false
+    profiles:
+      supported: false
   fields:
     - name: GCP_PROJECT_ID
       displayName: Project ID
@@ -20,7 +22,7 @@ spec:
       componentProps:
         type: text
         required: false
-        placeholder: 'project-id'
+        placeholder: "project-id"
         tooltip: The project ID for the Google Cloud Monitoring API to send data to. This defaults to the Application Credentials project ID (which is automatically detected when running on GCP). Setting this can override the Application Credentials project ID. Required if running Odigos outside of Google Cloud.
 
     - name: GCP_APPLICATION_CREDENTIALS
@@ -30,5 +32,5 @@ spec:
       componentProps:
         type: text
         required: false
-        placeholder: 'Credentials config... (optional)'
+        placeholder: "Credentials config... (optional)"
         tooltip: The JSON GCP Application Credentials file for the GCP project. Either a Workload Identity Federation config file or Service Account Key. Required if running Odigos outside of Google Cloud.

--- a/destinations/data/grafanacloudloki.yaml
+++ b/destinations/data/grafanacloudloki.yaml
@@ -13,6 +13,8 @@ spec:
       supported: false
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: GRAFANA_CLOUD_LOKI_ENDPOINT
       displayName: Endpoint

--- a/destinations/data/grafanacloudprometheus.yaml
+++ b/destinations/data/grafanacloudprometheus.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: false
+    profiles:
+      supported: false
   fields:
     - name: GRAFANA_CLOUD_PROMETHEUS_RW_ENDPOINT
       displayName: Prometheus Remote Write Endpoint
@@ -20,7 +22,7 @@ spec:
       componentProps:
         type: text
         required: true
-        placeholder: 'https://{hostname}.grafana.net/api/prom/push'
+        placeholder: "https://{hostname}.grafana.net/api/prom/push"
         tooltip: This is the URL of the Prometheus service. From the grafana cloud UI, Prometheus page, make sure you copy the URL from “Remote Write Endpoint” section, and not the first Endpoint which is used for queries
     - name: GRAFANA_CLOUD_PROMETHEUS_USERNAME
       displayName: Username / Instance ID
@@ -28,8 +30,8 @@ spec:
       componentProps:
         type: text
         required: true
-        placeholder: '12345678'
-        tooltip: 'You can find the Username / Instance ID on the Prometheus page. Value is a number.'
+        placeholder: "12345678"
+        tooltip: "You can find the Username / Instance ID on the Prometheus page. Value is a number."
     - name: GRAFANA_CLOUD_PROMETHEUS_PASSWORD
       displayName: Password / Api Token
       secret: true
@@ -38,18 +40,18 @@ spec:
         type: password
         required: true
         tooltip: This field is refered to as "password" or "Grafana.com API Token" in the Grafana Cloud UI. You can manage tokens in your "Account Settings" page under the "SECURITY" section in the "Access Policies" page. Make sure your token scope includes `metrics:write` scope.
-        placeholder: 'glc_eyJvIj...'
+        placeholder: "glc_eyJvIj..."
     - name: PROMETHEUS_RESOURCE_ATTRIBUTES_LABELS
       displayName: Resource Attributes Labels
       componentType: multiInput
       componentProps:
-        tooltip: 'use these OpenTelemetry resource attributes as prometheus labels for each metric data point'
+        tooltip: "use these OpenTelemetry resource attributes as prometheus labels for each metric data point"
       initialValue: '["k8s.container.name", "k8s.pod.name", "k8s.namespace.name"]'
     - name: PROMETHEUS_RESOURCE_EXTERNAL_LABELS
       displayName: External Labels
       componentType: keyValuePairs
       componentProps:
-        titleKey: 'Label Name'
-        titleButton: 'Add Label'
-        titleValue: 'Value'
-        tooltip: 'map of labels names and values to be attached to each metric data point'
+        titleKey: "Label Name"
+        titleButton: "Add Label"
+        titleValue: "Value"
+        tooltip: "map of labels names and values to be attached to each metric data point"

--- a/destinations/data/grafanacloudtempo.yaml
+++ b/destinations/data/grafanacloudtempo.yaml
@@ -13,6 +13,8 @@ spec:
       supported: false
     logs:
       supported: false
+    profiles:
+      supported: false
   fields:
     - name: GRAFANA_CLOUD_TEMPO_ENDPOINT
       displayName: Endpoint
@@ -37,4 +39,4 @@ spec:
         type: password
         required: true
         tooltip: This field is refered to as "password" or "Grafana.com API Token" in the Grafana Cloud UI. You can manage tokens in your "Account Settings" page under the "SECURITY" section in the "Access Policies" page. Make sure your token scope includes `traces:write` scope.
-        placeholder: 'glc_eyJvIj...'
+        placeholder: "glc_eyJvIj..."

--- a/destinations/data/greptime.yaml
+++ b/destinations/data/greptime.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: false
+    profiles:
+      supported: false
   fields:
     - name: GREPTIME_ENDPOINT
       displayName: OTLP HTTP Endpoint

--- a/destinations/data/groundcover.yaml
+++ b/destinations/data/groundcover.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: GROUNDCOVER_ENDPOINT
       displayName: Groundcover inCloud Site

--- a/destinations/data/honeycomb.yaml
+++ b/destinations/data/honeycomb.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: HONEYCOMB_API_KEY
       displayName: API Key
@@ -31,4 +33,3 @@ spec:
         required: true
         tooltip: Choose one of the endpoints in the dropdown (`api.honeycomb.io` is the US instance, `api.eu1.honeycomb.io` is EU instance)
   testConnectionSupported: true
-  

--- a/destinations/data/hyperdx.yaml
+++ b/destinations/data/hyperdx.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: HYPERDX_API_KEY
       displayName: HyperDX API Key
@@ -32,9 +34,9 @@ spec:
       renderCondition: ["SIGNALS", "INCLUDES", "logs"]
       hideFromReadData: ["HYPERDX_LOG_NORMALIZER", "==", "false"]
       customReadDataLabels:
-        - condition: 'true'
-          title: 'Log Normalizer'
-          value: 'Enabled'
+        - condition: "true"
+          title: "Log Normalizer"
+          value: "Enabled"
   note:
     type: Check
     content: |

--- a/destinations/data/instana.yaml
+++ b/destinations/data/instana.yaml
@@ -13,14 +13,16 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: INSTANA_ENDPOINT
       displayName: OTLP gRPC Endpoint
       componentType: input
       componentProps:
         required: true
-        placeholder: 'otlp-{color}-saas.instana.io'
-        tooltip: 'Domain name of the otlp-acceptor component of the Instana backend.'
+        placeholder: "otlp-{color}-saas.instana.io"
+        tooltip: "Domain name of the otlp-acceptor component of the Instana backend."
     - name: INSTANA_AGENT_KEY
       displayName: Agent Key
       secret: true
@@ -28,7 +30,7 @@ spec:
       componentProps:
         type: password
         required: true
-        tooltip: 'The agent key of the Instana for targeting the Instana backend.'
+        tooltip: "The agent key of the Instana for targeting the Instana backend."
   note:
     type: Warning
     content: |

--- a/destinations/data/jaeger.yaml
+++ b/destinations/data/jaeger.yaml
@@ -13,6 +13,8 @@ spec:
       supported: false
     logs:
       supported: false
+    profiles:
+      supported: false
   fields:
     - name: JAEGER_URL
       displayName: Jaeger OTLP gRPC Endpoint
@@ -26,21 +28,21 @@ spec:
       initialValue: false
       componentProps:
         required: false
-        tooltip: 'Secure connection'
+        tooltip: "Secure connection"
       customReadDataLabels:
-        - condition: 'true'
-          title: 'TLS'
-          value: 'Encrypted'
-        - condition: 'false'
-          title: 'TLS'
-          value: 'Unencrypted'
+        - condition: "true"
+          title: "TLS"
+          value: "Encrypted"
+        - condition: "false"
+          title: "TLS"
+          value: "Unencrypted"
     - name: JAEGER_CA_PEM
       displayName: Certificate Authority
       componentType: textarea
       componentProps:
         required: false
-        placeholder: '-----BEGIN CERTIFICATE-----'
-        tooltip: 'When using TLS, provide the CA certificate in PEM format to verify the server. If empty uses system root CA'
-      renderCondition: ['JAEGER_TLS_ENABLED', '==', 'true']
-      hideFromReadData: ['true']
+        placeholder: "-----BEGIN CERTIFICATE-----"
+        tooltip: "When using TLS, provide the CA certificate in PEM format to verify the server. If empty uses system root CA"
+      renderCondition: ["JAEGER_TLS_ENABLED", "==", "true"]
+      hideFromReadData: ["true"]
   testConnectionSupported: true

--- a/destinations/data/kafka.yaml
+++ b/destinations/data/kafka.yaml
@@ -13,41 +13,43 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: KAFKA_PROTOCOL_VERSION
       displayName: Protocol Version
       componentType: input
       componentProps:
         required: true
-        placeholder: '2.0.0'
-        tooltip: 'Kafka protocol version.'
+        placeholder: "2.0.0"
+        tooltip: "Kafka protocol version."
     - name: KAFKA_BROKERS
       displayName: Brokers
       componentType: multiInput
       componentProps:
         required: false
-        tooltip: 'The list of kafka brokers'
+        tooltip: "The list of kafka brokers"
       initialValue: '["localhost:9092"]'
     - name: KAFKA_RESOLVE_CANONICAL_BOOTSTRAP_SERVERS_ONLY
       displayName: Resolve Canonical Bootstrap Servers Only
       componentType: checkbox
       componentProps:
         required: false
-        tooltip: 'Whether to resolve then reverse-lookup broker IPs during startup.'
+        tooltip: "Whether to resolve then reverse-lookup broker IPs during startup."
       initialValue: false
     - name: KAFKA_CLIENT_ID
       displayName: Client ID
       componentType: input
       componentProps:
         required: false
-        tooltip: 'The client ID to configure the Sarama Kafka client with. The client ID will be used for all produce requests.'
-      initialValue: 'sarama'
+        tooltip: "The client ID to configure the Sarama Kafka client with. The client ID will be used for all produce requests."
+      initialValue: "sarama"
     - name: KAFKA_TOPIC
       displayName: Topic
       componentType: input
       componentProps:
         required: false
-        tooltip: 'The name of the default kafka topic to export to (default = otlp_spans for traces, otlp_metrics for metrics, otlp_logs for logs).'
+        tooltip: "The name of the default kafka topic to export to (default = otlp_spans for traces, otlp_metrics for metrics, otlp_logs for logs)."
     - name: KAFKA_TOPIC_FROM_ATTRIBUTE
       displayName: Topic from Attribute
       componentType: input
@@ -62,28 +64,28 @@ spec:
           - otlp_proto
           - otlp_json
         required: false
-        tooltip: 'The encoding of the traces sent to kafka.'
-      initialValue: 'otlp_proto'
+        tooltip: "The encoding of the traces sent to kafka."
+      initialValue: "otlp_proto"
     - name: KAFKA_PARTITION_TRACES_BY_ID
       displayName: Partition Traces by ID
       componentType: checkbox
       componentProps:
         required: false
-        tooltip: 'Configures the exporter to include the trace ID as the message key in trace messages sent to kafka. Please note: this setting does not have any effect on Jaeger encoding exporters since Jaeger exporters include trace ID as the message key by default.'
+        tooltip: "Configures the exporter to include the trace ID as the message key in trace messages sent to kafka. Please note: this setting does not have any effect on Jaeger encoding exporters since Jaeger exporters include trace ID as the message key by default."
       initialValue: false
     - name: KAFKA_PARTITION_METRICS_BY_RESOURCE_ATTRIBUTES
       displayName: Partition Metrics by Resource Attributes
       componentType: checkbox
       componentProps:
         required: false
-        tooltip: 'Configures the exporter to include the hash of sorted resource attributes as the message partitioning key in metric messages sent to kafka.'
+        tooltip: "Configures the exporter to include the hash of sorted resource attributes as the message partitioning key in metric messages sent to kafka."
       initialValue: false
     - name: KAFKA_PARTITION_LOGS_BY_RESOURCE_ATTRIBUTES
       displayName: Partition Logs by Resource Attributes
       componentType: checkbox
       componentProps:
         required: false
-        tooltip: 'Configures the exporter to include the hash of sorted resource attributes as the message partitioning key in log messages sent to kafka.'
+        tooltip: "Configures the exporter to include the hash of sorted resource attributes as the message partitioning key in log messages sent to kafka."
       initialValue: false
     - name: KAFKA_AUTH_METHOD
       displayName: Auth Method
@@ -94,16 +96,16 @@ spec:
           - none
           - plain_text
         required: true
-        tooltip: 'The auth method to use.'
-      initialValue: 'none'
+        tooltip: "The auth method to use."
+      initialValue: "none"
     - name: KAFKA_USERNAME
       displayName: Username
       componentType: input
       componentProps:
         required: false
-        tooltip: 'The username to use.'
-      renderCondition: ['KAFKA_AUTH_METHOD', '==', 'plain_text']
-      hideFromReadData: ['KAFKA_AUTH_METHOD', '!=', 'plain_text']
+        tooltip: "The username to use."
+      renderCondition: ["KAFKA_AUTH_METHOD", "==", "plain_text"]
+      hideFromReadData: ["KAFKA_AUTH_METHOD", "!=", "plain_text"]
     - name: KAFKA_PASSWORD
       displayName: Password
       componentType: input
@@ -111,37 +113,37 @@ spec:
       componentProps:
         type: password
         required: false
-        tooltip: 'The password to use.'
-      renderCondition: ['KAFKA_AUTH_METHOD', '==', 'plain_text']
-      hideFromReadData: ['KAFKA_AUTH_METHOD', '!=', 'plain_text']
+        tooltip: "The password to use."
+      renderCondition: ["KAFKA_AUTH_METHOD", "==", "plain_text"]
+      hideFromReadData: ["KAFKA_AUTH_METHOD", "!=", "plain_text"]
     - name: KAFKA_METADATA_FULL
       displayName: Metadata Full
       componentType: checkbox
       componentProps:
         required: false
-        tooltip: 'Whether to maintain a full set of metadata. When disabled, the client does not make the initial request to broker at the startup.'
+        tooltip: "Whether to maintain a full set of metadata. When disabled, the client does not make the initial request to broker at the startup."
       initialValue: false
     - name: KAFKA_METADATA_MAX_RETRY
       displayName: Metadata Max Retry
       componentType: input
       componentProps:
         required: false
-        tooltip: 'The number of retries to get metadata.'
-      initialValue: '3'
+        tooltip: "The number of retries to get metadata."
+      initialValue: "3"
     - name: KAFKA_METADATA_BACKOFF_RETRY
       displayName: Metadata Backoff Retry
       componentType: input
       componentProps:
         required: false
-        tooltip: 'How long to wait between metadata retries.'
-      initialValue: '250ms'
+        tooltip: "How long to wait between metadata retries."
+      initialValue: "250ms"
     - name: KAFKA_TIMEOUT
       displayName: Timeout
       componentType: input
       componentProps:
         required: false
-        tooltip: 'Is the timeout for every attempt to send data to the backend.'
-      initialValue: '5s'
+        tooltip: "Is the timeout for every attempt to send data to the backend."
+      initialValue: "5s"
     - name: KAFKA_RETRY_ON_FAILURE_ENABLED
       displayName: Enable Retry on Failure
       componentType: checkbox
@@ -153,42 +155,42 @@ spec:
       componentType: input
       componentProps:
         required: false
-        tooltip: 'Time to wait after the first failure before retrying; ignored if `enabled` is `false`.'
-      initialValue: '5s'
-      renderCondition: ['KAFKA_RETRY_ON_FAILURE_ENABLED', '==', 'true']
-      hideFromReadData: ['KAFKA_RETRY_ON_FAILURE_ENABLED', '==', 'false']
+        tooltip: "Time to wait after the first failure before retrying; ignored if `enabled` is `false`."
+      initialValue: "5s"
+      renderCondition: ["KAFKA_RETRY_ON_FAILURE_ENABLED", "==", "true"]
+      hideFromReadData: ["KAFKA_RETRY_ON_FAILURE_ENABLED", "==", "false"]
     - name: KAFKA_RETRY_ON_FAILURE_MAX_INTERVAL
       displayName: Max Interval
       componentType: input
       componentProps:
         required: false
-        tooltip: 'Is the upper bound on backoff; ignored if `enabled` is `false`.'
-      initialValue: '30s'
-      renderCondition: ['KAFKA_RETRY_ON_FAILURE_ENABLED', '==', 'true']
-      hideFromReadData: ['KAFKA_RETRY_ON_FAILURE_ENABLED', '==', 'false']
+        tooltip: "Is the upper bound on backoff; ignored if `enabled` is `false`."
+      initialValue: "30s"
+      renderCondition: ["KAFKA_RETRY_ON_FAILURE_ENABLED", "==", "true"]
+      hideFromReadData: ["KAFKA_RETRY_ON_FAILURE_ENABLED", "==", "false"]
     - name: KAFKA_RETRY_ON_FAILURE_MAX_ELAPSED_TIME
       displayName: Max Elapsed Time
       componentType: input
       componentProps:
         required: false
-        tooltip: 'Is the maximum amount of time spent trying to send a batch; ignored if `enabled` is `false`.'
-      initialValue: '120s'
-      renderCondition: ['KAFKA_RETRY_ON_FAILURE_ENABLED', '==', 'true']
-      hideFromReadData: ['KAFKA_RETRY_ON_FAILURE_ENABLED', '==', 'false']
+        tooltip: "Is the maximum amount of time spent trying to send a batch; ignored if `enabled` is `false`."
+      initialValue: "120s"
+      renderCondition: ["KAFKA_RETRY_ON_FAILURE_ENABLED", "==", "true"]
+      hideFromReadData: ["KAFKA_RETRY_ON_FAILURE_ENABLED", "==", "false"]
     - name: KAFKA_PRODUCER_MAX_MESSAGE_BYTES
       displayName: Producer Max Message Bytes
       componentType: input
       componentProps:
         required: false
-        tooltip: 'The maximum permitted size of a message in bytes.'
-      initialValue: '1000000'
+        tooltip: "The maximum permitted size of a message in bytes."
+      initialValue: "1000000"
     - name: KAFKA_PRODUCER_REQUIRED_ACKS
       displayName: Producer Required Acks
       componentType: input
       componentProps:
         required: false
-        tooltip: 'Controls when a message is regarded as transmitted.'
-      initialValue: '1'
+        tooltip: "Controls when a message is regarded as transmitted."
+      initialValue: "1"
     - name: KAFKA_PRODUCER_COMPRESSION
       displayName: Producer Compression
       componentType: dropdown
@@ -200,15 +202,15 @@ spec:
           - lz4
           - zstd
         required: false
-        tooltip: 'The compression used when producing messages to kafka.'
-      initialValue: 'none'
+        tooltip: "The compression used when producing messages to kafka."
+      initialValue: "none"
     - name: KAFKA_PRODUCER_FLUSH_MAX_MESSAGES
       displayName: Producer Flush Max Messages
       componentType: input
       componentProps:
         required: false
-        tooltip: 'The maximum number of messages the producer will send in a single broker request.'
-      initialValue: '0'
+        tooltip: "The maximum number of messages the producer will send in a single broker request."
+      initialValue: "0"
   note:
     type: Note
     content: |

--- a/destinations/data/kloudmate.yaml
+++ b/destinations/data/kloudmate.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: KLOUDMATE_API_KEY
       displayName: KloudMate API Key

--- a/destinations/data/last9.yaml
+++ b/destinations/data/last9.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: LAST9_OTLP_ENDPOINT
       displayName: Last9 OpenTelemetry Endpoint
@@ -27,4 +29,4 @@ spec:
       componentProps:
         type: password
         required: true
-        placeholder: 'Basic ...'
+        placeholder: "Basic ..."

--- a/destinations/data/lightstep.yaml
+++ b/destinations/data/lightstep.yaml
@@ -13,6 +13,8 @@ spec:
       supported: false
     logs:
       supported: false
+    profiles:
+      supported: false
   fields:
     - name: LIGHTSTEP_ACCESS_TOKEN
       displayName: Access Token

--- a/destinations/data/logzio.yaml
+++ b/destinations/data/logzio.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: LOGZIO_REGION
       displayName: Region

--- a/destinations/data/loki.yaml
+++ b/destinations/data/loki.yaml
@@ -13,6 +13,8 @@ spec:
       supported: false
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: LOKI_URL
       displayName: Endpoint
@@ -28,8 +30,8 @@ spec:
       componentProps:
         type: text
         required: false
-        tooltip: 'use this X-Scope-OrgID if you need to scope the data to a specific org. Multiple orgs can be chained using `|`'
-        placeholder: 'org1|org2|org3'
+        tooltip: "use this X-Scope-OrgID if you need to scope the data to a specific org. Multiple orgs can be chained using `|`"
+        placeholder: "org1|org2|org3"
     - name: LOKI_USERNAME
       displayName: Basic Auth Username
       componentType: input

--- a/destinations/data/lumigo.yaml
+++ b/destinations/data/lumigo.yaml
@@ -13,11 +13,13 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: LUMIGO_ENDPOINT
       displayName: Lumigo OTLP HTTP Endpoint
       componentType: input
-      initialValue: 'https://ga-otlp.lumigo-tracer-edge.golumigo.com'
+      initialValue: "https://ga-otlp.lumigo-tracer-edge.golumigo.com"
       componentProps:
         type: text
         required: true

--- a/destinations/data/middleware.yaml
+++ b/destinations/data/middleware.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: MW_TARGET
       displayName: Endpoint

--- a/destinations/data/newrelic.yaml
+++ b/destinations/data/newrelic.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: NEWRELIC_API_KEY
       displayName: License Key

--- a/destinations/data/observe.yaml
+++ b/destinations/data/observe.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: OBSERVE_CUSTOMER_ID
       displayName: Customer ID

--- a/destinations/data/oneuptime.yaml
+++ b/destinations/data/oneuptime.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: ONEUPTIME_INGESTION_KEY
       displayName: Telemetry Ingestion Key

--- a/destinations/data/openobserve.yaml
+++ b/destinations/data/openobserve.yaml
@@ -13,6 +13,8 @@ spec:
       supported: false
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: OPEN_OBSERVE_ENDPOINT
       displayName: OTLP HTTP Endpoint

--- a/destinations/data/oracle.yaml
+++ b/destinations/data/oracle.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: false
+    profiles:
+      supported: false
   fields:
     - name: ORACLE_ENDPOINT
       displayName: OTLP HTTP Endpoint
@@ -20,7 +22,7 @@ spec:
       componentProps:
         type: text
         required: true
-        tooltip: 'The data upload endpoint of the Oracle APM domain.'
+        tooltip: "The data upload endpoint of the Oracle APM domain."
     - name: ORACLE_DATA_KEY
       displayName: Data Key
       componentType: input
@@ -36,5 +38,5 @@ spec:
         values:
           - private
           - public
-        tooltip: 'The type of the data key, relevant for Traces. Metrics are always authenticated with a private data key.'
+        tooltip: "The type of the data key, relevant for Traces. Metrics are always authenticated with a private data key."
       initialValue: private

--- a/destinations/data/otlp.yaml
+++ b/destinations/data/otlp.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: OTLP_GRPC_ENDPOINT
       displayName: OTLP gRPC Endpoint
@@ -20,7 +22,7 @@ spec:
       componentProps:
         type: text
         required: true
-        placeholder: 'host:port'
+        placeholder: "host:port"
         tooltip: The format is `host:port`, host is required, port is optional and defaults to the default OTLP gRPC port `4317`.
     - name: OTLP_GRPC_COMPRESSION
       displayName: Destination Compression Type
@@ -35,46 +37,46 @@ spec:
           - deflate
           - zstd
         required: false
-        tooltip: 'Compression type to use for the destination. The default is `none`. The compression type must be supported by the destination.'
-      initialValue: 'none'
+        tooltip: "Compression type to use for the destination. The default is `none`. The compression type must be supported by the destination."
+      initialValue: "none"
     - name: OTLP_GRPC_HEADERS
       displayName: Headers
       componentType: keyValuePairs
       componentProps:
         required: false
-        tooltip: 'Headers is the option to set custom GRPC headers for OTLP GRPC destination. If specified, please provide each header in the format: key:value. Multiple headers can be added. Keys must be non-empty strings and follow standard HTTP header conventions. Values must be non-empty strings and may include alphanumerics, whitespace, and standard punctuation.'
+        tooltip: "Headers is the option to set custom GRPC headers for OTLP GRPC destination. If specified, please provide each header in the format: key:value. Multiple headers can be added. Keys must be non-empty strings and follow standard HTTP header conventions. Values must be non-empty strings and may include alphanumerics, whitespace, and standard punctuation."
     - name: OTLP_GRPC_OAUTH2_ENABLED
       displayName: Enable OAuth2
       componentType: checkbox
       initialValue: false
       componentProps:
         required: false
-        tooltip: 'Enable OAuth2 client credentials authentication'
+        tooltip: "Enable OAuth2 client credentials authentication"
       customReadDataLabels:
-        - condition: 'true'
-          title: 'OAuth2'
-          value: 'Enabled'
-        - condition: 'false'
-          title: 'OAuth2'
-          value: 'Disabled'
+        - condition: "true"
+          title: "OAuth2"
+          value: "Enabled"
+        - condition: "false"
+          title: "OAuth2"
+          value: "Disabled"
     - name: OTLP_GRPC_OAUTH2_CLIENT_ID
       displayName: OAuth2 Client ID
       componentType: input
       componentProps:
         type: text
         required: false # TODO: required only if 'Enable OAuth2' is true
-        placeholder: 'your-client-id'
-        tooltip: 'OAuth2 client identifier for client credentials flow'
-      renderCondition: ['OTLP_GRPC_OAUTH2_ENABLED', '==', 'true']
+        placeholder: "your-client-id"
+        tooltip: "OAuth2 client identifier for client credentials flow"
+      renderCondition: ["OTLP_GRPC_OAUTH2_ENABLED", "==", "true"]
     - name: OTLP_GRPC_OAUTH2_CLIENT_SECRET
       displayName: OAuth2 Client Secret
       componentType: input
       componentProps:
         type: password
         required: false # TODO: required only if 'Enable OAuth2' is true
-        placeholder: 'your-client-secret'
-        tooltip: 'OAuth2 client secret for client credentials flow'
-      renderCondition: ['OTLP_GRPC_OAUTH2_ENABLED', '==', 'true']
+        placeholder: "your-client-secret"
+        tooltip: "OAuth2 client secret for client credentials flow"
+      renderCondition: ["OTLP_GRPC_OAUTH2_ENABLED", "==", "true"]
       secret: true
     - name: OTLP_GRPC_OAUTH2_TOKEN_URL
       displayName: OAuth2 Token URL
@@ -82,56 +84,56 @@ spec:
       componentProps:
         type: text
         required: false # TODO: required only if 'Enable OAuth2' is true
-        placeholder: 'https://example.com/oauth2/token'
-        tooltip: 'OAuth2 token endpoint URL for obtaining access tokens'
-      renderCondition: ['OTLP_GRPC_OAUTH2_ENABLED', '==', 'true']
+        placeholder: "https://example.com/oauth2/token"
+        tooltip: "OAuth2 token endpoint URL for obtaining access tokens"
+      renderCondition: ["OTLP_GRPC_OAUTH2_ENABLED", "==", "true"]
     - name: OTLP_GRPC_OAUTH2_SCOPES
       displayName: OAuth2 Scopes
       componentType: input
       componentProps:
         type: text
         required: false
-        placeholder: 'api.metrics,api.traces'
+        placeholder: "api.metrics,api.traces"
         tooltip: 'Comma-separated list of OAuth2 scopes to request (e.g., "api.metrics,api.traces")'
-      renderCondition: ['OTLP_GRPC_OAUTH2_ENABLED', '==', 'true']
+      renderCondition: ["OTLP_GRPC_OAUTH2_ENABLED", "==", "true"]
     - name: OTLP_GRPC_OAUTH2_AUDIENCE
       displayName: OAuth2 Audience
       componentType: input
       componentProps:
         type: text
         required: false
-        placeholder: 'api.example.com'
-        tooltip: 'OAuth2 audience parameter for token requests'
-      renderCondition: ['OTLP_GRPC_OAUTH2_ENABLED', '==', 'true']
+        placeholder: "api.example.com"
+        tooltip: "OAuth2 audience parameter for token requests"
+      renderCondition: ["OTLP_GRPC_OAUTH2_ENABLED", "==", "true"]
     - name: OTLP_GRPC_TLS_ENABLED
       displayName: Enable TLS
       componentType: checkbox
       initialValue: false
       componentProps:
         required: false
-        tooltip: 'Secure connection'
+        tooltip: "Secure connection"
       customReadDataLabels:
-        - condition: 'true'
-          title: 'TLS'
-          value: 'Encrypted'
-        - condition: 'false'
-          title: 'TLS'
-          value: 'Unencrypted'
+        - condition: "true"
+          title: "TLS"
+          value: "Encrypted"
+        - condition: "false"
+          title: "TLS"
+          value: "Unencrypted"
     - name: OTLP_GRPC_CA_PEM
       displayName: Certificate Authority
       componentType: textarea
       componentProps:
         required: false
-        placeholder: '-----BEGIN CERTIFICATE-----'
-        tooltip: 'When using TLS, provide the CA certificate in PEM format to verify the server. If empty uses system root CA'
-      renderCondition: ['OTLP_GRPC_TLS_ENABLED', '==', 'true']
-      hideFromReadData: ['true']
+        placeholder: "-----BEGIN CERTIFICATE-----"
+        tooltip: "When using TLS, provide the CA certificate in PEM format to verify the server. If empty uses system root CA"
+      renderCondition: ["OTLP_GRPC_TLS_ENABLED", "==", "true"]
+      hideFromReadData: ["true"]
     - name: OTLP_GRPC_INSECURE_SKIP_VERIFY
       displayName: Insecure Skip Verify
       componentType: checkbox
       initialValue: false
       componentProps:
         required: false
-        tooltip: 'Skip TLS certificate verification'
-      renderCondition: ['OTLP_GRPC_TLS_ENABLED', '==', 'true']
+        tooltip: "Skip TLS certificate verification"
+      renderCondition: ["OTLP_GRPC_TLS_ENABLED", "==", "true"]
   testConnectionSupported: true

--- a/destinations/data/otlphttp.yaml
+++ b/destinations/data/otlphttp.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: OTLP_HTTP_ENDPOINT
       displayName: OTLP http Endpoint
@@ -20,7 +22,7 @@ spec:
       componentProps:
         type: text
         required: true
-        placeholder: 'http://host:port'
+        placeholder: "http://host:port"
         tooltip: The format is `host:port`, host is required, port is optional and defaults to the default OTLP HTTP port `4318`.
 
     - name: OTLP_HTTP_BASIC_AUTH_USERNAME
@@ -29,7 +31,7 @@ spec:
       componentProps:
         type: text
         required: false
-        placeholder: 'username'
+        placeholder: "username"
         tooltip: in case the otlp receiver requires basic auth, this is the username
 
     - name: OTLP_HTTP_BASIC_AUTH_PASSWORD
@@ -38,7 +40,7 @@ spec:
       componentProps:
         type: password
         required: false
-        placeholder: 'password'
+        placeholder: "password"
         tooltip: in case the otlp receiver requires basic auth, this is the password
       secret: true
 
@@ -48,14 +50,14 @@ spec:
       initialValue: false
       componentProps:
         required: false
-        tooltip: 'Enable OAuth2 client credentials authentication'
+        tooltip: "Enable OAuth2 client credentials authentication"
       customReadDataLabels:
-        - condition: 'true'
-          title: 'OAuth2'
-          value: 'Enabled'
-        - condition: 'false'
-          title: 'OAuth2'
-          value: 'Disabled'
+        - condition: "true"
+          title: "OAuth2"
+          value: "Enabled"
+        - condition: "false"
+          title: "OAuth2"
+          value: "Disabled"
 
     - name: OTLP_HTTP_OAUTH2_CLIENT_ID
       displayName: OAuth2 Client ID
@@ -63,9 +65,9 @@ spec:
       componentProps:
         type: text
         required: false # TODO: required only if 'Enable OAuth2' is true
-        placeholder: 'your-client-id'
-        tooltip: 'OAuth2 client identifier for client credentials flow'
-      renderCondition: ['OTLP_HTTP_OAUTH2_ENABLED', '==', 'true']
+        placeholder: "your-client-id"
+        tooltip: "OAuth2 client identifier for client credentials flow"
+      renderCondition: ["OTLP_HTTP_OAUTH2_ENABLED", "==", "true"]
 
     - name: OTLP_HTTP_OAUTH2_CLIENT_SECRET
       displayName: OAuth2 Client Secret
@@ -73,9 +75,9 @@ spec:
       componentProps:
         type: password
         required: false # TODO: required only if 'Enable OAuth2' is true
-        placeholder: 'your-client-secret'
-        tooltip: 'OAuth2 client secret for client credentials flow'
-      renderCondition: ['OTLP_HTTP_OAUTH2_ENABLED', '==', 'true']
+        placeholder: "your-client-secret"
+        tooltip: "OAuth2 client secret for client credentials flow"
+      renderCondition: ["OTLP_HTTP_OAUTH2_ENABLED", "==", "true"]
       secret: true
 
     - name: OTLP_HTTP_OAUTH2_TOKEN_URL
@@ -84,9 +86,9 @@ spec:
       componentProps:
         type: text
         required: false # TODO: required only if 'Enable OAuth2' is true
-        placeholder: 'https://example.com/oauth2/token'
-        tooltip: 'OAuth2 token endpoint URL for obtaining access tokens'
-      renderCondition: ['OTLP_HTTP_OAUTH2_ENABLED', '==', 'true']
+        placeholder: "https://example.com/oauth2/token"
+        tooltip: "OAuth2 token endpoint URL for obtaining access tokens"
+      renderCondition: ["OTLP_HTTP_OAUTH2_ENABLED", "==", "true"]
 
     - name: OTLP_HTTP_OAUTH2_SCOPES
       displayName: OAuth2 Scopes
@@ -94,9 +96,9 @@ spec:
       componentProps:
         type: text
         required: false
-        placeholder: 'api.metrics,api.traces'
+        placeholder: "api.metrics,api.traces"
         tooltip: 'Comma-separated list of OAuth2 scopes to request (e.g., "api.metrics,api.traces")'
-      renderCondition: ['OTLP_HTTP_OAUTH2_ENABLED', '==', 'true']
+      renderCondition: ["OTLP_HTTP_OAUTH2_ENABLED", "==", "true"]
 
     - name: OTLP_HTTP_OAUTH2_AUDIENCE
       displayName: OAuth2 Audience
@@ -104,9 +106,9 @@ spec:
       componentProps:
         type: text
         required: false
-        placeholder: 'api.example.com'
-        tooltip: 'OAuth2 audience parameter for token requests'
-      renderCondition: ['OTLP_HTTP_OAUTH2_ENABLED', '==', 'true']
+        placeholder: "api.example.com"
+        tooltip: "OAuth2 audience parameter for token requests"
+      renderCondition: ["OTLP_HTTP_OAUTH2_ENABLED", "==", "true"]
 
     - name: OTLP_HTTP_COMPRESSION
       displayName: Destination Compression Type
@@ -121,14 +123,14 @@ spec:
           - deflate
           - zstd
         required: false
-        tooltip: 'Compression type to use for the destination. The default is `none`. The compression type must be supported by the destination.'
-      initialValue: 'none'
+        tooltip: "Compression type to use for the destination. The default is `none`. The compression type must be supported by the destination."
+      initialValue: "none"
     - name: OTLP_HTTP_HEADERS
       displayName: Headers
       componentType: keyValuePairs
       componentProps:
         required: false
-        tooltip: 'Headers is the option to set custom HTTP headers for OTLP HTTP destination. If specified, please provide each header in the format: key:value. Multiple headers can be added. Keys must be non-empty strings and follow standard HTTP header conventions. Values must be non-empty strings and may include alphanumerics, whitespace, and standard punctuation.'
+        tooltip: "Headers is the option to set custom HTTP headers for OTLP HTTP destination. If specified, please provide each header in the format: key:value. Multiple headers can be added. Keys must be non-empty strings and follow standard HTTP header conventions. Values must be non-empty strings and may include alphanumerics, whitespace, and standard punctuation."
 
     - name: OTLP_HTTP_TRACES_ENDPOINT
       displayName: OTLP http traces Endpoint
@@ -136,7 +138,7 @@ spec:
       componentProps:
         type: text
         required: false
-        placeholder: 'http://host:port/v1/traces'
+        placeholder: "http://host:port/v1/traces"
         tooltip: The format is `host:port`, host is required, port is optional and defaults to the default OTLP HTTP port `4318`, if missing `http://host:port/v1/traces` will be used.
 
     - name: OTLP_HTTP_METRICS_ENDPOINT
@@ -145,7 +147,7 @@ spec:
       componentProps:
         type: text
         required: false
-        placeholder: 'http://host:port/v1/metrics'
+        placeholder: "http://host:port/v1/metrics"
         tooltip: The format is `host:port`, host is required, port is optional and defaults to the default OTLP HTTP port `4318`, if missing `http://host:port/v1/metrics` will be used.
 
     - name: OTLP_HTTP_LOGS_ENDPOINT
@@ -154,7 +156,7 @@ spec:
       componentProps:
         type: text
         required: false
-        placeholder: 'http://host:port/v1/logs'
+        placeholder: "http://host:port/v1/logs"
         tooltip: The format is `host:port`, host is required, port is optional and defaults to the default OTLP HTTP port `4318`, if missing `http://host:port/v1/logs` will be used.
 
     - name: OTLP_HTTP_TLS_ENABLED
@@ -163,29 +165,29 @@ spec:
       initialValue: false
       componentProps:
         required: false
-        tooltip: 'Secure connection'
+        tooltip: "Secure connection"
       customReadDataLabels:
-        - condition: 'true'
-          title: 'TLS'
-          value: 'Encrypted'
-        - condition: 'false'
-          title: 'TLS'
-          value: 'Unencrypted'
+        - condition: "true"
+          title: "TLS"
+          value: "Encrypted"
+        - condition: "false"
+          title: "TLS"
+          value: "Unencrypted"
     - name: OTLP_HTTP_CA_PEM
       displayName: Certificate Authority
       componentType: textarea
       componentProps:
         required: false
-        placeholder: '-----BEGIN CERTIFICATE-----'
-        tooltip: 'When using TLS, provide the CA certificate in PEM format to verify the server. If empty uses system root CA'
-      renderCondition: ['OTLP_HTTP_TLS_ENABLED', '==', 'true']
-      hideFromReadData: ['true']
+        placeholder: "-----BEGIN CERTIFICATE-----"
+        tooltip: "When using TLS, provide the CA certificate in PEM format to verify the server. If empty uses system root CA"
+      renderCondition: ["OTLP_HTTP_TLS_ENABLED", "==", "true"]
+      hideFromReadData: ["true"]
     - name: OTLP_HTTP_INSECURE_SKIP_VERIFY
       displayName: Insecure Skip Verify
       componentType: checkbox
       initialValue: false
       componentProps:
         required: false
-        tooltip: 'Skip TLS certificate verification'
-      renderCondition: ['OTLP_HTTP_TLS_ENABLED', '==', 'true']
+        tooltip: "Skip TLS certificate verification"
+      renderCondition: ["OTLP_HTTP_TLS_ENABLED", "==", "true"]
   testConnectionSupported: true

--- a/destinations/data/prometheus.yaml
+++ b/destinations/data/prometheus.yaml
@@ -14,6 +14,8 @@ spec:
       spanMetricsEnabledByDefault: true
     logs:
       supported: false
+    profiles:
+      supported: false
   fields:
     - name: PROMETHEUS_REMOTEWRITE_URL
       displayName: Remote Write URL
@@ -25,7 +27,7 @@ spec:
       displayName: Resource Attributes Labels (Deprecated)
       componentType: multiInput
       componentProps:
-        tooltip: 'deprecated. will be removed soon.'
+        tooltip: "deprecated. will be removed soon."
       # initialValue: '["k8s.container.name", "k8s.pod.name", "k8s.namespace.name"]'
     - name: PROMETHEUS_USE_AUTHENTICATION
       displayName: Use Authentication
@@ -40,16 +42,16 @@ spec:
       componentProps:
         type: password
         required: false
-        tooltip: 'use this bearer token if your prometheus remote write endpoint requires authentication'
-        placeholder: 'your-bearer-token'
+        tooltip: "use this bearer token if your prometheus remote write endpoint requires authentication"
+        placeholder: "your-bearer-token"
     - name: PROMETHEUS_BASIC_AUTH_USERNAME
       displayName: Basic Auth Username
       componentType: input
       componentProps:
         type: text
         required: false
-        tooltip: 'username for basic authentication (if your prometheus remote write endpoint requires basic auth)'
-        placeholder: 'username'
+        tooltip: "username for basic authentication (if your prometheus remote write endpoint requires basic auth)"
+        placeholder: "username"
     - name: PROMETHEUS_BASIC_AUTH_PASSWORD
       displayName: Basic Auth Password
       componentType: input
@@ -57,5 +59,5 @@ spec:
       componentProps:
         type: password
         required: false
-        tooltip: 'password for basic authentication (if your prometheus remote write endpoint requires basic auth)'
-        placeholder: 'password'
+        tooltip: "password for basic authentication (if your prometheus remote write endpoint requires basic auth)"
+        placeholder: "password"

--- a/destinations/data/qryn.yaml
+++ b/destinations/data/qryn.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: QRYN_OSS_URL
       displayName: API Url

--- a/destinations/data/quickwit.yaml
+++ b/destinations/data/quickwit.yaml
@@ -13,6 +13,8 @@ spec:
       supported: false
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: QUICKWIT_URL
       displayName: Quickwit OTLP gRPC Endpoint
@@ -20,5 +22,5 @@ spec:
       componentProps:
         type: text
         required: true
-        placeholder: 'quickwit.example.com:7281'
-        tooltip: 'The unencrypted gRPC endpoint of the Quickwit OTLP receiver (indexer component). The default Quickwit gRPC port if not changed is `7281`'
+        placeholder: "quickwit.example.com:7281"
+        tooltip: "The unencrypted gRPC endpoint of the Quickwit OTLP receiver (indexer component). The default Quickwit gRPC port if not changed is `7281`"

--- a/destinations/data/seq.yaml
+++ b/destinations/data/seq.yaml
@@ -13,13 +13,15 @@ spec:
       supported: false
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: SEQ_ENDPOINT
       displayName: OTLP HTTP Endpoint
       componentType: input
       componentProps:
         required: true
-        tooltip: 'The format is `http://host:port`, `host` is required and equals the cluster internal DNS record of the Seq instance, `port` is required and equals any of the exposed ports of the Seq instance (defaults to 5341), do not add the rest of the path `/ingest/otlp/v1/*`.'
+        tooltip: "The format is `http://host:port`, `host` is required and equals the cluster internal DNS record of the Seq instance, `port` is required and equals any of the exposed ports of the Seq instance (defaults to 5341), do not add the rest of the path `/ingest/otlp/v1/*`."
     - name: SEQ_API_KEY
       displayName: API Key
       componentType: input
@@ -27,4 +29,4 @@ spec:
       componentProps:
         type: password
         required: false
-        tooltip: 'The API key is generated in the Seq instance. The API key must have the `Ingest` permission.'
+        tooltip: "The API key is generated in the Seq instance. The API key must have the `Ingest` permission."

--- a/destinations/data/signalfx.yaml
+++ b/destinations/data/signalfx.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: false
+    profiles:
+      supported: false
   fields:
     - name: SIGNALFX_ACCESS_TOKEN
       displayName: Access Token

--- a/destinations/data/signoz.yaml
+++ b/destinations/data/signoz.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: SIGNOZ_URL
       displayName: Collector Endpoint

--- a/destinations/data/splunk.yaml
+++ b/destinations/data/splunk.yaml
@@ -13,6 +13,8 @@ spec:
       supported: false
     logs:
       supported: false
+    profiles:
+      supported: false
   fields:
     - name: SPLUNK_ACCESS_TOKEN
       displayName: Access Token

--- a/destinations/data/splunkotlp.yaml
+++ b/destinations/data/splunkotlp.yaml
@@ -13,6 +13,8 @@ spec:
       supported: false
     logs:
       supported: false
+    profiles:
+      supported: false
   fields:
     - name: SPLUNK_ACCESS_TOKEN
       displayName: Access Token
@@ -37,8 +39,8 @@ spec:
           - none
           - gzip
         required: false
-        tooltip: 'Compression type to use for the destination. The default is `none`.'
-      initialValue: 'none'
+        tooltip: "Compression type to use for the destination. The default is `none`."
+      initialValue: "none"
 
     - name: SPLUNK_OTLP_TLS_ENABLED
       displayName: Enable TLS
@@ -46,28 +48,28 @@ spec:
       initialValue: false
       componentProps:
         required: false
-        tooltip: 'Secure connection'
+        tooltip: "Secure connection"
       customReadDataLabels:
-        - condition: 'true'
-          title: 'TLS'
-          value: 'Encrypted'
-        - condition: 'false'
-          title: 'TLS'
-          value: 'Unencrypted'
+        - condition: "true"
+          title: "TLS"
+          value: "Encrypted"
+        - condition: "false"
+          title: "TLS"
+          value: "Unencrypted"
     - name: SPLUNK_OTLP_CA_PEM
       displayName: Certificate Authority
       componentType: textarea
       componentProps:
         required: false
-        placeholder: '-----BEGIN CERTIFICATE-----'
-        tooltip: 'When using TLS, provide the CA certificate in PEM format to verify the server. If empty uses system root CA'
-      renderCondition: ['SPLUNK_OTLP_TLS_ENABLED', '==', 'true']
-      hideFromReadData: ['true']
+        placeholder: "-----BEGIN CERTIFICATE-----"
+        tooltip: "When using TLS, provide the CA certificate in PEM format to verify the server. If empty uses system root CA"
+      renderCondition: ["SPLUNK_OTLP_TLS_ENABLED", "==", "true"]
+      hideFromReadData: ["true"]
     - name: SPLUNK_OTLP_INSECURE_SKIP_VERIFY
       displayName: Insecure Skip Verify
       componentType: checkbox
       initialValue: false
       componentProps:
         required: false
-        tooltip: 'Skip TLS certificate verification'
-      renderCondition: ['SPLUNK_OTLP_TLS_ENABLED', '==', 'true']
+        tooltip: "Skip TLS certificate verification"
+      renderCondition: ["SPLUNK_OTLP_TLS_ENABLED", "==", "true"]

--- a/destinations/data/sumologic.yaml
+++ b/destinations/data/sumologic.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: SUMOLOGIC_COLLECTION_URL
       displayName: Source URL

--- a/destinations/data/telemetryhub.yaml
+++ b/destinations/data/telemetryhub.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: TELEMETRY_HUB_API_KEY
       displayName: API Key

--- a/destinations/data/tempo.yaml
+++ b/destinations/data/tempo.yaml
@@ -13,6 +13,8 @@ spec:
       supported: false
     logs:
       supported: false
+    profiles:
+      supported: false
   fields:
     - name: TEMPO_URL
       displayName: Endpoint

--- a/destinations/data/tingyun.yaml
+++ b/destinations/data/tingyun.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: false
+    profiles:
+      supported: false
   fields:
     - name: TINGYUN_ENDPOINT
       displayName: OTLP HTTP Endpoint

--- a/destinations/data/traceloop.yaml
+++ b/destinations/data/traceloop.yaml
@@ -13,11 +13,13 @@ spec:
       supported: true
     logs:
       supported: false
+    profiles:
+      supported: false
   fields:
     - name: TRACELOOP_ENDPOINT
       displayName: Traceloop OTLP HTTP Endpoint
       componentType: input
-      initialValue: 'https://api.traceloop.com'
+      initialValue: "https://api.traceloop.com"
       componentProps:
         type: text
         required: true

--- a/destinations/data/uptrace.yaml
+++ b/destinations/data/uptrace.yaml
@@ -13,6 +13,8 @@ spec:
       supported: true
     logs:
       supported: true
+    profiles:
+      supported: false
   fields:
     - name: UPTRACE_DSN
       displayName: Data Source Name (DSN)
@@ -23,8 +25,8 @@ spec:
     - name: UPTRACE_ENDPOINT
       displayName: Endpoint
       componentType: input
-      initialValue: 'https://otlp.uptrace.dev:4317'
+      initialValue: "https://otlp.uptrace.dev:4317"
       componentProps:
         type: text
         required: false
-        tooltip: 'Overwrite Uptrace endpoint when self-hosting'
+        tooltip: "Overwrite Uptrace endpoint when self-hosting"

--- a/destinations/data/victoriametricscloud.yaml
+++ b/destinations/data/victoriametricscloud.yaml
@@ -14,6 +14,8 @@ spec:
       spanMetricsEnabledByDefault: true
     logs:
       supported: false
+    profiles:
+      supported: false
   fields:
     - name: VICTORIA_METRICS_CLOUD_ENDPOINT
       displayName: OTLP HTTP Endpoint

--- a/destinations/model.go
+++ b/destinations/model.go
@@ -32,6 +32,9 @@ type Spec struct {
 		Logs struct {
 			Supported bool `yaml:"supported"`
 		}
+		Profiles struct {
+			Supported bool `yaml:"supported"`
+		}
 	}
 	Fields                  []Field `yaml:"fields"`
 	TestConnectionSupported bool    `yaml:"testConnectionSupported"`

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -474,9 +474,10 @@ type ComplexityRoot struct {
 	}
 
 	ExportedSignals struct {
-		Logs    func(childComplexity int) int
-		Metrics func(childComplexity int) int
-		Traces  func(childComplexity int) int
+		Logs     func(childComplexity int) int
+		Metrics  func(childComplexity int) int
+		Profiles func(childComplexity int) int
+		Traces   func(childComplexity int) int
 	}
 
 	GatewayDeploymentInfo struct {
@@ -1324,9 +1325,10 @@ type ComplexityRoot struct {
 	}
 
 	SupportedSignals struct {
-		Logs    func(childComplexity int) int
-		Metrics func(childComplexity int) int
-		Traces  func(childComplexity int) int
+		Logs     func(childComplexity int) int
+		Metrics  func(childComplexity int) int
+		Profiles func(childComplexity int) int
+		Traces   func(childComplexity int) int
 	}
 
 	TailSamplingConfig struct {
@@ -3529,6 +3531,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ExportedSignals.Metrics(childComplexity), true
+
+	case "ExportedSignals.profiles":
+		if e.complexity.ExportedSignals.Profiles == nil {
+			break
+		}
+
+		return e.complexity.ExportedSignals.Profiles(childComplexity), true
 
 	case "ExportedSignals.traces":
 		if e.complexity.ExportedSignals.Traces == nil {
@@ -7284,6 +7293,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.SupportedSignals.Metrics(childComplexity), true
+
+	case "SupportedSignals.profiles":
+		if e.complexity.SupportedSignals.Profiles == nil {
+			break
+		}
+
+		return e.complexity.SupportedSignals.Profiles(childComplexity), true
 
 	case "SupportedSignals.traces":
 		if e.complexity.SupportedSignals.Traces == nil {
@@ -18639,6 +18655,8 @@ func (ec *executionContext) fieldContext_Destination_exportedSignals(_ context.C
 				return ec.fieldContext_ExportedSignals_metrics(ctx, field)
 			case "logs":
 				return ec.fieldContext_ExportedSignals_logs(ctx, field)
+			case "profiles":
+				return ec.fieldContext_ExportedSignals_profiles(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ExportedSignals", field.Name)
 		},
@@ -19512,6 +19530,8 @@ func (ec *executionContext) fieldContext_DestinationTypesCategoryItem_supportedS
 				return ec.fieldContext_SupportedSignals_metrics(ctx, field)
 			case "logs":
 				return ec.fieldContext_SupportedSignals_logs(ctx, field)
+			case "profiles":
+				return ec.fieldContext_SupportedSignals_profiles(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type SupportedSignals", field.Name)
 		},
@@ -22835,6 +22855,50 @@ func (ec *executionContext) _ExportedSignals_logs(ctx context.Context, field gra
 }
 
 func (ec *executionContext) fieldContext_ExportedSignals_logs(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ExportedSignals",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ExportedSignals_profiles(ctx context.Context, field graphql.CollectedField, obj *model.ExportedSignals) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ExportedSignals_profiles(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Profiles, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ExportedSignals_profiles(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "ExportedSignals",
 		Field:      field,
@@ -47359,6 +47423,54 @@ func (ec *executionContext) fieldContext_SupportedSignals_logs(_ context.Context
 	return fc, nil
 }
 
+func (ec *executionContext) _SupportedSignals_profiles(ctx context.Context, field graphql.CollectedField, obj *model.SupportedSignals) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SupportedSignals_profiles(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Profiles, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.ObservabilitySignalSupport)
+	fc.Result = res
+	return ec.marshalNObservabilitySignalSupport2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐObservabilitySignalSupport(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SupportedSignals_profiles(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SupportedSignals",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "supported":
+				return ec.fieldContext_ObservabilitySignalSupport_supported(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ObservabilitySignalSupport", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _TailSamplingConfig_disabled(ctx context.Context, field graphql.CollectedField, obj *model.TailSamplingConfig) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_TailSamplingConfig_disabled(ctx, field)
 	if err != nil {
@@ -51153,7 +51265,7 @@ func (ec *executionContext) unmarshalInputExportedSignalsInput(ctx context.Conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"traces", "metrics", "logs"}
+	fieldsInOrder := [...]string{"traces", "metrics", "logs", "profiles"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -51181,6 +51293,13 @@ func (ec *executionContext) unmarshalInputExportedSignalsInput(ctx context.Conte
 				return it, err
 			}
 			it.Logs = data
+		case "profiles":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("profiles"))
+			data, err := ec.unmarshalNBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Profiles = data
 		}
 	}
 
@@ -56302,6 +56421,11 @@ func (ec *executionContext) _ExportedSignals(ctx context.Context, sel ast.Select
 			}
 		case "logs":
 			out.Values[i] = ec._ExportedSignals_logs(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "profiles":
+			out.Values[i] = ec._ExportedSignals_profiles(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -63585,6 +63709,11 @@ func (ec *executionContext) _SupportedSignals(ctx context.Context, sel ast.Selec
 			}
 		case "logs":
 			out.Values[i] = ec._SupportedSignals_logs(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "profiles":
+			out.Values[i] = ec._SupportedSignals_profiles(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -522,15 +522,17 @@ type EnvVar struct {
 }
 
 type ExportedSignals struct {
-	Traces  bool `json:"traces"`
-	Metrics bool `json:"metrics"`
-	Logs    bool `json:"logs"`
+	Traces   bool `json:"traces"`
+	Metrics  bool `json:"metrics"`
+	Logs     bool `json:"logs"`
+	Profiles bool `json:"profiles"`
 }
 
 type ExportedSignalsInput struct {
-	Traces  bool `json:"traces"`
-	Metrics bool `json:"metrics"`
-	Logs    bool `json:"logs"`
+	Traces   bool `json:"traces"`
+	Metrics  bool `json:"metrics"`
+	Logs     bool `json:"logs"`
+	Profiles bool `json:"profiles"`
 }
 
 type FieldInput struct {
@@ -1605,9 +1607,10 @@ type StringConditionInput struct {
 }
 
 type SupportedSignals struct {
-	Traces  *ObservabilitySignalSupport `json:"traces"`
-	Metrics *ObservabilitySignalSupport `json:"metrics"`
-	Logs    *ObservabilitySignalSupport `json:"logs"`
+	Traces   *ObservabilitySignalSupport `json:"traces"`
+	Metrics  *ObservabilitySignalSupport `json:"metrics"`
+	Logs     *ObservabilitySignalSupport `json:"logs"`
+	Profiles *ObservabilitySignalSupport `json:"profiles"`
 }
 
 type TailSamplingConfig struct {

--- a/frontend/graph/schema.graphqls
+++ b/frontend/graph/schema.graphqls
@@ -324,6 +324,7 @@ type SupportedSignals {
   traces: ObservabilitySignalSupport!
   metrics: ObservabilitySignalSupport!
   logs: ObservabilitySignalSupport!
+  profiles: ObservabilitySignalSupport!
 }
 
 type ObservabilitySignalSupport {
@@ -371,6 +372,7 @@ type ExportedSignals {
   traces: Boolean!
   metrics: Boolean!
   logs: Boolean!
+  profiles: Boolean!
 }
 
 type Destination {
@@ -403,6 +405,7 @@ input ExportedSignalsInput {
   traces: Boolean!
   metrics: Boolean!
   logs: Boolean!
+  profiles: Boolean!
 }
 
 input PersistNamespaceItemInput {

--- a/frontend/services/destinations.go
+++ b/frontend/services/destinations.go
@@ -88,6 +88,9 @@ func DestinationTypeConfigToCategoryItem(destConfig destinations.Destination) mo
 			Logs: &model.ObservabilitySignalSupport{
 				Supported: destConfig.Spec.Signals.Logs.Supported,
 			},
+			Profiles: &model.ObservabilitySignalSupport{
+				Supported: destConfig.Spec.Signals.Profiles.Supported,
+			},
 		},
 		Fields: fields,
 	}
@@ -240,9 +243,10 @@ func K8sDestinationToEndpointFormat(k8sDest v1alpha1.Destination, secretFields m
 		Disabled:        disabled,
 		DataStreamNames: ExtractDataStreamsFromDestination(k8sDest),
 		ExportedSignals: &model.ExportedSignals{
-			Traces:  isSignalExported(k8sDest, common.TracesObservabilitySignal),
-			Metrics: isSignalExported(k8sDest, common.MetricsObservabilitySignal),
-			Logs:    isSignalExported(k8sDest, common.LogsObservabilitySignal),
+			Traces:   isSignalExported(k8sDest, common.TracesObservabilitySignal),
+			Metrics:  isSignalExported(k8sDest, common.MetricsObservabilitySignal),
+			Logs:     isSignalExported(k8sDest, common.LogsObservabilitySignal),
+			Profiles: isSignalExported(k8sDest, common.ProfilesObservabilitySignal),
 		},
 		Fields:          string(fieldsJSON),
 		DestinationType: &destTypeConfig,
@@ -283,6 +287,9 @@ func ExportedSignalsObjectToSlice(signals *model.ExportedSignalsInput) []common.
 	}
 	if signals.Logs {
 		resp = append(resp, common.LogsObservabilitySignal)
+	}
+	if signals.Profiles {
+		resp = append(resp, common.ProfilesObservabilitySignal)
 	}
 
 	return resp

--- a/frontend/webapp/graphql/mutations/destination.ts
+++ b/frontend/webapp/graphql/mutations/destination.ts
@@ -12,6 +12,7 @@ export const CREATE_DESTINATION = gql`
         logs
         metrics
         traces
+        profiles
       }
       destinationType {
         type
@@ -25,6 +26,9 @@ export const CREATE_DESTINATION = gql`
             supported
           }
           traces {
+            supported
+          }
+          profiles {
             supported
           }
         }

--- a/frontend/webapp/graphql/queries/destination.ts
+++ b/frontend/webapp/graphql/queries/destination.ts
@@ -21,6 +21,9 @@ export const GET_DESTINATION_CATEGORIES = gql`
             traces {
               supported
             }
+            profiles {
+              supported
+            }
           }
           fields {
             name
@@ -65,6 +68,7 @@ export const GET_DESTINATIONS = gql`
           logs
           metrics
           traces
+          profiles
         }
         destinationType {
           type
@@ -78,6 +82,9 @@ export const GET_DESTINATIONS = gql`
               supported
             }
             traces {
+              supported
+            }
+            profiles {
               supported
             }
           }


### PR DESCRIPTION
- Added `ProfilesObservabilitySignal` to `signals.go`.
- Updated `Spec` struct in `model.go` to include support for profiles.
- Modified YAML configuration files for multiple destinations (e.g., AWS, Azure, Datadog) to include profiles support with a default of `false`.
- Ensured consistent tooltip formatting across various fields in destination configurations.

This change improves the observability capabilities of the system by allowing for profile data collection.

```release-note
feat: add profiles observability signal to destinations
```

emergency-ticket id: EMR-1685
