### PR TITLE
PLAT-1097 | feat(nav): show Sampling Rules entry in nav bar

### DIFF
--- a/frontend/webapp/utils/functions/navigation.ts
+++ b/frontend/webapp/utils/functions/navigation.ts
@@ -2,7 +2,7 @@ import { ROUTES } from '../constants';
 import { SVG } from '@odigos/ui-kit/types';
 import { NavbarProps } from '@odigos/ui-kit/components/v2';
 import { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
-import { OverviewIcon, PipelineCollectorIcon, ServiceMapIcon, SettingsIcon } from '@odigos/ui-kit/icons';
+import { OverviewIcon, PipelineCollectorIcon, SamplingIcon, ServiceMapIcon, SettingsIcon } from '@odigos/ui-kit/icons';
 
 const getPayloadForIcon = (router: AppRouterInstance, currentPath: string, targetPath: string, label: string, icon: SVG): NavbarProps['icons'][number] => {
   return {
@@ -19,7 +19,7 @@ export const getNavbarIcons = (router: AppRouterInstance, currentPath: string) =
     getPayloadForIcon(router, currentPath, ROUTES.OVERVIEW, 'Overview', OverviewIcon),
     getPayloadForIcon(router, currentPath, ROUTES.SERVICE_MAP, 'Service Map', ServiceMapIcon),
     getPayloadForIcon(router, currentPath, ROUTES.PIPELINE_COLLECTORS, 'Collectors Pipeline', PipelineCollectorIcon),
-    // getPayloadForIcon(router, currentPath, ROUTES.SAMPLING, 'Sampling Rules', SamplingIcon),
+    getPayloadForIcon(router, currentPath, ROUTES.SAMPLING, 'Sampling Rules', SamplingIcon),
     getPayloadForIcon(router, currentPath, ROUTES.SETTINGS, 'Settings', SettingsIcon),
   ];
 


### PR DESCRIPTION
Show the Sampling Rules entry in the side nav bar so users can reach the sampling page from the navigation.

#### What this PR does / why we need it:
The Sampling Rules nav item already existed in `frontend/webapp/utils/functions/navigation.ts` but was commented out. This PR enables it (and adds the missing `SamplingIcon` import) so the route at `/sampling` is reachable from the side nav, alongside Overview, Service Map, Collectors Pipeline and Settings.

Linear: [PLAT-1097](https://linear.app/odigos/issue/PLAT-1097/show-sampling-icon-in-nav-bar)

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
Add Sampling Rules entry to the navigation bar.
```

Made with [Cursor](https://cursor.com)