### PR TITLE
CORE-1120 | fix(otelcol-linux): add CAP_SYS_RESOURCE so eBPF profiler can raise RLIMIT_MEMLOCK

### DIFF
--- a/collector/distribution/odigos-otelcol/odigos-otelcol.service
+++ b/collector/distribution/odigos-otelcol/odigos-otelcol.service
@@ -12,9 +12,16 @@ Type=simple
 User=odigos
 Group=odigos
 
-AmbientCapabilities=CAP_SYS_ADMIN CAP_BPF CAP_PERFMON CAP_SYSLOG CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
-CapabilityBoundingSet=CAP_SYS_ADMIN CAP_BPF CAP_PERFMON CAP_SYSLOG CAP_SYS_PTRACE CAP_DAC_READ_SEARCH
-NoNewPrivileges=false
+AmbientCapabilities=CAP_SYS_ADMIN CAP_BPF CAP_PERFMON CAP_SYSLOG CAP_SYS_PTRACE CAP_DAC_READ_SEARCH CAP_SYS_RESOURCE
+CapabilityBoundingSet=CAP_SYS_ADMIN CAP_BPF CAP_PERFMON CAP_SYSLOG CAP_SYS_PTRACE CAP_DAC_READ_SEARCH CAP_SYS_RESOURCE
+
+# Memlock is required by the eBPF profiler. CAP_SYS_RESOURCE above lets the
+# process self-raise the limit, but only on kernels >= 5.11 where BPF map
+# memory is memcg-accounted and the rlimit is effectively bypassed. On older
+# kernels (RHEL 8 / 4.18, Amazon Linux 2 / 4.14) RLIMIT_MEMLOCK is hard-
+# enforced and the receiver crashes with 'failed to adjust rlimit: operation
+# not permitted' regardless of the capability. Cheap to keep on all kernels.
+LimitMEMLOCK=infinity
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
#### What this PR does / why we need it:

Two systemd-unit changes on `odigos-otelcol.service` so the embedded eBPF profiling receiver can actually start on the supported kernel range.

**1. Add `CAP_SYS_RESOURCE` to the ambient + bounding caps.**
The eBPF profiling receiver self-raises `RLIMIT_MEMLOCK` during BPF load (rlimit.MaximizeMemlock → prlimit), which fails with EPERM and crash-loops the collector without it. Affects all kernels  the call isn't memcg-aware.

**2. Add `LimitMEMLOCK=infinity`.**
The cap alone is sufficient on kernels >= 5.11 where BPF map memory is memcg-accounted and the rlimit is effectively bypassed.
On older kernels shipping in supported distros: **RHEL 8 (4.18), Amazon Linux 2 (4.14), older Debian/Ubuntu LTS** `RLIMIT_MEMLOCK` is hard-enforced at the default ~8 MB ceiling, and the profiler crashes with `failed to adjust rlimit: operation not permitted` regardless of `CAP_SYS_RESOURCE`.

Dropped `NoNewPrivileges=false` because it's redundant
(systemd already defaults to false for system services; verified profiling works with it omitted and with =true).


#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
Grant CAP_SYS_RESOURCE and LimitMEMLOCK=infinity so the eBPF profiling receiver can load on kernels <5.11 (RHEL 8, Amazon Linux 2)
```