### PR TITLE
PLAT-1066: default KC_HOSTNAME_STRICT_HTTPS to true when auth.externalUrl is empty

### DIFF
--- a/helm/odigos-central/templates/keycloak/deployment.yaml
+++ b/helm/odigos-central/templates/keycloak/deployment.yaml
@@ -77,7 +77,11 @@ spec:
               value: {{ regexReplaceAll "^[^:]*:" $hostWithPort "" | quote }}
             {{- end }}
             - name: KC_HOSTNAME_STRICT_HTTPS
-              value: {{ ternary "true" "false" (hasPrefix "https" $externalUrl) | quote }}
+              {{- if .Values.auth.externalUrl }}
+              value: {{ ternary "true" "false" (hasPrefix "https" .Values.auth.externalUrl) | quote }}
+              {{- else }}
+              value: "true"
+              {{- end }}
             - name: KC_HOSTNAME_STRICT_BACKCHANNEL
               value: "true"
             - name: KC_PROXY


### PR DESCRIPTION
Default `KC_HOSTNAME_STRICT_HTTPS` to `true` when `auth.externalUrl` is unset, so the chart no longer breaks central-backend ↔ Keycloak admin-token calls in clusters whose pod CIDR is outside RFC 1918.

#### What this PR does / why we need it:

The chart in v1.24 unconditionally rendered:

```yaml
- name: KC_HOSTNAME_STRICT_HTTPS
  value: {{ ternary "true" "false" (hasPrefix "https" $externalUrl) | quote }}
```

`$externalUrl` defaults to `http://localhost:8081` when `auth.externalUrl` is empty, so the ternary fell through to `"false"`. With `KC_HOSTNAME_STRICT_HTTPS=false`, Keycloak applies its master realm `sslRequired=external` check against the actual request scheme. Keycloak's `NetworkUtils.isPrivate()` only treats RFC 1918 ranges (10/8, 172.16/12, 192.168/16) and loopback as internal — so a pod IP outside those ranges (e.g. T-Mobile's TKE cluster on `198.18.0.0/15`) gets classified as external and the in-cluster `http://keycloak:8080/realms/master/protocol/openid-connect/token` call is rejected with HTTP 403 `"HTTPS required"`. central-backend then loops on `Failed to get admin token` forever and the system never initializes.

In v1.17 this env var was not set at all, so Keycloak used its built-in default of `true` (which treats any request as effectively HTTPS for the SSL check) and the in-cluster admin call worked regardless of pod source IP.

This PR conditionally renders the value:

- `auth.externalUrl=https://...` → `true` (unchanged)
- `auth.externalUrl=http://...` → `false` (unchanged — preserves the explicit local-dev SSO escape hatch for browser callbacks)
- `auth.externalUrl` unset → `true` (was `false`, the bug)

Reproduced and verified end-to-end on a kind cluster configured with `podSubnet: 198.18.0.0/16`. With the fix, fresh `v1.24.3` install logs `Successfully obtained Keycloak admin token` instead of the 403 loop. Render tests confirm template output for all three `auth.externalUrl` cases.

Linear: https://linear.app/odigos/issue/PLAT-1066

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
Fix odigos-central upgrade to v1.24.x failing with "HTTPS required" when central-backend talks to Keycloak in clusters whose pod CIDR is outside RFC 1918. The chart now defaults KC_HOSTNAME_STRICT_HTTPS to true when auth.externalUrl is unset.
```

Made with [Cursor](https://cursor.com)