### PR TITLE
PLAT-1107: surface static-pod sources as Unsupported on non-onprem tiers

### DIFF
--- a/frontend/graph/status/rollout.go
+++ b/frontend/graph/status/rollout.go
@@ -27,6 +27,8 @@ func workloadRolloutStatusCondition(reason *string) model.DesiredStateProgress {
 		return model.DesiredStateProgressIrrelevant // rollout state is irrelevant in this case (no rollout for cronjob for example)
 	case v1alpha1.WorkloadRolloutReasonWaitingInQueue:
 		return model.DesiredStateProgressWaiting // waiting for other workloads to complete their rollouts
+	case v1alpha1.WorkloadRolloutReasonWorkloadNotSupporting:
+		return model.DesiredStateProgressUnsupported // workload kind (e.g. static pod) permanently cannot be rolled out
 	}
 
 	return model.DesiredStateProgressUnknown

--- a/frontend/graph/status/workloadodigoshealth.go
+++ b/frontend/graph/status/workloadodigoshealth.go
@@ -1,8 +1,31 @@
 package status
 
+import (
+	"github.com/odigos-io/odigos/frontend/graph/model"
+)
+
 const (
 	WorkloadOdigosHealthStatus = "WorkloadOdigosHealth"
 )
+
+// StaticPodEnterpriseFeatureHealthStatus returns an "Unsupported" health-status condition
+// when the given workload kind is a StaticPod and the cluster is not on the on-prem tier.
+// StaticPod instrumentation is an enterprise feature, so on community tier we surface this
+// as a permanent, informational condition (mapped to a disabled-looking visual in the UI)
+// instead of letting the workload look perpetually unhealthy due to missing telemetry.
+// Returns nil if the workload is not a static pod or the tier is on-prem.
+func StaticPodEnterpriseFeatureHealthStatus(kind model.K8sResourceKind, tier model.Tier) *model.DesiredConditionStatus {
+	if kind != model.K8sResourceKindStaticPod || tier == model.TierOnprem {
+		return nil
+	}
+	reasonStr := string(WorkloadOdigosHealthStatusReasonEnterpriseFeature)
+	return &model.DesiredConditionStatus{
+		Name:       WorkloadOdigosHealthStatus,
+		Status:     model.DesiredStateProgressUnsupported,
+		ReasonEnum: &reasonStr,
+		Message:    "Static pod instrumentation is an enterprise (on-prem) feature",
+	}
+}
 
 type WorkloadOdigosHealthStatusReason string
 
@@ -10,4 +33,8 @@ const (
 	WorkloadOdigosHealthStatusReasonSuccess                     WorkloadOdigosHealthStatusReason = "Success"
 	WorkloadOdigosHealthStatusReasonSuccessAndEmittingTelemetry WorkloadOdigosHealthStatusReason = "SuccessAndEmittingTelemetry"
 	WorkloadOdigosHealthStatusReasonDisabled                    WorkloadOdigosHealthStatusReason = "DisabledForInstrumentation"
+	// WorkloadOdigosHealthStatusReasonEnterpriseFeature indicates that the workload requires an
+	// enterprise tier feature (e.g. static pod instrumentation) that is not available on the
+	// current Odigos tier. The condition is permanent for this cluster until the tier is upgraded.
+	WorkloadOdigosHealthStatusReasonEnterpriseFeature WorkloadOdigosHealthStatusReason = "EnterpriseFeature"
 )

--- a/frontend/graph/workload.resolvers.go
+++ b/frontend/graph/workload.resolvers.go
@@ -100,6 +100,11 @@ func (r *k8sWorkloadResolver) WorkloadOdigosHealthStatus(ctx context.Context, ob
 	if obj.WorkloadOdigosHealthStatus != nil {
 		return obj.WorkloadOdigosHealthStatus, nil
 	}
+	if obj != nil && obj.ID != nil {
+		if override := status.StaticPodEnterpriseFeatureHealthStatus(obj.ID.Kind, services.GetTier(ctx)); override != nil {
+			return override, nil
+		}
+	}
 	l := loaders.For(ctx)
 	ic, err := l.GetInstrumentationConfig(ctx, *obj.ID)
 	if err != nil {
@@ -784,9 +789,14 @@ func (r *queryResolver) Workloads(ctx context.Context, filter *model.WorkloadFil
 	workloadIds := l.GetWorkloadIds()
 	results := make([]*model.K8sWorkload, 0, len(workloadIds))
 
+	// Resolved once per request and threaded through populateWorkloadFields so
+	// tier-gated checks (e.g. static-pod enterprise gating) don't re-fetch
+	// the deployment ConfigMap per workload in large clusters.
+	tier := services.GetTier(ctx)
+
 	for _, id := range workloadIds {
 		w := &model.K8sWorkload{ID: &id}
-		r.populateWorkloadFields(ctx, l, w)
+		r.populateWorkloadFields(ctx, l, w, tier)
 		results = append(results, w)
 	}
 

--- a/frontend/graph/workload_populate.go
+++ b/frontend/graph/workload_populate.go
@@ -69,7 +69,10 @@ func populateNamespaceWorkloadLightFields(ctx context.Context, l *loaders.Loader
 // gqlgen spawning a goroutine per field per workload.
 // Errors are logged but don't fail the entire batch — individual workloads
 // get nil/zero values for fields that fail to resolve.
-func (r *queryResolver) populateWorkloadFields(ctx context.Context, l *loaders.Loaders, w *model.K8sWorkload) {
+//
+// tier is the Odigos tier resolved once by the caller; passed in to avoid
+// re-fetching it per workload in the hot list path.
+func (r *queryResolver) populateWorkloadFields(ctx context.Context, l *loaders.Loaders, w *model.K8sWorkload, tier model.Tier) {
 	id := *w.ID
 
 	ic, _ := l.GetInstrumentationConfig(ctx, id)
@@ -238,6 +241,11 @@ func (r *queryResolver) populateWorkloadFields(ctx context.Context, l *loaders.L
 		})
 	}
 	healthConditions = append(healthConditions, agentInjected, processesHealth, expectingTelemetry)
+
+	if override := status.StaticPodEnterpriseFeatureHealthStatus(id.Kind, tier); override != nil {
+		w.WorkloadOdigosHealthStatus = override
+		return
+	}
 
 	mostSevere := aggregateConditionsBySeverity(healthConditions)
 	if mostSevere == nil {

--- a/frontend/services/deployment_config.go
+++ b/frontend/services/deployment_config.go
@@ -43,6 +43,17 @@ func GetConfig(ctx context.Context) model.Config {
 	return buildConfigResponse(ctx, odigosDeployment.Data)
 }
 
+// GetTier returns just the Odigos tier from the deployment ConfigMap. This is a
+// cheaper alternative to GetConfig when only the tier is needed (e.g. for tier-gated
+// feature checks during workload resolution). Falls back to community on read errors.
+func GetTier(ctx context.Context) model.Tier {
+	cm, err := kube.DefaultClient.CoreV1().ConfigMaps(env.GetCurrentNamespace()).Get(ctx, k8sconsts.OdigosDeploymentConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return model.Tier(common.CommunityOdigosTier)
+	}
+	return model.Tier(cm.Data[k8sconsts.OdigosDeploymentConfigMapTierKey])
+}
+
 func buildConfigResponse(ctx context.Context, deploymentData map[string]string) model.Config {
 	var response model.Config
 	config, err := GetOdigosConfiguration(ctx)


### PR DESCRIPTION
Static pod instrumentation is an enterprise (on-prem) feature, but when a namespace was instrumented on community tier the static pods inside it appeared in the Sources list with an unhealthy / Unknown aggregate status (no telemetry, ghost InstrumentationConfig). This made it look like something was broken when in reality the workload is just gated by tier.
<img width="1600" height="844" alt="image" src="https://github.com/user-attachments/assets/b96e80fe-af82-42ad-8230-eb12d1aae726" />
<img width="1015" height="844" alt="image" src="https://github.com/user-attachments/assets/6a12fba1-1952-4997-a127-75f57afa3e85" />


```release-note
On community tier, static pod sources (e.g. kube-apiserver, etcd) selected
via a Namespace source are now displayed as "Unsupported" with a clear
message explaining the feature requires the on-prem tier, instead of
appearing perpetually unhealthy.
```

