### PR TITLE
Fix agent directory traversal permissions

### DIFF
--- a/odiglet/pkg/instrumentation/fs/agents.go
+++ b/odiglet/pkg/instrumentation/fs/agents.go
@@ -103,6 +103,10 @@ func CopyAgentsDirectoryToHost() error {
 		logger.Error("Error creating dotnet deprecated directories", "err", err)
 		return err
 	}
+	if err := ensureDirectoryTraversalPermissions(k8sconsts.OdigosAgentsDirectory); err != nil {
+		logger.Error("Error ensuring instrumentation directory permissions", "err", err)
+		return err
+	}
 
 	logger.Info("Odigos agents directory copied to host", "elapsed", time.Since(startTime))
 

--- a/odiglet/pkg/instrumentation/fs/copy.go
+++ b/odiglet/pkg/instrumentation/fs/copy.go
@@ -19,6 +19,8 @@ const (
 
 	// 32 KB buffer for I/O operations
 	bufferSize = 32 * 1024
+
+	directoryTraversalMode os.FileMode = 0755
 )
 
 // getNumberOfWorkers determines the number of concurrent workers to use for copying files.
@@ -38,7 +40,7 @@ func copyDirectories(srcDir string, destDir string) error {
 	}
 
 	// Create the destination directory if it doesn't exist
-	err = os.MkdirAll(destDir, os.ModePerm)
+	err = os.MkdirAll(destDir, directoryTraversalMode)
 	if err != nil {
 		return err
 	}
@@ -63,7 +65,7 @@ func copyDirectories(srcDir string, destDir string) error {
 	close(fileChan)
 	wg.Wait()
 	logger.Info("Finished copying instrumentation files to host", "duration", time.Since(start))
-	return nil
+	return ensureDirectoryTraversalPermissions(destDir)
 }
 
 func createDotnetDeprecatedDirectories(destDir string) error {
@@ -77,11 +79,11 @@ func createDotnetDeprecatedDirectories(destDir string) error {
 	glibcDirWithArch := filepath.Join(destDir, "linux-glibc-"+arch)
 	muslDirWithArch := filepath.Join(destDir, "linux-musl-"+arch)
 
-	err = os.MkdirAll(glibcDirWithArch, os.ModePerm)
+	err = os.MkdirAll(glibcDirWithArch, directoryTraversalMode)
 	if err != nil {
 		return err
 	}
-	err = os.MkdirAll(muslDirWithArch, os.ModePerm)
+	err = os.MkdirAll(muslDirWithArch, directoryTraversalMode)
 	if err != nil {
 		return err
 	}
@@ -136,7 +138,7 @@ func copyFile(src, dst string, buf []byte) error {
 	defer srcFile.Close()
 
 	// Create destination file and directories if needed
-	err = os.MkdirAll(filepath.Dir(dst), os.ModePerm)
+	err = os.MkdirAll(filepath.Dir(dst), directoryTraversalMode)
 	if err != nil {
 		return err
 	}
@@ -164,6 +166,52 @@ func copyFile(src, dst string, buf []byte) error {
 	}
 
 	return nil
+}
+
+func ensureDirectoryTraversalPermissions(root string) error {
+	if err := ensureDirectoryTraversalPermission(root); err != nil {
+		return err
+	}
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if err := ensureDirectoryTraversalPermissions(filepath.Join(root, entry.Name())); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ensureDirectoryTraversalPermission(dir string) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return nil
+	}
+
+	mode := info.Mode().Perm()
+	fixedMode := mode
+	if mode&0400 != 0 {
+		fixedMode |= 0100
+	}
+	if mode&0040 != 0 {
+		fixedMode |= 0010
+	}
+	if mode&0004 != 0 {
+		fixedMode |= 0001
+	}
+	if fixedMode == mode {
+		return nil
+	}
+	return os.Chmod(dir, fixedMode)
 }
 
 func HostContainsEbpfDir(dir string) bool {

--- a/odiglet/pkg/instrumentation/fs/copy_test.go
+++ b/odiglet/pkg/instrumentation/fs/copy_test.go
@@ -3,6 +3,7 @@ package fs
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -93,6 +94,42 @@ func TestCopyDirectories(t *testing.T) {
 
 		if srcStat.Size() != destStat.Size() {
 			t.Fatalf("file sizes do not match: %s (%d) != %s (%d)", srcFile, srcStat.Size(), destFile, destStat.Size())
+		}
+	}
+}
+
+func TestEnsureDirectoryTraversalPermissions(t *testing.T) {
+	root := t.TempDir()
+	nestedDir := filepath.Join(root, "java", "nested")
+	if err := os.MkdirAll(nestedDir, 0755); err != nil {
+		t.Fatalf("failed to create nested directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nestedDir, "javaagent.jar"), []byte("agent"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	restrictedJavaDir := filepath.Join(root, "java")
+	defer os.Chmod(restrictedJavaDir, 0755)
+	defer os.Chmod(nestedDir, 0755)
+
+	if err := os.Chmod(nestedDir, 0644); err != nil {
+		t.Fatalf("failed to restrict nested directory: %v", err)
+	}
+	if err := os.Chmod(restrictedJavaDir, 0644); err != nil {
+		t.Fatalf("failed to restrict java directory: %v", err)
+	}
+
+	if err := ensureDirectoryTraversalPermissions(root); err != nil {
+		t.Fatalf("ensureDirectoryTraversalPermissions failed: %v", err)
+	}
+
+	for _, dir := range []string{restrictedJavaDir, nestedDir} {
+		info, err := os.Stat(dir)
+		if err != nil {
+			t.Fatalf("failed to stat directory %s: %v", dir, err)
+		}
+		if got := info.Mode().Perm(); got&0111 != 0111 {
+			t.Fatalf("directory %s is not traversable, mode: %v", dir, got)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- ensure copied instrumentation directories keep traversal execute bits when copied to the host
- use 0755 for agent directory creation instead of os.ModePerm
- add a regression test for directories such as /var/odigos/java being left as 0644

## Why
Fixes #4769. A directory mode like 0644 lets the file exist but prevents non-root instrumented containers from traversing /var/odigos/java to read javaagent.jar.

## Verification
- go test ./pkg/instrumentation/fs -run TestEnsureDirectoryTraversalPermissions -count=1
- go test ./pkg/instrumentation/fs -count=1
- go test ./pkg/instrumentation/...

## Note
I also tried go test ./... in the odiglet module on macOS/arm64, but it is blocked by Linux/eBPF-only packages and missing generated bpf objects, for example bpf_arm64_bpfel.o and syscall.Mount symbols.