### PR TITLE
CORE-1063: change extract attribute processor arg names

### DIFF
--- a/api/config/crd/bases/odigos.io_actions.yaml
+++ b/api/config/crd/bases/odigos.io_actions.yaml
@@ -116,15 +116,15 @@ spec:
                             Required when using DataFormat.
                             You can input either LookupKey+DataFormat, or supply your own Regex.
                           type: string
-                        targetAttributeName:
-                          description: TargetAttributeName is the name of the new span
-                            attribute the extracted value will be written to.
-                          type: string
                         regex:
                           description: |-
                             Regex is a custom regular expression with a single capture group whose value is
                             written to the new span attribute named TargetAttributeName.
                             You can input either Regex, or LookupKey+DataFormat.
+                          type: string
+                        targetAttributeName:
+                          description: TargetAttributeName is the name of the new
+                            span attribute the extracted value will be written to.
                           type: string
                       required:
                       - targetAttributeName

--- a/api/config/crd/bases/odigos.io_actions.yaml
+++ b/api/config/crd/bases/odigos.io_actions.yaml
@@ -93,37 +93,41 @@ spec:
                     items:
                       description: |-
                         Extraction describes a single extraction rule applied by the
-                        odigosextractattribute processor. Either (Source + DataFormat) or
-                        Regex must be provided; the captured value is written to Target.
+                        odigosextractattribute processor. Either (LookupKey + DataFormat) or
+                        Regex must be provided; the captured value is written to a new span
+                        attribute named TargetAttributeName.
                       properties:
                         dataFormat:
                           description: |-
                             A pre-set definition which resolves into a regex (e.g. JSON DataFormat would give a regex that searches
-                            inside a JSON string), which also applies Source for searching inside it.
-                            Required when using Source.
-                            You can input either Source+DataFormat, or supply your own Regex.
+                            inside a JSON string), which also applies LookupKey for searching inside it.
+                            Required when using LookupKey.
+                            You can input either LookupKey+DataFormat, or supply your own Regex.
                           enum:
-                          - url
+                          - resource_path
                           - json
+                          - sql
+                          type: string
+                        lookupKey:
+                          description: |-
+                            LookupKey is the literal key to search for inside the scanned span attributes.
+                            It is plugged into the pre-set regex pattern selected by DataFormat (e.g. for JSON,
+                            the processor will look for `"<lookupKey>": "<value>"` and capture the value).
+                            Required when using DataFormat.
+                            You can input either LookupKey+DataFormat, or supply your own Regex.
+                          type: string
+                        targetAttributeName:
+                          description: TargetAttributeName is the name of the new span
+                            attribute the extracted value will be written to.
                           type: string
                         regex:
                           description: |-
                             Regex is a custom regular expression with a single capture group whose value is
-                            written to Target.
-                            You can input either Regex, or Source+DataFormat.
-                          type: string
-                        source:
-                          description: |-
-                            The string key that is searched within the pre-set regex patterns resolved by DataFormat.
-                            Required when using DataFormat.
-                            You can input either Source+DataFormat, or supply your own Regex.
-                          type: string
-                        target:
-                          description: Target is the attribute key the extracted value
-                            will be written to on the span.
+                            written to the new span attribute named TargetAttributeName.
+                            You can input either Regex, or LookupKey+DataFormat.
                           type: string
                       required:
-                      - target
+                      - targetAttributeName
                       type: object
                     minItems: 1
                     type: array

--- a/api/odigos/v1alpha1/actions/extractattribute.go
+++ b/api/odigos/v1alpha1/actions/extractattribute.go
@@ -6,41 +6,45 @@ import (
 
 const ActionNameExtractAttribute = "ExtractAttribute"
 
-// +kubebuilder:validation:Enum=url;json
+// +kubebuilder:validation:Enum=resource_path;json;sql
 type DataFormat string
 
 const (
-	FormatURL  DataFormat = "url"
+	FormatResourcePath  DataFormat = "resource_path"
 	FormatJSON DataFormat = "json"
+	FormatSQL  DataFormat = "sql"
 )
 
 // Extraction describes a single extraction rule applied by the
-// odigosextractattribute processor. Either (Source + DataFormat) or
-// Regex must be provided; the captured value is written to Target.
+// odigosextractattribute processor. Either (LookupKey + DataFormat) or
+// Regex must be provided; the captured value is written to a new span
+// attribute named TargetAttributeName.
 //
 // +kubebuilder:object:generate=true
 // +kubebuilder:deepcopy-gen=true
 type Extraction struct {
-	// Target is the attribute key the extracted value will be written to on the span.
+	// TargetAttributeName is the name of the new span attribute the extracted value will be written to.
 	// +kubebuilder:validation:Required
-	Target string `json:"target"`
+	TargetAttributeName string `json:"targetAttributeName"`
 
-	// The string key that is searched within the pre-set regex patterns resolved by DataFormat.
+	// LookupKey is the literal key to search for inside the scanned span attributes.
+	// It is plugged into the pre-set regex pattern selected by DataFormat (e.g. for JSON,
+	// the processor will look for `"<lookupKey>": "<value>"` and capture the value).
 	// Required when using DataFormat.
-	// You can input either Source+DataFormat, or supply your own Regex.
+	// You can input either LookupKey+DataFormat, or supply your own Regex.
 	// +kubebuilder:validation:Optional
-	Source string `json:"source,omitempty"`
+	LookupKey string `json:"lookupKey,omitempty"`
 
 	// A pre-set definition which resolves into a regex (e.g. JSON DataFormat would give a regex that searches
-	// inside a JSON string), which also applies Source for searching inside it.
-	// Required when using Source.
-	// You can input either Source+DataFormat, or supply your own Regex.
+	// inside a JSON string), which also applies LookupKey for searching inside it.
+	// Required when using LookupKey.
+	// You can input either LookupKey+DataFormat, or supply your own Regex.
 	// +kubebuilder:validation:Optional
 	DataFormat DataFormat `json:"dataFormat,omitempty"`
 
 	// Regex is a custom regular expression with a single capture group whose value is
-	// written to Target.
-	// You can input either Regex, or Source+DataFormat.
+	// written to the new span attribute named TargetAttributeName.
+	// You can input either Regex, or LookupKey+DataFormat.
 	// +kubebuilder:validation:Optional
 	Regex string `json:"regex,omitempty"`
 }

--- a/autoscaler/controllers/actions/extractattribute_controller.go
+++ b/autoscaler/controllers/actions/extractattribute_controller.go
@@ -27,14 +27,14 @@ type extractAttributeProcessorConfig struct {
 }
 
 type extractAttributeRule struct {
-	Target     string `json:"target"`
-	Source     string `json:"source,omitempty"`
-	DataFormat string `json:"data_format,omitempty"`
-	Regex      string `json:"regex,omitempty"`
+	TargetAttributeName string `json:"target_attribute_name"`
+	LookupKey        string `json:"lookup_key,omitempty"`
+	DataFormat       string `json:"data_format,omitempty"`
+	Regex            string `json:"regex,omitempty"`
 }
 
 // extractAttributeConfig translates the API-level ExtractAttributeConfig into the processor-level config and validates cross-field invariants
-// that the CRD schema cannot express on its own (Source+DataForm vs. Regex).
+// that the CRD schema cannot express on its own (LookupKey+DataFormat vs. Regex).
 func extractAttributeConfig(cfg *actions.ExtractAttributeConfig) (extractAttributeProcessorConfig, error) {
 	if cfg == nil {
 		return extractAttributeProcessorConfig{}, fmt.Errorf("extractAttribute config is nil")
@@ -46,38 +46,38 @@ func extractAttributeConfig(cfg *actions.ExtractAttributeConfig) (extractAttribu
 	config := extractAttributeProcessorConfig{
 		Extractions: make([]extractAttributeRule, 0, len(cfg.Extractions)),
 	}
-	seenTargets := make(map[string]int, len(cfg.Extractions))
+	seenNames := make(map[string]int, len(cfg.Extractions))
 	for i, extraction := range cfg.Extractions {
-		if extraction.Target == "" {
-			return config, fmt.Errorf("extractions[%d]: target is required", i)
+		if extraction.TargetAttributeName == "" {
+			return config, fmt.Errorf("extractions[%d]: targetAttributeName is required", i)
 		}
-		if prev, dup := seenTargets[extraction.Target]; dup {
-			return config, fmt.Errorf("extractions[%d]: duplicate target %q (also used by extractions[%d])", i, extraction.Target, prev)
+		if prev, dup := seenNames[extraction.TargetAttributeName]; dup {
+			return config, fmt.Errorf("extractions[%d]: duplicate targetAttributeName %q (also used by extractions[%d])", i, extraction.TargetAttributeName, prev)
 		}
-		seenTargets[extraction.Target] = i
+		seenNames[extraction.TargetAttributeName] = i
 
-		// Check the Source+DataForm vs. Regex logic - exactly one of them need to be used
-		hasSource := extraction.Source != ""
+		// Check the LookupKey+DataFormat vs. Regex logic - exactly one of them need to be used
+		hasLookupKey := extraction.LookupKey != ""
 		hasRegex := extraction.Regex != ""
 
-		if hasSource == hasRegex {
-			return config, fmt.Errorf("extractions[%d]: exactly one of source or regex must be set", i)
+		if hasLookupKey == hasRegex {
+			return config, fmt.Errorf("extractions[%d]: exactly one of lookupKey or regex must be set", i)
 		}
-		if hasSource && extraction.DataFormat == "" {
-			return config, fmt.Errorf("extractions[%d]: dataFormat is required when source is set", i)
+		if hasLookupKey && extraction.DataFormat == "" {
+			return config, fmt.Errorf("extractions[%d]: dataFormat is required when lookupKey is set", i)
 		}
 		if hasRegex && extraction.DataFormat != "" {
 			return config, fmt.Errorf("extractions[%d]: dataFormat must be empty when regex is set", i)
 		}
-		if hasRegex && extraction.Source != "" {
-			return config, fmt.Errorf("extractions[%d]: source must be empty when regex is set", i)
+		if hasRegex && extraction.LookupKey != "" {
+			return config, fmt.Errorf("extractions[%d]: lookupKey must be empty when regex is set", i)
 		}
 
 		config.Extractions = append(config.Extractions, extractAttributeRule{
-			Target:     extraction.Target,
-			Source:     extraction.Source,
-			DataFormat: string(extraction.DataFormat),
-			Regex:      extraction.Regex,
+			TargetAttributeName: extraction.TargetAttributeName,
+			LookupKey:        extraction.LookupKey,
+			DataFormat:       string(extraction.DataFormat),
+			Regex:            extraction.Regex,
 		})
 	}
 	return config, nil

--- a/autoscaler/controllers/actions/extractattribute_controller_test.go
+++ b/autoscaler/controllers/actions/extractattribute_controller_test.go
@@ -39,10 +39,10 @@ type extractAttributeRawConfig struct {
 }
 
 type extractAttributeRawRule struct {
-	Target     string `json:"target"`
-	Source     string `json:"source,omitempty"`
-	DataFormat string `json:"data_format,omitempty"`
-	Regex      string `json:"regex,omitempty"`
+	TargetAttributeName string `json:"target_attribute_name"`
+	LookupKey        string `json:"lookup_key,omitempty"`
+	DataFormat       string `json:"data_format,omitempty"`
+	Regex            string `json:"regex,omitempty"`
 }
 
 var _ = Describe("ExtractAttribute Controller", func() {
@@ -56,8 +56,8 @@ var _ = Describe("ExtractAttribute Controller", func() {
 	})
 
 	Context("When creating an Action with ExtractAttribute", func() {
-		It("Should create a Processor with the correct type and snake_case config (source+dataFormat)", func() {
-			By("Creating an Action with ExtractAttribute using source+dataFormat")
+		It("Should create a Processor with the correct type and snake_case config (lookupKey+dataFormat)", func() {
+			By("Creating an Action with ExtractAttribute using lookupKey+dataFormat")
 			action := &odigosv1.Action{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      ActionName,
@@ -71,9 +71,9 @@ var _ = Describe("ExtractAttribute Controller", func() {
 					ExtractAttribute: &odigosactions.ExtractAttributeConfig{
 						Extractions: []odigosactions.Extraction{
 							{
-								Target:     "study.id",
-								Source:     "study_id",
-								DataFormat: odigosactions.FormatJSON,
+								TargetAttributeName: "study.id",
+								LookupKey:        "study_id",
+								DataFormat:       odigosactions.FormatJSON,
 							},
 						},
 					},
@@ -105,8 +105,8 @@ var _ = Describe("ExtractAttribute Controller", func() {
 			var rendered extractAttributeRawConfig
 			Expect(json.Unmarshal(processor.Spec.ProcessorConfig.Raw, &rendered)).Should(Succeed())
 			Expect(rendered.Extractions).Should(HaveLen(1))
-			Expect(rendered.Extractions[0].Target).Should(Equal("study.id"))
-			Expect(rendered.Extractions[0].Source).Should(Equal("study_id"))
+			Expect(rendered.Extractions[0].TargetAttributeName).Should(Equal("study.id"))
+			Expect(rendered.Extractions[0].LookupKey).Should(Equal("study_id"))
 			Expect(rendered.Extractions[0].DataFormat).Should(Equal("json"))
 			Expect(rendered.Extractions[0].Regex).Should(BeEmpty())
 
@@ -130,8 +130,8 @@ var _ = Describe("ExtractAttribute Controller", func() {
 					ExtractAttribute: &odigosactions.ExtractAttributeConfig{
 						Extractions: []odigosactions.Extraction{
 							{
-								Target: "request.id",
-								Regex:  `request_id=([A-Za-z0-9-]+)`,
+								TargetAttributeName: "request.id",
+								Regex:            `request_id=([A-Za-z0-9-]+)`,
 							},
 						},
 					},
@@ -150,13 +150,13 @@ var _ = Describe("ExtractAttribute Controller", func() {
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
-			By("Checking that regex-only extractions omit source and data_format")
+			By("Checking that regex-only extractions omit lookup_key and data_format")
 			var rendered extractAttributeRawConfig
 			Expect(json.Unmarshal(processor.Spec.ProcessorConfig.Raw, &rendered)).Should(Succeed())
 			Expect(rendered.Extractions).Should(HaveLen(1))
-			Expect(rendered.Extractions[0].Target).Should(Equal("request.id"))
+			Expect(rendered.Extractions[0].TargetAttributeName).Should(Equal("request.id"))
 			Expect(rendered.Extractions[0].Regex).Should(Equal(`request_id=([A-Za-z0-9-]+)`))
-			Expect(rendered.Extractions[0].Source).Should(BeEmpty())
+			Expect(rendered.Extractions[0].LookupKey).Should(BeEmpty())
 			Expect(rendered.Extractions[0].DataFormat).Should(BeEmpty())
 		})
 
@@ -173,18 +173,18 @@ var _ = Describe("ExtractAttribute Controller", func() {
 					ExtractAttribute: &odigosactions.ExtractAttributeConfig{
 						Extractions: []odigosactions.Extraction{
 							{
-								Target:     "extracted_study.id",
-								Source:     "studies",
-								DataFormat: odigosactions.FormatURL,
+								TargetAttributeName: "extracted_study.id",
+								LookupKey:        "studies",
+								DataFormat:       odigosactions.FormatResourcePath,
 							},
 							{
-								Target:     "extracted_project.id",
-								Source:     "projects",
-								DataFormat: odigosactions.FormatURL,
+								TargetAttributeName: "extracted_project.id",
+								LookupKey:        "projects",
+								DataFormat:       odigosactions.FormatResourcePath,
 							},
 							{
-								Target: "trace.id",
-								Regex:  `traceId=([0-9a-f]+)`,
+								TargetAttributeName: "trace.id",
+								Regex:            `traceId=([0-9a-f]+)`,
 							},
 						},
 					},
@@ -206,17 +206,17 @@ var _ = Describe("ExtractAttribute Controller", func() {
 			Expect(json.Unmarshal(processor.Spec.ProcessorConfig.Raw, &rendered)).Should(Succeed())
 			Expect(rendered.Extractions).Should(HaveLen(3))
 
-			Expect(rendered.Extractions[0].Target).Should(Equal("extracted_study.id"))
-			Expect(rendered.Extractions[0].Source).Should(Equal("studies"))
-			Expect(rendered.Extractions[0].DataFormat).Should(Equal("url"))
+			Expect(rendered.Extractions[0].TargetAttributeName).Should(Equal("extracted_study.id"))
+			Expect(rendered.Extractions[0].LookupKey).Should(Equal("studies"))
+			Expect(rendered.Extractions[0].DataFormat).Should(Equal("resource_path"))
 
-			Expect(rendered.Extractions[1].Target).Should(Equal("extracted_project.id"))
-			Expect(rendered.Extractions[1].Source).Should(Equal("projects"))
-			Expect(rendered.Extractions[1].DataFormat).Should(Equal("url"))
+			Expect(rendered.Extractions[1].TargetAttributeName).Should(Equal("extracted_project.id"))
+			Expect(rendered.Extractions[1].LookupKey).Should(Equal("projects"))
+			Expect(rendered.Extractions[1].DataFormat).Should(Equal("resource_path"))
 
-			Expect(rendered.Extractions[2].Target).Should(Equal("trace.id"))
+			Expect(rendered.Extractions[2].TargetAttributeName).Should(Equal("trace.id"))
 			Expect(rendered.Extractions[2].Regex).Should(Equal(`traceId=([0-9a-f]+)`))
-			Expect(rendered.Extractions[2].Source).Should(BeEmpty())
+			Expect(rendered.Extractions[2].LookupKey).Should(BeEmpty())
 			Expect(rendered.Extractions[2].DataFormat).Should(BeEmpty())
 		})
 
@@ -237,9 +237,9 @@ var _ = Describe("ExtractAttribute Controller", func() {
 					ExtractAttribute: &odigosactions.ExtractAttributeConfig{
 						Extractions: []odigosactions.Extraction{
 							{
-								Target:     "user.id",
-								Source:     "user_id",
-								DataFormat: odigosactions.FormatJSON,
+								TargetAttributeName: "user.id",
+								LookupKey:        "user_id",
+								DataFormat:       odigosactions.FormatJSON,
 							},
 						},
 					},
@@ -266,23 +266,23 @@ var _ = Describe("ExtractAttribute Controller", func() {
 	})
 
 	Context("When the ExtractAttribute config is invalid", func() {
-		It("Should not create a Processor when source and regex are both set", func() {
-			By("Creating an Action with both source and regex set on an extraction")
+		It("Should not create a Processor when lookupKey and regex are both set", func() {
+			By("Creating an Action with both lookupKey and regex set on an extraction")
 			action := &odigosv1.Action{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      ActionName + "-invalid-both",
 					Namespace: ActionNamespace,
 				},
 				Spec: odigosv1.ActionSpec{
-					ActionName: "invalid - both source and regex",
+					ActionName: "invalid - both lookupKey and regex",
 					Signals:    []common.ObservabilitySignal{common.TracesObservabilitySignal},
 					ExtractAttribute: &odigosactions.ExtractAttributeConfig{
 						Extractions: []odigosactions.Extraction{
 							{
-								Target:     "x",
-								Source:     "user_id",
-								DataFormat: odigosactions.FormatJSON,
-								Regex:      `user_id=(\d+)`,
+								TargetAttributeName: "x",
+								LookupKey:        "user_id",
+								DataFormat:       odigosactions.FormatJSON,
+								Regex:            `user_id=(\d+)`,
 							},
 						},
 					},
@@ -302,8 +302,8 @@ var _ = Describe("ExtractAttribute Controller", func() {
 			}, timeout, interval).Should(BeTrue())
 		})
 
-		It("Should not create a Processor when source is set without dataFormat", func() {
-			By("Creating an Action with source but no dataFormat")
+		It("Should not create a Processor when lookupKey is set without dataFormat", func() {
+			By("Creating an Action with lookupKey but no dataFormat")
 			action := &odigosv1.Action{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      ActionName + "-invalid-format",
@@ -315,8 +315,8 @@ var _ = Describe("ExtractAttribute Controller", func() {
 					ExtractAttribute: &odigosactions.ExtractAttributeConfig{
 						Extractions: []odigosactions.Extraction{
 							{
-								Target: "x",
-								Source: "user_id",
+								TargetAttributeName: "x",
+								LookupKey:        "user_id",
 							},
 						},
 					},

--- a/collector/processors/odigosextractattributeprocessor/README.md
+++ b/collector/processors/odigosextractattributeprocessor/README.md
@@ -8,6 +8,8 @@ attributes and surfaces them as new, normalized attributes.
 Useful when identifiers (study IDs, tenant IDs, request IDs, etc.) are buried inside SQL statements,
 JSON blobs, or URL paths, and you want them as first-class span attributes.
 
+Searches the various payload span attributes generated in Odigos.
+
 Supports **traces** only.
 
 ## Status
@@ -21,28 +23,29 @@ Supports **traces** only.
 
 The processor holds a list of **extractions**. For every span it walks each extraction independently,
 scans the span's string-valued attributes, and on the first regex match writes the captured value to
-that extraction's `target`. Misses leave the target untouched. Multiple targets can be populated from
-one span.
+a new span attribute named by that extraction's `target_attribute_name`. Misses leave the span untouched.
+Multiple new attributes can be populated from one span.
 
 ## Configuration
 
-Each entry in `extractions` is self-contained. It uses **either** a preset pattern (`source` +
-`data_format`) **or** a custom `regex`, and always writes to its own `target`. Preset and regex
-entries can be mixed freely in the same list.
+Each entry in `extractions` is self-contained. It uses **either** a preset pattern (`lookup_key` +
+`data_format`) **or** a custom `regex`, and always writes to its own `target_attribute_name`. Preset
+and regex entries can be mixed freely in the same list.
 
 ### Extraction fields
 
-| field         | required | description |
-|---------------|----------|-------------|
-| `target`      | yes      | Destination span attribute name. Must be unique across entries. |
-| `source`      | XOR with `regex` | Literal key to search for, using the pattern selected by `data_format`. |
-| `data_format` | with `source` | One of `json` or `url`. |
-| `regex`       | XOR with `source` | A Go (RE2) regex with one capture group. |
+| field                | required | description |
+|----------------------|----------|-------------|
+| `target_attribute_name` | yes      | Name of the new span attribute the extracted value will be written to. Must be unique across entries. |
+| `lookup_key`         | use this or `regex` | Literal key to search for, using the pattern selected by `data_format`. |
+| `data_format`        | use with `lookup_key` | One of `json`, `sql`, or `resource_path`. Points to a pre-set regex which is combined with `lookup_key`. |
+| `regex`              | use this or `lookup_key` | A Go (RE2) regex with one capture group, which is the key searched for. |
 
 ### Preset formats
 
-- **`json`** -- JSON / SQL key-value pairs: `"key": "value"`, `key = 'value'`, `key:value`, etc.
-- **`url`** -- URL path segments: `/key/<value>`.
+- **`json`** -- JSON key-value pairs (colon separator): `"key": "value"`, `key:value`, `{"key": 42}`.
+- **`sql`** -- SQL key-value pairs (equals separator): `key = 'value'`, `key=value`, `WHERE key=42`.
+- **`resource_path`** -- URL path segments: `/key/<value>`.
 
 ### Examples
 
@@ -52,14 +55,14 @@ Mixed preset and regex entries:
 processors:
   odigosextractattribute:
     extractions:
-      - source: study_id
+      - lookup_key: study_id
         data_format: json
-        target: study.id
-      - source: studies
-        data_format: url
-        target: study.id.url
+        target_attribute_name: study.id
+      - lookup_key: studies
+        data_format: resource_path
+        target_attribute_name: study.id.url
       - regex: 'request_id=([0-9a-f-]+)'
-        target: request.id
+        target_attribute_name: request.id
 ```
 
 Multiple URL segments from a DICOM path:
@@ -68,24 +71,24 @@ Multiple URL segments from a DICOM path:
 processors:
   odigosextractattribute:
     extractions:
-      - source: studies
-        data_format: url
-        target: study.id
-      - source: series
-        data_format: url
-        target: series.id
-      - source: instances
-        data_format: url
-        target: instance.id
+      - lookup_key: studies
+        data_format: resource_path
+        target_attribute_name: study.id
+      - lookup_key: series
+        data_format: resource_path
+        target_attribute_name: series.id
+      - lookup_key: instances
+        data_format: resource_path
+        target_attribute_name: instance.id
 ```
 
 ### Validation rules
 
 - `extractions` must not be empty.
-- Each entry must have a non-empty `target`, unique across all entries.
-- Each entry must set exactly one of `source` or `regex`.
-- When `source` is set, `data_format` must be `json` or `url`.
-- When `regex` is set, `data_format` and `source` must be empty.
+- Each entry must have a non-empty `target_attribute_name`, unique across all entries.
+- Each entry must set exactly one of `lookup_key` or `regex`.
+- When `lookup_key` is set, `data_format` must be `json`, `sql`, or `resource_path`.
+- When `regex` is set, `data_format` and `lookup_key` must be empty.
 
 ## Development
 

--- a/collector/processors/odigosextractattributeprocessor/config.go
+++ b/collector/processors/odigosextractattributeprocessor/config.go
@@ -9,10 +9,10 @@ import (
 type DataFormat string
 
 const (
-	FormatUnset DataFormat = ""
-	FormatResourcePath   DataFormat = "resource_path"
-	FormatJSON  DataFormat = "json"
-	FormatSQL   DataFormat = "sql"
+	FormatUnset        DataFormat = ""
+	FormatResourcePath DataFormat = "resource_path"
+	FormatJSON         DataFormat = "json"
+	FormatSQL          DataFormat = "sql"
 )
 
 // Extraction is one self-contained extraction rule.
@@ -20,9 +20,9 @@ const (
 // to a new span attribute named TargetAttributeName.
 type Extraction struct {
 	TargetAttributeName string     `mapstructure:"target_attribute_name"`
-	LookupKey        string     `mapstructure:"lookup_key"`
-	DataFormat       DataFormat `mapstructure:"data_format"`
-	Regex            string     `mapstructure:"regex"`
+	LookupKey           string     `mapstructure:"lookup_key"`
+	DataFormat          DataFormat `mapstructure:"data_format"`
+	Regex               string     `mapstructure:"regex"`
 }
 
 type Config struct {

--- a/collector/processors/odigosextractattributeprocessor/config.go
+++ b/collector/processors/odigosextractattributeprocessor/config.go
@@ -10,17 +10,19 @@ type DataFormat string
 
 const (
 	FormatUnset DataFormat = ""
-	FormatURL   DataFormat = "url"
+	FormatResourcePath   DataFormat = "resource_path"
 	FormatJSON  DataFormat = "json"
+	FormatSQL   DataFormat = "sql"
 )
 
 // Extraction is one self-contained extraction rule.
-// It uses either a preset pattern (Source+DataFormat) or a custom Regex, and writes the captured value to Target.
+// It uses either a preset pattern (LookupKey+DataFormat) or a custom Regex, and writes the captured value
+// to a new span attribute named TargetAttributeName.
 type Extraction struct {
-	Target     string     `mapstructure:"target"`
-	Source     string     `mapstructure:"source"`
-	DataFormat DataFormat `mapstructure:"data_format"`
-	Regex      string     `mapstructure:"regex"`
+	TargetAttributeName string     `mapstructure:"target_attribute_name"`
+	LookupKey        string     `mapstructure:"lookup_key"`
+	DataFormat       DataFormat `mapstructure:"data_format"`
+	Regex            string     `mapstructure:"regex"`
 }
 
 type Config struct {
@@ -34,35 +36,35 @@ func (cfg *Config) Validate() error {
 		return fmt.Errorf("extractions must not be empty")
 	}
 
-	seenTargets := make(map[string]int, len(cfg.Extractions))
+	seenNames := make(map[string]int, len(cfg.Extractions))
 	for i, extraction := range cfg.Extractions {
-		if extraction.Target == "" {
-			return fmt.Errorf("extractions[%d]: target is required", i)
+		if extraction.TargetAttributeName == "" {
+			return fmt.Errorf("extractions[%d]: target_attribute_name is required", i)
 		}
-		// Make sure we don't have extractions with the same targets
-		if prev, dup := seenTargets[extraction.Target]; dup {
-			return fmt.Errorf("extractions[%d]: duplicate target %q (also used by extractions[%d])", i, extraction.Target, prev)
+		// Make sure we don't have extractions writing to the same new attribute name
+		if prev, dup := seenNames[extraction.TargetAttributeName]; dup {
+			return fmt.Errorf("extractions[%d]: duplicate target_attribute_name %q (also used by extractions[%d])", i, extraction.TargetAttributeName, prev)
 		}
-		seenTargets[extraction.Target] = i
+		seenNames[extraction.TargetAttributeName] = i
 
-		hasSource := extraction.Source != ""
+		hasLookupKey := extraction.LookupKey != ""
 		hasRegex := extraction.Regex != ""
 
-		if hasSource && hasRegex {
-			return fmt.Errorf("extractions[%d]: cannot set both source and regex - choose one", i)
+		if hasLookupKey && hasRegex {
+			return fmt.Errorf("extractions[%d]: cannot set both lookup_key and regex - choose one", i)
 		}
-		if !hasSource && !hasRegex {
-			return fmt.Errorf("extractions[%d]: must set either source or regex", i)
+		if !hasLookupKey && !hasRegex {
+			return fmt.Errorf("extractions[%d]: must set either lookup_key or regex", i)
 		}
 
-		if hasSource {
+		if hasLookupKey {
 			switch extraction.DataFormat {
-			case FormatURL, FormatJSON:
+			case FormatResourcePath, FormatJSON, FormatSQL:
 			case FormatUnset:
-				return fmt.Errorf("extractions[%d]: data_format is required when source is set", i)
+				return fmt.Errorf("extractions[%d]: data_format is required when lookup_key is set", i)
 			default:
-				return fmt.Errorf("extractions[%d]: invalid data_format %q (must be %q or %q)",
-					i, extraction.DataFormat, FormatURL, FormatJSON)
+				return fmt.Errorf("extractions[%d]: invalid data_format %q (must be %q, %q, or %q)",
+					i, extraction.DataFormat, FormatResourcePath, FormatJSON, FormatSQL)
 			}
 		}
 
@@ -70,8 +72,8 @@ func (cfg *Config) Validate() error {
 			if extraction.DataFormat != FormatUnset {
 				return fmt.Errorf("extractions[%d]: data_format must not be set when using regex", i)
 			}
-			if extraction.Source != "" {
-				return fmt.Errorf("extractions[%d]: source must not be set when using regex", i)
+			if extraction.LookupKey != "" {
+				return fmt.Errorf("extractions[%d]: lookup_key must not be set when using regex", i)
 			}
 		}
 	}

--- a/collector/processors/odigosextractattributeprocessor/config_test.go
+++ b/collector/processors/odigosextractattributeprocessor/config_test.go
@@ -20,41 +20,41 @@ func TestConfig_Validate(t *testing.T) {
 			errContains: "extractions must not be empty",
 		},
 		{
-			name: "entry missing target",
+			name: "entry missing target_attribute_name",
 			cfg: Config{Extractions: []Extraction{
-				{Source: "study_id", DataFormat: FormatJSON},
+				{LookupKey: "study_id", DataFormat: FormatJSON},
 			}},
 			expectError: true,
-			errContains: "target is required",
+			errContains: "target_attribute_name is required",
 		},
 		{
-			name: "entry with neither source nor regex",
+			name: "entry with neither lookup_key nor regex",
 			cfg: Config{Extractions: []Extraction{
-				{Target: "study.id"},
+				{TargetAttributeName: "study.id"},
 			}},
 			expectError: true,
-			errContains: "must set either source or regex",
+			errContains: "must set either lookup_key or regex",
 		},
 		{
-			name: "entry with both source and regex",
+			name: "entry with both lookup_key and regex",
 			cfg: Config{Extractions: []Extraction{
-				{Source: "study_id", Regex: `(.+)`, DataFormat: FormatJSON, Target: "study.id"},
+				{LookupKey: "study_id", Regex: `(.+)`, DataFormat: FormatJSON, TargetAttributeName: "study.id"},
 			}},
 			expectError: true,
-			errContains: "cannot set both source and regex",
+			errContains: "cannot set both lookup_key and regex",
 		},
 		{
-			name: "source without data_format",
+			name: "lookup_key without data_format",
 			cfg: Config{Extractions: []Extraction{
-				{Source: "study_id", Target: "study.id"},
+				{LookupKey: "study_id", TargetAttributeName: "study.id"},
 			}},
 			expectError: true,
-			errContains: "data_format is required when source is set",
+			errContains: "data_format is required when lookup_key is set",
 		},
 		{
-			name: "source with invalid data_format",
+			name: "lookup_key with invalid data_format",
 			cfg: Config{Extractions: []Extraction{
-				{Source: "study_id", DataFormat: DataFormat("xml"), Target: "study.id"},
+				{LookupKey: "study_id", DataFormat: DataFormat("xml"), TargetAttributeName: "study.id"},
 			}},
 			expectError: true,
 			errContains: "invalid data_format",
@@ -62,49 +62,50 @@ func TestConfig_Validate(t *testing.T) {
 		{
 			name: "regex with stray data_format",
 			cfg: Config{Extractions: []Extraction{
-				{Regex: `(.+)`, DataFormat: FormatJSON, Target: "out"},
+				{Regex: `(.+)`, DataFormat: FormatJSON, TargetAttributeName: "out"},
 			}},
 			expectError: true,
 			errContains: "data_format must not be set when using regex",
 		},
 		{
-			name: "duplicate target across entries",
+			name: "duplicate target_attribute_name across entries",
 			cfg: Config{Extractions: []Extraction{
-				{Source: "study_id", DataFormat: FormatJSON, Target: "study.id"},
-				{Source: "study_uuid", DataFormat: FormatJSON, Target: "study.id"},
+				{LookupKey: "study_id", DataFormat: FormatJSON, TargetAttributeName: "study.id"},
+				{LookupKey: "study_uuid", DataFormat: FormatJSON, TargetAttributeName: "study.id"},
 			}},
 			expectError: true,
-			errContains: "duplicate target",
+			errContains: "duplicate target_attribute_name",
 		},
 		{
 			name: "valid: all preset entries",
 			cfg: Config{Extractions: []Extraction{
-				{Source: "study_id", DataFormat: FormatJSON, Target: "study.id"},
-				{Source: "studies", DataFormat: FormatURL, Target: "study.id.url"},
+				{LookupKey: "study_id", DataFormat: FormatJSON, TargetAttributeName: "study.id"},
+				{LookupKey: "studies", DataFormat: FormatResourcePath, TargetAttributeName: "study.id.url"},
+				{LookupKey: "study_id", DataFormat: FormatSQL, TargetAttributeName: "study.id.sql"},
 			}},
 			expectError: false,
 		},
 		{
 			name: "valid: all regex entries",
 			cfg: Config{Extractions: []Extraction{
-				{Regex: `study_id=([^\s]+)`, Target: "study.id"},
-				{Regex: `request_id=([0-9a-f-]+)`, Target: "request.id"},
+				{Regex: `study_id=([^\s]+)`, TargetAttributeName: "study.id"},
+				{Regex: `request_id=([0-9a-f-]+)`, TargetAttributeName: "request.id"},
 			}},
 			expectError: false,
 		},
 		{
 			name: "valid: mixed preset and regex entries",
 			cfg: Config{Extractions: []Extraction{
-				{Source: "study_id", DataFormat: FormatJSON, Target: "study.id"},
-				{Regex: `request_id=([0-9a-f-]+)`, Target: "request.id"},
+				{LookupKey: "study_id", DataFormat: FormatJSON, TargetAttributeName: "study.id"},
+				{Regex: `request_id=([0-9a-f-]+)`, TargetAttributeName: "request.id"},
 			}},
 			expectError: false,
 		},
 		{
-			name: "valid: same source key with different data_formats and targets",
+			name: "valid: same lookup_key with different data_formats and target_attribute_names",
 			cfg: Config{Extractions: []Extraction{
-				{Source: "study_id", DataFormat: FormatJSON, Target: "study.id.json"},
-				{Source: "study_id", DataFormat: FormatURL, Target: "study.id.url"},
+				{LookupKey: "study_id", DataFormat: FormatJSON, TargetAttributeName: "study.id.json"},
+				{LookupKey: "study_id", DataFormat: FormatResourcePath, TargetAttributeName: "study.id.url"},
 			}},
 			expectError: false,
 		},

--- a/collector/processors/odigosextractattributeprocessor/processor.go
+++ b/collector/processors/odigosextractattributeprocessor/processor.go
@@ -20,8 +20,8 @@ var RELEVANT_SPAN_ATTRIBUTES = map[string]struct{}{
 }
 
 type extractor struct {
-	regex  *regexp.Regexp
-	target string
+	regex            *regexp.Regexp
+	targetAttributeName string
 }
 
 type extractAttributeProcessor struct {
@@ -54,12 +54,12 @@ func compileRegexExtractors(cfg *Config) ([]extractor, error) {
 				return nil, fmt.Errorf("extractions[%d]: invalid regex: %w", i, err)
 			}
 		} else {
-			regex, err = buildExtractionRegex(extraction.Source, extraction.DataFormat)
+			regex, err = buildExtractionRegex(extraction.LookupKey, extraction.DataFormat)
 			if err != nil {
 				return nil, fmt.Errorf("extractions[%d]: %w", i, err)
 			}
 		}
-		out = append(out, extractor{regex: regex, target: extraction.Target})
+		out = append(out, extractor{regex: regex, targetAttributeName: extraction.TargetAttributeName})
 	}
 	return out, nil
 }
@@ -81,23 +81,23 @@ func (p *extractAttributeProcessor) processTraces(_ context.Context, traces ptra
 func (p *extractAttributeProcessor) processSpan(span ptrace.Span) {
 	for _, e := range p.extractors {
 		// Don't override an attribute that already exists on the span
-		if _, exists := span.Attributes().Get(e.target); exists {
+		if _, exists := span.Attributes().Get(e.targetAttributeName); exists {
 			continue
 		}
-		if value, ok := extractFromAttributes(span, e.regex); ok {
+		if value, ok := extractFromPayload(span, e.regex); ok {
 			p.logger.Debug("extraction matched",
-				zap.String("target", e.target),
+				zap.String("target_attribute_name", e.targetAttributeName),
 				zap.String("value", value),
 				zap.String("regex", e.regex.String()),
 				zap.Stringer("spanId", span.SpanID()),
 			)
-			span.Attributes().PutStr(e.target, value)
+			span.Attributes().PutStr(e.targetAttributeName, value)
 		}
 	}
 }
 
-// extractFromAttributes scans the span's string-valued attributes and returns the first capture group re produces.
-func extractFromAttributes(span ptrace.Span, re *regexp.Regexp) (string, bool) {
+// extractFromPayload scans the span's string-valued attributes which are payloads and returns the first capture group re produces.
+func extractFromPayload(span ptrace.Span, re *regexp.Regexp) (string, bool) {
 
 	var (
 		result string
@@ -131,15 +131,25 @@ func extractFromAttributes(span ptrace.Span, re *regexp.Regexp) (string, bool) {
 func buildExtractionRegex(key string, format DataFormat) (*regexp.Regexp, error) {
 	escapedKey := regexp.QuoteMeta(key)
 	switch format {
-	case FormatJSON: // Also works for SQL
+	case FormatJSON:
 		// Examples (key = "user_id"):
-		//   JSON quoted:    {"user_id": "abc123", "name": "foo"}      -> captures "abc123"
-		//   JSON unquoted:  {user_id: 42, name: "foo"}                -> captures "42"
-		//   SQL equals:     WHERE user_id = '42' AND status = 'ok'    -> captures "42"
-		//   SQL no spaces:  WHERE user_id=42                          -> captures "42"
-		// Anchored on a boundary so "my_user_id" does NOT match when key is "user_id".
-		return regexp.MustCompile(`(?:^|[\s,{("'])["']?` + escapedKey + `["']?\s*[:=]\s*["']?([^"'\s,;)}]+)`), nil
-	case FormatURL:
+		//   Quoted:     {"user_id": "abc123", "name": "foo"}   -> captures "abc123"
+		//   Unquoted:   {user_id: 42, name: "foo"}             -> captures "42"
+		//   Tight:      {"user_id":"abc"}                      -> captures "abc"
+		//   Nested:     {"outer":{"user_id":"x"}}              -> captures "x"
+		// Separator is ":" (JSON). Key must be preceded by start-of-string, whitespace, "{", or ",", optionally
+		// wrapped in quotes, so substrings like "my_user_id" do NOT match.
+		return regexp.MustCompile(`(?:^|[\s,{])"?` + escapedKey + `"?\s*:\s*"?([^"\s,}\]]+)`), nil
+	case FormatSQL:
+		// Examples (key = "user_id"):
+		//   Quoted:     WHERE user_id = '42' AND status = 'ok'  -> captures "42"
+		//   Tight:      WHERE user_id='abc'                     -> captures "abc"
+		//   Unquoted:   WHERE user_id=42                        -> captures "42"
+		//   Multiline:  "...\n      WHERE user_id = '42'\n..."  -> captures "42"
+		// Separator is "=" (SQL). Key must be preceded by start-of-string, whitespace, "(", or ",", so substrings
+		// like "my_user_id" do NOT match.
+		return regexp.MustCompile(`(?:^|[\s,(])` + escapedKey + `\s*=\s*'?([^'\s,;)]+)`), nil
+	case FormatResourcePath:
 		// Examples (key = "orders"):
 		//   Path:           /api/v1/orders/abc-123                     -> captures "abc-123"
 		//   Full URL:       https://example.com/orders/42?foo=bar      -> captures "42"

--- a/collector/processors/odigosextractattributeprocessor/processor.go
+++ b/collector/processors/odigosextractattributeprocessor/processor.go
@@ -20,7 +20,7 @@ var RELEVANT_SPAN_ATTRIBUTES = map[string]struct{}{
 }
 
 type extractor struct {
-	regex            *regexp.Regexp
+	regex               *regexp.Regexp
 	targetAttributeName string
 }
 

--- a/collector/processors/odigosextractattributeprocessor/processor_test.go
+++ b/collector/processors/odigosextractattributeprocessor/processor_test.go
@@ -24,66 +24,34 @@ func TestBuildExtractionRegex_JSON(t *testing.T) {
 		extracted string // empty string means "expect no match"
 	}{
 		{
-			name:      "json double-quoted",
+			name:      "double-quoted",
 			key:       "study_id",
 			input:     `{"study_id": "abc-123"}`,
 			extracted: "abc-123",
 		},
 		{
-			name:      "json double-quoted, no space",
+			name:      "double-quoted, no space",
 			key:       "study_id",
 			input:     `{"study_id":"abc-123"}`,
 			extracted: "abc-123",
 		},
 		{
-			name:      "json with sibling keys",
+			name:      "with sibling keys",
 			key:       "study_id",
 			input:     `{"study_id": "1.3.6.1.4.1.40744.71.65797265067703624152858272792653363228","cooking_status": "Completed"}`,
 			extracted: "1.3.6.1.4.1.40744.71.65797265067703624152858272792653363228",
 		},
 		{
-			name:      "nested json object",
+			name:      "nested object",
 			key:       "study_id",
 			input:     `{"outer":{"study_id":"x"}}`,
 			extracted: "x",
-		},
-		{
-			name:      "sql single-quoted",
-			key:       "study_id",
-			input:     `WHERE study_id = '1.3.6.1.4.1.40744.71.65797265067703624152858272792653363228' RETURNING id`,
-			extracted: "1.3.6.1.4.1.40744.71.65797265067703624152858272792653363228",
-		},
-		{
-			name:      "sql single-quoted, tight",
-			key:       "study_id",
-			input:     `WHERE study_id='abc'`,
-			extracted: "abc",
-		},
-		{
-			name: "sql multi-line statement",
-			key:  "study_id",
-			input: "UPDATE orders\n      SET study_caching_status = 'Completed', study_location_code = 'cloud'\n" +
-				"      WHERE study_id = '1.3.6.1.4.1.40744.71.65797265067703624152858272792653363228'\n" +
-				"      RETURNING id",
-			extracted: "1.3.6.1.4.1.40744.71.65797265067703624152858272792653363228",
-		},
-		{
-			name:      "unquoted value with equals",
-			key:       "study_id",
-			input:     `study_id=abc`,
-			extracted: "abc",
 		},
 		{
 			name:      "unquoted value with colon and space",
 			key:       "study_id",
 			input:     `study_id: abc`,
 			extracted: "abc",
-		},
-		{
-			name:      "unquoted value with spaced equals",
-			key:       "study_id",
-			input:     `study_id = abc-123`,
-			extracted: "abc-123",
 		},
 		{
 			name:      "numeric value",
@@ -112,12 +80,6 @@ func TestBuildExtractionRegex_JSON(t *testing.T) {
 			extracted: "",
 		},
 		{
-			name:      "underscore-joined key",
-			key:       "study_id",
-			input:     `my_study_id = 'nope'`,
-			extracted: "",
-		},
-		{
 			name:      "unrelated key",
 			key:       "study_id",
 			input:     `{"other":"value"}`,
@@ -127,6 +89,12 @@ func TestBuildExtractionRegex_JSON(t *testing.T) {
 			name:      "empty content",
 			key:       "study_id",
 			input:     ``,
+			extracted: "",
+		},
+		{
+			name:      "sql equals does not match json",
+			key:       "study_id",
+			input:     `WHERE study_id = 'abc'`,
 			extracted: "",
 		},
 
@@ -151,6 +119,115 @@ func TestBuildExtractionRegex_JSON(t *testing.T) {
 			assert.NoError(t, err)
 			got := firstCapture(re.FindStringSubmatch(tc.input))
 			assert.Equal(t, tc.extracted, got, "json regex(key=%q) on %q", tc.key, tc.input)
+		})
+	}
+}
+
+func TestBuildExtractionRegex_SQL(t *testing.T) {
+	tests := []struct {
+		name      string
+		key       string
+		input     string
+		extracted string // empty string means "expect no match"
+	}{
+		{
+			name:      "single-quoted value",
+			key:       "study_id",
+			input:     `WHERE study_id = '1.3.6.1.4.1.40744.71.65797265067703624152858272792653363228' RETURNING id`,
+			extracted: "1.3.6.1.4.1.40744.71.65797265067703624152858272792653363228",
+		},
+		{
+			name:      "single-quoted, tight",
+			key:       "study_id",
+			input:     `WHERE study_id='abc'`,
+			extracted: "abc",
+		},
+		{
+			name: "multi-line statement",
+			key:  "study_id",
+			input: "UPDATE orders\n      SET study_caching_status = 'Completed', study_location_code = 'cloud'\n" +
+				"      WHERE study_id = '1.3.6.1.4.1.40744.71.65797265067703624152858272792653363228'\n" +
+				"      RETURNING id",
+			extracted: "1.3.6.1.4.1.40744.71.65797265067703624152858272792653363228",
+		},
+		{
+			name:      "unquoted value at start",
+			key:       "study_id",
+			input:     `study_id=abc`,
+			extracted: "abc",
+		},
+		{
+			name:      "unquoted value with spaced equals",
+			key:       "study_id",
+			input:     `study_id = abc-123`,
+			extracted: "abc-123",
+		},
+		{
+			name:      "numeric value",
+			key:       "study_id",
+			input:     `WHERE study_id=42`,
+			extracted: "42",
+		},
+		{
+			name:      "key inside parenthesized predicate",
+			key:       "study_id",
+			input:     `WHERE (study_id='abc') AND status='ok'`,
+			extracted: "abc",
+		},
+		{
+			name:      "value terminated by trailing semicolon",
+			key:       "study_id",
+			input:     `WHERE study_id=42;`,
+			extracted: "42",
+		},
+
+		// False positives -- these should NOT match.
+		{
+			name:      "underscore-joined key",
+			key:       "study_id",
+			input:     `my_study_id = 'nope'`,
+			extracted: "",
+		},
+		{
+			name:      "substring key suffix",
+			key:       "study_id",
+			input:     `WHERE study_id_v2 = 'nope'`,
+			extracted: "",
+		},
+		{
+			name:      "json colon does not match sql",
+			key:       "study_id",
+			input:     `{"study_id": "abc"}`,
+			extracted: "",
+		},
+		{
+			name:      "empty content",
+			key:       "study_id",
+			input:     ``,
+			extracted: "",
+		},
+
+		// Ensure regex metacharacters in the key are treated literally.
+		{
+			name:      "key with dot, literal match",
+			key:       "a.b",
+			input:     `WHERE a.b = 'matched'`,
+			extracted: "matched",
+		},
+		{
+			name:      "key with dot, metachar does not cross-match",
+			key:       "a.b",
+			input:     `WHERE aXb = 'nope'`,
+			extracted: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			re, err := buildExtractionRegex(tc.key, FormatSQL)
+			assert.NoError(t, err)
+			got := firstCapture(re.FindStringSubmatch(tc.input))
+			assert.Equal(t, tc.extracted, got, "sql regex(key=%q) on %q", tc.key, tc.input)
 		})
 	}
 }
@@ -254,7 +331,7 @@ func TestBuildExtractionRegex_URL(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			re, err := buildExtractionRegex(tc.key, FormatURL)
+			re, err := buildExtractionRegex(tc.key, FormatResourcePath)
 			assert.NoError(t, err)
 			got := firstCapture(re.FindStringSubmatch(tc.input))
 			assert.Equal(t, tc.extracted, got, "url regex(key=%q) on %q", tc.key, tc.input)

--- a/docs/snippets/shared/pipeline/actions/attributes/extractattribute.mdx
+++ b/docs/snippets/shared/pipeline/actions/attributes/extractattribute.mdx
@@ -12,9 +12,9 @@ import AssumeNoMeaning from '/snippets/shared/assume-no-meaning.mdx';
     - `messaging.message.payload`
     - `http.request.payload`
     - `http.response.payload`
-  - If the `target` attribute already exists on the span, it will **not** be overridden.
-  - Each extraction must specify either `source` + `dataFormat`, **or** a custom `regex` — not both. When using `regex`, the pattern must contain exactly one capture group; the value of the first capture group is written to `target`.
-  - Each `target` must be unique within a single action.
+  - If the `targetAttributeName` attribute already exists on the span, it will **not** be overridden.
+  - Each extraction must specify either `lookupKey` + `dataFormat`, **or** a custom `regex` — not both. When using `regex`, the pattern must contain exactly one capture group; the value of the first capture group is written to the attribute named `targetAttributeName`.
+  - Each `targetAttributeName` must be unique within a single action.
 </Warning>
 
 ## Use Cases
@@ -67,25 +67,26 @@ The ExtractAttribute action is configured using the `odigos.io/v1alpha1.Action` 
         **extractions** `object[]` : An ordered array of extraction rules to apply to each span. Must contain at least one entry.
         - This field is *required*
         <AccordionGroup>
-          <Accordion title="target *">
-            **target** `string` : The attribute key the extracted value will be written to on the span.
+          <Accordion title="targetAttributeName *">
+            **targetAttributeName** `string` : The name of the new span attribute the extracted value will be written to.
             - This field is *required*
             - Must be unique across all extractions in the same action.
           </Accordion>
-          <Accordion title="source">
-            **source** `string` : The key to look up inside the scanned attributes (resolved via `dataFormat` into a regex).
+          <Accordion title="lookupKey">
+            **lookupKey** `string` : The literal key to look up inside the scanned attributes (resolved via `dataFormat` into a regex).
             - This field is *required* when `dataFormat` is set, and must be omitted when `regex` is set.
           </Accordion>
           <Accordion title="dataFormat">
-            **dataFormat** `string` : A pre-set format that defines how `source` is matched inside the scanned attributes.
-            - This field is *required* when `source` is set, and must be omitted when `regex` is set.
+            **dataFormat** `string` : A pre-set format that defines how `lookupKey` is matched inside the scanned attributes.
+            - This field is *required* when `lookupKey` is set, and must be omitted when `regex` is set.
             - Supported values:
-              - `json` — matches `key: value` / `key = value` pairs in JSON envelopes **and** in SQL statements (e.g. `WHERE order_id = '42'`).
-              - `url` — matches `key/value` segments inside URL paths (e.g. `/projects/test-project`), stopping at the next `/`, whitespace, `?`, `&`, `#`, or quote.
+              - `json` — matches `key: value` pairs in JSON envelopes (e.g. `{"order_id": "42"}` or `order_id: 42`).
+              - `sql` — matches `key = value` pairs in SQL statements (e.g. `WHERE order_id = '42'` or `order_id=42`).
+              - `resource_path` — matches `key/value` segments inside URL paths (e.g. `/projects/test-project`), stopping at the next `/`, whitespace, `?`, `&`, `#`, or quote.
           </Accordion>
           <Accordion title="regex">
-            **regex** `string` : A custom regular expression with a single capture group whose value is written to `target`.
-            - This field is *required* when `source` and `dataFormat` are not set.
+            **regex** `string` : A custom regular expression with a single capture group whose value is written to the attribute named `targetAttributeName`.
+            - This field is *required* when `lookupKey` and `dataFormat` are not set.
             - The first capture group of the first match is used.
           </Accordion>
         </AccordionGroup>
@@ -96,7 +97,7 @@ The ExtractAttribute action is configured using the `odigos.io/v1alpha1.Action` 
 
 <Tip>
   Each extraction rule must use **exactly one** of:
-  - `source` + `dataFormat` — for the built-in JSON/SQL/URL matchers, or
+  - `lookupKey` + `dataFormat` — for the built-in JSON/SQL/URL matchers, or
   - `regex` — for a custom pattern with a single capture group.
 </Tip>
 
@@ -110,7 +111,7 @@ The following example demonstrates the four extraction variations against a sing
 
 After the action runs, the span will be enriched with the following extracted attributes:
 
-| Target attribute               | Extracted value  |
+| New attribute name             | Extracted value  |
 | ------------------------------ | ---------------- |
 | `extracted.json.task_id`       | `task-7f3a9b2c`  |
 | `extracted.sql.invoice_id`     | `42`             |
@@ -136,29 +137,29 @@ After the action runs, the span will be enriched with the following extracted at
       extractAttribute:
         extractions:
           # JSON variation - matches a JSON envelope inside messaging.message.payload
-          - source: task_id
+          - lookupKey: task_id
             dataFormat: json
-            target: extracted.json.task_id
+            targetAttributeName: extracted.json.task_id
 
-          # SQL variation - the json dataFormat also handles SQL `key = 'value'` syntax
-          - source: invoice_id
-            dataFormat: json
-            target: extracted.sql.invoice_id
+          # SQL variation - matches `key = 'value'` syntax in SQL statements
+          - lookupKey: invoice_id
+            dataFormat: sql
+            targetAttributeName: extracted.sql.invoice_id
 
           # URL variation - matches `key/value` segments inside http.request.payload
-          - source: tenants
-            dataFormat: url
-            target: extracted.url.tenant
-          - source: regions
-            dataFormat: url
-            target: extracted.url.region
-          - source: jobs
-            dataFormat: url
-            target: extracted.url.job
+          - lookupKey: tenants
+            dataFormat: resource_path
+            targetAttributeName: extracted.url.tenant
+          - lookupKey: regions
+            dataFormat: resource_path
+            targetAttributeName: extracted.url.region
+          - lookupKey: jobs
+            dataFormat: resource_path
+            targetAttributeName: extracted.url.job
 
-          # Custom regex variation - one capture group, value goes to target
+          # Custom regex variation - one capture group, value goes to the new attribute
           - regex: "req-([a-z0-9]+)"
-            target: extracted.regex.request_id
+            targetAttributeName: extracted.regex.request_id
     ```
   </Step>
   <Step>

--- a/extract-attribute-processor-resource-path.yaml
+++ b/extract-attribute-processor-resource-path.yaml
@@ -1,0 +1,18 @@
+apiVersion: odigos.io/v1alpha1
+kind: Processor
+metadata:
+  name: extract-study-id-from-study-id
+  namespace: odigos-system
+spec:
+  type: odigosextractattribute
+  processorName: "extract study.id from study_id key in body"
+  signals:
+    - TRACES
+  collectorRoles:
+    - CLUSTER_GATEWAY
+  orderHint: 1
+  processorConfig:
+    extractions:
+      - lookup_key: study_id
+        data_format: sql
+        target_attribute_name: study_naty.id

--- a/extract-attribute-processor-studies.yaml
+++ b/extract-attribute-processor-studies.yaml
@@ -1,0 +1,21 @@
+apiVersion: odigos.io/v1alpha1
+kind: Processor
+metadata:
+  name: extract-study-id-from-studies
+  namespace: odigos-system
+spec:
+  type: odigosextractattribute
+  processorName: "extract study.id from /studies/<id>/ and project.id from /projects/<id>/ URL path"
+  signals:
+    - TRACES
+  collectorRoles:
+    - CLUSTER_GATEWAY
+  orderHint: 1
+  processorConfig:
+    extractions:
+      - lookup_key: studies
+        data_format: resource_path
+        target_attribute_name: naty_extracted_study.id
+      - lookup_key: projects
+        data_format: resource_path
+        target_attribute_name: naty_extracted_project.id

--- a/extract-attribute-processor.yaml
+++ b/extract-attribute-processor.yaml
@@ -1,0 +1,18 @@
+apiVersion: odigos.io/v1alpha1
+kind: Processor
+metadata:
+  name: extract-study-id-from-study-id
+  namespace: odigos-system
+spec:
+  type: odigosextractattribute
+  processorName: "extract study.id from study_id key in body"
+  signals:
+    - TRACES
+  collectorRoles:
+    - CLUSTER_GATEWAY
+  orderHint: 1
+  processorConfig:
+    extractions:
+      - lookup_key: study_id
+        data_format: json
+        target_attribute_name: study_naty.id

--- a/helm/odigos/templates/crds/odigos.io_actions.yaml
+++ b/helm/odigos/templates/crds/odigos.io_actions.yaml
@@ -116,15 +116,15 @@ spec:
                             Required when using DataFormat.
                             You can input either LookupKey+DataFormat, or supply your own Regex.
                           type: string
-                        targetAttributeName:
-                          description: TargetAttributeName is the name of the new span
-                            attribute the extracted value will be written to.
-                          type: string
                         regex:
                           description: |-
                             Regex is a custom regular expression with a single capture group whose value is
                             written to the new span attribute named TargetAttributeName.
                             You can input either Regex, or LookupKey+DataFormat.
+                          type: string
+                        targetAttributeName:
+                          description: TargetAttributeName is the name of the new
+                            span attribute the extracted value will be written to.
                           type: string
                       required:
                       - targetAttributeName

--- a/helm/odigos/templates/crds/odigos.io_actions.yaml
+++ b/helm/odigos/templates/crds/odigos.io_actions.yaml
@@ -93,37 +93,41 @@ spec:
                     items:
                       description: |-
                         Extraction describes a single extraction rule applied by the
-                        odigosextractattribute processor. Either (Source + DataFormat) or
-                        Regex must be provided; the captured value is written to Target.
+                        odigosextractattribute processor. Either (LookupKey + DataFormat) or
+                        Regex must be provided; the captured value is written to a new span
+                        attribute named TargetAttributeName.
                       properties:
                         dataFormat:
                           description: |-
                             A pre-set definition which resolves into a regex (e.g. JSON DataFormat would give a regex that searches
-                            inside a JSON string), which also applies Source for searching inside it.
-                            Required when using Source.
-                            You can input either Source+DataFormat, or supply your own Regex.
+                            inside a JSON string), which also applies LookupKey for searching inside it.
+                            Required when using LookupKey.
+                            You can input either LookupKey+DataFormat, or supply your own Regex.
                           enum:
-                          - url
+                          - resource_path
                           - json
+                          - sql
+                          type: string
+                        lookupKey:
+                          description: |-
+                            LookupKey is the literal key to search for inside the scanned span attributes.
+                            It is plugged into the pre-set regex pattern selected by DataFormat (e.g. for JSON,
+                            the processor will look for `"<lookupKey>": "<value>"` and capture the value).
+                            Required when using DataFormat.
+                            You can input either LookupKey+DataFormat, or supply your own Regex.
+                          type: string
+                        targetAttributeName:
+                          description: TargetAttributeName is the name of the new span
+                            attribute the extracted value will be written to.
                           type: string
                         regex:
                           description: |-
                             Regex is a custom regular expression with a single capture group whose value is
-                            written to Target.
-                            You can input either Regex, or Source+DataFormat.
-                          type: string
-                        source:
-                          description: |-
-                            The string key that is searched within the pre-set regex patterns resolved by DataFormat.
-                            Required when using DataFormat.
-                            You can input either Source+DataFormat, or supply your own Regex.
-                          type: string
-                        target:
-                          description: Target is the attribute key the extracted value
-                            will be written to on the span.
+                            written to the new span attribute named TargetAttributeName.
+                            You can input either Regex, or LookupKey+DataFormat.
                           type: string
                       required:
-                      - target
+                      - targetAttributeName
                       type: object
                     minItems: 1
                     type: array

--- a/tests/e2e/actions/03-extract-attribute-action.yaml
+++ b/tests/e2e/actions/03-extract-attribute-action.yaml
@@ -10,26 +10,26 @@ spec:
   extractAttribute:
     extractions:
       # JSON variation - matches in messaging.message.payload
-      - source: study_id
+      - lookupKey: study_id
         dataFormat: json
-        target: extracted.json.study_id
+        targetAttributeName: extracted.json.study_id
 
-      # SQL variation (FormatJSON regex also handles SQL syntax) - matches in db.statement
-      - source: order_id
-        dataFormat: json
-        target: extracted.sql.order_id
+      # SQL variation - matches in db.statement
+      - lookupKey: order_id
+        dataFormat: sql
+        targetAttributeName: extracted.sql.order_id
 
       # URL variation - all three match in http.request.payload
-      - source: projects
-        dataFormat: url
-        target: extracted.url.project
-      - source: locations
-        dataFormat: url
-        target: extracted.url.location
-      - source: studies
-        dataFormat: url
-        target: extracted.url.study
+      - lookupKey: projects
+        dataFormat: resource_path
+        targetAttributeName: extracted.url.project
+      - lookupKey: locations
+        dataFormat: resource_path
+        targetAttributeName: extracted.url.location
+      - lookupKey: studies
+        dataFormat: resource_path
+        targetAttributeName: extracted.url.study
 
       # Free regex variation - matches in db.statement
       - regex: "req-([a-z0-9]+)"
-        target: extracted.regex.request_id
+        targetAttributeName: extracted.regex.request_id

--- a/tests/e2e/actions/chainsaw-test.yaml
+++ b/tests/e2e/actions/chainsaw-test.yaml
@@ -8,9 +8,9 @@ spec:
     A minimal Flask app sets db.statement, http.request.payload, and
     messaging.message.payload on every span. The ExtractAttribute action
     extracts values from those attributes using all four processor
-    variations: JSON, SQL (via json DataFormat), URL (multi-key), and
-    free regex. The test asserts that every extracted target attribute
-    appears on spans collected by the simple-trace-db.
+    variations: JSON, SQL, URL (multi-key), and free regex. The test
+    asserts that every extracted target attribute appears on spans
+    collected by the simple-trace-db.
   skipDelete: true
   steps:
     - name: Prepare destination


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Change extract attribute processor arg names:
target -> target_attribute_name
source -> lookup_key
data_format(json,url) -> (json, sql, resource_path)


#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Change extract attribute processor argument names:
target -> target_attribute_name, source -> lookup_key, data_format(json,url) -> (json, sql, resource_path)
```
