### PR TITLE
ci: use reusable cherry-pick action from ci-core

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -13,157 +13,19 @@ jobs:
     permissions:
       id-token: write
     outputs:
-      run_cherry_pick: ${{ steps.publish_job_outputs.outputs.run_cherry_pick }}
-      versions: ${{ steps.publish_job_outputs.outputs.versions }}
-      pr_number: ${{ steps.publish_job_outputs.outputs.pr_number }}
-      merge_commit_sha: ${{ steps.publish_job_outputs.outputs.merge_commit_sha }}
-      pr_title: ${{ steps.publish_job_outputs.outputs.pr_title }}
-      pr_user_login: ${{ steps.publish_job_outputs.outputs.pr_user_login }}
-      original_pr_body: ${{ steps.publish_job_outputs.outputs.original_pr_body }}
+      run_cherry_pick: ${{ steps.extract.outputs.run_cherry_pick }}
+      versions: ${{ steps.extract.outputs.versions }}
+      pr_number: ${{ steps.extract.outputs.pr_number }}
+      merge_commit_sha: ${{ steps.extract.outputs.merge_commit_sha }}
+      pr_title: ${{ steps.extract.outputs.pr_title }}
+      pr_user_login: ${{ steps.extract.outputs.pr_user_login }}
+      original_pr_body: ${{ steps.extract.outputs.original_pr_body }}
     steps:
-
-      - name: Get sts tokens
-        id: sts-cherry-pick-decision
-        uses: odigos-io/ci-core/sts@main
+      - name: Extract cherry-pick targets
+        id: extract
+        uses: odigos-io/ci-core/cherry-pick@main
         with:
-          scope: odigos-io/odigos
-          identity: cherry-pick-decision
-          output-git-config: "true"
-
-      - name: Find merged PR for commit
-        id: find_pr
-        env:
-          GH_TOKEN: ${{ steps.sts-cherry-pick-decision.outputs.GH_TOKEN }}
-        run: |
-          set -euo pipefail
-          SHA="${{ github.sha }}"
-          REPO="${{ github.repository }}"
-          mkdir -p .cherry-pick-workflow
-          ERR_LOG=".cherry-pick-workflow/gh-api-stderr.log"
-
-          set +e
-          PR_JSON=$(gh api "repos/${REPO}/commits/${SHA}/pulls" \
-            --jq '[.[] | select(.merged_at != null and .base.ref == "main")] | sort_by(.merged_at) | reverse | .[0] // empty' 2>"$ERR_LOG")
-          GH_EXIT=$?
-          set -euo pipefail
-
-          if [[ -s "$ERR_LOG" ]]; then
-            echo "::warning::gh api stderr while listing PRs for commit $SHA:"
-            cat "$ERR_LOG"
-          fi
-
-          if [[ "$GH_EXIT" -ne 0 ]]; then
-            echo "::error::gh api failed (exit $GH_EXIT) listing pull requests for commit $SHA. This is not the same as having no linked PR; fix auth, rate limits, or API usage. See stderr in the warning above."
-            exit 1
-          fi
-
-          if [[ -z "$PR_JSON" || "$PR_JSON" == "null" ]]; then
-            echo "No merged PR associated with commit $SHA (e.g. direct push to main)"
-            echo "has_pr=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          printf '%s\n' "$PR_JSON" > .cherry-pick-workflow/pr.json
-          echo "has_pr=true" >> "$GITHUB_OUTPUT"
-          echo "Found merged PR $(jq -r '.number' .cherry-pick-workflow/pr.json) for commit $SHA"
-
-      - name: Write PR metadata and body files
-        id: pr_files
-        if: steps.find_pr.outputs.has_pr == 'true'
-        run: |
-          set -euo pipefail
-          PR_JSON=".cherry-pick-workflow/pr.json"
-          jq -r '.body // empty' "$PR_JSON" > .cherry-pick-workflow/pr_body.txt
-          jq -r '.title // empty' "$PR_JSON" > .cherry-pick-workflow/pr_title.txt
-
-      - name: Parse cherry-pick versions from PR body
-        id: parse_versions
-        if: steps.find_pr.outputs.has_pr == 'true' && steps.pr_files.outcome == 'success'
-        run: |
-          set -euo pipefail
-          PR_BODY_FILE=".cherry-pick-workflow/pr_body.txt"
-          PR_BODY=$(cat "$PR_BODY_FILE")
-
-          CHERRY_PICK_LINE=$(echo "$PR_BODY" | grep -i "^cherry-pick:" || true)
-          if [[ -z "$CHERRY_PICK_LINE" ]]; then
-            echo "No cherry-pick marker found in PR description"
-            echo "versions=[]" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "Found cherry-pick line: $CHERRY_PICK_LINE"
-          # Strip CR (Windows/CRLF PR bodies); command substitution strips trailing LF but not CR.
-          VERSIONS_STR=$(printf '%s' "$CHERRY_PICK_LINE" | tr -d '\r' | sed -E 's/^[Cc]herry-pick:\s*//')
-
-          VALID_VERSIONS=()
-          IFS=',' read -ra VERSION_ARRAY <<< "$VERSIONS_STR"
-          for version in "${VERSION_ARRAY[@]}"; do
-            version=$(printf '%s' "$version" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-            if [[ "$version" =~ ^1\.[0-9]+$ ]]; then
-              version="v${version}"
-            fi
-            if [[ "$version" =~ ^v1\.[0-9]+$ ]]; then
-              VALID_VERSIONS+=("\"$version\"")
-              echo "Valid version found: $version"
-            else
-              echo "Warning: Invalid version format '$version' (expected v1.X or 1.X)"
-            fi
-          done
-
-          if [[ ${#VALID_VERSIONS[@]} -eq 0 ]]; then
-            echo "versions=[]" >> "$GITHUB_OUTPUT"
-            echo "No valid cherry-pick versions found"
-          else
-            JSON_ARRAY="[$(IFS=,; echo "${VALID_VERSIONS[*]}")]"
-            echo "versions=$JSON_ARRAY" >> "$GITHUB_OUTPUT"
-            echo "Cherry-pick versions to process: $JSON_ARRAY"
-          fi
-
-      - name: Publish job outputs
-        id: publish_job_outputs
-        if: always() && steps.find_pr.outcome == 'success'
-        env:
-          PARSE_VERSIONS: ${{ steps.parse_versions.outputs.versions }}
-        run: |
-          set -euo pipefail
-
-          if [[ "${{ steps.find_pr.outputs.has_pr }}" != "true" ]]; then
-            echo "run_cherry_pick=false" >> "$GITHUB_OUTPUT"
-            echo "versions=[]" >> "$GITHUB_OUTPUT"
-            echo "pr_number=" >> "$GITHUB_OUTPUT"
-            echo "merge_commit_sha=" >> "$GITHUB_OUTPUT"
-            echo "pr_title=" >> "$GITHUB_OUTPUT"
-            echo "pr_user_login=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [[ "${{ steps.pr_files.outcome }}" != "success" || "${{ steps.parse_versions.outcome }}" != "success" ]]; then
-            echo "::error::PR file or version parse step did not succeed"
-            exit 1
-          fi
-
-          PR_JSON=".cherry-pick-workflow/pr.json"
-          echo "pr_number=$(jq -r '.number' "$PR_JSON")" >> "$GITHUB_OUTPUT"
-          echo "merge_commit_sha=$(jq -r '.merge_commit_sha' "$PR_JSON")" >> "$GITHUB_OUTPUT"
-          echo "pr_user_login=$(jq -r '.user.login // empty' "$PR_JSON")" >> "$GITHUB_OUTPUT"
-
-          echo "pr_title<<EOF" >> "$GITHUB_OUTPUT"
-          cat .cherry-pick-workflow/pr_title.txt >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
-
-          VERSIONS="${PARSE_VERSIONS:-[]}"
-          echo "versions=$VERSIONS" >> "$GITHUB_OUTPUT"
-
-          if [[ "$VERSIONS" != "[]" ]]; then
-            echo "run_cherry_pick=true" >> "$GITHUB_OUTPUT"
-            {
-              echo 'original_pr_body<<PRBODY'
-              cat .cherry-pick-workflow/pr_body.txt
-              echo 'PRBODY'
-            } >> "$GITHUB_OUTPUT"
-          else
-            echo "run_cherry_pick=false" >> "$GITHUB_OUTPUT"
-          fi
+          operation: extract
 
   cherry-pick:
     needs: extract-versions
@@ -176,95 +38,14 @@ jobs:
       matrix:
         version: ${{ fromJson(needs.extract-versions.outputs.versions) }}
     steps:
-
-      - name: Create Cherry-Pick PR token
-        id: cherry-pick-pr-sts
-        uses: odigos-io/ci-core/sts@main
+      - name: Backport to release branch
+        uses: odigos-io/ci-core/cherry-pick@main
         with:
-          scope: odigos-io/odigos
-          identity: create-pr
-          output-git-config: true
-
-      - name: Determine Release Branch
-        id: branch
-        run: |
-          VERSION="${{ matrix.version }}"
-          RELEASE_BRANCH="releases/${VERSION}.0"
-          echo "release_branch=$RELEASE_BRANCH" >> $GITHUB_OUTPUT
-          echo "Processing version $VERSION -> branch $RELEASE_BRANCH"
-
-      - name: Checkout Release Branch
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ steps.branch.outputs.release_branch }}
-          fetch-depth: 0
-          token: ${{ steps.cherry-pick-pr-sts.outputs.GH_TOKEN }}
-
-      - name: Verify Release Branch Exists
-        env:
-          GH_TOKEN: ${{ steps.cherry-pick-pr-sts.outputs.GH_TOKEN }}
-        run: |
-          RELEASE_BRANCH="${{ steps.branch.outputs.release_branch }}"
-          if ! git ls-remote --exit-code --heads origin "$RELEASE_BRANCH" > /dev/null 2>&1; then
-            echo "Error: Release branch '$RELEASE_BRANCH' does not exist"
-            exit 1
-          fi
-          echo "Release branch '$RELEASE_BRANCH' exists"
-
-      - name: Cherry Pick Commit
-        id: cherry_pick
-        run: |
-          MERGE_COMMIT="${{ needs.extract-versions.outputs.merge_commit_sha }}"
-          echo "Cherry-picking commit $MERGE_COMMIT"
-
-          git fetch origin main
-
-          git config user.name "$(git log -1 --format='%an' "$MERGE_COMMIT")"
-          git config user.email "$(git log -1 --format='%ae' "$MERGE_COMMIT")"
-
-          PARENT_COUNT=$(git rev-list --parents -n 1 "$MERGE_COMMIT" 2>/dev/null | awk '{print NF-1}' || echo 0)
-          if [[ "$PARENT_COUNT" -gt 1 ]]; then
-            echo "Merge commit detected; using cherry-pick -m 1"
-            if ! git cherry-pick -m 1 "$MERGE_COMMIT"; then
-              echo "Cherry-pick failed. There may be conflicts."
-              git cherry-pick --abort || true
-              exit 1
-            fi
-          else
-            echo "Single-parent commit (e.g. squash merge); cherry-pick without -m"
-            if ! git cherry-pick "$MERGE_COMMIT"; then
-              echo "Cherry-pick failed. There may be conflicts."
-              git cherry-pick --abort || true
-              exit 1
-            fi
-          fi
-
-          echo "Successfully cherry-picked commit $MERGE_COMMIT"
-
-      - name: Create Pull Request
-        id: create_pr
-        uses: peter-evans/create-pull-request@v8
-        with:
-          token: ${{ steps.cherry-pick-pr-sts.outputs.GH_TOKEN }}
-          branch: cherry-pick/${{ matrix.version }}/${{ needs.extract-versions.outputs.pr_number }}
-          base: ${{ steps.branch.outputs.release_branch }}
-          title: "Cherry-pick: ${{ needs.extract-versions.outputs.pr_title }} (backport to ${{ matrix.version }})"
-          body: |
-            This PR cherry-picks #${{ needs.extract-versions.outputs.pr_number }} to the ${{ matrix.version }} release branch.
-
-            Original PR: #${{ needs.extract-versions.outputs.pr_number }}
-            Original Author: @${{ needs.extract-versions.outputs.pr_user_login }}
-
-            ---
-
-            ${{ needs.extract-versions.outputs.original_pr_body }}
-          labels: cherry-pick
-
-      - name: Notify Slack
-        if: always()
-        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
-        with:
-          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-          success-description: "Cherry-pick PR created for ${{ matrix.version }}: ${{ steps.create_pr.outputs.pull-request-url }}"
-          failure-description: "ERROR: Failed to cherry-pick PR #${{ needs.extract-versions.outputs.pr_number }} to ${{ matrix.version }}"
-          tag: ${{ matrix.version }}
+          operation: backport
+          version: ${{ matrix.version }}
+          merge-commit-sha: ${{ needs.extract-versions.outputs.merge_commit_sha }}
+          pr-number: ${{ needs.extract-versions.outputs.pr_number }}
+          pr-title: ${{ needs.extract-versions.outputs.pr_title }}
+          pr-user-login: ${{ needs.extract-versions.outputs.pr_user_login }}
+          original-pr-body: ${{ needs.extract-versions.outputs.original_pr_body }}
+          slack-webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: CORE-000

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
