### PR TITLE
ci: use depot to build odigos

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,7 +98,7 @@ jobs:
 
   build-agents:
     name: build-agents
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - name: Set up Docker Buildx
@@ -238,7 +238,7 @@ jobs:
 
   build-and-test-odiglet:
     name: build-and-test-odiglet
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-2
     steps:
       - uses: actions/checkout@v5
       - name: Set up Docker Buildx


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: CORE-000

depot cache our ecr agent images and prevent many of the 429 rate limit issues we are currently having with github runners

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
