### PR TITLE
CORE-1049: support updating python instrumentation automatically

### DIFF
--- a/.github/chainguard/trigger-agent-version-updater.sts.yaml
+++ b/.github/chainguard/trigger-agent-version-updater.sts.yaml
@@ -1,5 +1,5 @@
 issuer: https://token.actions.githubusercontent.com
-subject_pattern: repo:odigos-io/(opentelemetry-node|opentelemetry-ruby|opentelemetry-php):ref:(refs/tags/.*|refs/heads/main|refs/heads/releases/v[0-9]+\.[0-9]+\.x$)
+subject_pattern: repo:odigos-io/(opentelemetry-node|opentelemetry-ruby|opentelemetry-php|odigos-opentelemetry-python):ref:(refs/tags/.*|refs/heads/main|refs/heads/releases/v[0-9]+\.[0-9]+\.x$)
 
 permissions:
 

--- a/.github/workflows/update-instrumentation-agents-version.yml
+++ b/.github/workflows/update-instrumentation-agents-version.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       agents_category: 
-        description: "Category of the agents to update (supported values: nodejs, php, ruby)"
+        description: "Category of the agents to update (supported values: nodejs, php, ruby, python)"
         required: true
         type: string
       new_agent_version:
@@ -55,26 +55,19 @@ jobs:
           # Normalize agents category and determine agent type
           AGENTS_CATEGORY_LOWER=$(echo "$AGENTS_CATEGORY" | tr '[:upper:]' '[:lower:]')
           
-          if [ "$AGENTS_CATEGORY_LOWER" = "nodejs-community" ] || \
-             [ "$AGENTS_CATEGORY_LOWER" = "nodejs" ]; then
-            AGENT_TYPE="java-community"
-            echo "agent_type=nodejs-community" >> $GITHUB_OUTPUT
-            echo "agent_version=$AGENT_VERSION" >> $GITHUB_OUTPUT
-          elif [ "$AGENTS_CATEGORY_LOWER" = "php-community" ] || \
-               [ "$AGENTS_CATEGORY_LOWER" = "php" ]; then
-            AGENT_TYPE="php-community"
-            echo "agent_type=php-community" >> $GITHUB_OUTPUT
-            echo "agent_version=$AGENT_VERSION" >> $GITHUB_OUTPUT
-          elif [ "$AGENTS_CATEGORY_LOWER" = "ruby-community" ] || \
-               [ "$AGENTS_CATEGORY_LOWER" = "ruby" ]; then
-            AGENT_TYPE="ruby-community"
-            echo "agent_type=ruby-community" >> $GITHUB_OUTPUT
-            echo "agent_version=$AGENT_VERSION" >> $GITHUB_OUTPUT
-          else
-            echo "ERROR: Invalid agents_category '$AGENTS_CATEGORY'. Supported values: nodejs-community, nodejs, php-community, php"
-            exit 1
-          fi
-          
+          case "$AGENTS_CATEGORY_LOWER" in
+            nodejs|nodejs-community) AGENT_TYPE="nodejs-community" ;;
+            php|php-community)       AGENT_TYPE="php-community" ;;
+            ruby|ruby-community)     AGENT_TYPE="ruby-community" ;;
+            python|python-community) AGENT_TYPE="python-community" ;;
+            *)
+              echo "ERROR: Invalid agents_category '$AGENTS_CATEGORY'. Supported values: nodejs-community, nodejs, php-community, php, ruby-community, ruby, python-community, python"
+              exit 1
+              ;;
+          esac
+
+          echo "agent_type=$AGENT_TYPE" >> $GITHUB_OUTPUT
+          echo "agent_version=$AGENT_VERSION" >> $GITHUB_OUTPUT
           echo "agents_category=$AGENTS_CATEGORY" >> $GITHUB_OUTPUT
 
       - name: Update Agent Version
@@ -82,7 +75,12 @@ jobs:
         run: |
           export AGENT_DISTRO="${{ steps.agent.outputs.agent_type }}"
           export AGENT_VERSION="${{ steps.agent.outputs.agent_version }}"
-          make -f deps.mk upgrade-odiglet-agent-version
+          # python-community ships two image tags, so it calls a specific make target to avoid updating both
+          if [ "$AGENT_DISTRO" = "python-community" ]; then
+            make -f deps.mk upgrade-odiglet-python-community-version
+          else
+            make -f deps.mk upgrade-odiglet-agent-version
+          fi
 
       - name: Get agent version updater token
         id: agent-version-sts

--- a/odiglet/deps.mk
+++ b/odiglet/deps.mk
@@ -13,3 +13,19 @@ upgrade-odiglet-agent-version:
 		sed -i -E 's|$(AGENT_DISTRO):[0-9A-Za-z._-]+|$(AGENT_DISTRO):$(AGENT_VERSION)|g' Dockerfile; \
 		sed -i -E 's|$(AGENT_DISTRO):[0-9A-Za-z._-]+|$(AGENT_DISTRO):$(AGENT_VERSION)|g' debug.Dockerfile; \
 	fi
+
+# python-community has two image tags pinned in the dockerfiles, this upgrades the specific agent version that needs to be updated and not python3.8
+.PHONY: upgrade-odiglet-python-community-version
+upgrade-odiglet-python-community-version:
+	@if [ -z "$(AGENT_VERSION)" ]; then \
+		echo 'ERROR: AGENT_VERSION is required. Example: make upgrade-odiglet-python-community-version AGENT_VERSION=v0.1.66'; \
+		exit 1; \
+	fi
+	@echo "Updating python-community agent image tag to $(AGENT_VERSION) in Dockerfile and debug.Dockerfile (preserving -py3.8 pin)"
+	@if [ "$(shell uname)" = "Darwin" ]; then \
+		sed -i '' -E 's|python-community:[0-9A-Za-z._-]+( +/instrumentations/python )|python-community:$(AGENT_VERSION)\1|g' Dockerfile; \
+		sed -i '' -E 's|python-community:[0-9A-Za-z._-]+( +/instrumentations/python )|python-community:$(AGENT_VERSION)\1|g' debug.Dockerfile; \
+	else \
+		sed -i -E 's|python-community:[0-9A-Za-z._-]+( +/instrumentations/python )|python-community:$(AGENT_VERSION)\1|g' Dockerfile; \
+		sed -i -E 's|python-community:[0-9A-Za-z._-]+( +/instrumentations/python )|python-community:$(AGENT_VERSION)\1|g' debug.Dockerfile; \
+	fi


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Supports updating the python agent in the odiglet dockerfile after each python release, by automatically opening a PR.
Adds a make target, sts and the plumbing in the github actions.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
