### PR TITLE
refactor: CORE-999 - Add YAML tags to IntrumentationRules structs to use them properly in Vmagnet (GraphQL)

### DIFF
--- a/common/api/instrumentationrules/code_attributes.go
+++ b/common/api/instrumentationrules/code_attributes.go
@@ -6,25 +6,25 @@ type CodeAttributes struct {
 
 	// Should record the `code.column` attribute.
 	// if unset, the value will resolve from other relevant rules, or fallback to false
-	Column *bool `json:"column,omitempty"`
+	Column *bool `json:"column,omitempty" yaml:"column,omitempty"`
 
 	// Should record the `code.filepath` attribute.
 	// if unset, the value will resolve from other relevant rules, or fallback to false
-	FilePath *bool `json:"filePath,omitempty"`
+	FilePath *bool `json:"filePath,omitempty" yaml:"filePath,omitempty"`
 
 	// Should record the `code.function` attribute.
 	// if unset, the value will resolve from other relevant rules, or fallback to false
-	Function *bool `json:"function,omitempty"`
+	Function *bool `json:"function,omitempty" yaml:"function,omitempty"`
 
 	// Should record the `code.lineno` attribute.
 	// if unset, the value will resolve from other relevant rules, or fallback to false
-	LineNumber *bool `json:"lineNumber,omitempty"`
+	LineNumber *bool `json:"lineNumber,omitempty" yaml:"lineNumber,omitempty"`
 
 	// Should record the `code.namespace` attribute.
 	// if unset, the value will resolve from other relevant rules, or fallback to false
-	Namespace *bool `json:"namespace,omitempty"`
+	Namespace *bool `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 
 	// Should record the `code.stacktrace` attribute.
 	// if unset, the value will resolve from other relevant rules, or fallback to false
-	Stacktrace *bool `json:"stackTrace,omitempty"`
+	Stacktrace *bool `json:"stackTrace,omitempty" yaml:"stackTrace,omitempty"`
 }

--- a/common/api/instrumentationrules/custom_instrumentation.go
+++ b/common/api/instrumentationrules/custom_instrumentation.go
@@ -8,8 +8,8 @@ import (
 // +kubebuilder:object:generate=true
 // +kubebuilder:deepcopy-gen=true
 type CustomInstrumentations struct {
-	Golang []GolangCustomProbe `json:"golang,omitempty"`
-	Java   []JavaCustomProbe   `json:"java,omitempty"`
+	Golang []GolangCustomProbe `json:"golang,omitempty" yaml:"golang,omitempty"`
+	Java   []JavaCustomProbe   `json:"java,omitempty" yaml:"java,omitempty"`
 }
 
 // Verify iterates all custom instrumentations' probes and validates them.
@@ -38,8 +38,8 @@ func (ci *CustomInstrumentations) Verify() error {
 // +kubebuilder:object:generate=true
 // +kubebuilder:deepcopy-gen=true
 type JavaCustomProbe struct {
-	ClassName  string `json:"className,omitempty"`
-	MethodName string `json:"methodName,omitempty"`
+	ClassName  string `json:"className,omitempty" yaml:"className,omitempty"`
+	MethodName string `json:"methodName,omitempty" yaml:"methodName,omitempty"`
 }
 
 // For java we always require both class name and method name
@@ -65,17 +65,17 @@ func (jcp *JavaCustomProbe) String() string {
 // +kubebuilder:deepcopy-gen=true
 type GolangCustomProbe struct {
 	// PackageName is the name of the golang package (ie net/http); Package name is always required
-	PackageName string `json:"packageName"`
+	PackageName string `json:"packageName" yaml:"packageName"`
 	// FunctionName is the name of the golang function to be instrumented, ie package name is "net/http" and the function
 	// name will be "ListenAndServe"; Function name is disallowed if ReceiverName and ReceiverMethodName are provided
-	FunctionName string `json:"functionName,omitempty"`
+	FunctionName string `json:"functionName,omitempty" yaml:"functionName,omitempty"`
 	// ReceiverName is the name of the golang receiver struct to be instrumented, ie for the "net/http" package, "response" is a receiver struct
 	// ReceiverName is disallowed if FunctionName is provided; Receiver must be a concrete type (not an interface)
-	ReceiverName string `json:"receiverName,omitempty"`
+	ReceiverName string `json:"receiverName,omitempty" yaml:"receiverName,omitempty"`
 	// ReceiverMethodName is the name of the golang method, given a receiver struct, to be instrumented
 	// for example for "net/http" package, "response" is a receiver struct and "WriteHeader" is a method of that struct
 	// ReceiverMethodName is mandatory if ReceiverName is provided, and disallowed if FunctionName is provided
-	ReceiverMethodName string `json:"receiverMethodName,omitempty"`
+	ReceiverMethodName string `json:"receiverMethodName,omitempty" yaml:"receiverMethodName,omitempty"`
 }
 
 // For golang we require package name and either function name or receiver name + method name

--- a/common/api/instrumentationrules/ebpf_log_capture.go
+++ b/common/api/instrumentationrules/ebpf_log_capture.go
@@ -6,5 +6,5 @@ type EbpfLogCapture struct {
 	// Enabled switches the logs pipeline to use only the eBPF receiver,
 	// replacing the filelog receiver, and enables eBPF-based log capture
 	// in odiglet for instrumented processes.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 }

--- a/common/api/instrumentationrules/haedsamplingfallbackfraction.go
+++ b/common/api/instrumentationrules/haedsamplingfallbackfraction.go
@@ -10,5 +10,5 @@ type HeadSamplingFallbackFraction struct {
 	// +kubebuilder:default:=1
 	// +kubebuilder:validation:Minimum:=0
 	// +kubebuilder:validation:Maximum:=1
-	FractionToKeep float64 `json:"fractionToKeep,omitempty"`
+	FractionToKeep float64 `json:"fractionToKeep,omitempty" yaml:"fractionToKeep,omitempty"`
 }

--- a/common/api/instrumentationrules/http_headers.go
+++ b/common/api/instrumentationrules/http_headers.go
@@ -5,5 +5,5 @@ package instrumentationrules
 type HttpHeadersCollection struct {
 
 	// Limit payload collection to specific header keys.
-	HeaderKeys []string `json:"headerKeys,omitempty"`
+	HeaderKeys []string `json:"headerKeys,omitempty" yaml:"headerKeys,omitempty"`
 }

--- a/common/api/instrumentationrules/otel-sdk.go
+++ b/common/api/instrumentationrules/otel-sdk.go
@@ -7,5 +7,5 @@ type OtelDistros struct {
 	// Set a list of distribution names that take priority over the default distributions.
 	// if a language is not in this list, the default distribution will be used.
 	// if multiple distributions are specified for the same language, in one or many rules, the behavior is undefined.
-	OtelDistroNames []string `json:"otelDistroNames"`
+	OtelDistroNames []string `json:"otelDistroNames" yaml:"otelDistroNames"`
 }

--- a/common/api/instrumentationrules/payloadcollection.go
+++ b/common/api/instrumentationrules/payloadcollection.go
@@ -9,14 +9,14 @@ type HttpPayloadCollection struct {
 	// Limit payload collection to specific mime types based on the content type header.
 	// When not specified, all mime types payloads will be collected.
 	// Empty array will make the rule ineffective.
-	MimeTypes *[]string `json:"mimeTypes,omitempty"`
+	MimeTypes *[]string `json:"mimeTypes,omitempty" yaml:"mimeTypes,omitempty"`
 
 	// Maximum length of the payload to collect.
 	// If the payload is longer than this value, it will be truncated or dropped, based on the value of `dropPartialPayloads` config option
-	MaxPayloadLength *int64 `json:"maxPayloadLength,omitempty"`
+	MaxPayloadLength *int64 `json:"maxPayloadLength,omitempty" yaml:"maxPayloadLength,omitempty"`
 
 	// If payload exceeds MaxPayloadLength, controls whether to truncate it or drop it entirely.
-	DropPartialPayloads *bool `json:"dropPartialPayloads,omitempty"`
+	DropPartialPayloads *bool `json:"dropPartialPayloads,omitempty" yaml:"dropPartialPayloads,omitempty"`
 }
 
 // Rule for collecting payloads for a Db Query Text
@@ -26,15 +26,15 @@ type DbQueryPayloadCollection struct {
 
 	// Maximum length of the payload to collect.
 	// If the payload is longer than this value, it will be truncated or dropped, based on the value of `dropPartialPayloads` config option
-	MaxPayloadLength *int64 `json:"maxPayloadLength,omitempty"`
+	MaxPayloadLength *int64 `json:"maxPayloadLength,omitempty" yaml:"maxPayloadLength,omitempty"`
 
 	// If payload exceeds MaxPayloadLength, controls whether to truncate it or drop it entirely.
-	DropPartialPayloads *bool `json:"dropPartialPayloads,omitempty"`
+	DropPartialPayloads *bool `json:"dropPartialPayloads,omitempty" yaml:"dropPartialPayloads,omitempty"`
 
 	// The sanitization policy to use for collecting the DB query payloads.
 	// If not specified, the default sanitization policy will be used:
 	// (collect sanitized payloads if possible, and fall back to full if sanitization isn't supported).
-	SanitizationPolicy *consts.DbQuerySanitizationPolicy `json:"sanitizationPolicy,omitempty"`
+	SanitizationPolicy *consts.DbQuerySanitizationPolicy `json:"sanitizationPolicy,omitempty" yaml:"sanitizationPolicy,omitempty"`
 }
 
 // Rule for collecting messaging related payloads
@@ -44,10 +44,10 @@ type MessagingPayloadCollection struct {
 
 	// Maximum length of the payload to collect.
 	// If the payload is longer than this value, it will be truncated or dropped, based on the value of `dropPartialPayloads` config option
-	MaxPayloadLength *int64 `json:"maxPayloadLength,omitempty"`
+	MaxPayloadLength *int64 `json:"maxPayloadLength,omitempty" yaml:"maxPayloadLength,omitempty"`
 
 	// If payload exceeds MaxPayloadLength, controls whether to truncate it or drop it entirely.
-	DropPartialPayloads *bool `json:"dropPartialPayloads,omitempty"`
+	DropPartialPayloads *bool `json:"dropPartialPayloads,omitempty" yaml:"dropPartialPayloads,omitempty"`
 }
 
 // +kubebuilder:object:generate=true
@@ -55,15 +55,15 @@ type MessagingPayloadCollection struct {
 type PayloadCollection struct {
 	// Collect HTTP request payload data when available.
 	// Can be a client (outgoing) request or a server (incoming) request, depending on the instrumentation library
-	HttpRequest *HttpPayloadCollection `json:"httpRequest,omitempty"`
+	HttpRequest *HttpPayloadCollection `json:"httpRequest,omitempty" yaml:"httpRequest,omitempty"`
 
 	// rule for collecting the response part of an http payload.
 	// Can be a client response or a server response, depending on the instrumentation library
-	HttpResponse *HttpPayloadCollection `json:"httpResponse,omitempty"`
+	HttpResponse *HttpPayloadCollection `json:"httpResponse,omitempty" yaml:"httpResponse,omitempty"`
 
 	// rule for collecting db payloads for the mentioned workload and instrumentation libraries
-	DbQuery *DbQueryPayloadCollection `json:"dbQuery,omitempty"`
+	DbQuery *DbQueryPayloadCollection `json:"dbQuery,omitempty" yaml:"dbQuery,omitempty"`
 
 	// rule for collecting messaging payloads for the mentioned workload and instrumentation libraries
-	Messaging *MessagingPayloadCollection `json:"messaging,omitempty"`
+	Messaging *MessagingPayloadCollection `json:"messaging,omitempty" yaml:"messaging,omitempty"`
 }

--- a/common/api/instrumentationrules/trace_config.go
+++ b/common/api/instrumentationrules/trace_config.go
@@ -4,5 +4,5 @@ package instrumentationrules
 // +kubebuilder:deepcopy-gen=true
 type TraceConfig struct {
 	// Disabled will disable tracing for the rule.
-	Disabled *bool `json:"disabled,omitempty"`
+	Disabled *bool `json:"disabled,omitempty" yaml:"disabled,omitempty"`
 }

--- a/common/api/instrumentationrules/trace_verbosity.go
+++ b/common/api/instrumentationrules/trace_verbosity.go
@@ -5,11 +5,11 @@ import "github.com/odigos-io/odigos/common"
 type InstrumentationLibrary struct {
 
 	// the programming language of the relevant library
-	Language common.ProgrammingLanguage `json:"Language"`
+	Language common.ProgrammingLanguage `json:"Language" yaml:"Language"`
 
 	// the name of the library to configure. required.
 	// exact syntax and format depends on the programming language.
-	LibraryName string `json:"libraryName"`
+	LibraryName string `json:"libraryName" yaml:"libraryName"`
 }
 
 // +kubebuilder:object:generate=true
@@ -19,10 +19,10 @@ type TraceVerbosity struct {
 
 	// instrumentation libraries to configure
 	// the library name shouold be the same as the "instrumentation scope name" that can be found on the generate span attributes.
-	DisabledLibraries []InstrumentationLibrary `json:"disabledLibraries,omitempty"`
+	DisabledLibraries []InstrumentationLibrary `json:"disabledLibraries,omitempty" yaml:"disabledLibraries,omitempty"`
 
 	// for instrumentation libraries that are disabled by default, this field can be used to enable them.
 	// the list of such libraries is small and depends on the language and agent type.
 	// common example: nodejs fs, dns, net instrumentations are disabled by default and can be opt-in for trace collection.
-	EnabledLibraries []InstrumentationLibrary `json:"enabledLibraries,omitempty"`
+	EnabledLibraries []InstrumentationLibrary `json:"enabledLibraries,omitempty" yaml:"enabledLibraries,omitempty"`
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Now that the VMAgent loads the instrumentation rules (Go Struct) directly from the OSS, they need to have YAML tags for the CLI / graphQL to parse their value correctly.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
