### PR TITLE
CORE-924 | feat(odiglet): use lower GOMEMLIMIT percentage for high-memory configs

### DIFF
--- a/helm/odigos/templates/_helpers.tpl
+++ b/helm/odigos/templates/_helpers.tpl
@@ -108,6 +108,34 @@ true
 {{- end }}
 {{- end }}
 
+{{/*
+  Odiglet-specific GOMEMLIMIT: odiglet allocates significant memory for eBPF maps
+  which live outside the Go heap. The Go runtime is unaware of this memory, so we
+  use a lower GOMEMLIMIT percentage (default 60%) for memory limits >= 500Mi to
+  leave enough headroom for eBPF allocations. Below 500Mi the standard 80% is used.
+*/}}
+{{- define "odigos.odiglet.gomemlimit" -}}
+{{- $resources := include "odigos.odiglet.resolvedResources" . | fromYaml -}}
+{{- $limits := get $resources "limits" -}}
+{{- $requests := get $resources "requests" -}}
+
+{{- $raw := (get $limits "memory") | default (get $requests "memory") -}}
+{{- $number := regexFind "^[0-9]+" $raw -}}
+{{- $unit := regexFind "[a-zA-Z]+$" $raw -}}
+
+{{- if and $number $unit }}
+  {{- $num := int $number -}}
+  {{- $pct := 80 -}}
+  {{- if ge $num 500 -}}
+    {{- $pct = int (default 60 .Values.odiglet.odiglet.goMemLimitPercentage) -}}
+  {{- end -}}
+  {{- $val := div (mul $num $pct) 100 -}}
+  {{- printf "%d%sB" $val $unit -}}
+{{- else }}
+  {{- fail (printf "Invalid memory limit format for GOMEMLIMIT: %q" $raw) -}}
+{{- end }}
+{{- end }}
+
 {{/* Returns "true" when UI requires write permissions (non-readonly UI or central backend set) */}}
 {{- define "odigos.ui.requiresWritePermissions" -}}
   {{- if or (ne .Values.ui.uiMode "readonly") (ne .Values.centralProxy.centralBackendURL "") -}}

--- a/helm/odigos/templates/odiglet/daemonset.yaml
+++ b/helm/odigos/templates/odiglet/daemonset.yaml
@@ -212,7 +212,7 @@ spec:
                   key: odigos-onprem-token
           {{- end }}
             - name: GOMEMLIMIT
-              value: {{ include "odigos.gomemlimitFromResources" (dict "Resources" (include "odigos.odiglet.resolvedResources" . | fromYaml)) }}
+              value: {{ include "odigos.odiglet.gomemlimit" . }}
           {{- if .Values.odiglet.noHostPid }}
             - name: ODIGOS_PROC_DIR
               value: /hostproc

--- a/helm/odigos/values.schema.json
+++ b/helm/odigos/values.schema.json
@@ -1477,6 +1477,12 @@
               "required": [],
               "title": "capabilities"
             },
+            "goMemLimitPercentage": {
+              "default": "60",
+              "description": "Percentage of the memory limit to use for GOMEMLIMIT when the odiglet\nmemory limit is \u003e= 500Mi. Below 500Mi the default 80% is used.\nOdiglet allocates significant memory for eBPF maps which live outside\nthe Go heap. The Go runtime is unaware of this memory, so GOMEMLIMIT\nmust leave enough headroom for these allocations to avoid OOM kills.",
+              "required": [],
+              "title": "goMemLimitPercentage"
+            },
             "livenessProbe": {
               "additionalProperties": false,
               "properties": {

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -887,6 +887,16 @@ odiglet:
     appArmorProfile:
       type: "Unconfined"
 
+    # @schema
+    # description: |-
+    #   Percentage of the memory limit to use for GOMEMLIMIT when the odiglet
+    #   memory limit is >= 500Mi. Below 500Mi the default 80% is used.
+    #   Odiglet allocates significant memory for eBPF maps which live outside
+    #   the Go heap. The Go runtime is unaware of this memory, so GOMEMLIMIT
+    #   must leave enough headroom for these allocations to avoid OOM kills.
+    # @schema
+    # goMemLimitPercentage: 60
+
   # @schema
   # description: |-
   #   traceIdSuffix is a unique, 1 byte hex constant identifier for timestamp based trace id generation.


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Odiglet allocates memory for eBPF maps outside the Go heap. When the memory limit is >= 500Mi, use 60% (configurable via odiglet.goMemLimitPercentage) instead of the default 80% to leave headroom for these allocations and avoid OOM kills.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
