### PR TITLE
CORE-1010: Set odiglet agents init memory limit to 12MB

### DIFF
--- a/helm/odigos/templates/odiglet/daemonset.yaml
+++ b/helm/odigos/templates/odiglet/daemonset.yaml
@@ -129,13 +129,16 @@ spec:
           # # it does not run any actual code, just pulls the image
           # we add the resources here to make sure any policy that may validate resources exist
           # is satisfied, there should be no need to configure this as this is not running anything.
+          # NOTE: memory limit is set to 12Mi which is the OpenShift minimum
+          # (https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/nodes/working-with-clusters#nodes-cluster-resource-configure-about_nodes-cluster-resource-configure);
+          # going lower causes kubelet to reject the pod with "set memory limit ... too low".
           resources:
             requests:
               cpu: 1m
-              memory: 10Mi
+              memory: 12Mi
             limits:
               cpu: 1m
-              memory: 10Mi
+              memory: 12Mi
       {{- end }}
       containers:
         - name: odiglet


### PR DESCRIPTION
#### What this PR does / why we need it:
This updates the odiglet pre-pull agents init container to 12MB, which is the [openshift minimum for memory limits](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/nodes/working-with-clusters#nodes-cluster-resource-configure-about_nodes-cluster-resource-configure)

Without this, installing on openshift gives the following error:

```
Warning  Failed          1s (x4 over 27s)  kubelet            Error: set memory limit 10485760 too low; should be at least 12582912 bytes
```

This container doesn't actually do anything, so it doesn't need a high limit. But openshift apparently enforces a cluster wide minimum limit.

Considered gating this limit on openshift installs, but it's a minor change that doesn't really need the added complexity of more conditionals in the helm chart.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
fix: increase odiglet agents init container memory limit to 12MB to satisfy OpenShift minimum
```

cherry-pick:v1.26