### PR TITLE
feat(sampling): add SourceSampling query for workload-specific sampling rules

### DIFF
--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -1172,6 +1172,7 @@ type ComplexityRoot struct {
 		RemoteConfig                      func(childComplexity int) int
 		Sampling                          func(childComplexity int) int
 		SourceConditions                  func(childComplexity int) int
+		SourceSampling                    func(childComplexity int, workloadID model.K8sWorkloadIDInput) int
 		Workloads                         func(childComplexity int, filter *model.WorkloadFilter) int
 		WorkloadsByIds                    func(childComplexity int, ids []*model.K8sWorkloadIDInput) int
 	}
@@ -1306,8 +1307,20 @@ type ComplexityRoot struct {
 		RuntimeVersion         func(childComplexity int) int
 	}
 
+	SourceContainerSampling struct {
+		ContainerName            func(childComplexity int) int
+		CostReductionRules       func(childComplexity int) int
+		HighlyRelevantOperations func(childComplexity int) int
+		NoisyOperations          func(childComplexity int) int
+	}
+
 	SourceProfilingResult struct {
 		ProfileJSON func(childComplexity int) int
+	}
+
+	SourceSampling struct {
+		Containers func(childComplexity int) int
+		WorkloadID func(childComplexity int) int
 	}
 
 	SourcesScopes struct {
@@ -1517,6 +1530,7 @@ type QueryResolver interface {
 	Pod(ctx context.Context, namespace string, name string) (*model.PodDetails, error)
 	ProfilingSlots(ctx context.Context) (*model.ProfilingSlots, error)
 	Sampling(ctx context.Context) (*model.Sampling, error)
+	SourceSampling(ctx context.Context, workloadID model.K8sWorkloadIDInput) (*model.SourceSampling, error)
 	Workloads(ctx context.Context, filter *model.WorkloadFilter) ([]*model.K8sWorkload, error)
 	WorkloadsByIds(ctx context.Context, ids []*model.K8sWorkloadIDInput) ([]*model.K8sWorkload, error)
 	Namespaces(ctx context.Context) ([]*model.K8sNamespace, error)
@@ -6738,6 +6752,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.SourceConditions(childComplexity), true
 
+	case "Query.sourceSampling":
+		if e.complexity.Query.SourceSampling == nil {
+			break
+		}
+
+		args, err := ec.field_Query_sourceSampling_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.SourceSampling(childComplexity, args["workloadId"].(model.K8sWorkloadIDInput)), true
+
 	case "Query.workloads":
 		if e.complexity.Query.Workloads == nil {
 			break
@@ -7252,12 +7278,54 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.SourceContainer.RuntimeVersion(childComplexity), true
 
+	case "SourceContainerSampling.containerName":
+		if e.complexity.SourceContainerSampling.ContainerName == nil {
+			break
+		}
+
+		return e.complexity.SourceContainerSampling.ContainerName(childComplexity), true
+
+	case "SourceContainerSampling.costReductionRules":
+		if e.complexity.SourceContainerSampling.CostReductionRules == nil {
+			break
+		}
+
+		return e.complexity.SourceContainerSampling.CostReductionRules(childComplexity), true
+
+	case "SourceContainerSampling.highlyRelevantOperations":
+		if e.complexity.SourceContainerSampling.HighlyRelevantOperations == nil {
+			break
+		}
+
+		return e.complexity.SourceContainerSampling.HighlyRelevantOperations(childComplexity), true
+
+	case "SourceContainerSampling.noisyOperations":
+		if e.complexity.SourceContainerSampling.NoisyOperations == nil {
+			break
+		}
+
+		return e.complexity.SourceContainerSampling.NoisyOperations(childComplexity), true
+
 	case "SourceProfilingResult.profileJson":
 		if e.complexity.SourceProfilingResult.ProfileJSON == nil {
 			break
 		}
 
 		return e.complexity.SourceProfilingResult.ProfileJSON(childComplexity), true
+
+	case "SourceSampling.containers":
+		if e.complexity.SourceSampling.Containers == nil {
+			break
+		}
+
+		return e.complexity.SourceSampling.Containers(childComplexity), true
+
+	case "SourceSampling.workloadId":
+		if e.complexity.SourceSampling.WorkloadID == nil {
+			break
+		}
+
+		return e.complexity.SourceSampling.WorkloadID(childComplexity), true
 
 	case "SourcesScopes.languages":
 		if e.complexity.SourcesScopes.Languages == nil {
@@ -9864,6 +9932,34 @@ func (ec *executionContext) field_Query_pod_argsName(
 	}
 
 	var zeroVal string
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Query_sourceSampling_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Query_sourceSampling_argsWorkloadID(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["workloadId"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Query_sourceSampling_argsWorkloadID(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (model.K8sWorkloadIDInput, error) {
+	if _, ok := rawArgs["workloadId"]; !ok {
+		var zeroVal model.K8sWorkloadIDInput
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("workloadId"))
+	if tmp, ok := rawArgs["workloadId"]; ok {
+		return ec.unmarshalNK8sWorkloadIdInput2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadIDInput(ctx, tmp)
+	}
+
+	var zeroVal model.K8sWorkloadIDInput
 	return zeroVal, nil
 }
 
@@ -43478,6 +43574,67 @@ func (ec *executionContext) fieldContext_Query_sampling(_ context.Context, field
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_sourceSampling(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_sourceSampling(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().SourceSampling(rctx, fc.Args["workloadId"].(model.K8sWorkloadIDInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.SourceSampling)
+	fc.Result = res
+	return ec.marshalNSourceSampling2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourceSampling(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_sourceSampling(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "workloadId":
+				return ec.fieldContext_SourceSampling_workloadId(ctx, field)
+			case "containers":
+				return ec.fieldContext_SourceSampling_containers(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SourceSampling", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_sourceSampling_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_workloads(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_workloads(ctx, field)
 	if err != nil {
@@ -47151,6 +47308,234 @@ func (ec *executionContext) fieldContext_SourceContainer_otelDistroName(_ contex
 	return fc, nil
 }
 
+func (ec *executionContext) _SourceContainerSampling_containerName(ctx context.Context, field graphql.CollectedField, obj *model.SourceContainerSampling) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SourceContainerSampling_containerName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ContainerName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SourceContainerSampling_containerName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SourceContainerSampling",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SourceContainerSampling_noisyOperations(ctx context.Context, field graphql.CollectedField, obj *model.SourceContainerSampling) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SourceContainerSampling_noisyOperations(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NoisyOperations, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.NoisyOperationRule)
+	fc.Result = res
+	return ec.marshalNNoisyOperationRule2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐNoisyOperationRuleᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SourceContainerSampling_noisyOperations(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SourceContainerSampling",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "ruleId":
+				return ec.fieldContext_NoisyOperationRule_ruleId(ctx, field)
+			case "name":
+				return ec.fieldContext_NoisyOperationRule_name(ctx, field)
+			case "disabled":
+				return ec.fieldContext_NoisyOperationRule_disabled(ctx, field)
+			case "sourceScopes":
+				return ec.fieldContext_NoisyOperationRule_sourceScopes(ctx, field)
+			case "operation":
+				return ec.fieldContext_NoisyOperationRule_operation(ctx, field)
+			case "percentageAtMost":
+				return ec.fieldContext_NoisyOperationRule_percentageAtMost(ctx, field)
+			case "notes":
+				return ec.fieldContext_NoisyOperationRule_notes(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type NoisyOperationRule", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SourceContainerSampling_highlyRelevantOperations(ctx context.Context, field graphql.CollectedField, obj *model.SourceContainerSampling) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SourceContainerSampling_highlyRelevantOperations(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.HighlyRelevantOperations, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.HighlyRelevantOperationRule)
+	fc.Result = res
+	return ec.marshalNHighlyRelevantOperationRule2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐHighlyRelevantOperationRuleᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SourceContainerSampling_highlyRelevantOperations(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SourceContainerSampling",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "ruleId":
+				return ec.fieldContext_HighlyRelevantOperationRule_ruleId(ctx, field)
+			case "name":
+				return ec.fieldContext_HighlyRelevantOperationRule_name(ctx, field)
+			case "disabled":
+				return ec.fieldContext_HighlyRelevantOperationRule_disabled(ctx, field)
+			case "sourceScopes":
+				return ec.fieldContext_HighlyRelevantOperationRule_sourceScopes(ctx, field)
+			case "error":
+				return ec.fieldContext_HighlyRelevantOperationRule_error(ctx, field)
+			case "durationAtLeastMs":
+				return ec.fieldContext_HighlyRelevantOperationRule_durationAtLeastMs(ctx, field)
+			case "operation":
+				return ec.fieldContext_HighlyRelevantOperationRule_operation(ctx, field)
+			case "percentageAtLeast":
+				return ec.fieldContext_HighlyRelevantOperationRule_percentageAtLeast(ctx, field)
+			case "notes":
+				return ec.fieldContext_HighlyRelevantOperationRule_notes(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type HighlyRelevantOperationRule", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SourceContainerSampling_costReductionRules(ctx context.Context, field graphql.CollectedField, obj *model.SourceContainerSampling) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SourceContainerSampling_costReductionRules(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CostReductionRules, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.CostReductionRule)
+	fc.Result = res
+	return ec.marshalNCostReductionRule2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐCostReductionRuleᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SourceContainerSampling_costReductionRules(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SourceContainerSampling",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "ruleId":
+				return ec.fieldContext_CostReductionRule_ruleId(ctx, field)
+			case "name":
+				return ec.fieldContext_CostReductionRule_name(ctx, field)
+			case "disabled":
+				return ec.fieldContext_CostReductionRule_disabled(ctx, field)
+			case "sourceScopes":
+				return ec.fieldContext_CostReductionRule_sourceScopes(ctx, field)
+			case "operation":
+				return ec.fieldContext_CostReductionRule_operation(ctx, field)
+			case "percentageAtMost":
+				return ec.fieldContext_CostReductionRule_percentageAtMost(ctx, field)
+			case "notes":
+				return ec.fieldContext_CostReductionRule_notes(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CostReductionRule", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _SourceProfilingResult_profileJson(ctx context.Context, field graphql.CollectedField, obj *model.SourceProfilingResult) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_SourceProfilingResult_profileJson(ctx, field)
 	if err != nil {
@@ -47190,6 +47575,112 @@ func (ec *executionContext) fieldContext_SourceProfilingResult_profileJson(_ con
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SourceSampling_workloadId(ctx context.Context, field graphql.CollectedField, obj *model.SourceSampling) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SourceSampling_workloadId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.WorkloadID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.K8sWorkloadID)
+	fc.Result = res
+	return ec.marshalNK8sWorkloadId2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SourceSampling_workloadId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SourceSampling",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "namespace":
+				return ec.fieldContext_K8sWorkloadId_namespace(ctx, field)
+			case "kind":
+				return ec.fieldContext_K8sWorkloadId_kind(ctx, field)
+			case "name":
+				return ec.fieldContext_K8sWorkloadId_name(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type K8sWorkloadId", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SourceSampling_containers(ctx context.Context, field graphql.CollectedField, obj *model.SourceSampling) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SourceSampling_containers(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Containers, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.SourceContainerSampling)
+	fc.Result = res
+	return ec.marshalNSourceContainerSampling2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourceContainerSamplingᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SourceSampling_containers(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SourceSampling",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "containerName":
+				return ec.fieldContext_SourceContainerSampling_containerName(ctx, field)
+			case "noisyOperations":
+				return ec.fieldContext_SourceContainerSampling_noisyOperations(ctx, field)
+			case "highlyRelevantOperations":
+				return ec.fieldContext_SourceContainerSampling_highlyRelevantOperations(ctx, field)
+			case "costReductionRules":
+				return ec.fieldContext_SourceContainerSampling_costReductionRules(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SourceContainerSampling", field.Name)
 		},
 	}
 	return fc, nil
@@ -62852,6 +63343,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "sourceSampling":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_sourceSampling(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "workloads":
 			field := field
 
@@ -64161,6 +64674,60 @@ func (ec *executionContext) _SourceContainer(ctx context.Context, sel ast.Select
 	return out
 }
 
+var sourceContainerSamplingImplementors = []string{"SourceContainerSampling"}
+
+func (ec *executionContext) _SourceContainerSampling(ctx context.Context, sel ast.SelectionSet, obj *model.SourceContainerSampling) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, sourceContainerSamplingImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("SourceContainerSampling")
+		case "containerName":
+			out.Values[i] = ec._SourceContainerSampling_containerName(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "noisyOperations":
+			out.Values[i] = ec._SourceContainerSampling_noisyOperations(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "highlyRelevantOperations":
+			out.Values[i] = ec._SourceContainerSampling_highlyRelevantOperations(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "costReductionRules":
+			out.Values[i] = ec._SourceContainerSampling_costReductionRules(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var sourceProfilingResultImplementors = []string{"SourceProfilingResult"}
 
 func (ec *executionContext) _SourceProfilingResult(ctx context.Context, sel ast.SelectionSet, obj *model.SourceProfilingResult) graphql.Marshaler {
@@ -64174,6 +64741,50 @@ func (ec *executionContext) _SourceProfilingResult(ctx context.Context, sel ast.
 			out.Values[i] = graphql.MarshalString("SourceProfilingResult")
 		case "profileJson":
 			out.Values[i] = ec._SourceProfilingResult_profileJson(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var sourceSamplingImplementors = []string{"SourceSampling"}
+
+func (ec *executionContext) _SourceSampling(ctx context.Context, sel ast.SelectionSet, obj *model.SourceSampling) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, sourceSamplingImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("SourceSampling")
+		case "workloadId":
+			out.Values[i] = ec._SourceSampling_workloadId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "containers":
+			out.Values[i] = ec._SourceSampling_containers(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -67219,6 +67830,11 @@ func (ec *executionContext) marshalNK8sWorkloadId2ᚖgithubᚗcomᚋodigosᚑio�
 	return ec._K8sWorkloadId(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNK8sWorkloadIdInput2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadIDInput(ctx context.Context, v any) (model.K8sWorkloadIDInput, error) {
+	res, err := ec.unmarshalInputK8sWorkloadIdInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNK8sWorkloadIdInput2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadIDInputᚄ(ctx context.Context, v any) ([]*model.K8sWorkloadIDInput, error) {
 	var vSlice []any
 	vSlice = graphql.CoerceList(v)
@@ -68486,6 +69102,74 @@ func (ec *executionContext) marshalNSourceContainer2ᚖgithubᚗcomᚋodigosᚑi
 		return graphql.Null
 	}
 	return ec._SourceContainer(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNSourceContainerSampling2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourceContainerSamplingᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.SourceContainerSampling) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNSourceContainerSampling2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourceContainerSampling(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNSourceContainerSampling2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourceContainerSampling(ctx context.Context, sel ast.SelectionSet, v *model.SourceContainerSampling) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._SourceContainerSampling(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNSourceSampling2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourceSampling(ctx context.Context, sel ast.SelectionSet, v model.SourceSampling) graphql.Marshaler {
+	return ec._SourceSampling(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNSourceSampling2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourceSampling(ctx context.Context, sel ast.SelectionSet, v *model.SourceSampling) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._SourceSampling(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNSpanAttributeFilter2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSpanAttributeFilter(ctx context.Context, sel ast.SelectionSet, v *model.SpanAttributeFilter) graphql.Marshaler {

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -1577,9 +1577,21 @@ type SourceContainer struct {
 	OtelDistroName         *string `json:"otelDistroName,omitempty"`
 }
 
+type SourceContainerSampling struct {
+	ContainerName            string                         `json:"containerName"`
+	NoisyOperations          []*NoisyOperationRule          `json:"noisyOperations"`
+	HighlyRelevantOperations []*HighlyRelevantOperationRule `json:"highlyRelevantOperations"`
+	CostReductionRules       []*CostReductionRule           `json:"costReductionRules"`
+}
+
 // Pyroscope-style flame profile for one source (JSON string).
 type SourceProfilingResult struct {
 	ProfileJSON string `json:"profileJson"`
+}
+
+type SourceSampling struct {
+	WorkloadID *K8sWorkloadID             `json:"workloadId"`
+	Containers []*SourceContainerSampling `json:"containers"`
 }
 
 type SourcesScopes struct {

--- a/frontend/graph/sampling.graphqls
+++ b/frontend/graph/sampling.graphqls
@@ -268,8 +268,42 @@ type Sampling {
   rules: [SamplingRules!]!
 }
 
+# ---- Per-source (workload) computed sampling view ----
+
+# Sampling rules that apply to a single container of a source (workload),
+# after evaluating each rule's source scope (workload + namespace + language)
+# against the workload identity and the container's detected language.
+# If runtime detection has not yet produced a language for the container,
+# language-scoped rules will not match for that container.
+type SourceContainerSampling {
+  # name of the container in the pod manifest.
+  containerName: String!
+
+  # head sampling rules (noisy operations) that apply to this container.
+  noisyOperations: [NoisyOperationRule!]!
+
+  # tail sampling rules (highly relevant operations) that apply to this container.
+  highlyRelevantOperations: [HighlyRelevantOperationRule!]!
+
+  # tail sampling rules (cost reduction) that apply to this container.
+  costReductionRules: [CostReductionRule!]!
+}
+
+# Computed sampling view for a specific source (workload).
+# The containers list mirrors the workload's pod-manifest containers and exposes,
+# per container, the subset of cluster-wide sampling rules whose source scope matches.
+type SourceSampling {
+  workloadId: K8sWorkloadId!
+  containers: [SourceContainerSampling!]!
+}
+
 extend type Query {
   sampling: Sampling!
+
+  # returns the sampling rules that apply to each container of the given source (workload).
+  # all sampling rules in the cluster are evaluated against the workload identity and the
+  # container's detected language, and only matching rules are included in the result.
+  sourceSampling(workloadId: K8sWorkloadIdInput!): SourceSampling!
 }
 
 extend type Mutation {

--- a/frontend/graph/sampling.resolvers.go
+++ b/frontend/graph/sampling.resolvers.go
@@ -74,6 +74,11 @@ func (r *queryResolver) Sampling(ctx context.Context) (*model.Sampling, error) {
 	}, nil
 }
 
+// SourceSampling is the resolver for the sourceSampling field.
+func (r *queryResolver) SourceSampling(ctx context.Context, workloadID model.K8sWorkloadIDInput) (*model.SourceSampling, error) {
+	return sampling.GetSourceSamplingForWorkload(ctx, r.K8sCacheClient, workloadID)
+}
+
 // Rules is the resolver for the rules field.
 func (r *samplingResolver) Rules(ctx context.Context, obj *model.Sampling) ([]*model.SamplingRules, error) {
 	return sampling.GetAllSamplingRuleGroups(ctx)

--- a/frontend/services/sampling/source_sampling.go
+++ b/frontend/services/sampling/source_sampling.go
@@ -1,0 +1,173 @@
+package sampling
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/odigos-io/odigos/api/k8sconsts"
+	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	"github.com/odigos-io/odigos/common"
+	"github.com/odigos-io/odigos/frontend/graph/model"
+	"github.com/odigos-io/odigos/k8sutils/pkg/env"
+	"github.com/odigos-io/odigos/k8sutils/pkg/scope"
+	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetSourceSamplingForWorkload computes the sampling rules that apply to each
+// container of the given workload.
+//
+// All sampling rules in the cluster are evaluated against the workload identity
+// and the container's detected language using SourceScopeMatchesContainer; only
+// rules whose source scope matches are included in the result. The container set
+// is taken from the workload's InstrumentationConfig spec (one entry per pod
+// manifest container) so that containers without runtime-detected languages are
+// still represented (with a null language and only un-language-scoped rules).
+func GetSourceSamplingForWorkload(ctx context.Context, k8sCacheClient client.Client, workloadID model.K8sWorkloadIDInput) (*model.SourceSampling, error) {
+	pw := k8sconsts.PodWorkload{
+		Namespace: workloadID.Namespace,
+		Kind:      k8sconsts.WorkloadKind(workloadID.Kind),
+		Name:      workloadID.Name,
+	}
+
+	containerLanguages, err := resolveContainerLanguages(ctx, k8sCacheClient, pw)
+	if err != nil {
+		return nil, err
+	}
+
+	samplings, err := listSamplingCRs(ctx, k8sCacheClient)
+	if err != nil {
+		return nil, err
+	}
+
+	containers := make([]*model.SourceContainerSampling, 0, len(containerLanguages))
+	for _, cl := range containerLanguages {
+		containers = append(containers, computeContainerSampling(samplings, pw, cl))
+	}
+
+	return &model.SourceSampling{
+		WorkloadID: &model.K8sWorkloadID{
+			Namespace: workloadID.Namespace,
+			Kind:      workloadID.Kind,
+			Name:      workloadID.Name,
+		},
+		Containers: containers,
+	}, nil
+}
+
+// containerLanguage pairs a container's name with the detected programming
+// language (or zero value when detection has not produced one yet).
+type containerLanguage struct {
+	name     string
+	language common.ProgrammingLanguage
+	// detected is false when the container exists in the pod manifest but
+	// runtime detection has not yet produced a language for it.
+	detected bool
+}
+
+// resolveContainerLanguages returns one entry per container in the workload's
+// pod manifest, populating the detected language when available. Containers
+// without a runtime-detected language are still included so the UI can render
+// them and only language-scoped sampling rules will be filtered out.
+func resolveContainerLanguages(ctx context.Context, k8sCacheClient client.Client, pw k8sconsts.PodWorkload) ([]containerLanguage, error) {
+	var ic v1alpha1.InstrumentationConfig
+	icName := workload.CalculateWorkloadRuntimeObjectName(pw.Name, pw.Kind)
+	err := k8sCacheClient.Get(ctx, client.ObjectKey{Namespace: pw.Namespace, Name: icName}, &ic)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// no IC means the workload is not marked for instrumentation;
+			// no sampling rules can be evaluated for it.
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to fetch instrumentation config for %s/%s/%s: %w", pw.Namespace, pw.Kind, pw.Name, err)
+	}
+
+	languageByContainer := make(map[string]common.ProgrammingLanguage, len(ic.Status.RuntimeDetailsByContainer))
+	for _, rd := range ic.Status.RuntimeDetailsByContainer {
+		languageByContainer[rd.ContainerName] = rd.Language
+	}
+
+	seen := make(map[string]struct{})
+	result := make([]containerLanguage, 0, len(ic.Spec.Containers))
+
+	addContainer := func(name string) {
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		lang, ok := languageByContainer[name]
+		result = append(result, containerLanguage{
+			name:     name,
+			language: lang,
+			detected: ok,
+		})
+	}
+
+	for _, c := range ic.Spec.Containers {
+		addContainer(c.ContainerName)
+	}
+	// include any runtime-detected container that's missing from spec (defensive).
+	for _, rd := range ic.Status.RuntimeDetailsByContainer {
+		addContainer(rd.ContainerName)
+	}
+
+	return result, nil
+}
+
+// listSamplingCRs returns every Sampling CR in the odigos namespace.
+func listSamplingCRs(ctx context.Context, k8sCacheClient client.Client) ([]v1alpha1.Sampling, error) {
+	odigosNs := env.GetCurrentNamespace()
+	var list v1alpha1.SamplingList
+	if err := k8sCacheClient.List(ctx, &list, client.InNamespace(odigosNs)); err != nil {
+		return nil, fmt.Errorf("failed to list sampling CRs: %w", err)
+	}
+	return list.Items, nil
+}
+
+// computeContainerSampling returns the sampling rules that match the given
+// container by evaluating each rule's source scope against the workload identity
+// and the container's language. When the language is undetected, language-scoped
+// rules will not match — see SourceScopeMatchesContainer for the semantics.
+func computeContainerSampling(samplings []v1alpha1.Sampling, pw k8sconsts.PodWorkload, cl containerLanguage) *model.SourceContainerSampling {
+	noisy := []*model.NoisyOperationRule{}
+	relevant := []*model.HighlyRelevantOperationRule{}
+	cost := []*model.CostReductionRule{}
+
+	language := cl.language
+	if !cl.detected {
+		language = common.UnknownProgrammingLanguage
+	}
+
+	for i := range samplings {
+		spec := &samplings[i].Spec
+
+		for j := range spec.NoisyOperations {
+			rule := &spec.NoisyOperations[j]
+			if scope.SourceScopeMatchesContainer(rule.SourceScopes, pw, language) {
+				noisy = append(noisy, convertNoisyOperationToModel(rule))
+			}
+		}
+
+		for j := range spec.HighlyRelevantOperations {
+			rule := &spec.HighlyRelevantOperations[j]
+			if scope.SourceScopeMatchesContainer(rule.SourceScopes, pw, language) {
+				relevant = append(relevant, convertHighlyRelevantOperationToModel(rule))
+			}
+		}
+
+		for j := range spec.CostReductionRules {
+			rule := &spec.CostReductionRules[j]
+			if scope.SourceScopeMatchesContainer(rule.SourceScopes, pw, language) {
+				cost = append(cost, convertCostReductionRuleToModel(rule))
+			}
+		}
+	}
+
+	return &model.SourceContainerSampling{
+		ContainerName:            cl.name,
+		NoisyOperations:          noisy,
+		HighlyRelevantOperations: relevant,
+		CostReductionRules:       cost,
+	}
+}

--- a/frontend/webapp/graphql/queries/sampling.ts
+++ b/frontend/webapp/graphql/queries/sampling.ts
@@ -70,3 +70,25 @@ export const GET_SAMPLING_RULES = gql`
     }
   }
 `;
+
+// Returns the computed sampling view for a single source (workload), with the
+// cluster-wide rules pre-filtered per container based on each rule's source
+// scope (workload identity + container language). Used by the Source Drawer
+// "Sampling" tab to show only the rules that actually apply to this source.
+export const GET_SOURCE_SAMPLING = gql`
+  query GetSourceSampling($workloadId: K8sWorkloadIdInput!) {
+    sourceSampling(workloadId: $workloadId) {
+      workloadId {
+        namespace
+        kind
+        name
+      }
+      containers {
+        containerName
+        noisyOperations { ${NOISY_OPERATION_FIELDS} }
+        highlyRelevantOperations { ${HIGHLY_RELEVANT_OPERATION_FIELDS} }
+        costReductionRules { ${COST_REDUCTION_RULE_FIELDS} }
+      }
+    }
+  }
+`;

--- a/frontend/webapp/hooks/sampling/index.ts
+++ b/frontend/webapp/hooks/sampling/index.ts
@@ -1,1 +1,2 @@
 export * from './useSamplingRuleCRUD';
+export * from './useSourceSampling';

--- a/frontend/webapp/hooks/sampling/useSourceSampling.ts
+++ b/frontend/webapp/hooks/sampling/useSourceSampling.ts
@@ -1,0 +1,39 @@
+import { useCallback } from 'react';
+import { useLazyQuery } from '@apollo/client';
+import { Crud, StatusType, type WorkloadId } from '@odigos/ui-kit/types';
+import { useNotificationStore } from '@odigos/ui-kit/store';
+import { GET_SOURCE_SAMPLING } from '@/graphql';
+import type { SourceSampling, SourceSamplingQueryResponse } from '@/types';
+
+interface UseSourceSampling {
+  fetchSourceSampling: (source: WorkloadId) => Promise<SourceSampling | undefined>;
+}
+
+// Wraps the `sourceSampling(workloadId)` query — returns the cluster-wide
+// sampling rules pre-filtered per container of the given source (workload),
+// based on each rule's source scope. Use from the Source Drawer "Sampling"
+// tab to render only the rules that actually apply to the source.
+//
+// Example: await fetchSourceSampling({ namespace: 'demo', kind: 'Deployment', name: 'membership' })
+//       => { workloadId: { ... }, containers: [{ containerName: 'membership', noisyOperations: [...], ... }] }
+export const useSourceSampling = (): UseSourceSampling => {
+  const { addNotification } = useNotificationStore();
+
+  const [queryFn] = useLazyQuery<SourceSamplingQueryResponse, { workloadId: WorkloadId }>(GET_SOURCE_SAMPLING, {
+    fetchPolicy: 'network-only',
+  });
+
+  const fetchSourceSampling: UseSourceSampling['fetchSourceSampling'] = useCallback(
+    async (source) => {
+      const { error, data } = await queryFn({ variables: { workloadId: source } });
+      if (error) {
+        addNotification({ type: StatusType.Error, title: Crud.Read, message: error.cause?.message || error.message });
+        return undefined;
+      }
+      return data?.sourceSampling;
+    },
+    [queryFn, addNotification],
+  );
+
+  return { fetchSourceSampling };
+};

--- a/frontend/webapp/types/sampling.ts
+++ b/frontend/webapp/types/sampling.ts
@@ -140,3 +140,24 @@ export interface SamplingQueryResponse {
     rules: SamplingRules[];
   };
 }
+
+// Computed sampling for a single source (workload), grouped by container.
+// Mirrors the GraphQL `SourceContainerSampling` type — each container exposes
+// only the rules whose source scope matches this workload + container language.
+export interface SourceContainerSampling {
+  containerName: string;
+  noisyOperations: NoisyOperationRule[];
+  highlyRelevantOperations: HighlyRelevantOperationRule[];
+  costReductionRules: CostReductionRule[];
+}
+
+// Mirrors the GraphQL `SourceSampling` type — the per-source view of computed
+// sampling rules, returned by the `sourceSampling(workloadId)` query.
+export interface SourceSampling {
+  workloadId: K8sWorkloadId;
+  containers: SourceContainerSampling[];
+}
+
+export interface SourceSamplingQueryResponse {
+  sourceSampling: SourceSampling;
+}


### PR DESCRIPTION
This commit introduces a new GraphQL query `sourceSampling` that retrieves sampling rules applicable to each container of a specified workload. It includes the addition of new types `SourceSampling` and `SourceContainerSampling` to represent the structure of the response. The resolver for this query has been implemented to compute the relevant sampling rules based on the workload's identity and container languages.

#### Changelog entry:
```release-note
Add `sourceSampling` query to retrieve sampling rules for workload containers.
```

---

# Example fetch result:

```ts
export const MOCK_SOURCE_SAMPLING_MEMBERSHIP: SourceSampling = {
  workloadId: {
    namespace: 'demo',
    kind: K8sResourceKind.Deployment,
    name: 'membership',
  },
  containers: [
    {
      containerName: 'membership',
      noisyOperations: [
        {
          ruleId: '94364a69d1bf6ba6',
          name: 'noisy-golang',
          disabled: false,
          percentageAtMost: 10,
          notes: null,
          sourceScopes: {
            sources: [],
            namespaces: [],
            languages: ['go'],
          },
          operation: {
            httpServer: { route: '/noisy/golang', routePrefix: null, method: 'GET' },
            httpClient: null,
          },
        },
        {
          ruleId: '1a19e4afdc131115',
          name: 'noisy-membership',
          disabled: false,
          percentageAtMost: 20,
          notes: null,
          sourceScopes: {
            sources: [{ namespace: 'demo', kind: K8sResourceKind.Deployment, name: 'membership' }],
            namespaces: [],
            languages: [],
          },
          operation: {
            httpServer: { route: '/noisy/membership', routePrefix: null, method: 'GET' },
            httpClient: null,
          },
        },
        {
          ruleId: '27ce7bcaa346017c',
          name: 'noisy-cluster',
          disabled: false,
          percentageAtMost: 30,
          notes: null,
          sourceScopes: null,
          operation: {
            httpServer: { route: '/noisy/cluster', routePrefix: null, method: 'GET' },
            httpClient: null,
          },
        },
      ],
      highlyRelevantOperations: [
        {
          ruleId: 'f65d0f5260ac9bd4',
          name: 'highly-relevant-golang',
          disabled: false,
          error: false,
          durationAtLeastMs: null,
          percentageAtLeast: 95,
          notes: null,
          sourceScopes: {
            sources: [],
            namespaces: [],
            languages: ['go'],
          },
          operation: {
            httpServer: { route: '/relevant/golang', routePrefix: null, method: 'POST' },
            kafkaConsumer: null,
            kafkaProducer: null,
          },
        },
        {
          ruleId: 'ee06ff18efd52dd7',
          name: 'highly-relevant-membership',
          disabled: false,
          error: false,
          durationAtLeastMs: null,
          percentageAtLeast: 90,
          notes: null,
          sourceScopes: {
            sources: [{ namespace: 'demo', kind: K8sResourceKind.Deployment, name: 'membership' }],
            namespaces: [],
            languages: [],
          },
          operation: {
            httpServer: { route: '/relevant/membership', routePrefix: null, method: 'POST' },
            kafkaConsumer: null,
            kafkaProducer: null,
          },
        },
        {
          ruleId: 'bfed40498d14a766',
          name: 'highly-relevant-cluster',
          disabled: false,
          error: true,
          durationAtLeastMs: 500,
          percentageAtLeast: 100,
          notes: null,
          sourceScopes: null,
          operation: {
            httpServer: { route: '/relevant/cluster', routePrefix: null, method: 'POST' },
            kafkaConsumer: null,
            kafkaProducer: null,
          },
        },
      ],
      costReductionRules: [
        {
          ruleId: '422ca678a0a9ada3',
          name: 'cost-reduction-golang',
          disabled: false,
          percentageAtMost: 15,
          notes: null,
          sourceScopes: {
            sources: [],
            namespaces: [],
            languages: ['go'],
          },
          operation: {
            httpServer: { route: '/cost/golang', routePrefix: null, method: 'GET' },
            kafkaConsumer: null,
            kafkaProducer: null,
          },
        },
        {
          ruleId: 'c6ae84ff0850dce8',
          name: 'cost-reduction-membership',
          disabled: false,
          percentageAtMost: 25,
          notes: null,
          sourceScopes: {
            sources: [{ namespace: 'demo', kind: K8sResourceKind.Deployment, name: 'membership' }],
            namespaces: [],
            languages: [],
          },
          operation: {
            httpServer: null,
            kafkaConsumer: { kafkaTopic: 'membership-events' },
            kafkaProducer: null,
          },
        },
        {
          ruleId: '7d99e79ee702f5ca',
          name: 'cost-reduction-cluster',
          disabled: false,
          percentageAtMost: 50,
          notes: null,
          sourceScopes: null,
          operation: {
            httpServer: null,
            kafkaConsumer: null,
            kafkaProducer: { kafkaTopic: 'cluster-events' },
          },
        },
      ],
    },
  ],
};
```

emergency-ticket id: EMR-1789
