### PR TITLE
CORE-1000: Add OBI container override to source e2e

### DIFF
--- a/tests/common/apply/install-simple-demo.yaml
+++ b/tests/common/apply/install-simple-demo.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: coupon
-          image: ghcr.io/odigos-io/simple-demo/odigos-demo-coupon:v0.1.35
+          image: ghcr.io/odigos-io/simple-demo/odigos-demo-coupon:v0.1.36
           imagePullPolicy: IfNotPresent
           env:
             - name: MEMBERSHIP_SERVICE_HOST
@@ -67,7 +67,7 @@ spec:
     spec:
       containers:
         - name: currency
-          image: ghcr.io/odigos-io/simple-demo/odigos-demo-currency:v0.1.35
+          image: ghcr.io/odigos-io/simple-demo/odigos-demo-currency:v0.1.36
           imagePullPolicy: IfNotPresent
           env:
             - name: GEOLOCATION_SERVICE_HOST
@@ -140,7 +140,7 @@ spec:
     spec:
       containers:
         - name: frontend
-          image: ghcr.io/odigos-io/simple-demo/odigos-demo-frontend:v0.1.35
+          image: ghcr.io/odigos-io/simple-demo/odigos-demo-frontend:v0.1.36
           imagePullPolicy: IfNotPresent
           env:
             - name: INVENTORY_SERVICE_HOST
@@ -153,6 +153,8 @@ spec:
               value: currency:8080
             - name: GEOLOCATION_SERVICE_HOST
               value: geolocation:8080
+            - name: SHIPPING_SERVICE_HOST
+              value: shipping:8080
           ports:
             - containerPort: 8080
 ---
@@ -190,7 +192,7 @@ spec:
     spec:
       containers:
         - name: geolocation
-          image: ghcr.io/odigos-io/simple-demo/odigos-demo-geolocation:v0.1.35
+          image: ghcr.io/odigos-io/simple-demo/odigos-demo-geolocation:v0.1.36
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000
@@ -264,7 +266,7 @@ spec:
     spec:
       containers:
         - name: inventory
-          image: ghcr.io/odigos-io/simple-demo/odigos-demo-inventory:v0.1.35
+          image: ghcr.io/odigos-io/simple-demo/odigos-demo-inventory:v0.1.36
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -304,7 +306,7 @@ spec:
     spec:
       containers:
         - name: membership
-          image: ghcr.io/odigos-io/simple-demo/odigos-demo-membership:v0.1.35
+          image: ghcr.io/odigos-io/simple-demo/odigos-demo-membership:v0.1.36
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -347,7 +349,7 @@ spec:
     spec:
       containers:
         - name: pricing
-          image: ghcr.io/odigos-io/simple-demo/odigos-demo-pricing:v0.1.35
+          image: ghcr.io/odigos-io/simple-demo/odigos-demo-pricing:v0.1.36
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -360,6 +362,49 @@ metadata:
 spec:
   selector:
     app: pricing
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+
+---
+##################################################
+# Shipping (C++)
+##################################################
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shipping
+  namespace: default
+  labels:
+    app: shipping
+spec:
+  selector:
+    matchLabels:
+      app: shipping
+  template:
+    metadata:
+      labels:
+        app: shipping
+    spec:
+      containers:
+        - name: shipping
+          image: ghcr.io/odigos-io/simple-demo/odigos-demo-shipping:v0.1.36
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          env:
+            - name: PORT
+              value: "8080"
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: shipping
+  namespace: default
+spec:
+  selector:
+    app: shipping
   ports:
     - protocol: TCP
       port: 8080

--- a/tests/common/assert/simple-demo-installed.yaml
+++ b/tests/common/assert/simple-demo-installed.yaml
@@ -109,3 +109,19 @@ status:
   readyReplicas: 1
   availableReplicas: 1
   updatedReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shipping
+  namespace: default
+status:
+  conditions:
+    - type: Available
+      status: "True"
+    - type: Progressing
+      status: "True"
+  replicas: 1
+  readyReplicas: 1
+  availableReplicas: 1
+  updatedReplicas: 1

--- a/tests/common/assert/simple-demo-instrumented-full.yaml
+++ b/tests/common/assert/simple-demo-instrumented-full.yaml
@@ -376,7 +376,7 @@ status:
   runtimeDetailsByContainer:
     - containerName: frontend
       language: java
-      runtimeVersion: 17.0.18+8
+      runtimeVersion: 17.0.19+10
 ---
 apiVersion: odigos.io/v1alpha1
 kind: InstrumentationConfig
@@ -393,7 +393,7 @@ status:
   runtimeDetailsByContainer:
     - containerName: inventory
       language: python
-      runtimeVersion: 3.11.14
+      runtimeVersion: 3.11.15
 ---
 apiVersion: odigos.io/v1alpha1
 kind: InstrumentationConfig

--- a/tests/common/assert/simple-demo-runtime-detected.yaml
+++ b/tests/common/assert/simple-demo-runtime-detected.yaml
@@ -30,7 +30,7 @@ status:
   runtimeDetailsByContainer:
     - containerName: frontend
       language: java
-      runtimeVersion: 17.0.18+8
+      runtimeVersion: 17.0.19+10
 ---
 apiVersion: odigos.io/v1alpha1
 kind: InstrumentationConfig
@@ -50,7 +50,7 @@ status:
         - name: PYTHONPATH
           value: /app # this env exists in the test image
       language: python
-      runtimeVersion: 3.11.14
+      runtimeVersion: 3.11.15
 ---
 apiVersion: odigos.io/v1alpha1
 kind: InstrumentationConfig

--- a/tests/e2e/source/01-shipping-instrumented.yaml
+++ b/tests/e2e/source/01-shipping-instrumented.yaml
@@ -1,0 +1,22 @@
+apiVersion: odigos.io/v1alpha1
+kind: InstrumentationConfig
+metadata:
+  name: deployment-shipping
+  namespace: default
+  ownerReferences:
+    - apiVersion: apps/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Deployment
+      name: shipping
+spec:
+  agentInjectionEnabled: true
+  containers:
+    - agentEnabled: true
+      containerName: shipping
+      otelDistroName: opentelemetry-ebpf-instrumentation
+  serviceName: shipping-reported
+status:
+  runtimeDetailsByContainer:
+    - containerName: shipping
+      language: cplusplus

--- a/tests/e2e/source/01-sources.yaml
+++ b/tests/e2e/source/01-sources.yaml
@@ -95,3 +95,20 @@ spec:
     namespace: default
     kind: Deployment
   otelServiceName: geolocation-reported
+---
+apiVersion: odigos.io/v1alpha1
+kind: Source
+metadata:
+  name: shipping
+  namespace: default
+  labels:
+    odigos.io/e2e: source
+spec:
+  workload:
+    name: shipping
+    namespace: default
+    kind: Deployment
+  otelServiceName: shipping-reported
+  containerOverrides:
+    - containerName: shipping
+      otelDistroName: opentelemetry-ebpf-instrumentation

--- a/tests/e2e/source/01-workloads.yaml
+++ b/tests/e2e/source/01-workloads.yaml
@@ -46,3 +46,12 @@ metadata:
   generation: 2
   name: geolocation
   namespace: default
+---
+# Shipping is instrumented with OBI (eBPF), which does not require a pod restart,
+# so its generation is expected to remain at 1.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  generation: 1
+  name: shipping
+  namespace: default

--- a/tests/e2e/source/02-workloads.yaml
+++ b/tests/e2e/source/02-workloads.yaml
@@ -46,3 +46,12 @@ metadata:
   generation: 3
   name: geolocation
   namespace: default
+---
+# Shipping is instrumented with OBI (eBPF), so neither instrumenting nor
+# uninstrumenting triggers a pod restart; its generation stays at 1.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  generation: 1
+  name: shipping
+  namespace: default

--- a/tests/e2e/source/README.md
+++ b/tests/e2e/source/README.md
@@ -4,25 +4,42 @@ This e2e extensively tests the use of Source objects for instrumentation, uninst
 
 It has the following phases:
 
-1. **Setup** - Install Odigos, simple-trace-db, and the Demo app.
+1. **Setup** - Install Odigos, simple-trace-db, and the Demo app
+   ([simple-demo](https://github.com/odigos-io/simple-demo) `v0.1.36`). The demo app now
+   includes the C++ `shipping` service, which is instrumented in this test via the OBI
+   container override.
 
 2. **Workload instrumentation** - Create a Source for each individual workload, include a reported for each source. Add simple-trace-db as a destination. Verify:
     1. InstrumentationConfigs are created for each deployment
     2. Db is ready to receive traces
     3. The Odigos pipeline is ready
-    4. Each deployment rolls out a new (instrumented) revision
-    5. Generated traffic results in expected spans
-    6. Context propagation works across deployments (service name is identical to the one configured by the Source)
-    7. Resource attributes are present
-    8. Span attributes are present
-    9. Collector metrics are collected by UI
+    4. Each deployment rolls out a new (instrumented) revision (except `shipping`, see below)
+    5. The `shipping` Source uses a `containerOverrides` entry that selects the
+       `opentelemetry-ebpf-instrumentation` (OBI) distro, as described in
+       [the Odigos OBI docs](https://docs.odigos.io/oss/instrumentations/obi). Because OBI does
+       not require a pod restart, `shipping`'s generation remains at `1` and its
+       `InstrumentationConfig` is asserted to report `otelDistroName:
+       opentelemetry-ebpf-instrumentation` together with `language: cplusplus`.
+    6. Generated traffic to the frontend's `/buy` endpoint fans out to the C++ `shipping`
+       service (via `SHIPPING_SERVICE_HOST`) and produces server spans observable through
+       OBI (verified via `wait-for-shipping-trace.yaml`)
+    7. Context propagation works across deployments (service name is identical to the one configured by the Source)
+    8. Resource attributes are present
+    9. Span attributes are present
+    10. Collector metrics are collected by UI
 
 3. **Workload uninstrumentation** - Delete all Source objects for deployments. Verify:
-    1. Workloads roll out a new (uninstrumented) revision
+    1. Workloads roll out a new (uninstrumented) revision (except `shipping`, which stays at
+       generation `1` because OBI never required a restart in the first place)
 
 
 ## Workload generations and revisions
 
 The various `*-workloads.yaml` files for each phase of the test look the `metadata.generation` value.
 It is used to verify that the Odigos controllers have triggered an instrumentation rollout.
+
+`shipping` is an exception: it is instrumented via OBI (eBPF) which sets `noRestartRequired:
+true` on its `runtimeAgent`. As a result Odigos does not patch the pod spec to enable OBI, so
+the deployment's `metadata.generation` stays at `1` through both the instrumentation and
+uninstrumentation phases.
 

--- a/tests/e2e/source/chainsaw-test.yaml
+++ b/tests/e2e/source/chainsaw-test.yaml
@@ -86,6 +86,16 @@ spec:
             timeout: 70s
             content: ../../common/wait_for_rollout.sh
 
+    - name: '[2 - Workload Instrumentation] Shipping (C++) instrumented with OBI container override'
+      try:
+        - assert:
+            timeout: 4m
+            file: 01-shipping-instrumented.yaml
+      catch:
+        - podLogs:
+            name: odiglet
+            namespace: odigos-test
+
     - name: '[2 - Workload Instrumentation] Generate Traffic'
       try:
         - apply:
@@ -114,6 +124,27 @@ spec:
             content: |
               java_pod_name=$(kubectl get pods -n default -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep ^frontend)
               kubectl logs $java_pod_name -n default
+
+    - name: '[2 - Workload Instrumentation] Wait For Shipping Trace (OBI)'
+      try:
+        - script:
+            timeout: 3m
+            content: |
+              while true; do
+                ../../common/simple_trace_db_query_runner.sh wait-for-shipping-trace.yaml
+                if [ $? -eq 0 ]; then
+                  break
+                fi
+                sleep 2
+              done
+      catch:
+        - script:
+            content: |
+              shipping_pod_name=$(kubectl get pods -n default -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep ^shipping)
+              kubectl logs "$shipping_pod_name" -n default || true
+        - podLogs:
+            name: odiglet
+            namespace: odigos-test
 
     - name: '[2 - Workload Instrumentation] Verify Trace - Context Propagation'
       try:

--- a/tests/e2e/source/wait-for-shipping-trace.yaml
+++ b/tests/e2e/source/wait-for-shipping-trace.yaml
@@ -1,0 +1,15 @@
+apiVersion: e2e.tests.odigos.io/v1
+kind: TraceTest
+description: |
+  Verifies that the C++ shipping service from simple-demo v0.1.36 emits server
+  spans once it is instrumented via the OBI container override
+  (opentelemetry-ebpf-instrumentation). The frontend's /buy traffic fans out
+  to shipping (via SHIPPING_SERVICE_HOST), so OBI should produce server spans
+  reported under the configured service name.
+query: |
+  length([?(
+    span.serviceName == 'shipping' &&
+    span.kind == 'server'
+  )]) > `0`
+expected:
+  minimum: 1


### PR DESCRIPTION
#### What this PR does / why we need it:
This adds a test for using OBI with a C++ app via manual source override to the source e2e test, introducing the new shipping service in simple demo v0.36

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
