### PR TITLE
CORE-1052 | fix(profiling): forward profiles for every active Source, not just those with collector-side rules

### DIFF
--- a/autoscaler/controllers/common/profiling_otlp.go
+++ b/autoscaler/controllers/common/profiling_otlp.go
@@ -67,6 +67,8 @@ func K8sAttributesProfilesProcessorConfig() config.GenericMap {
 				"k8s.deployment.name",
 				"k8s.statefulset.name",
 				"k8s.daemonset.name",
+				"k8s.job.name",
+				"k8s.cronjob.name",
 				"container.id",
 			},
 		},
@@ -122,7 +124,9 @@ func ProfilingServiceNameTransformConfig() config.GenericMap {
 			`set(resource.attributes["service.name"], resource.attributes["k8s.deployment.name"]) where resource.attributes["k8s.deployment.name"] != nil`,
 			`set(resource.attributes["service.name"], resource.attributes["k8s.statefulset.name"]) where resource.attributes["k8s.deployment.name"] == nil and resource.attributes["k8s.statefulset.name"] != nil`,
 			`set(resource.attributes["service.name"], resource.attributes["k8s.daemonset.name"]) where resource.attributes["k8s.deployment.name"] == nil and resource.attributes["k8s.statefulset.name"] == nil and resource.attributes["k8s.daemonset.name"] != nil`,
-			`set(resource.attributes["service.name"], resource.attributes["k8s.pod.name"]) where resource.attributes["k8s.deployment.name"] == nil and resource.attributes["k8s.statefulset.name"] == nil and resource.attributes["k8s.daemonset.name"] == nil and resource.attributes["k8s.pod.name"] != nil`,
+			`set(resource.attributes["service.name"], resource.attributes["k8s.cronjob.name"]) where resource.attributes["k8s.deployment.name"] == nil and resource.attributes["k8s.statefulset.name"] == nil and resource.attributes["k8s.daemonset.name"] == nil and resource.attributes["k8s.cronjob.name"] != nil`,
+			`set(resource.attributes["service.name"], resource.attributes["k8s.job.name"]) where resource.attributes["k8s.deployment.name"] == nil and resource.attributes["k8s.statefulset.name"] == nil and resource.attributes["k8s.daemonset.name"] == nil and resource.attributes["k8s.cronjob.name"] == nil and resource.attributes["k8s.job.name"] != nil`,
+			`set(resource.attributes["service.name"], resource.attributes["k8s.pod.name"]) where resource.attributes["k8s.deployment.name"] == nil and resource.attributes["k8s.statefulset.name"] == nil and resource.attributes["k8s.daemonset.name"] == nil and resource.attributes["k8s.cronjob.name"] == nil and resource.attributes["k8s.job.name"] == nil and resource.attributes["k8s.pod.name"] != nil`,
 		},
 	}
 }

--- a/collector/extension/odigosconfigk8sextension/cache.go
+++ b/collector/extension/odigosconfigk8sextension/cache.go
@@ -89,20 +89,23 @@ func (c *cache) Get(key string) (*commonapi.ContainerCollectorConfig, bool) {
 	return val, found
 }
 
-// hasContainersForWorkloadPrefix returns true when the workload key prefix (e.g. "ns/Kind/name/")
-// has at least one full container cache key. Used for profile filtering where resource attributes
-// may not include k8s.container.name.
-//
-// The len(containerKeys) > 0 check is load-bearing, not defensive. The index entry's lifetime is
-// the union of its containerKeys and dataStreams: SetDataStreams creates an entry with an empty
-// containerKeys map, and Delete only removes the entry when both sets are empty. So entry != nil
-// alone does not imply "has at least one InstrumentationConfig container entry" — a workload that
-// only has data-stream labels would falsely return true without the length check.
-func (c *cache) hasContainersForWorkloadPrefix(workloadKeyPrefix string) bool {
+// isSourceWorkloadPrefix returns true when the workload key prefix (e.g. "ns/Kind/name/")
+// has an entry in the workloadKeysIndex — i.e. an InstrumentationConfig currently exists for
+// the workload. Used by odigosprofilesprocessor (which only has ns/kind/name on the resource,
+// not k8s.container.name) to forward profiles only for active Sources.
+func (c *cache) isSourceWorkloadPrefix(workloadKeyPrefix string) bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	entry := c.workloadKeysIndex[workloadKeyPrefix]
-	return entry != nil && len(entry.containerKeys) > 0
+	_, ok := c.workloadKeysIndex[workloadKeyPrefix]
+	return ok
+}
+
+// removeWorkloadEntry removes the entry for the given workload key prefix from the
+// workloadKeysIndex. Called by the informer on InstrumentationConfig delete events
+func (c *cache) removeWorkloadEntry(workloadKeyPrefix string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.workloadKeysIndex, workloadKeyPrefix)
 }
 
 // Set stores the required config for the given workload key, updates the workload keys index, then invokes all registered callbacks.

--- a/collector/extension/odigosconfigk8sextension/informer.go
+++ b/collector/extension/odigosconfigk8sextension/informer.go
@@ -147,6 +147,8 @@ func (o *OdigosWorkloadConfig) handleInstrumentationConfigDelete(obj interface{}
 		return
 	}
 	o.syncWorkloadToDesiredState(workloadKey, nil, nil)
+	workloadIndexKey := WorkloadKeyString(workloadKey.Namespace, workloadKey.Kind, workloadKey.Name) + "/"
+	o.cache.removeWorkloadEntry(workloadIndexKey)
 }
 
 // containerEntry is a single container's cache key and config for the desired state.

--- a/collector/extension/odigosconfigk8sextension/odigosconfig.go
+++ b/collector/extension/odigosconfigk8sextension/odigosconfig.go
@@ -57,12 +57,15 @@ func (o *OdigosWorkloadConfig) GetFromResource(res pcommon.Resource) (*commonapi
 	return o.cache.Get(key)
 }
 
-func (o *OdigosWorkloadConfig) HasCachedWorkloadContainerConfig(res pcommon.Resource) bool {
+// IsActiveSource reports whether the workload identified on the resource (namespace/kind/name)
+// is an active Odigos Source — i.e. the informer currently holds an InstrumentationConfig
+// for it. See cache.isSourceWorkloadPrefix for the contract.
+func (o *OdigosWorkloadConfig) IsActiveSource(res pcommon.Resource) bool {
 	prefix, err := workloadContainerKeyFromResourceAttributes(res.Attributes())
 	if err != nil {
 		return false
 	}
-	return o.cache.hasContainersForWorkloadPrefix(prefix)
+	return o.cache.isSourceWorkloadPrefix(prefix)
 }
 
 // GetWorkloadCacheKey returns the cache key for the container identified by the given resource.

--- a/collector/processors/odigosprofilesprocessor/processor.go
+++ b/collector/processors/odigosprofilesprocessor/processor.go
@@ -64,7 +64,7 @@ func (p *odigosProfilesProcessor) Shutdown(context.Context) error {
 
 func (p *odigosProfilesProcessor) processProfiles(ctx context.Context, pd pprofile.Profiles) (pprofile.Profiles, error) {
 	pd.ResourceProfiles().RemoveIf(func(rp pprofile.ResourceProfiles) bool {
-		if p.provider.HasCachedWorkloadContainerConfig(rp.Resource()) {
+		if p.provider.IsActiveSource(rp.Resource()) {
 			return false
 		}
 		if p.telemetryBuilder != nil {

--- a/collector/processors/odigosprofilesprocessor/processor_test.go
+++ b/collector/processors/odigosprofilesprocessor/processor_test.go
@@ -23,7 +23,7 @@ func (s *stubOdigosConfigExtension) GetFromResource(pcommon.Resource) (*commonap
 	return nil, false
 }
 
-func (s *stubOdigosConfigExtension) HasCachedWorkloadContainerConfig(res pcommon.Resource) bool {
+func (s *stubOdigosConfigExtension) IsActiveSource(res pcommon.Resource) bool {
 	attrs := res.Attributes()
 	ns, _ := attrs.Get(string(semconv.K8SNamespaceNameKey))
 	dep, ok := attrs.Get(string(semconv.K8SDeploymentNameKey))

--- a/common/collector/odigosconfigext.go
+++ b/common/collector/odigosconfigext.go
@@ -25,10 +25,9 @@ type OdigosConfigExtension interface {
 	// GetFromResource returns the container collector config for the given resource if it exists.
 	GetFromResource(res pcommon.Resource) (*commonapi.ContainerCollectorConfig, bool)
 
-	// HasCachedWorkloadContainerConfig reports whether the extension cache has at least one
-	// container config row for the workload identified on the resource (namespace/kind/name).
-	// Unlike GetFromResource, this does not require k8s.container.name.
-	HasCachedWorkloadContainerConfig(res pcommon.Resource) bool
+	// IsActiveSource reports whether the workload identified on the resource (namespace/kind/name)
+	// is an active Odigos Source i.e. the extension currently holds an InstrumentationConfig for it
+	IsActiveSource(res pcommon.Resource) bool
 
 	// GetWorkloadCacheKey returns the cache key for the container identified by the given resource.
 	// Key format is platform-specific (e.g. "namespace/kind/name/containerName" for K8s). Processors use this


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->

Previously we only checked containerKeys for the workload, and those keys were populated only when the IC carried any collector-side rule (URL templatization / tail sampling). This breaks the cases where IC doesn't contain any collector rules.

Now we check whether the workload's entry itself exists in the cache, which directly reflects whether an InstrumentationConfig exists for the workload, which is a direct reflection of the Source.



#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
None
```

cherry-pick: 1.27