### PR TITLE
CORE-1120 | fix(otelcol-linux): grant Linux capabilities required by eBPF profiler in systemd unit

### DIFF
--- a/collector/distribution/odigos-otelcol/odigos-otelcol.service
+++ b/collector/distribution/odigos-otelcol/odigos-otelcol.service
@@ -12,8 +12,9 @@ Type=simple
 User=odigos
 Group=odigos
 
-AmbientCapabilities=CAP_SYS_ADMIN CAP_BPF CAP_PERFMON
-CapabilityBoundingSet=CAP_SYS_ADMIN CAP_BPF CAP_PERFMON
+AmbientCapabilities=CAP_SYS_ADMIN CAP_BPF CAP_PERFMON CAP_SYSLOG CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
+CapabilityBoundingSet=CAP_SYS_ADMIN CAP_BPF CAP_PERFMON CAP_SYSLOG CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
+NoNewPrivileges=false
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
The eBPF profiler receiver shipped in otelcol-linux/v1.22.0 needs
CAP_SYSLOG (read /proc/kallsyms with kernel.kptr_restrict>=1),
CAP_SYS_PTRACE,
CAP_DAC_READ_SEARCH (read /proc/[pid]/{mem,maps,exe} across uids),
and NoNewPrivileges=false

Without these the service crash-loops at startup with "failed to load eBPF tracer: failed to read kernel symbols: unable to read kallsyms addresses - check capabilities" as soon as a profiles pipeline is enabled.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Upgrade Odigos Collector service permissions to enable eBPF based Continuous Profiling of Services in VM
```
