### PR TITLE
fix: respect explicit false CLI boolean flags

### DIFF
--- a/cli/cmd/cleanup.go
+++ b/cli/cmd/cleanup.go
@@ -51,7 +51,7 @@ All other Odigos components and system resources are deleted automatically by He
 		odigosNsFound := !resources.IsErrNoOdigosNamespaceFound(err)
 
 		if odigosNsFound {
-			if !cmd.Flag("yes").Changed {
+			if !mustGetBoolFlag(cmd, "yes") {
 				fmt.Printf("About to cleanup Odigos from namespace %s\n", ns)
 				confirmed, err := confirm.Ask("Are you sure?")
 				if err != nil || !confirmed {
@@ -82,7 +82,7 @@ All other Odigos components and system resources are deleted automatically by He
 			}
 			if autoRolloutDisabled {
 				fmt.Println("Odigos is configured to NOT rollout workloads automatically; existing pods will remain instrumented until a manual rollout is triggered.")
-			} else if !cmd.Flag("no-wait").Changed {
+			} else if !mustGetBoolFlag(cmd, "no-wait") {
 				err = waitForPodsToRolloutWithoutInstrumentation(ctx, client)
 				if err != nil {
 					fmt.Printf("\033[31mERROR\033[0m Failed to wait for pods to rollout without instrumentation: %s\n", err)
@@ -93,7 +93,7 @@ All other Odigos components and system resources are deleted automatically by He
 			// If the user only wants to uninstall instrumentation, we exit here.
 			// This flag being used by users who want to remove instrumentation without removing the entire Odigos setup,
 			// And by cleanup jobs that runs as helm pre-uninstall hook before helm uninstall command.
-			if cmd.Flag("instrumentation-only").Changed {
+			if mustGetBoolFlag(cmd, "instrumentation-only") {
 				fmt.Println("Cleaning up Odigos instrumentation resources... new approeach")
 				// Node labels are added by the Odiglet, and since it's not managed by Helm, we need to clean them up here.
 				// In CLI logic, this is done in UninstallClusterResources after the Odiglet is deleted.

--- a/cli/cmd/flags.go
+++ b/cli/cmd/flags.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func mustGetBoolFlag(cmd *cobra.Command, name string) bool {
+	value, err := cmd.Flags().GetBool(name)
+	if err != nil {
+		fmt.Printf("\033[31mERROR\033[0m Failed to read %s flag: %s\n", name, err)
+		os.Exit(1)
+	}
+	return value
+}

--- a/cli/cmd/flags_test.go
+++ b/cli/cmd/flags_test.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestMustGetBoolFlagUsesFlagValue(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{
+			name: "unset flag",
+			args: nil,
+			want: false,
+		},
+		{
+			name: "implicit true flag",
+			args: []string{"--yes"},
+			want: true,
+		},
+		{
+			name: "explicit false flag",
+			args: []string{"--yes=false"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{
+				Use: "test",
+				Run: func(cmd *cobra.Command, args []string) {},
+			}
+			cmd.Flags().Bool("yes", false, "skip the confirmation prompt")
+			cmd.SetArgs(tt.args)
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() returned error: %v", err)
+			}
+
+			if got := mustGetBoolFlag(cmd, "yes"); got != tt.want {
+				t.Fatalf("mustGetBoolFlag() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/cmd/pro-dep.go
+++ b/cli/cmd/pro-dep.go
@@ -128,7 +128,7 @@ var centralUninstallCmdDep = &cobra.Command{
 			os.Exit(1)
 		}
 
-		if !cmd.Flag("yes").Changed {
+		if !mustGetBoolFlag(cmd, "yes") {
 			fmt.Printf("About to uninstall Odigos Central from namespace %s\n", ns)
 			confirmed, err := confirm.Ask("Are you sure?")
 			if err != nil || !confirmed {
@@ -191,7 +191,7 @@ var centralUpgradeCmdDep = &cobra.Command{
 			os.Exit(1)
 		}
 
-		if !cmd.Flag("yes").Changed {
+		if !mustGetBoolFlag(cmd, "yes") {
 			fmt.Printf("About to upgrade Odigos Central UI in namespace %s to version %s\n", ns, versionFlagDep)
 			confirmed, err := confirm.Ask("Are you sure?")
 			if err != nil || !confirmed {

--- a/cli/cmd/sources.go
+++ b/cli/cmd/sources.go
@@ -236,7 +236,7 @@ It is important to note that if a Source [name] is provided, all --workload-* fl
 		} else {
 			namespaceText, providedWorkloadFlags, namespaceList, labelSet := parseSourceLabelFlags()
 
-			if !cmd.Flag("yes").Changed {
+			if !mustGetBoolFlag(cmd, "yes") {
 				fmt.Printf("About to delete all Sources in %s that match:\n%s", namespaceText, providedWorkloadFlags)
 				confirmed, err := confirm.Ask("Are you sure?")
 				if err != nil || !confirmed {
@@ -316,7 +316,7 @@ It is important to note that if a Source [name] is provided, all --workload-* fl
 		} else {
 			namespaceText, providedWorkloadFlags, namespaceList, labelSet := parseSourceLabelFlags()
 
-			if !cmd.Flag("yes").Changed {
+			if !mustGetBoolFlag(cmd, "yes") {
 				fmt.Printf("About to update all Sources in %s that match:\n%s", namespaceText, providedWorkloadFlags)
 				confirmed, err := confirm.Ask("Are you sure?")
 				if err != nil || !confirmed {
@@ -618,7 +618,7 @@ func updateOrCreateSourceForObject(ctx context.Context, client *kube.Client, wor
 			if len(sourceList) > 0 {
 				fmt.Printf("NOTE: Configured Namespace Source, but the following Workload Sources will not be affected (individual Workload Sources take priority over Namespace Sources):\n")
 				for _, line := range sourceList {
-					fmt.Printf(line)
+					fmt.Print(line)
 				}
 			}
 		}

--- a/cli/cmd/uninstall-dep.go
+++ b/cli/cmd/uninstall-dep.go
@@ -61,7 +61,7 @@ and rollback any metadata changes made to your objects.`,
 		odigosNsFound := !resources.IsErrNoOdigosNamespaceFound(err)
 
 		if odigosNsFound {
-			if !cmd.Flag("yes").Changed {
+			if !mustGetBoolFlag(cmd, "yes") {
 				fmt.Printf("About to uninstall Odigos from namespace %s\n", ns)
 				confirmed, err := confirm.Ask("Are you sure?")
 				if err != nil || !confirmed {
@@ -92,7 +92,7 @@ and rollback any metadata changes made to your objects.`,
 			}
 			if autoRolloutDisabled {
 				fmt.Println("Odigos is configured to NOT rollout workloads automatically; existing pods will remain instrumented until a manual rollout is triggered.")
-			} else if !cmd.Flag("no-wait").Changed {
+			} else if !mustGetBoolFlag(cmd, "no-wait") {
 				err = waitForPodsToRolloutWithoutInstrumentation(ctx, client)
 				if err != nil {
 					fmt.Printf("\033[31mERROR\033[0m Failed to wait for pods to rollout without instrumentation: %s\n", err)
@@ -103,7 +103,7 @@ and rollback any metadata changes made to your objects.`,
 			// If the user only wants to uninstall instrumentation, we exit here.
 			// This flag being used by users who want to remove instrumentation without removing the entire Odigos setup,
 			// And by cleanup jobs that runs as helm pre-uninstall hook before helm uninstall command.
-			if cmd.Flag("instrumentation-only").Changed {
+			if mustGetBoolFlag(cmd, "instrumentation-only") {
 				// Node labels are added by the Odiglet, and since it's not managed by Helm, we need to clean them up here.
 				// In CLI logic, this is done in UninstallClusterResources after the Odiglet is deleted.
 				cmdutil.CreateKubeResourceWithLogging(ctx, "Cleaning up Odigos node labels",


### PR DESCRIPTION
#### What this PR does / why we need it:
Small CLI footgun fix. Some bool flags used `Flag(...).Changed`, so `--yes=false` behaved like `--yes`. Same thing for `--no-wait=false` and `--instrumentation-only=false`.

Repro, no cluster magic needed, its just Cobra flag parsing:
- old behavior: a bool flag with `--yes=false` has `Changed == true`, so confirmation gets skipped
- fixed behavior: commands read the actual bool value via `GetBool`, so `false` stays false

Also swapped one `fmt.Printf(line)` to `fmt.Print(line)` because `go test ./cmd` tripped vet there.

Tested:
`cd cli && go test ./...`

No related issue found from a quick `gh issue/pr` search, afaict.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
Fix CLI boolean flags so explicit false values like `--yes=false` are respected.
```