### PR TITLE
fix: add more valid chars to url templatization email regex

### DIFF
--- a/collector/processors/odigosurltemplateprocessor/README.md
+++ b/collector/processors/odigosurltemplateprocessor/README.md
@@ -135,7 +135,7 @@ By default, the processor will split the path to segment (e.g. "/user/1234" -> [
 - hex-encoded strings - `^(?:[0-9a-fA-F]{2}){8,}$` -> `{id}` (`6f2a9cdeab34f01e`, `6F2A9CDEAB34F01E`)
 - long numbers anywhere - `\d{7,}` -> `{id}` (`1234567`, `INC328962358623904`, `sb_12345678901234567890_us`)
 - common [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) date-time formats - `^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}(?::\d{2})?)?(?:Z|[+-]\d{4})?$` -> `{date}` (`2023-10-01T12:00:00+0000`)
-- emails - `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$` like `foo@bar.io` -> `{email}`
+- emails - `` ^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$ `` like `foo@bar.io` -> `{email}`
 - unicode replacement character - `�` -> `{id}` (assume this is dynamic value and not static path segment)
 
 These default rules will not templatize paths like `/user/john`, `/user/s111222`, `/users/123456_789` which will be copied as is into the span name and attribute with potentially high cardinality.

--- a/collector/processors/odigosurltemplateprocessor/processor_test.go
+++ b/collector/processors/odigosurltemplateprocessor/processor_test.go
@@ -696,6 +696,30 @@ func TestProcessor_EmailAddresses(t *testing.T) {
 			expectedAttrValue: "/user/{email}",
 		},
 		{
+			name:          "email local part with RFC 5322 special chars",
+			spanKind:      ptrace.SpanKindServer,
+			inputSpanName: "GET",
+			inputSpanAttrs: map[string]any{
+				"http.request.method": "GET",
+				"url.path":            "/user/!#$%&'*+=?^`{|}~@example.com",
+			},
+			expectedSpanName:  "GET /user/{email}",
+			expectedAttrKey:   "http.route",
+			expectedAttrValue: "/user/{email}",
+		},
+		{
+			name:          "email local part with apostrophe",
+			spanKind:      ptrace.SpanKindServer,
+			inputSpanName: "GET",
+			inputSpanAttrs: map[string]any{
+				"http.request.method": "GET",
+				"url.path":            "/user/o'brien@example.com",
+			},
+			expectedSpanName:  "GET /user/{email}",
+			expectedAttrKey:   "http.route",
+			expectedAttrValue: "/user/{email}",
+		},
+		{
 			name:          "exact match no suffix",
 			spanKind:      ptrace.SpanKindServer,
 			inputSpanName: "GET",

--- a/collector/processors/odigosurltemplateprocessor/templatize.go
+++ b/collector/processors/odigosurltemplateprocessor/templatize.go
@@ -65,7 +65,7 @@ var (
 	datesRegex = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}(?::\d{2})?)?(?:Z|[+-]\d{4})?$`)
 
 	// matches email addresses
-	emailRegex = regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
+	emailRegex = regexp.MustCompile(`^[a-zA-Z0-9.!#$%&'*+/=?^_` + "`" + `{|}~-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
 
 	// assume any invalid unicode character is not a static path segment
 	replacementChar = regexp.MustCompile(`�`)


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: CORE-1003

to capture valid emails like "o'reilly@example.com"

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
add more valid chars to url templatization email regex for default templatization rules
```
