### PR TITLE
fix: CORE-1056 - Fix a deadlock in Deviceplugin that causes terminati…

### DIFF
--- a/deviceplugin/pkg/internal.go
+++ b/deviceplugin/pkg/internal.go
@@ -42,7 +42,14 @@ func runDeviceManager() error {
 	}
 
 	manager := dpm.NewManager(lister, commonlogger.ToLogr())
-	manager.Run(ctx)
+	manager.Run(ctx) // Blocks until SIGTERM/SIGINT
+
+	// Cancel context so background goroutines (pprof, log-level watcher) can shut down.
+	// manager.Run blocks until SIGTERM/SIGINT; once it returns the context must be
+	// cancelled before we wait, otherwise we deadlock: pprofDone waits on ctx.Done()
+	// while cancel() is deferred until after pprofDone — a circular dependency.
+	// NO-OP, can be called multiple times.
+	cancel()
 
 	// Wait for pprof server to finish
 	<-pprofDone


### PR DESCRIPTION
…ng the PODs (SIGTERM) to take longer than expected

#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
BugFix: Fix a deadlock in the deviceplugin SIGTERM handling
#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
