### PR TITLE
feat: add auto-rollback status to gql

### DIFF
--- a/frontend/gqlgen.yml
+++ b/frontend/gqlgen.yml
@@ -83,6 +83,8 @@ models:
         resolver: true
       rollout:
         resolver: true
+      autoRollback:
+        resolver: true
       containers:
         resolver: true
       pods:

--- a/frontend/graph/computed/odigosconfig.go
+++ b/frontend/graph/computed/odigosconfig.go
@@ -1,0 +1,9 @@
+package computed
+
+import "time"
+
+type AutoRollbackConfig struct {
+	Enabled         bool
+	GraceTime       time.Duration
+	StabilityWindow time.Duration
+}

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -678,6 +678,7 @@ type ComplexityRoot struct {
 
 	K8sWorkload struct {
 		AgentEnabled               func(childComplexity int) int
+		AutoRollback               func(childComplexity int) int
 		Conditions                 func(childComplexity int) int
 		Containers                 func(childComplexity int) int
 		DataStreamNames            func(childComplexity int) int
@@ -727,9 +728,15 @@ type ComplexityRoot struct {
 		Enabled func(childComplexity int) int
 	}
 
+	K8sWorkloadAutoRollback struct {
+		AutoRollbackStatus func(childComplexity int) int
+		RollbackOccurred   func(childComplexity int) int
+	}
+
 	K8sWorkloadConditions struct {
 		AgentInjected         func(childComplexity int) int
 		AgentInjectionEnabled func(childComplexity int) int
+		AutoRollback          func(childComplexity int) int
 		ExpectingTelemetry    func(childComplexity int) int
 		ProcessesAgentHealth  func(childComplexity int) int
 		Rollout               func(childComplexity int) int
@@ -1424,6 +1431,7 @@ type K8sWorkloadResolver interface {
 	RuntimeInfo(ctx context.Context, obj *model.K8sWorkload) (*model.K8sWorkloadRuntimeInfo, error)
 	AgentEnabled(ctx context.Context, obj *model.K8sWorkload) (*model.K8sWorkloadAgentEnabled, error)
 	Rollout(ctx context.Context, obj *model.K8sWorkload) (*model.K8sWorkloadRollout, error)
+	AutoRollback(ctx context.Context, obj *model.K8sWorkload) (*model.K8sWorkloadAutoRollback, error)
 	Containers(ctx context.Context, obj *model.K8sWorkload) ([]*model.K8sWorkloadContainer, error)
 	Pods(ctx context.Context, obj *model.K8sWorkload) ([]*model.K8sWorkloadPod, error)
 	PodsAgentInjectionStatus(ctx context.Context, obj *model.K8sWorkload) (*model.DesiredConditionStatus, error)
@@ -4383,6 +4391,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.K8sWorkload.AgentEnabled(childComplexity), true
 
+	case "K8sWorkload.autoRollback":
+		if e.complexity.K8sWorkload.AutoRollback == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkload.AutoRollback(childComplexity), true
+
 	case "K8sWorkload.conditions":
 		if e.complexity.K8sWorkload.Conditions == nil {
 			break
@@ -4607,6 +4622,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.K8sWorkloadAgentEnabledContainerTraces.Enabled(childComplexity), true
 
+	case "K8sWorkloadAutoRollback.autoRollbackStatus":
+		if e.complexity.K8sWorkloadAutoRollback.AutoRollbackStatus == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadAutoRollback.AutoRollbackStatus(childComplexity), true
+
+	case "K8sWorkloadAutoRollback.rollbackOccurred":
+		if e.complexity.K8sWorkloadAutoRollback.RollbackOccurred == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadAutoRollback.RollbackOccurred(childComplexity), true
+
 	case "K8sWorkloadConditions.agentInjected":
 		if e.complexity.K8sWorkloadConditions.AgentInjected == nil {
 			break
@@ -4620,6 +4649,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.K8sWorkloadConditions.AgentInjectionEnabled(childComplexity), true
+
+	case "K8sWorkloadConditions.autoRollback":
+		if e.complexity.K8sWorkloadConditions.AutoRollback == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadConditions.AutoRollback(childComplexity), true
 
 	case "K8sWorkloadConditions.expectingTelemetry":
 		if e.complexity.K8sWorkloadConditions.ExpectingTelemetry == nil {
@@ -28176,6 +28212,8 @@ func (ec *executionContext) fieldContext_K8sNamespace_workloads(_ context.Contex
 				return ec.fieldContext_K8sWorkload_agentEnabled(ctx, field)
 			case "rollout":
 				return ec.fieldContext_K8sWorkload_rollout(ctx, field)
+			case "autoRollback":
+				return ec.fieldContext_K8sWorkload_autoRollback(ctx, field)
 			case "containers":
 				return ec.fieldContext_K8sWorkload_containers(ctx, field)
 			case "pods":
@@ -28395,6 +28433,8 @@ func (ec *executionContext) fieldContext_K8sWorkload_conditions(_ context.Contex
 				return ec.fieldContext_K8sWorkloadConditions_agentInjectionEnabled(ctx, field)
 			case "rollout":
 				return ec.fieldContext_K8sWorkloadConditions_rollout(ctx, field)
+			case "autoRollback":
+				return ec.fieldContext_K8sWorkloadConditions_autoRollback(ctx, field)
 			case "agentInjected":
 				return ec.fieldContext_K8sWorkloadConditions_agentInjected(ctx, field)
 			case "processesAgentHealth":
@@ -28600,6 +28640,53 @@ func (ec *executionContext) fieldContext_K8sWorkload_rollout(_ context.Context, 
 				return ec.fieldContext_K8sWorkloadRollout_rolloutStatus(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type K8sWorkloadRollout", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkload_autoRollback(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkload_autoRollback(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.K8sWorkload().AutoRollback(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.K8sWorkloadAutoRollback)
+	fc.Result = res
+	return ec.marshalOK8sWorkloadAutoRollback2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadAutoRollback(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkload_autoRollback(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkload",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "autoRollbackStatus":
+				return ec.fieldContext_K8sWorkloadAutoRollback_autoRollbackStatus(ctx, field)
+			case "rollbackOccurred":
+				return ec.fieldContext_K8sWorkloadAutoRollback_rollbackOccurred(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type K8sWorkloadAutoRollback", field.Name)
 		},
 	}
 	return fc, nil
@@ -29814,6 +29901,104 @@ func (ec *executionContext) fieldContext_K8sWorkloadAgentEnabledContainerTraces_
 	return fc, nil
 }
 
+func (ec *executionContext) _K8sWorkloadAutoRollback_autoRollbackStatus(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadAutoRollback) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadAutoRollback_autoRollbackStatus(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AutoRollbackStatus, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.DesiredConditionStatus)
+	fc.Result = res
+	return ec.marshalNDesiredConditionStatus2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐDesiredConditionStatus(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadAutoRollback_autoRollbackStatus(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadAutoRollback",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "name":
+				return ec.fieldContext_DesiredConditionStatus_name(ctx, field)
+			case "status":
+				return ec.fieldContext_DesiredConditionStatus_status(ctx, field)
+			case "reasonEnum":
+				return ec.fieldContext_DesiredConditionStatus_reasonEnum(ctx, field)
+			case "message":
+				return ec.fieldContext_DesiredConditionStatus_message(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DesiredConditionStatus", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkloadAutoRollback_rollbackOccurred(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadAutoRollback) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadAutoRollback_rollbackOccurred(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RollbackOccurred, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadAutoRollback_rollbackOccurred(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadAutoRollback",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _K8sWorkloadConditions_runtimeDetection(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadConditions) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_K8sWorkloadConditions_runtimeDetection(ctx, field)
 	if err != nil {
@@ -29945,6 +30130,57 @@ func (ec *executionContext) _K8sWorkloadConditions_rollout(ctx context.Context, 
 }
 
 func (ec *executionContext) fieldContext_K8sWorkloadConditions_rollout(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadConditions",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "name":
+				return ec.fieldContext_DesiredConditionStatus_name(ctx, field)
+			case "status":
+				return ec.fieldContext_DesiredConditionStatus_status(ctx, field)
+			case "reasonEnum":
+				return ec.fieldContext_DesiredConditionStatus_reasonEnum(ctx, field)
+			case "message":
+				return ec.fieldContext_DesiredConditionStatus_message(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DesiredConditionStatus", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkloadConditions_autoRollback(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadConditions) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadConditions_autoRollback(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AutoRollback, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.DesiredConditionStatus)
+	fc.Result = res
+	return ec.marshalODesiredConditionStatus2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐDesiredConditionStatus(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadConditions_autoRollback(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "K8sWorkloadConditions",
 		Field:      field,
@@ -43235,6 +43471,8 @@ func (ec *executionContext) fieldContext_Query_workloads(ctx context.Context, fi
 				return ec.fieldContext_K8sWorkload_agentEnabled(ctx, field)
 			case "rollout":
 				return ec.fieldContext_K8sWorkload_rollout(ctx, field)
+			case "autoRollback":
+				return ec.fieldContext_K8sWorkload_autoRollback(ctx, field)
 			case "containers":
 				return ec.fieldContext_K8sWorkload_containers(ctx, field)
 			case "pods":
@@ -43328,6 +43566,8 @@ func (ec *executionContext) fieldContext_Query_workloadsByIds(ctx context.Contex
 				return ec.fieldContext_K8sWorkload_agentEnabled(ctx, field)
 			case "rollout":
 				return ec.fieldContext_K8sWorkload_rollout(ctx, field)
+			case "autoRollback":
+				return ec.fieldContext_K8sWorkload_autoRollback(ctx, field)
 			case "containers":
 				return ec.fieldContext_K8sWorkload_containers(ctx, field)
 			case "pods":
@@ -58379,6 +58619,39 @@ func (ec *executionContext) _K8sWorkload(ctx context.Context, sel ast.SelectionS
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "autoRollback":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._K8sWorkload_autoRollback(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "containers":
 			field := field
 
@@ -58974,6 +59247,50 @@ func (ec *executionContext) _K8sWorkloadAgentEnabledContainerTraces(ctx context.
 	return out
 }
 
+var k8sWorkloadAutoRollbackImplementors = []string{"K8sWorkloadAutoRollback"}
+
+func (ec *executionContext) _K8sWorkloadAutoRollback(ctx context.Context, sel ast.SelectionSet, obj *model.K8sWorkloadAutoRollback) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, k8sWorkloadAutoRollbackImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("K8sWorkloadAutoRollback")
+		case "autoRollbackStatus":
+			out.Values[i] = ec._K8sWorkloadAutoRollback_autoRollbackStatus(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "rollbackOccurred":
+			out.Values[i] = ec._K8sWorkloadAutoRollback_rollbackOccurred(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var k8sWorkloadConditionsImplementors = []string{"K8sWorkloadConditions"}
 
 func (ec *executionContext) _K8sWorkloadConditions(ctx context.Context, sel ast.SelectionSet, obj *model.K8sWorkloadConditions) graphql.Marshaler {
@@ -58991,6 +59308,8 @@ func (ec *executionContext) _K8sWorkloadConditions(ctx context.Context, sel ast.
 			out.Values[i] = ec._K8sWorkloadConditions_agentInjectionEnabled(ctx, field, obj)
 		case "rollout":
 			out.Values[i] = ec._K8sWorkloadConditions_rollout(ctx, field, obj)
+		case "autoRollback":
+			out.Values[i] = ec._K8sWorkloadConditions_autoRollback(ctx, field, obj)
 		case "agentInjected":
 			out.Values[i] = ec._K8sWorkloadConditions_agentInjected(ctx, field, obj)
 		case "processesAgentHealth":
@@ -69874,6 +70193,13 @@ func (ec *executionContext) marshalOK8sWorkloadAgentEnabledContainerTraces2ᚖgi
 		return graphql.Null
 	}
 	return ec._K8sWorkloadAgentEnabledContainerTraces(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOK8sWorkloadAutoRollback2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadAutoRollback(ctx context.Context, sel ast.SelectionSet, v *model.K8sWorkloadAutoRollback) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._K8sWorkloadAutoRollback(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOK8sWorkloadContainer2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.K8sWorkloadContainer) graphql.Marshaler {

--- a/frontend/graph/loaders/getters.go
+++ b/frontend/graph/loaders/getters.go
@@ -2,8 +2,11 @@ package loaders
 
 import (
 	"context"
+	"time"
 
 	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	"github.com/odigos-io/odigos/common"
+	"github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/frontend/graph/computed"
 	"github.com/odigos-io/odigos/frontend/graph/model"
 )
@@ -17,6 +20,45 @@ func (l *Loaders) GetIgnoredContainers() map[string]struct{} {
 		ignoredContainers[container] = struct{}{}
 	}
 	return ignoredContainers
+}
+
+func (l *Loaders) GetAutoRollbackConfig() *computed.AutoRollbackConfig {
+	if l.odigosConfiguration == nil {
+		return nil
+	}
+
+	enabled := true
+	if l.odigosConfiguration.RollbackDisabled != nil && *l.odigosConfiguration.RollbackDisabled {
+		enabled = false
+	}
+
+	stabilityWindow := consts.DefaultAutoRollbackStabilityWindow
+	if l.odigosConfiguration.RollbackStabilityWindow != "" {
+		sw, err := time.ParseDuration(l.odigosConfiguration.RollbackStabilityWindow)
+		if err != nil {
+			return nil
+		}
+		stabilityWindow = sw
+	}
+
+	graceTime := consts.DefaultAutoRollbackGraceTime
+	if l.odigosConfiguration.RollbackGraceTime != "" {
+		gt, err := time.ParseDuration(l.odigosConfiguration.RollbackGraceTime)
+		if err != nil {
+			return nil
+		}
+		graceTime = gt
+	}
+
+	return &computed.AutoRollbackConfig{
+		Enabled:         enabled,
+		GraceTime:       graceTime,
+		StabilityWindow: stabilityWindow,
+	}
+}
+
+func (l *Loaders) GetOdigosConfiguration() *common.OdigosConfiguration {
+	return l.odigosConfiguration
 }
 
 func (l *Loaders) GetNamespaces(ctx context.Context) ([]string, error) {

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -875,6 +875,7 @@ type K8sWorkload struct {
 	RuntimeInfo                *K8sWorkloadRuntimeInfo              `json:"runtimeInfo,omitempty"`
 	AgentEnabled               *K8sWorkloadAgentEnabled             `json:"agentEnabled,omitempty"`
 	Rollout                    *K8sWorkloadRollout                  `json:"rollout,omitempty"`
+	AutoRollback               *K8sWorkloadAutoRollback             `json:"autoRollback,omitempty"`
 	Containers                 []*K8sWorkloadContainer              `json:"containers,omitempty"`
 	Pods                       []*K8sWorkloadPod                    `json:"pods,omitempty"`
 	PodsAgentInjectionStatus   *DesiredConditionStatus              `json:"podsAgentInjectionStatus"`
@@ -917,10 +918,16 @@ type K8sWorkloadAgentEnabledContainerTraces struct {
 	Enabled bool `json:"enabled"`
 }
 
+type K8sWorkloadAutoRollback struct {
+	AutoRollbackStatus *DesiredConditionStatus `json:"autoRollbackStatus"`
+	RollbackOccurred   bool                    `json:"rollbackOccurred"`
+}
+
 type K8sWorkloadConditions struct {
 	RuntimeDetection      *DesiredConditionStatus `json:"runtimeDetection,omitempty"`
 	AgentInjectionEnabled *DesiredConditionStatus `json:"agentInjectionEnabled,omitempty"`
 	Rollout               *DesiredConditionStatus `json:"rollout,omitempty"`
+	AutoRollback          *DesiredConditionStatus `json:"autoRollback,omitempty"`
 	AgentInjected         *DesiredConditionStatus `json:"agentInjected,omitempty"`
 	ProcessesAgentHealth  *DesiredConditionStatus `json:"processesAgentHealth,omitempty"`
 	ExpectingTelemetry    *DesiredConditionStatus `json:"expectingTelemetry,omitempty"`

--- a/frontend/graph/status/rollback.go
+++ b/frontend/graph/status/rollback.go
@@ -1,13 +1,73 @@
 package status
 
+import (
+	"fmt"
+	"time"
+
+	odigosv1alpha1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	"github.com/odigos-io/odigos/frontend/graph/computed"
+	"github.com/odigos-io/odigos/frontend/graph/model"
+)
+
 const (
 	RollbackStatus = "Rollback"
 )
 
-type RollbackReason string
+type AutoRollbackReason string
 
 const (
-	RollbackReasonRollbackTriggered RollbackReason = "RollbackTriggered"
-	RollbackReasonRollbackCompleted RollbackReason = "RollbackCompleted"
-	RollbackReasonRollbackFailed    RollbackReason = "RollbackFailed"
+	AutoRollbackReasonDisabled          AutoRollbackReason = "Disabled"
+	AutoRollbackReasonAgentNotEnabled   AutoRollbackReason = "AgentNotEnabled"
+	AutoRollbackReasonRollbackOccurred  AutoRollbackReason = "RollbackOccurred"
+	AutoRollbackReasonStable            AutoRollbackReason = "Stable"
+	AutoRollbackReasonEvaluating        AutoRollbackReason = "Evaluating"
+	AutoRollbackReasonWaitingForRollout AutoRollbackReason = "WaitingForRollout"
 )
+
+func createAutoRollbackStatus(reason AutoRollbackReason, message string, status model.DesiredStateProgress) *model.DesiredConditionStatus {
+	reasonStr := string(reason)
+	return &model.DesiredConditionStatus{
+		Name:       RollbackStatus,
+		Status:     status,
+		ReasonEnum: &reasonStr,
+		Message:    message,
+	}
+}
+
+func CalculateAutoRollbackStatus(ic *odigosv1alpha1.InstrumentationConfig, autoRollbackConfig *computed.AutoRollbackConfig) *model.DesiredConditionStatus {
+
+	// if the workload is not marked for instrumentation, the auto rollback status is not applicable.
+	if ic == nil {
+		return nil
+	}
+
+	// disabled in config
+	if !autoRollbackConfig.Enabled {
+		return createAutoRollbackStatus(AutoRollbackReasonDisabled, "Auto rollback is disabled in the odigos configuration", model.DesiredStateProgressIrrelevant)
+	}
+
+	// agent injection is not enabled (e.g. no agent, other agent, etc.)
+	// in this case the auto rollback is not applicable.
+	if !ic.Spec.AgentInjectionEnabled {
+		return createAutoRollbackStatus(AutoRollbackReasonAgentNotEnabled, "odigos agent is not set to run with this source, auto rollback is not applicable", model.DesiredStateProgressIrrelevant)
+	}
+
+	// if we know it was rolled back due to auto-heal
+	if ic.Status.RollbackOccurred {
+		return createAutoRollbackStatus(AutoRollbackReasonRollbackOccurred, "odigos detected a crash and rolled back the source to protect your application", model.DesiredStateProgressNotice)
+	}
+
+	// rollback is only checked after the workload is rolled out.
+	if ic.Status.InstrumentationTime == nil {
+		return createAutoRollbackStatus(AutoRollbackReasonWaitingForRollout, "source stability will be checked after the source is rolled out by odigos", model.DesiredStateProgressWaiting)
+	}
+
+	// check if we reached the stability window
+	timeSinceInstrumentation := time.Since(ic.Status.InstrumentationTime.Time)
+	if timeSinceInstrumentation < autoRollbackConfig.StabilityWindow {
+		// if we are within the stability window, and did not mark the rollback occurred, we are still evaluating
+		return createAutoRollbackStatus(AutoRollbackReasonEvaluating, fmt.Sprintf("evaluating pods for stability for %s", autoRollbackConfig.StabilityWindow), model.DesiredStateProgressWaiting)
+	}
+
+	return createAutoRollbackStatus(AutoRollbackReasonStable, fmt.Sprintf("pods are stable after instrumentation", autoRollbackConfig.StabilityWindow), model.DesiredStateProgressSuccess)
+}

--- a/frontend/graph/status/rollback.go
+++ b/frontend/graph/status/rollback.go
@@ -66,8 +66,8 @@ func CalculateAutoRollbackStatus(ic *odigosv1alpha1.InstrumentationConfig, autoR
 	timeSinceInstrumentation := time.Since(ic.Status.InstrumentationTime.Time)
 	if timeSinceInstrumentation < autoRollbackConfig.StabilityWindow {
 		// if we are within the stability window, and did not mark the rollback occurred, we are still evaluating
-		return createAutoRollbackStatus(AutoRollbackReasonEvaluating, fmt.Sprintf("evaluating pods for stability for %s", autoRollbackConfig.StabilityWindow), model.DesiredStateProgressWaiting)
+		return createAutoRollbackStatus(AutoRollbackReasonEvaluating, fmt.Sprintf("evaluating pods stability for %s", autoRollbackConfig.StabilityWindow), model.DesiredStateProgressWaiting)
 	}
 
-	return createAutoRollbackStatus(AutoRollbackReasonStable, fmt.Sprintf("pods are stable after instrumentation", autoRollbackConfig.StabilityWindow), model.DesiredStateProgressSuccess)
+	return createAutoRollbackStatus(AutoRollbackReasonStable, "pods are stable after instrumentation", model.DesiredStateProgressSuccess)
 }

--- a/frontend/graph/workload.graphqls
+++ b/frontend/graph/workload.graphqls
@@ -220,6 +220,11 @@ type K8sWorkloadRollout {
   rolloutStatus: DesiredConditionStatus!
 }
 
+type K8sWorkloadAutoRollback {
+  autoRollbackStatus: DesiredConditionStatus!
+  rollbackOccurred: Boolean!
+}
+
 # the override values being used for a single workload container.
 type K8sWorkloadContainerOverrides {
   containerName: String!
@@ -471,6 +476,7 @@ type K8sWorkloadConditions {
   runtimeDetection: DesiredConditionStatus
   agentInjectionEnabled: DesiredConditionStatus
   rollout: DesiredConditionStatus
+  autoRollback: DesiredConditionStatus
   agentInjected: DesiredConditionStatus
   processesAgentHealth: DesiredConditionStatus
   expectingTelemetry: DesiredConditionStatus
@@ -508,6 +514,10 @@ type K8sWorkload {
   agentEnabled: K8sWorkloadAgentEnabled
 
   rollout: K8sWorkloadRollout
+
+  # status for the auto rollback feature.
+  # used to monitor freshly instrumented sources and roll them back in case of any suspicious status.
+  autoRollback: K8sWorkloadAutoRollback
 
   # show all info for a specific source container.
   containers: [K8sWorkloadContainer!]

--- a/frontend/graph/workload.resolvers.go
+++ b/frontend/graph/workload.resolvers.go
@@ -117,9 +117,12 @@ func (r *k8sWorkloadResolver) WorkloadOdigosHealthStatus(ctx context.Context, ob
 
 	conditions := []*model.DesiredConditionStatus{}
 	if ic != nil {
+		autoRollbackConfig := l.GetAutoRollbackConfig()
+
 		conditions = append(conditions, status.CalculateRuntimeInspectionStatus(ic))
 		conditions = append(conditions, status.CalculateAgentInjectionEnabledStatus(ic))
 		conditions = append(conditions, status.CalculateRolloutStatus(ic))
+		conditions = append(conditions, status.CalculateAutoRollbackStatus(ic, autoRollbackConfig))
 	} else {
 		reasonStr := string(status.WorkloadOdigosHealthStatusReasonDisabled)
 		conditions = append(conditions, &model.DesiredConditionStatus{
@@ -194,9 +197,12 @@ func (r *k8sWorkloadResolver) Conditions(ctx context.Context, obj *model.K8sWork
 		return nil, err
 	}
 
+	autoRollbackConfig := l.GetAutoRollbackConfig()
+
 	runtimeDetection := status.CalculateRuntimeInspectionStatus(ic)
 	agentInjectionEnabled := status.CalculateAgentInjectionEnabledStatus(ic)
 	rollout := status.CalculateRolloutStatus(ic)
+	autoRollback := status.CalculateAutoRollbackStatus(ic, autoRollbackConfig)
 	agentInjected := status.CalculateAgentInjectedStatus(ic, pods)
 	containerNamesWithOptionalPodManifestInjection := getContainerNamesWithOptionalPodManifestInjection(ic)
 	processesAgentHealth, err := aggregateProcessesHealthForWorkload(ctx, obj.ID, containerNamesWithOptionalPodManifestInjection)
@@ -219,6 +225,7 @@ func (r *k8sWorkloadResolver) Conditions(ctx context.Context, obj *model.K8sWork
 		RuntimeDetection:      runtimeDetection,
 		AgentInjectionEnabled: agentInjectionEnabled,
 		Rollout:               rollout,
+		AutoRollback:          autoRollback,
 		AgentInjected:         agentInjected,
 		ProcessesAgentHealth:  processesAgentHealth,
 		ExpectingTelemetry:    telemetryMetrics.TelemetryObservedStatus,
@@ -339,6 +346,26 @@ func (r *k8sWorkloadResolver) Rollout(ctx context.Context, obj *model.K8sWorkloa
 
 	return &model.K8sWorkloadRollout{
 		RolloutStatus: rolloutStatus,
+	}, nil
+}
+
+// AutoRollback is the resolver for the autoRollback field.
+func (r *k8sWorkloadResolver) AutoRollback(ctx context.Context, obj *model.K8sWorkload) (*model.K8sWorkloadAutoRollback, error) {
+	if obj == nil || obj.ID == nil {
+		return nil, nil
+	}
+	l := loaders.For(ctx)
+	ic, err := l.GetInstrumentationConfig(ctx, *obj.ID)
+	if err != nil || ic == nil {
+		return nil, err
+	}
+
+	autoRollbackConfig := l.GetAutoRollbackConfig()
+	autoRollbackStatus := status.CalculateAutoRollbackStatus(ic, autoRollbackConfig)
+
+	return &model.K8sWorkloadAutoRollback{
+		AutoRollbackStatus: autoRollbackStatus,
+		RollbackOccurred:   ic.Status.RollbackOccurred,
 	}, nil
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: PLAT-1170

Add conditions in gql for tracking the state of auto rollback for a workload. this text should be shown in the UI to give indication for a source if it was successful in stability check, if it's still evaluating, or any other relevant case


#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
