### PR TITLE
CORE-812: update destination docs

### DIFF
--- a/docs/snippets/shared/backends-overview.mdx
+++ b/docs/snippets/shared/backends-overview.mdx
@@ -22,7 +22,7 @@
 <img src="https://d15jtxgb40qetw.cloudfront.net/coralogix.svg" alt="coralogix" className="not-prose h-4" /> | [Coralogix](/backends/coralogix) | Managed | ✅ | ✅ | ✅ |  |
 <img src="https://d15jtxgb40qetw.cloudfront.net/dash0.svg" alt="dash0" className="not-prose h-4" /> | [Dash0](/backends/dash0) | Managed | ✅ | ✅ | ✅ |  |
 <img src="https://d15jtxgb40qetw.cloudfront.net/datadog.svg" alt="datadog" className="not-prose h-4" /> | [Datadog](/backends/datadog) | Managed | ✅ | ✅ | ✅ |  |
-<img src="https://d15jtxgb40qetw.cloudfront.net/opentelemetry.svg" alt="dynamic" className="not-prose h-4" /> | [Dynamic Destination](/backends/dynamic) | Self-Hosted | ✅ | ✅ | ✅ |  |
+<img src="https://d15jtxgb40qetw.cloudfront.net/opentelemetry.svg" alt="dynamic" className="not-prose h-4" /> | [Dynamic Destination](/backends/dynamic) | Self-Hosted | ✅ | ✅ | ✅ | ✅ |
 <img src="https://d15jtxgb40qetw.cloudfront.net/dynatrace.svg" alt="dynatrace" className="not-prose h-4" /> | [Dynatrace](/backends/dynatrace) | Managed | ✅ | ✅ | ✅ |  |
 <img src="https://d15jtxgb40qetw.cloudfront.net/elasticapm.svg" alt="elasticapm" className="not-prose h-4" /> | [Elastic APM](/backends/elasticapm) | Managed | ✅ | ✅ | ✅ |  |
 <img src="https://d15jtxgb40qetw.cloudfront.net/elasticsearch.svg" alt="elasticsearch" className="not-prose h-4" /> | [Elasticsearch](/backends/elasticsearch) | Self-Hosted | ✅ |  | ✅ |  |

--- a/docs/snippets/shared/backends/dynamic.mdx
+++ b/docs/snippets/shared/backends/dynamic.mdx
@@ -35,7 +35,7 @@ icon: 'signal-stream'
   ✅ Traces
   ✅ Metrics
   ✅ Logs
-  ❌ Profiles
+  ✅ Profiles
 </Accordion>
 
 - **DYNAMIC_DESTINATION_TYPE** `string` : Destination Type. The type of OpenTelemetry Collector Exporter to use for the destination.
@@ -82,6 +82,7 @@ There are two primary methods for configuring destinations in Odigos:
       - TRACES
       - METRICS
       - LOGS
+      - PROFILES
       type: dynamic
     ```
   </Step>


### PR DESCRIPTION
#### What this PR does / why we need it:
https://github.com/odigos-io/odigos/pull/4831 missed a destination docs update this adds it

```
cd docs
source ~/.venv/bin/activate
python3 sync-dest-doc.py
deactivate
```

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
