### PR TITLE
Rollback success

### DIFF
--- a/frontend/graph/status/rollback.go
+++ b/frontend/graph/status/rollback.go
@@ -66,7 +66,7 @@ func CalculateAutoRollbackStatus(ic *odigosv1alpha1.InstrumentationConfig, autoR
 	timeSinceInstrumentation := time.Since(ic.Status.InstrumentationTime.Time)
 	if timeSinceInstrumentation < autoRollbackConfig.StabilityWindow {
 		// if we are within the stability window, and did not mark the rollback occurred, we are still evaluating
-		return createAutoRollbackStatus(AutoRollbackReasonEvaluating, fmt.Sprintf("evaluating pods stability for %s", autoRollbackConfig.StabilityWindow), model.DesiredStateProgressWaiting)
+		return createAutoRollbackStatus(AutoRollbackReasonEvaluating, fmt.Sprintf("evaluating pods stability for %s", autoRollbackConfig.StabilityWindow), model.DesiredStateProgressSuccess)
 	}
 
 	return createAutoRollbackStatus(AutoRollbackReasonStable, "pods are stable after instrumentation", model.DesiredStateProgressSuccess)

--- a/frontend/graph/status/rollback.go
+++ b/frontend/graph/status/rollback.go
@@ -22,6 +22,7 @@ const (
 	AutoRollbackReasonStable            AutoRollbackReason = "Stable"
 	AutoRollbackReasonEvaluating        AutoRollbackReason = "Evaluating"
 	AutoRollbackReasonWaitingForRollout AutoRollbackReason = "WaitingForRollout"
+	AutoRollbackReasonNotApplicable     AutoRollbackReason = "NotApplicable"
 )
 
 func createAutoRollbackStatus(reason AutoRollbackReason, message string, status model.DesiredStateProgress) *model.DesiredConditionStatus {
@@ -55,6 +56,10 @@ func CalculateAutoRollbackStatus(ic *odigosv1alpha1.InstrumentationConfig, autoR
 	// if we know it was rolled back due to auto-heal
 	if ic.Status.RollbackOccurred {
 		return createAutoRollbackStatus(AutoRollbackReasonRollbackOccurred, "odigos detected a crash and rolled back the source to protect your application", model.DesiredStateProgressNotice)
+	}
+
+	if ic.Spec.PodManifestInjectionOptional {
+		return createAutoRollbackStatus(AutoRollbackReasonNotApplicable, "no stability check for source that odigos agent is not restarting", model.DesiredStateProgressIrrelevant)
 	}
 
 	// rollback is only checked after the workload is rolled out.


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: PLAT-1170

Fix 2 issues with rollback status:

1. while we evaluating the auto-heal for 1 hour after instrumentation - publish this case as success instead of waiting so it does not make the ui show a spinner for 1 hour.
2. if the workload is a "no-restart" workload, then it will not rollout thus will not rollback, return a relevant error

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
