### PR TITLE
fix: prefer no restart required over static pod in condition

### DIFF
--- a/instrumentor/controllers/agentenabled/rollout/rollout.go
+++ b/instrumentor/controllers/agentenabled/rollout/rollout.go
@@ -65,7 +65,13 @@ func Do(ctx context.Context, c client.Client, ic *odigosv1alpha1.Instrumentation
 		if ic == nil {
 			return RolloutResult{}, nil
 		}
-		changed := meta.SetStatusCondition(&ic.Status.Conditions, conditionStaticPodsNotSupported)
+
+		changed := false
+		if ic.Spec.PodManifestInjectionOptional {
+			changed = meta.SetStatusCondition(&ic.Status.Conditions, conditionRestartNotRequiredForDistro)
+		} else {
+			changed = meta.SetStatusCondition(&ic.Status.Conditions, conditionStaticPodsNotSupported)
+		}
 		return RolloutResult{StatusChanged: changed}, nil
 	}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: CORE-1094

For static go pods, we should set the condition from
"static pods don't support restart" -> "The selected instrumentation distributions do not require application restart".

first one is an error, while second one is "irrelevant"

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
fix status of source rollout when it's both not require a restart and static pod. prefer the "no restart" status over static pod
```
