### PR TITLE
feat: add gql workload field podsOdigosHealthStatus

### DIFF
--- a/frontend/gqlgen.yml
+++ b/frontend/gqlgen.yml
@@ -93,6 +93,8 @@ models:
         resolver: true
       podsHealthStatus:
         resolver: true
+      podsOdigosHealthStatus:
+        resolver: true
       workloadHealthStatus:
         resolver: true
       processesHealthStatus:

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -688,6 +688,7 @@ type ComplexityRoot struct {
 		Pods                       func(childComplexity int) int
 		PodsAgentInjectionStatus   func(childComplexity int) int
 		PodsHealthStatus           func(childComplexity int) int
+		PodsOdigosHealthStatus     func(childComplexity int) int
 		ProcessesHealthStatus      func(childComplexity int) int
 		RollbackOccurred           func(childComplexity int) int
 		Rollout                    func(childComplexity int) int
@@ -1436,6 +1437,7 @@ type K8sWorkloadResolver interface {
 	Pods(ctx context.Context, obj *model.K8sWorkload) ([]*model.K8sWorkloadPod, error)
 	PodsAgentInjectionStatus(ctx context.Context, obj *model.K8sWorkload) (*model.DesiredConditionStatus, error)
 	PodsHealthStatus(ctx context.Context, obj *model.K8sWorkload) (*model.DesiredConditionStatus, error)
+	PodsOdigosHealthStatus(ctx context.Context, obj *model.K8sWorkload) (*model.DesiredConditionStatus, error)
 	WorkloadHealthStatus(ctx context.Context, obj *model.K8sWorkload) (*model.DesiredConditionStatus, error)
 	ProcessesHealthStatus(ctx context.Context, obj *model.K8sWorkload) (*model.DesiredConditionStatus, error)
 	TelemetryMetrics(ctx context.Context, obj *model.K8sWorkload) ([]*model.K8sWorkloadTelemetryMetrics, error)
@@ -4460,6 +4462,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.K8sWorkload.PodsHealthStatus(childComplexity), true
+
+	case "K8sWorkload.podsOdigosHealthStatus":
+		if e.complexity.K8sWorkload.PodsOdigosHealthStatus == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkload.PodsOdigosHealthStatus(childComplexity), true
 
 	case "K8sWorkload.processesHealthStatus":
 		if e.complexity.K8sWorkload.ProcessesHealthStatus == nil {
@@ -28222,6 +28231,8 @@ func (ec *executionContext) fieldContext_K8sNamespace_workloads(_ context.Contex
 				return ec.fieldContext_K8sWorkload_podsAgentInjectionStatus(ctx, field)
 			case "podsHealthStatus":
 				return ec.fieldContext_K8sWorkload_podsHealthStatus(ctx, field)
+			case "podsOdigosHealthStatus":
+				return ec.fieldContext_K8sWorkload_podsOdigosHealthStatus(ctx, field)
 			case "workloadHealthStatus":
 				return ec.fieldContext_K8sWorkload_workloadHealthStatus(ctx, field)
 			case "processesHealthStatus":
@@ -28896,6 +28907,57 @@ func (ec *executionContext) _K8sWorkload_podsHealthStatus(ctx context.Context, f
 }
 
 func (ec *executionContext) fieldContext_K8sWorkload_podsHealthStatus(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkload",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "name":
+				return ec.fieldContext_DesiredConditionStatus_name(ctx, field)
+			case "status":
+				return ec.fieldContext_DesiredConditionStatus_status(ctx, field)
+			case "reasonEnum":
+				return ec.fieldContext_DesiredConditionStatus_reasonEnum(ctx, field)
+			case "message":
+				return ec.fieldContext_DesiredConditionStatus_message(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DesiredConditionStatus", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkload_podsOdigosHealthStatus(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkload_podsOdigosHealthStatus(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.K8sWorkload().PodsOdigosHealthStatus(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.DesiredConditionStatus)
+	fc.Result = res
+	return ec.marshalODesiredConditionStatus2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐDesiredConditionStatus(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkload_podsOdigosHealthStatus(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "K8sWorkload",
 		Field:      field,
@@ -43481,6 +43543,8 @@ func (ec *executionContext) fieldContext_Query_workloads(ctx context.Context, fi
 				return ec.fieldContext_K8sWorkload_podsAgentInjectionStatus(ctx, field)
 			case "podsHealthStatus":
 				return ec.fieldContext_K8sWorkload_podsHealthStatus(ctx, field)
+			case "podsOdigosHealthStatus":
+				return ec.fieldContext_K8sWorkload_podsOdigosHealthStatus(ctx, field)
 			case "workloadHealthStatus":
 				return ec.fieldContext_K8sWorkload_workloadHealthStatus(ctx, field)
 			case "processesHealthStatus":
@@ -43576,6 +43640,8 @@ func (ec *executionContext) fieldContext_Query_workloadsByIds(ctx context.Contex
 				return ec.fieldContext_K8sWorkload_podsAgentInjectionStatus(ctx, field)
 			case "podsHealthStatus":
 				return ec.fieldContext_K8sWorkload_podsHealthStatus(ctx, field)
+			case "podsOdigosHealthStatus":
+				return ec.fieldContext_K8sWorkload_podsOdigosHealthStatus(ctx, field)
 			case "workloadHealthStatus":
 				return ec.fieldContext_K8sWorkload_workloadHealthStatus(ctx, field)
 			case "processesHealthStatus":
@@ -58767,6 +58833,39 @@ func (ec *executionContext) _K8sWorkload(ctx context.Context, sel ast.SelectionS
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "podsOdigosHealthStatus":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._K8sWorkload_podsOdigosHealthStatus(ctx, field, obj)
 				return res
 			}
 

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -880,6 +880,7 @@ type K8sWorkload struct {
 	Pods                       []*K8sWorkloadPod                    `json:"pods,omitempty"`
 	PodsAgentInjectionStatus   *DesiredConditionStatus              `json:"podsAgentInjectionStatus"`
 	PodsHealthStatus           *DesiredConditionStatus              `json:"podsHealthStatus"`
+	PodsOdigosHealthStatus     *DesiredConditionStatus              `json:"podsOdigosHealthStatus,omitempty"`
 	WorkloadHealthStatus       *DesiredConditionStatus              `json:"workloadHealthStatus,omitempty"`
 	ProcessesHealthStatus      *DesiredConditionStatus              `json:"processesHealthStatus"`
 	TelemetryMetrics           []*K8sWorkloadTelemetryMetrics       `json:"telemetryMetrics"`

--- a/frontend/graph/status/podhealthodigos.go
+++ b/frontend/graph/status/podhealthodigos.go
@@ -14,12 +14,12 @@ const (
 type PodHealthOdigosStatusReason string
 
 const (
-	PodHealthOdigosStatusReasonHealthy                                    PodHealthOdigosStatusReason = "Healthy"
-	PodHealthOdigosStatusReasonNotInjected                                PodHealthOdigosStatusReason = "OdigosAgentNotInjected"
-	PodHealthOdigosStatusReasonInjectedUninstrumentedSource               PodHealthOdigosStatusReason = "OdigosAgentInjectedInUninstrumentedSource"
-	PodHealthOdigosStatusReasonInstrumentatedProcessUnhealthy             PodHealthOdigosStatusReason = "InstrumentatedProcessUnhealthy"
-	PodHealthOdigosStatusReasonNoInstrumentedProcesses                    PodHealthOdigosStatusReason = "NoInstrumentedProcesses"
-	PodHealthOdigosStatusReasonNoInstrumentedProcessesInStartingContainer PodHealthOdigosStatusReason = "NoInstrumentedProcessesInStartingContainer"
+	PodHealthOdigosStatusReasonHealthy                        PodHealthOdigosStatusReason = "Healthy"
+	PodHealthOdigosStatusReasonNotInjected                    PodHealthOdigosStatusReason = "OdigosAgentNotInjected"
+	PodHealthOdigosStatusReasonInjectedUninstrumentedSource   PodHealthOdigosStatusReason = "OdigosAgentInjectedInUninstrumentedSource"
+	PodHealthOdigosStatusReasonInstrumentatedProcessUnhealthy PodHealthOdigosStatusReason = "InstrumentatedProcessUnhealthy"
+	PodHealthOdigosStatusReasonNoInstrumentedProcesses        PodHealthOdigosStatusReason = "NoInstrumentedProcesses"
+	PodHealthOdigosStatusReasonNoPods                         PodHealthOdigosStatusReason = "NoPods"
 )
 
 func createPodContainerHealthOdigosStatus(reason PodHealthOdigosStatusReason, message string, status model.DesiredStateProgress) *model.DesiredConditionStatus {
@@ -98,4 +98,26 @@ func CalculatePodHealthOdigosStatus(computedPod *computed.CachedPod, containersO
 	}
 
 	return createPodHealthOdigosStatus(PodHealthOdigosStatusReasonHealthy, "odigos instrumentation in pod is healthy", model.DesiredStateProgressSuccess)
+}
+
+func MostSeverPodStatusToAggregated(mostSeverPodStatus *model.DesiredConditionStatus) *model.DesiredConditionStatus {
+	if mostSeverPodStatus == nil || mostSeverPodStatus.ReasonEnum == nil {
+		return nil
+	}
+
+	switch *mostSeverPodStatus.ReasonEnum {
+	case string(PodHealthOdigosStatusReasonHealthy):
+		return createPodHealthOdigosStatus(PodHealthOdigosStatusReasonHealthy, "odigos is healthy in all pods", model.DesiredStateProgressSuccess)
+	case string(PodHealthOdigosStatusReasonNotInjected):
+		return createPodHealthOdigosStatus(PodHealthOdigosStatusReasonNotInjected, "not all pods are running with odigos agent", mostSeverPodStatus.Status)
+	case string(PodHealthOdigosStatusReasonInjectedUninstrumentedSource):
+		return createPodHealthOdigosStatus(PodHealthOdigosStatusReasonInjectedUninstrumentedSource, "not all pods are running without odigos agent", mostSeverPodStatus.Status)
+	case string(PodHealthOdigosStatusReasonInstrumentatedProcessUnhealthy),
+		string(PodHealthOdigosStatusReasonNoInstrumentedProcesses),
+		string(PodHealthOdigosStatusReasonNoPods):
+		return mostSeverPodStatus
+	default:
+		return mostSeverPodStatus
+	}
+
 }

--- a/frontend/graph/workload.graphqls
+++ b/frontend/graph/workload.graphqls
@@ -534,6 +534,9 @@ type K8sWorkload {
   # this value is the general health of the workload, and issues here may not be related to odigos.
   podsHealthStatus: DesiredConditionStatus!
 
+  # aggregated value for the health of odigos instrumentation agent in all the pods of this workload.
+  podsOdigosHealthStatus: DesiredConditionStatus
+
   # aggregated value for the health of the workload, as reported on it's status field in kubernetes.
   # this value is not related to odigos, it can progress or error due to normal deployments in the cluster, not necessarily those related to odigos.
   workloadHealthStatus: DesiredConditionStatus

--- a/frontend/graph/workload.resolvers.go
+++ b/frontend/graph/workload.resolvers.go
@@ -597,6 +597,58 @@ func (r *k8sWorkloadResolver) PodsHealthStatus(ctx context.Context, obj *model.K
 	return aggregatePodHealthStatus, nil
 }
 
+// PodsOdigosHealthStatus is the resolver for the podsOdigosHealthStatus field.
+func (r *k8sWorkloadResolver) PodsOdigosHealthStatus(ctx context.Context, obj *model.K8sWorkload) (*model.DesiredConditionStatus, error) {
+	l := loaders.For(ctx)
+	pods, err := l.GetWorkloadPods(ctx, *obj.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	ic, err := l.GetInstrumentationConfig(ctx, *obj.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(pods) == 0 {
+		reasonStr := string(status.PodHealthOdigosStatusReasonNoPods)
+		return &model.DesiredConditionStatus{
+			Name:       status.PodHealthOdigosStatus,
+			Status:     model.DesiredStateProgressUnknown,
+			ReasonEnum: &reasonStr,
+			Message:    "no pods for this workload",
+		}, nil
+	}
+
+	// aggregate the health status of all containers in all pods
+	containersHealthConditions := make([]*model.DesiredConditionStatus, 0, len(pods))
+	for _, pod := range pods {
+		containersOdigosHealthConditions := make([]*model.DesiredConditionStatus, 0, len(pod.Containers))
+		for _, container := range pod.Containers {
+			containerConfig := getContainerConfigByName(ic, container.ContainerName)
+			iis, err := l.GetInstrumentationInstancesForContainer(ctx, loaders.PodContainerId{
+				Namespace:     pod.PodNamespace,
+				PodName:       pod.PodName,
+				ContainerName: container.ContainerName,
+			})
+			if err != nil {
+				return nil, err
+			}
+			healthStatus := status.CalculatePodContainerHealthOdigosStatus(&container, containerConfig, iis)
+			if healthStatus != nil {
+				containersOdigosHealthConditions = append(containersOdigosHealthConditions, healthStatus)
+			}
+		}
+		healthStatus := status.CalculatePodHealthOdigosStatus(&pod, containersOdigosHealthConditions)
+		if healthStatus != nil {
+			containersHealthConditions = append(containersHealthConditions, healthStatus)
+		}
+	}
+
+	agg := status.AggregateConditionsBySeverity(containersHealthConditions)
+	return status.MostSeverPodStatusToAggregated(agg), nil
+}
+
 // WorkloadHealthStatus is the resolver for the workloadHealthStatus field.
 func (r *k8sWorkloadResolver) WorkloadHealthStatus(ctx context.Context, obj *model.K8sWorkload) (*model.DesiredConditionStatus, error) {
 	l := loaders.For(ctx)


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: PLAT-1175

Add field to the workload gql to show if odigos is healthy in the workload pods.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
