### PR TITLE
CORE-936: Bump odiglet nodejs community agent for CVE fixes

### DIFF
--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -47,8 +47,8 @@ COPY --from=public.ecr.aws/odigos/agents/python-community:v1.0.81 /instrumentati
 COPY --from=public.ecr.aws/odigos/agents/nodejs-community:v0.6.2 /instrumentations/opentelemetry-node /instrumentations/opentelemetry-node
 COPY --from=public.ecr.aws/odigos/agents/nodejs-community:v0.6.2 /instrumentations/nodejs-community /instrumentations/nodejs-community
 # nodejs-community-14
-COPY --from=public.ecr.aws/odigos/agents/nodejs-community-14:v0.0.17 /instrumentations/opentelemetry-node-14 /instrumentations/opentelemetry-node-14
-COPY --from=public.ecr.aws/odigos/agents/nodejs-community-14:v0.0.17 /instrumentations/nodejs-community-14 /instrumentations/nodejs-community-14
+COPY --from=public.ecr.aws/odigos/agents/nodejs-community-14:v0.0.19 /instrumentations/opentelemetry-node-14 /instrumentations/opentelemetry-node-14
+COPY --from=public.ecr.aws/odigos/agents/nodejs-community-14:v0.0.19 /instrumentations/nodejs-community-14 /instrumentations/nodejs-community-14
 
 # nodejs-community
 COPY --from=dotnet-builder /dotnet-instrumentation /instrumentations/dotnet

--- a/odiglet/debug.Dockerfile
+++ b/odiglet/debug.Dockerfile
@@ -69,8 +69,8 @@ COPY --from=public.ecr.aws/odigos/agents/python-community:v1.0.78 /instrumentati
 COPY --from=public.ecr.aws/odigos/agents/nodejs-community:v0.6.2 /instrumentations/opentelemetry-node /instrumentations/opentelemetry-node
 COPY --from=public.ecr.aws/odigos/agents/nodejs-community:v0.6.2 /instrumentations/nodejs-community /instrumentations/nodejs-community
 # nodejs-community-14
-COPY --from=public.ecr.aws/odigos/agents/nodejs-community-14:v0.0.17 /instrumentations/opentelemetry-node-14 /instrumentations/opentelemetry-node-14
-COPY --from=public.ecr.aws/odigos/agents/nodejs-community-14:v0.0.17 /instrumentations/nodejs-community-14 /instrumentations/nodejs-community-14
+COPY --from=public.ecr.aws/odigos/agents/nodejs-community-14:v0.0.19 /instrumentations/opentelemetry-node-14 /instrumentations/opentelemetry-node-14
+COPY --from=public.ecr.aws/odigos/agents/nodejs-community-14:v0.0.19 /instrumentations/nodejs-community-14 /instrumentations/nodejs-community-14
 
 # dotnet-community
 COPY --from=dotnet-builder /dotnet-instrumentation /instrumentations/dotnet


### PR DESCRIPTION
#### What this PR does / why we need it:
This updates nodejs-community-14 to pull in cve fixes from https://github.com/odigos-io/opentelemetry-node/pull/100 and https://github.com/odigos-io/opentelemetry-node/pull/89

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
fix(nodejs-community-14): CVE-2026-42043 and GHSA-xq3m-2v4x-88gg
```
