### PR TITLE
fix: initialize sampling rules loading state as true

### DIFF
--- a/frontend/webapp/hooks/sampling/useSamplingRuleCRUD.ts
+++ b/frontend/webapp/hooks/sampling/useSamplingRuleCRUD.ts
@@ -62,7 +62,10 @@ export const useSamplingRuleCRUD = (): UseSamplingRuleCrud => {
   const { addNotification } = useNotificationStore();
   const [samplingRules, setSamplingRules] = useState<SamplingRules[]>([]);
   const [k8sHealthProbesConfig, setK8sHealthProbesConfig] = useState<K8sHealthProbesSamplingConfig | null>(null);
-  const [loading, setLoading] = useState(false);
+  // Initialize loading as true so the first render (before any fetch has resolved) reports
+  // "loading" — without this, consumers (e.g. the sampling onboarding modal) can't distinguish
+  // the pre-fetch initial state from a resolved-but-empty response and may auto-open prematurely.
+  const [loading, setLoading] = useState(true);
 
   const notifyUser = useCallback(
     (type: StatusType, title: string, message: string) => {

--- a/frontend/webapp/package.json
+++ b/frontend/webapp/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@apollo/client": "^3.13.9",
     "@apollo/experimental-nextjs-app-support": "^0.12.3",
-    "@odigos/ui-kit": "0.0.237",
+    "@odigos/ui-kit": "0.0.238",
     "graphql": "^16.13.2",
     "next": "15.5.14",
     "react": "19.2.5",

--- a/frontend/webapp/yarn.lock
+++ b/frontend/webapp/yarn.lock
@@ -635,10 +635,10 @@
   resolved "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
-"@odigos/ui-kit@0.0.237":
-  version "0.0.237"
-  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.237.tgz#648b356c732e4a291668f4d73a41707ce1ad5e8b"
-  integrity sha512-pGQiAJKjfZO5lCC0eGBRHAI9G0dv9nijXfCyVYcoyn+6RV5nW/T13sNFAE5WHBwjCR6wYHCMjbIRNvArrxq1jg==
+"@odigos/ui-kit@0.0.238":
+  version "0.0.238"
+  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.238.tgz#dd3af6bc342365ab5fe10e00138263af539d7411"
+  integrity sha512-aXKkR8u5huamAbS7EUvlN/1wsmY2C8dS6zHz11GTNuka2S26igZckMvBqXKRUan/leh/iBucxJntsEAityWnVw==
   dependencies:
     "@xyflow/react" "^12.10.2"
     elkjs "^0.11.1"


### PR DESCRIPTION
Pairs with [odigos-io/ui-kit#911](https://github.com/odigos-io/ui-kit/pull/911) to eliminate the sampling onboarding modal flicker on the sampling page.

#### What this PR does / why we need it:
`useSamplingRuleCRUD` initialized `loading` as `false`, so on the very first render the ui-kit's `SamplingRules` container saw `loading=false && samplingRules.length===0` and auto-opened the onboarding modal before the GraphQL fetch had a chance to resolve. The new `loading: true` initial value lets consumers distinguish the pre-fetch initial state from a resolved-but-empty response, so the onboarding decision is correctly deferred until the first fetch completes.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
fix: sampling onboarding modal no longer flickers on the sampling page when rules already exist
```

Made with [Cursor](https://cursor.com)

emergency-ticket id: EMR-1718
