### PR TITLE
CORE-1071 | feat(profiling): make VM profile-attrs PID→service cache survive collector reloads

### DIFF
--- a/collector/processors/odigosvmprofileattrsprocessor/processor.go
+++ b/collector/processors/odigosvmprofileattrsprocessor/processor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -14,7 +13,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/odigos-io/odigos/collector/processors/odigosvmprofileattrsprocessor/internal/metadata"
-	"github.com/odigos-io/odigos/common/unixfd"
 )
 
 // Resource attribute keys, sourced from semconv so they stay aligned with the eBPF profiler
@@ -31,9 +29,6 @@ type vmProfileAttrsProcessor struct {
 	cfg              *Config
 	attrCache        *profileAttrCache
 	telemetryBuilder *metadata.TelemetryBuilder
-
-	cancel context.CancelFunc
-	wg     sync.WaitGroup
 }
 
 // capabilities reports that this processor mutates pprofile data.
@@ -41,35 +36,20 @@ func (p *vmProfileAttrsProcessor) capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: true}
 }
 
-// start spawns the unixfd client goroutine that streams attribute events into the cache.
-// We derive runCtx from the Start ctx (OTel collector keeps it alive for the whole component
-// lifetime, cancelled only on collector shutdown). Shutdown also explicitly cancels for early
-// teardown during config reloads. This mirrors the pattern used by odigosebpfreceiver.
-func (p *vmProfileAttrsProcessor) start(ctx context.Context, _ component.Host) error {
-	runCtx, cancel := context.WithCancel(ctx)
-	p.cancel = cancel
-
-	p.wg.Add(1)
-	go func() {
-		defer p.wg.Done()
-		err := unixfd.ConnectAndListenProfileAttrs(runCtx, p.cfg.SocketPath, p.logger,
-			func(line string) { p.attrCache.applyEvent(line) },
-			func() { p.attrCache.reset() }, // wipe cache on each new session before snapshot replay
-		)
-		if err != nil && runCtx.Err() == nil {
-			p.logger.Error("profiles attr unix client stopped", zap.Error(err))
-		}
-	}()
-
+// start binds this processor to the process-global PID→attrs cache (and starts the
+// single unixfd client on first call). The cache + client are intentionally NOT
+// owned by the processor: a config reload destroys and rebuilds the processor, but
+// the singleton survives, so the cache stays warm and no profiles are dropped during
+// the rebuild. See shared_cache.go.
+func (p *vmProfileAttrsProcessor) start(_ context.Context, _ component.Host) error {
+	p.attrCache = sharedProfileAttrCache(p.cfg.SocketPath, p.logger)
 	return nil
 }
 
-// shutdown cancels the unixfd client and releases the telemetry builder.
+// shutdown releases the telemetry builder. It deliberately does NOT stop the unixfd
+// client or clear the cache — those are process-global (shared_cache.go) and must
+// survive config reloads (which call shutdown on the retiring processor).
 func (p *vmProfileAttrsProcessor) shutdown(context.Context) error {
-	if p.cancel != nil {
-		p.cancel()
-	}
-	p.wg.Wait()
 	if p.telemetryBuilder != nil {
 		p.telemetryBuilder.Shutdown()
 	}

--- a/collector/processors/odigosvmprofileattrsprocessor/processor_test.go
+++ b/collector/processors/odigosvmprofileattrsprocessor/processor_test.go
@@ -1,6 +1,7 @@
 package odigosvmprofileattrsprocessor
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,6 +11,23 @@ import (
 
 	"github.com/odigos-io/odigos/common/unixfd"
 )
+
+// resetSharedForTest cancels the singleton's client goroutine and resets package state
+// so each test starts clean and goleak (the generated TestMain) sees no lingering
+// goroutine. Production NEVER calls this — the client lives for the process lifetime.
+func resetSharedForTest(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		if sharedCancel != nil {
+			sharedCancel()
+			<-sharedDone
+		}
+		sharedOnce = sync.Once{}
+		sharedCache = nil
+		sharedCancel = nil
+		sharedDone = nil
+	})
+}
 
 func TestProfileAttrCache_RegisterUnregister(t *testing.T) {
 	cache := newProfileAttrCache()
@@ -145,4 +163,35 @@ func TestProfileAttrCache_ResetWipesState(t *testing.T) {
 	require.Equal(t, 0, c.size())
 	_, ok := c.get(1)
 	require.False(t, ok)
+}
+
+// TestSharedCache_SurvivesProcessorRebuild verifies the fix for the SIGHUP cache-loss
+// bug: the PID→attrs cache is process-global, so a config reload (which destroys and
+// rebuilds the processor) leaves the cache warm. Two start() calls — simulating the
+// pre- and post-reload processor instances — must share the same cache, and an entry
+// registered before the "reload" must survive it.
+func TestSharedCache_SurvivesProcessorRebuild(t *testing.T) {
+	resetSharedForTest(t)
+	cfg := &Config{SocketPath: "/tmp/odigos-test-nonexistent.sock"} // client retries harmlessly
+
+	p1 := &vmProfileAttrsProcessor{logger: zap.NewNop(), cfg: cfg}
+	require.NoError(t, p1.start(t.Context(), nil))
+
+	// Register a PID via the shared cache (as the live unixfd stream would).
+	p1.attrCache.applyEvent(unixfd.EncodeAttrRegister(7, "service.name:catalog"))
+	packed, ok := p1.attrCache.get(7)
+	require.True(t, ok)
+	require.Equal(t, "service.name:catalog", packed)
+
+	// Simulate a config reload: the old processor is shut down and a new one is built.
+	require.NoError(t, p1.shutdown(t.Context()))
+	p2 := &vmProfileAttrsProcessor{logger: zap.NewNop(), cfg: cfg}
+	require.NoError(t, p2.start(t.Context(), nil))
+
+	// The rebuilt processor must reference the SAME cache (not a fresh empty one)...
+	require.Same(t, p1.attrCache, p2.attrCache, "cache must survive the processor rebuild")
+	// ...and the entry registered before the reload must still be there.
+	packed, ok = p2.attrCache.get(7)
+	require.True(t, ok, "entry must survive the reload (no cache wipe)")
+	require.Equal(t, "service.name:catalog", packed)
 }

--- a/collector/processors/odigosvmprofileattrsprocessor/shared_cache.go
+++ b/collector/processors/odigosvmprofileattrsprocessor/shared_cache.go
@@ -1,0 +1,57 @@
+package odigosvmprofileattrsprocessor
+
+import (
+	"context"
+	"sync"
+
+	"go.uber.org/zap"
+
+	"github.com/odigos-io/odigos/common/unixfd"
+)
+
+// The PID→service.name cache and its single unixfd client are process-global, not
+// per-processor. This is deliberate: a collector config reload (SIGHUP) does a full
+// service.Shutdown()+rebuild, which destroys and recreates the processor. If the
+// cache lived on the processor, every reload would drop it, force a reconnect+reset,
+// and the rebuilt processor would enrich from an empty cache during warm-up —
+// silently dropping profiles on every config change (add a source/destination, etc.).
+//
+// By owning the cache + client at package scope on a context.Background()-scoped
+// goroutine, the connection stays open and the cache stays warm across reloads. The
+// rebuilt processor simply references the same surviving cache. The singleton is
+// created lazily on the first processor start() and lives for the whole process; it
+// is intentionally never torn down on processor shutdown.
+var (
+	sharedOnce   sync.Once
+	sharedCache  *profileAttrCache
+	sharedCancel context.CancelFunc // cancels the client ctx; only used by tests for cleanup
+	sharedDone   chan struct{}      // closed when the client goroutine exits (tests wait on it)
+)
+
+// sharedProfileAttrCache returns the process-global PID→attrs cache, starting the
+// single unixfd client that maintains it on first call. socketPath/logger from the
+// first caller win (all profiles processors in one collector share one VM-agent
+// socket, so this is the same value for every instance).
+func sharedProfileAttrCache(socketPath string, logger *zap.Logger) *profileAttrCache {
+	sharedOnce.Do(func() {
+		sharedCache = newProfileAttrCache()
+		// Derived from context.Background(): the client must outlive any individual
+		// processor instance so the cache survives config reloads. In production the
+		// cancel is never called (lives until process exit); tests cancel it to clean
+		// up the goroutine (goleak).
+		ctx, cancel := context.WithCancel(context.Background())
+		sharedCancel = cancel
+		sharedDone = make(chan struct{})
+		go func() {
+			defer close(sharedDone)
+			err := unixfd.ConnectAndListenProfileAttrs(ctx, socketPath, logger,
+				func(line string) { sharedCache.applyEvent(line) },
+				func() { sharedCache.reset() }, // wipe on each new session before snapshot replay
+			)
+			if err != nil && ctx.Err() == nil {
+				logger.Error("shared profiles attr unix client stopped", zap.Error(err))
+			}
+		}()
+	})
+	return sharedCache
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
The `odigosvmprofileattrsprocessor` PID→service.name cache (and its unixfd client to the VM agent) lived on the processor instance. A collector config reload (SIGHUP) does a full Shutdown()+rebuild, destroying the processor and its cache — so the rebuilt processor enriched profiles from an empty cache during warm-up and silently dropped them (`dropped_resource_profiles`) on every reload.

### Fix
Move the cache + client to a package-level singleton (`sync.Once`, `context.Background()` goroutine) that the processor only references. A reload rebuilds the processor but never touches the singleton, so the cache stays warm — zero drops across reloads. New `shared_cache.go`; `start()` binds the singleton, `shutdown()` no longer tears down the client; a cancellable context keeps the package goleak test clean.

### Testing
- Unit: `TestSharedCache_SurvivesProcessorRebuild`.
- Live on a VM: `systemctl reload odigos-otelcol` under traffic kept profiles flowing
  with no cold-cache drop spike; same collector PID (true reload).


#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Fix VM profiling dropping profiles on every collector config reload by making the PID→service.name enrichment cache process-global
```
