### PR TITLE
refactor: use matcher ifc in tail sampling processor

### DIFF
--- a/collector/processors/odigostailsamplingprocessor/category/config/comptedconfig.go
+++ b/collector/processors/odigostailsamplingprocessor/category/config/comptedconfig.go
@@ -3,8 +3,8 @@ package config
 import (
 	"go.opentelemetry.io/otel/attribute"
 
-	commonapisampling "github.com/odigos-io/odigos/common/api/sampling"
 	"github.com/odigos-io/odigos/collector/processors/odigostailsamplingprocessor/matchers"
+	commonapisampling "github.com/odigos-io/odigos/common/api/sampling"
 	"github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/common/odigosattributes"
 )

--- a/collector/processors/odigostailsamplingprocessor/category/config/comptedconfig.go
+++ b/collector/processors/odigostailsamplingprocessor/category/config/comptedconfig.go
@@ -28,25 +28,10 @@ type ComputedRule struct {
 	Matcher matchers.Matcher
 }
 
-type ComputedNoisyOperation struct {
-	ComputedRule
-	Rule commonapisampling.NoisyOperation
-}
-
-type ComputedHighlyRelevantOperation struct {
-	ComputedRule
-	Rule commonapisampling.HighlyRelevantOperation
-}
-
-type ComputedCostReductionRule struct {
-	ComputedRule
-	Rule commonapisampling.CostReductionRule
-}
-
 type ComputedWorkloadConfig struct {
-	NoisyOperations          []ComputedNoisyOperation
-	HighlyRelevantOperations []ComputedHighlyRelevantOperation
-	CostReductionRules       []ComputedCostReductionRule
+	NoisyOperations          []ComputedRule
+	HighlyRelevantOperations []ComputedRule
+	CostReductionRules       []ComputedRule
 }
 
 func compteRuleMetricsAttributes(category consts.SamplingCategory, ruleId string, ruleName string, ruleDisabled bool, dryRun bool) attribute.Set {
@@ -68,62 +53,53 @@ func compteRuleMetricsAttributes(category consts.SamplingCategory, ruleId string
 	return attribute.NewSet(rulesAttrs...)
 }
 
-func precomputeNoisyOperations(cfg *commonapisampling.TailSamplingSourceConfig, dryRun bool) []ComputedNoisyOperation {
-	out := make([]ComputedNoisyOperation, 0, len(cfg.NoisyOperations))
+func precomputeNoisyOperations(cfg *commonapisampling.TailSamplingSourceConfig, dryRun bool) []ComputedRule {
+	out := make([]ComputedRule, 0, len(cfg.NoisyOperations))
 	for _, rule := range cfg.NoisyOperations {
 		percentage := GetPercentageOrDefault0(rule.PercentageAtMost)
 		metricsAttributes := compteRuleMetricsAttributes(consts.SamplingCategoryNoise, rule.Id, rule.Name, rule.Disabled, dryRun)
-		out = append(out, ComputedNoisyOperation{
-			ComputedRule: ComputedRule{
-				RuleId:            rule.Id,
-				Name:              rule.Name,
-				Percentage:        percentage,
-				Disabled:          rule.Disabled,
-				MetricsAttributes: metricsAttributes,
-				Matcher:           matchers.NewHeadSamplingOperationMatcher(rule.Operation),
-			},
-			Rule: rule,
+		out = append(out, ComputedRule{
+			RuleId:            rule.Id,
+			Name:              rule.Name,
+			Percentage:        percentage,
+			Disabled:          rule.Disabled,
+			MetricsAttributes: metricsAttributes,
+			Matcher:           matchers.NewHeadSamplingOperationMatcher(rule.Operation),
 		})
 	}
 	return out
 }
 
-func precomputeHighlyRelevantOperations(cfg *commonapisampling.TailSamplingSourceConfig, dryRun bool) []ComputedHighlyRelevantOperation {
-	out := make([]ComputedHighlyRelevantOperation, 0, len(cfg.HighlyRelevantOperations))
+func precomputeHighlyRelevantOperations(cfg *commonapisampling.TailSamplingSourceConfig, dryRun bool) []ComputedRule {
+	out := make([]ComputedRule, 0, len(cfg.HighlyRelevantOperations))
 	for _, rule := range cfg.HighlyRelevantOperations {
 		percentage := GetPercentageOrDefault100(rule.PercentageAtLeast)
 		metricsAttributes := compteRuleMetricsAttributes(consts.SamplingCategoryHighlyRelevant, rule.Id, rule.Name, rule.Disabled, dryRun)
-		out = append(out, ComputedHighlyRelevantOperation{
-			ComputedRule: ComputedRule{
-				RuleId:            rule.Id,
-				Name:              rule.Name,
-				Percentage:        percentage,
-				Disabled:          rule.Disabled,
-				MetricsAttributes: metricsAttributes,
-				Matcher: matchers.NewHighlyRelevantOperationMatcher(
-					rule.Operation, rule.Error, rule.DurationAtLeastMs),
-			},
-			Rule: rule,
+		out = append(out, ComputedRule{
+			RuleId:            rule.Id,
+			Name:              rule.Name,
+			Percentage:        percentage,
+			Disabled:          rule.Disabled,
+			MetricsAttributes: metricsAttributes,
+			Matcher: matchers.NewHighlyRelevantOperationMatcher(
+				rule.Operation, rule.Error, rule.DurationAtLeastMs),
 		})
 	}
 	return out
 }
 
-func precomputeCostReductionRules(cfg *commonapisampling.TailSamplingSourceConfig, dryRun bool) []ComputedCostReductionRule {
-	out := make([]ComputedCostReductionRule, 0, len(cfg.CostReductionRules))
+func precomputeCostReductionRules(cfg *commonapisampling.TailSamplingSourceConfig, dryRun bool) []ComputedRule {
+	out := make([]ComputedRule, 0, len(cfg.CostReductionRules))
 	for _, rule := range cfg.CostReductionRules {
 		percentage := rule.PercentageAtMost
 		metricsAttributes := compteRuleMetricsAttributes(consts.SamplingCategoryCostReduction, rule.Id, rule.Name, rule.Disabled, dryRun)
-		out = append(out, ComputedCostReductionRule{
-			ComputedRule: ComputedRule{
-				RuleId:            rule.Id,
-				Name:              rule.Name,
-				Percentage:        percentage,
-				Disabled:          rule.Disabled,
-				MetricsAttributes: metricsAttributes,
-				Matcher:           matchers.NewTailSamplingOperationMatcher(rule.Operation),
-			},
-			Rule: rule,
+		out = append(out, ComputedRule{
+			RuleId:            rule.Id,
+			Name:              rule.Name,
+			Percentage:        percentage,
+			Disabled:          rule.Disabled,
+			MetricsAttributes: metricsAttributes,
+			Matcher:           matchers.NewTailSamplingOperationMatcher(rule.Operation),
 		})
 	}
 	return out

--- a/collector/processors/odigostailsamplingprocessor/category/config/comptedconfig.go
+++ b/collector/processors/odigostailsamplingprocessor/category/config/comptedconfig.go
@@ -4,6 +4,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	commonapisampling "github.com/odigos-io/odigos/common/api/sampling"
+	"github.com/odigos-io/odigos/collector/processors/odigostailsamplingprocessor/matchers"
 	"github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/common/odigosattributes"
 )
@@ -22,6 +23,9 @@ type ComputedRule struct {
 	// attributes set to use for this rule when reporting metrics
 	// fast path for metrics reporting without computing the attributes set for each span.
 	MetricsAttributes attribute.Set
+
+	// pre-built span matcher for this rule.
+	Matcher matchers.Matcher
 }
 
 type ComputedNoisyOperation struct {
@@ -76,6 +80,7 @@ func precomputeNoisyOperations(cfg *commonapisampling.TailSamplingSourceConfig, 
 				Percentage:        percentage,
 				Disabled:          rule.Disabled,
 				MetricsAttributes: metricsAttributes,
+				Matcher:           matchers.NewHeadSamplingOperationMatcher(rule.Operation),
 			},
 			Rule: rule,
 		})
@@ -95,6 +100,8 @@ func precomputeHighlyRelevantOperations(cfg *commonapisampling.TailSamplingSourc
 				Percentage:        percentage,
 				Disabled:          rule.Disabled,
 				MetricsAttributes: metricsAttributes,
+				Matcher: matchers.NewHighlyRelevantOperationMatcher(
+					rule.Operation, rule.Error, rule.DurationAtLeastMs),
 			},
 			Rule: rule,
 		})
@@ -114,6 +121,7 @@ func precomputeCostReductionRules(cfg *commonapisampling.TailSamplingSourceConfi
 				Percentage:        percentage,
 				Disabled:          rule.Disabled,
 				MetricsAttributes: metricsAttributes,
+				Matcher:           matchers.NewTailSamplingOperationMatcher(rule.Operation),
 			},
 			Rule: rule,
 		})

--- a/collector/processors/odigostailsamplingprocessor/category/costreduction/costreductionoperations.go
+++ b/collector/processors/odigostailsamplingprocessor/category/costreduction/costreductionoperations.go
@@ -56,16 +56,17 @@ func Evaluate(trace ptrace.Traces, configProvider config.TailSamplingConfigProvi
 
 // matchCostReductionRulesForSingleSpan returns every cost-reduction rule whose operation matcher passes for this span.
 // it also updates the rulesEvalResults and matchingRules maps based on the matched rules.
-func matchCostReductionRulesForSingleSpan(rulesEvalResults map[string]*category.RuleEvaluationResult, matchingRules map[string]*config.ComputedRule, span ptrace.Span, costReductionRules []config.ComputedCostReductionRule) []*config.ComputedCostReductionRule {
-	matchedRules := []*config.ComputedCostReductionRule{}
+func matchCostReductionRulesForSingleSpan(rulesEvalResults map[string]*category.RuleEvaluationResult, matchingRules map[string]*config.ComputedRule, span ptrace.Span, costReductionRules []config.ComputedRule) []*config.ComputedRule {
+	matchedRules := []*config.ComputedRule{}
 
-	for _, rule := range costReductionRules {
+	for i := range costReductionRules {
+		rule := &costReductionRules[i]
 		matched := rule.Matcher.Match(span)
-		metrics.RecordEvalResultForSingleSpan(rulesEvalResults, rule.ComputedRule, matched)
+		metrics.RecordEvalResultForSingleSpan(rulesEvalResults, *rule, matched)
 		if matched {
-			matchedRules = append(matchedRules, &rule)
-			if _, found := matchingRules[rule.ComputedRule.RuleId]; !found {
-				matchingRules[rule.ComputedRule.RuleId] = &rule.ComputedRule
+			matchedRules = append(matchedRules, rule)
+			if _, found := matchingRules[rule.RuleId]; !found {
+				matchingRules[rule.RuleId] = rule
 			}
 		}
 	}
@@ -75,15 +76,15 @@ func matchCostReductionRulesForSingleSpan(rulesEvalResults map[string]*category.
 
 // selectCostReductionRuleFromMatches picks the span-level rule using the same logic as the trace deciding rule
 // (see calculateCostReductionDecidingRule): smallest PercentageAtMost among enabled matches.
-func selectCostReductionRuleFromMatches(matchedRules []*config.ComputedCostReductionRule) *config.ComputedRule {
+func selectCostReductionRuleFromMatches(matchedRules []*config.ComputedRule) *config.ComputedRule {
 	byID := make(map[string]*config.ComputedRule, len(matchedRules))
 	for _, r := range matchedRules {
-		byID[r.ComputedRule.RuleId] = &r.ComputedRule
+		byID[r.RuleId] = r
 	}
 	return calculateCostReductionDecidingRule(byID)
 }
 
-func getCostReductionRulesConfig(configProvider config.TailSamplingConfigProvider, resource pcommon.Resource) []config.ComputedCostReductionRule {
+func getCostReductionRulesConfig(configProvider config.TailSamplingConfigProvider, resource pcommon.Resource) []config.ComputedRule {
 	tailSampling, found := configProvider.GetTailSamplingConfig(resource)
 	if !found || tailSampling == nil {
 		return nil

--- a/collector/processors/odigostailsamplingprocessor/category/costreduction/costreductionoperations.go
+++ b/collector/processors/odigostailsamplingprocessor/category/costreduction/costreductionoperations.go
@@ -8,7 +8,6 @@ import (
 	"github.com/odigos-io/odigos/collector/processors/odigostailsamplingprocessor/category/config"
 	"github.com/odigos-io/odigos/collector/processors/odigostailsamplingprocessor/category/metrics"
 	"github.com/odigos-io/odigos/collector/processors/odigostailsamplingprocessor/category/samplingspanattrs"
-	"github.com/odigos-io/odigos/collector/processors/odigostailsamplingprocessor/matchers"
 )
 
 type CostReductionEvaluationResult struct {
@@ -61,7 +60,7 @@ func matchCostReductionRulesForSingleSpan(rulesEvalResults map[string]*category.
 	matchedRules := []*config.ComputedCostReductionRule{}
 
 	for _, rule := range costReductionRules {
-		matched := matchers.TailSamplingOperationMatcher(rule.Rule.Operation, span)
+		matched := rule.Matcher.Match(span)
 		metrics.RecordEvalResultForSingleSpan(rulesEvalResults, rule.ComputedRule, matched)
 		if matched {
 			matchedRules = append(matchedRules, &rule)

--- a/collector/processors/odigostailsamplingprocessor/category/highlyrelevant/highlyrelevanceoperations.go
+++ b/collector/processors/odigostailsamplingprocessor/category/highlyrelevant/highlyrelevanceoperations.go
@@ -58,18 +58,19 @@ func Evaluate(trace ptrace.Traces, configProvider config.TailSamplingConfigProvi
 
 // matchHighlyRelevantRulesForSingleSpan returns every highly-relevant rule whose matchers all pass for this span.
 // it also updates the rulesEvalResults and matchingRules maps based on the matched rules.
-func matchHighlyRelevantRulesForSingleSpan(rulesEvalResults map[string]*category.RuleEvaluationResult, matchingRules map[string]*config.ComputedRule, span ptrace.Span, highlyRelevantOperations []config.ComputedHighlyRelevantOperation) []*config.ComputedRule {
+func matchHighlyRelevantRulesForSingleSpan(rulesEvalResults map[string]*category.RuleEvaluationResult, matchingRules map[string]*config.ComputedRule, span ptrace.Span, highlyRelevantOperations []config.ComputedRule) []*config.ComputedRule {
 	matchedRules := []*config.ComputedRule{}
 
-	for _, highlyRelevantOperation := range highlyRelevantOperations {
-		matched := highlyRelevantOperation.Matcher.Match(span)
+	for i := range highlyRelevantOperations {
+		rule := &highlyRelevantOperations[i]
+		matched := rule.Matcher.Match(span)
 
-		metrics.RecordEvalResultForSingleSpan(rulesEvalResults, highlyRelevantOperation.ComputedRule, matched)
+		metrics.RecordEvalResultForSingleSpan(rulesEvalResults, *rule, matched)
 
 		if matched {
-			matchedRules = append(matchedRules, &highlyRelevantOperation.ComputedRule)
-			if _, found := matchingRules[highlyRelevantOperation.ComputedRule.RuleId]; !found {
-				matchingRules[highlyRelevantOperation.ComputedRule.RuleId] = &highlyRelevantOperation.ComputedRule
+			matchedRules = append(matchedRules, rule)
+			if _, found := matchingRules[rule.RuleId]; !found {
+				matchingRules[rule.RuleId] = rule
 			}
 		}
 	}
@@ -87,7 +88,7 @@ func selectHighlyRelevantRuleFromMatches(matchedRules []*config.ComputedRule) *c
 	return calculateDecidingRule(byID)
 }
 
-func getHighlyRelevantOperationsConfig(configProvider config.TailSamplingConfigProvider, resource pcommon.Resource) []config.ComputedHighlyRelevantOperation {
+func getHighlyRelevantOperationsConfig(configProvider config.TailSamplingConfigProvider, resource pcommon.Resource) []config.ComputedRule {
 	tailSampling, found := configProvider.GetTailSamplingConfig(resource)
 	if !found || tailSampling == nil {
 		return nil

--- a/collector/processors/odigostailsamplingprocessor/category/highlyrelevant/highlyrelevanceoperations.go
+++ b/collector/processors/odigostailsamplingprocessor/category/highlyrelevant/highlyrelevanceoperations.go
@@ -8,7 +8,6 @@ import (
 	"github.com/odigos-io/odigos/collector/processors/odigostailsamplingprocessor/category/config"
 	"github.com/odigos-io/odigos/collector/processors/odigostailsamplingprocessor/category/metrics"
 	"github.com/odigos-io/odigos/collector/processors/odigostailsamplingprocessor/category/samplingspanattrs"
-	"github.com/odigos-io/odigos/collector/processors/odigostailsamplingprocessor/matchers"
 )
 
 type HighlyRelevantEvaluationResult struct {
@@ -63,10 +62,7 @@ func matchHighlyRelevantRulesForSingleSpan(rulesEvalResults map[string]*category
 	matchedRules := []*config.ComputedRule{}
 
 	for _, highlyRelevantOperation := range highlyRelevantOperations {
-		matched := true
-		matched = matched && matchers.TailSamplingOperationMatcher(highlyRelevantOperation.Rule.Operation, span)
-		matched = matched && matchers.SpanErrorMatcher(span, highlyRelevantOperation.Rule.Error)
-		matched = matched && matchers.SpanDurationMatcher(span, highlyRelevantOperation.Rule.DurationAtLeastMs)
+		matched := highlyRelevantOperation.Matcher.Match(span)
 
 		metrics.RecordEvalResultForSingleSpan(rulesEvalResults, highlyRelevantOperation.ComputedRule, matched)
 

--- a/collector/processors/odigostailsamplingprocessor/category/noisy/noisyoperations.go
+++ b/collector/processors/odigostailsamplingprocessor/category/noisy/noisyoperations.go
@@ -15,7 +15,7 @@ type NoisyOperationsEvaluationResult struct {
 // givin a root span for a trace, and a list of noisy operation sampling rules,
 // evaluate if the trace belongs to the noisy operations category,
 // and return the "matching rule" - e.g. the rule with the least percentage.
-func Evaluate(span ptrace.Span, noisyOperations []config.ComputedNoisyOperation) NoisyOperationsEvaluationResult {
+func Evaluate(span ptrace.Span, noisyOperations []config.ComputedRule) NoisyOperationsEvaluationResult {
 
 	rulesEvalResults := category.CategoryRulesEvaluationResults{}
 
@@ -24,11 +24,12 @@ func Evaluate(span ptrace.Span, noisyOperations []config.ComputedNoisyOperation)
 	// 1 occassionally, and more very rarely.
 	var leastPercentageRule *config.ComputedRule
 
-	for _, noisyOperation := range noisyOperations {
+	for i := range noisyOperations {
+		noisyOperation := &noisyOperations[i]
 
 		currentPercentage := noisyOperation.Percentage
 
-		if noisyOperation.Rule.Disabled {
+		if noisyOperation.Disabled {
 			continue
 		}
 
@@ -39,21 +40,20 @@ func Evaluate(span ptrace.Span, noisyOperations []config.ComputedNoisyOperation)
 			continue
 		}
 
-		// check if the operation matches the span.
 		matched := noisyOperation.Matcher.Match(span)
 
-		if _, found := rulesEvalResults[noisyOperation.Rule.Id]; !found {
-			rulesEvalResults[noisyOperation.Rule.Id] = &category.RuleEvaluationResult{
-				ComputedRule: noisyOperation.ComputedRule,
+		if _, found := rulesEvalResults[noisyOperation.RuleId]; !found {
+			rulesEvalResults[noisyOperation.RuleId] = &category.RuleEvaluationResult{
+				ComputedRule: *noisyOperation,
 			}
 		}
-		res := rulesEvalResults[noisyOperation.Rule.Id]
+		res := rulesEvalResults[noisyOperation.RuleId]
 		res.SpanCheckedCount++
 
 		// at this point, we already know the current percentage is least than the one seen so far,
 		// so if we have a match, we update.
 		if matched {
-			leastPercentageRule = &noisyOperation.ComputedRule
+			leastPercentageRule = noisyOperation
 			res.SpanMatchedCount++
 		}
 	}

--- a/collector/processors/odigostailsamplingprocessor/category/noisy/noisyoperations.go
+++ b/collector/processors/odigostailsamplingprocessor/category/noisy/noisyoperations.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/odigos-io/odigos/collector/processors/odigostailsamplingprocessor/category"
 	"github.com/odigos-io/odigos/collector/processors/odigostailsamplingprocessor/category/config"
-	"github.com/odigos-io/odigos/collector/processors/odigostailsamplingprocessor/matchers"
 )
 
 type NoisyOperationsEvaluationResult struct {
@@ -41,7 +40,7 @@ func Evaluate(span ptrace.Span, noisyOperations []config.ComputedNoisyOperation)
 		}
 
 		// check if the operation matches the span.
-		matched := matchers.HeadSamplingOperationMatcher(noisyOperation.Rule.Operation, span)
+		matched := noisyOperation.Matcher.Match(span)
 
 		if _, found := rulesEvalResults[noisyOperation.Rule.Id]; !found {
 			rulesEvalResults[noisyOperation.Rule.Id] = &category.RuleEvaluationResult{

--- a/collector/processors/odigostailsamplingprocessor/matchers/headsampling.go
+++ b/collector/processors/odigostailsamplingprocessor/matchers/headsampling.go
@@ -6,23 +6,35 @@ import (
 	commonapisampling "github.com/odigos-io/odigos/common/api/sampling"
 )
 
-func HeadSamplingOperationMatcher(operation *commonapisampling.HeadSamplingOperationMatcher, span ptrace.Span) bool {
+func NewHeadSamplingOperationMatcher(operation *commonapisampling.HeadSamplingOperationMatcher) Matcher {
 	if operation == nil {
-		// if operation is not specified, it will match any operation.
-		return true
+		return anyMatcher{}
 	}
-	if operation.HttpServer != nil {
-		return headSamplingOperationHttpServerMatcher(operation.HttpServer, span)
+	switch {
+	case operation.HttpServer != nil:
+		return newHeadSamplingHttpServerMatcher(operation.HttpServer)
+	case operation.HttpClient != nil:
+		return newHeadSamplingHttpClientMatcher(operation.HttpClient)
+	default:
+		return anyMatcher{}
 	}
-	if operation.HttpClient != nil {
-		return headSamplingOperationHttpClientMatcher(operation.HttpClient, span)
-	}
-	// no operation type specified, match any.
-	return true
 }
 
-func headSamplingOperationHttpServerMatcher(operation *commonapisampling.HeadSamplingHttpServerOperationMatcher, span ptrace.Span) bool {
+type headSamplingHttpServerMatcher struct {
+	method      string
+	route       string
+	routePrefix string
+}
 
+func newHeadSamplingHttpServerMatcher(operation *commonapisampling.HeadSamplingHttpServerOperationMatcher) Matcher {
+	return &headSamplingHttpServerMatcher{
+		method:      operation.Method,
+		route:       operation.Route,
+		routePrefix: operation.RoutePrefix,
+	}
+}
+
+func (m *headSamplingHttpServerMatcher) Match(span ptrace.Span) bool {
 	if span.Kind() != ptrace.SpanKindServer {
 		return false
 	}
@@ -31,18 +43,32 @@ func headSamplingOperationHttpServerMatcher(operation *commonapisampling.HeadSam
 	switch {
 	case !found:
 		return false
-	case operation.Method != "" && !compareHttpMethod(httpMethod, operation.Method):
+	case m.method != "" && !compareHttpMethod(httpMethod, m.method):
 		return false
-	case (operation.Route != "" || operation.RoutePrefix != "") && !matchHttpRoute(span, operation.Route, operation.RoutePrefix):
+	case (m.route != "" || m.routePrefix != "") && !matchHttpRoute(span, m.route, m.routePrefix):
 		return false
 	default:
 		return true
 	}
 }
 
-func headSamplingOperationHttpClientMatcher(operation *commonapisampling.HeadSamplingHttpClientOperationMatcher, span ptrace.Span) bool {
+type headSamplingHttpClientMatcher struct {
+	method                string
+	serverAddress         string
+	templatedPath         string
+	templatedPathPrefix   string
+}
 
-	// this matcher is for http client operations only, and only client spans are considered.
+func newHeadSamplingHttpClientMatcher(operation *commonapisampling.HeadSamplingHttpClientOperationMatcher) Matcher {
+	return &headSamplingHttpClientMatcher{
+		method:              operation.Method,
+		serverAddress:       operation.ServerAddress,
+		templatedPath:       operation.TemplatedPath,
+		templatedPathPrefix: operation.TemplatedPathPrefix,
+	}
+}
+
+func (m *headSamplingHttpClientMatcher) Match(span ptrace.Span) bool {
 	if span.Kind() != ptrace.SpanKindClient {
 		return false
 	}
@@ -51,11 +77,11 @@ func headSamplingOperationHttpClientMatcher(operation *commonapisampling.HeadSam
 	switch {
 	case !found:
 		return false
-	case operation.Method != "" && !compareHttpMethod(httpMethod, operation.Method):
+	case m.method != "" && !compareHttpMethod(httpMethod, m.method):
 		return false
-	case operation.ServerAddress != "" && !matchServerAddress(span, operation.ServerAddress):
+	case m.serverAddress != "" && !matchServerAddress(span, m.serverAddress):
 		return false
-	case (operation.TemplatedPath != "" || operation.TemplatedPathPrefix != "") && !matchTemplatedPath(span, operation.TemplatedPath, operation.TemplatedPathPrefix):
+	case (m.templatedPath != "" || m.templatedPathPrefix != "") && !matchTemplatedPath(span, m.templatedPath, m.templatedPathPrefix):
 		return false
 	default:
 		return true

--- a/collector/processors/odigostailsamplingprocessor/matchers/headsampling.go
+++ b/collector/processors/odigostailsamplingprocessor/matchers/headsampling.go
@@ -53,10 +53,10 @@ func (m *headSamplingHttpServerMatcher) Match(span ptrace.Span) bool {
 }
 
 type headSamplingHttpClientMatcher struct {
-	method                string
-	serverAddress         string
-	templatedPath         string
-	templatedPathPrefix   string
+	method              string
+	serverAddress       string
+	templatedPath       string
+	templatedPathPrefix string
 }
 
 func newHeadSamplingHttpClientMatcher(operation *commonapisampling.HeadSamplingHttpClientOperationMatcher) Matcher {

--- a/collector/processors/odigostailsamplingprocessor/matchers/headsampling_test.go
+++ b/collector/processors/odigostailsamplingprocessor/matchers/headsampling_test.go
@@ -151,7 +151,7 @@ func TestHeadSamplingOperationHttpServerMatcher(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			span := spanWithAttrsAndKind(t, tt.spanKind, tt.attrs)
-			got := headSamplingOperationHttpServerMatcher(tt.operation, span)
+			got := newHeadSamplingHttpServerMatcher(tt.operation).Match(span)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -315,7 +315,7 @@ func TestHeadSamplingOperationHttpClientMatcher(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			span := spanWithAttrsAndKind(t, tt.spanKind, tt.attrs)
-			got := headSamplingOperationHttpClientMatcher(tt.operation, span)
+			got := newHeadSamplingHttpClientMatcher(tt.operation).Match(span)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -397,7 +397,7 @@ func TestHeadSamplingOperationMatcher(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			span := spanWithAttrsAndKind(t, tt.spanKind, tt.attrs)
-			got := HeadSamplingOperationMatcher(tt.operation, span)
+			got := NewHeadSamplingOperationMatcher(tt.operation).Match(span)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/collector/processors/odigostailsamplingprocessor/matchers/highlyrelevance.go
+++ b/collector/processors/odigostailsamplingprocessor/matchers/highlyrelevance.go
@@ -2,22 +2,57 @@ package matchers
 
 import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	commonapisampling "github.com/odigos-io/odigos/common/api/sampling"
 )
 
-// SpanErrorMatcher returns true when the rule does not require an error, or when it does and the span has error status.
-func SpanErrorMatcher(span ptrace.Span, requireError bool) bool {
-	if !requireError {
+func NewHighlyRelevantOperationMatcher(operation *commonapisampling.TailSamplingOperationMatcher, requireError bool, durationMs *int) Matcher {
+	var matchers []Matcher
+	if operation != nil {
+		matchers = append(matchers, NewTailSamplingOperationMatcher(operation))
+	}
+	if requireError {
+		matchers = append(matchers, NewSpanErrorMatcher(requireError))
+	}
+	if durationMs != nil {
+		matchers = append(matchers, NewSpanDurationMatcher(durationMs))
+	}
+	if len(matchers) == 0 {
+		return anyMatcher{}
+	}
+	return newCompositeMatcher(matchers...)
+}
+
+type spanErrorMatcher struct {
+	requireError bool
+}
+
+func NewSpanErrorMatcher(requireError bool) Matcher {
+	return &spanErrorMatcher{requireError: requireError}
+}
+
+// Match returns true when the rule does not require an error, or when it does and the span has error status.
+func (m *spanErrorMatcher) Match(span ptrace.Span) bool {
+	if !m.requireError {
 		return true
 	}
 	return span.Status().Code() == ptrace.StatusCodeError
 }
 
-// SpanDurationMatcher returns true when no minimum duration is required, or when the span duration is at least the given threshold in milliseconds.
-func SpanDurationMatcher(span ptrace.Span, durationMs *int) bool {
-	if durationMs == nil {
+type spanDurationMatcher struct {
+	durationMs *int
+}
+
+func NewSpanDurationMatcher(durationMs *int) Matcher {
+	return &spanDurationMatcher{durationMs: durationMs}
+}
+
+// Match returns true when no minimum duration is required, or when the span duration is at least the given threshold in milliseconds.
+func (m *spanDurationMatcher) Match(span ptrace.Span) bool {
+	if m.durationMs == nil {
 		return true
 	}
 	spanDurationNano := uint64(span.EndTimestamp() - span.StartTimestamp())
-	thresholdNano := uint64(*durationMs) * 1e6
+	thresholdNano := uint64(*m.durationMs) * 1e6
 	return spanDurationNano >= thresholdNano
 }

--- a/collector/processors/odigostailsamplingprocessor/matchers/highlyrelevance_test.go
+++ b/collector/processors/odigostailsamplingprocessor/matchers/highlyrelevance_test.go
@@ -46,7 +46,7 @@ func TestSpanErrorMatcher(t *testing.T) {
 			if tt.spanHasError {
 				span.Status().SetCode(ptrace.StatusCodeError)
 			}
-			got := SpanErrorMatcher(span, tt.requireError)
+			got := NewSpanErrorMatcher(tt.requireError).Match(span)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -106,7 +106,7 @@ func TestSpanDurationMatcher(t *testing.T) {
 			span := spanWithAttrs(t, nil)
 			span.SetStartTimestamp(pcommon.Timestamp(tt.spanStartNs))
 			span.SetEndTimestamp(pcommon.Timestamp(tt.spanEndNs))
-			got := SpanDurationMatcher(span, tt.durationMs)
+			got := NewSpanDurationMatcher(tt.durationMs).Match(span)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/collector/processors/odigostailsamplingprocessor/matchers/matcher.go
+++ b/collector/processors/odigostailsamplingprocessor/matchers/matcher.go
@@ -1,0 +1,30 @@
+package matchers
+
+import "go.opentelemetry.io/collector/pdata/ptrace"
+
+type Matcher interface {
+	Match(span ptrace.Span) bool
+}
+
+type anyMatcher struct{}
+
+func (anyMatcher) Match(span ptrace.Span) bool {
+	return true
+}
+
+type compositeMatcher struct {
+	matchers []Matcher
+}
+
+func newCompositeMatcher(matchers ...Matcher) Matcher {
+	return &compositeMatcher{matchers: matchers}
+}
+
+func (m *compositeMatcher) Match(span ptrace.Span) bool {
+	for _, matcher := range m.matchers {
+		if !matcher.Match(span) {
+			return false
+		}
+	}
+	return true
+}

--- a/collector/processors/odigostailsamplingprocessor/matchers/tailsampling.go
+++ b/collector/processors/odigostailsamplingprocessor/matchers/tailsampling.go
@@ -6,60 +6,82 @@ import (
 	commonapisampling "github.com/odigos-io/odigos/common/api/sampling"
 )
 
-func TailSamplingOperationMatcher(operation *commonapisampling.TailSamplingOperationMatcher, span ptrace.Span) bool {
+func NewTailSamplingOperationMatcher(operation *commonapisampling.TailSamplingOperationMatcher) Matcher {
 	if operation == nil {
-		// if operation is not specified, it will match any operation.
-		return true
+		return anyMatcher{}
 	}
 	switch {
 	case operation.HttpServer != nil:
-		return operationHttpServerMatcher(operation.HttpServer, span)
+		return newTailSamplingHttpServerMatcher(operation.HttpServer)
 	case operation.KafkaConsumer != nil:
-		return operationKafkaConsumerMatcher(operation.KafkaConsumer, span)
+		return newTailSamplingKafkaConsumerMatcher(operation.KafkaConsumer)
 	case operation.KafkaProducer != nil:
-		return operationKafkaProducerMatcher(operation.KafkaProducer, span)
+		return newTailSamplingKafkaProducerMatcher(operation.KafkaProducer)
+	default:
+		return anyMatcher{}
 	}
-	// no operation type specified, match any.
-	return true
 }
 
-// given a span and a http server operation matcher, will attempt to match the span to the matcher.
-//
-// will return true when:
+type tailSamplingHttpServerMatcher struct {
+	method      string
+	route       string
+	routePrefix string
+}
+
+func newTailSamplingHttpServerMatcher(operation *commonapisampling.TailSamplingHttpServerOperationMatcher) Matcher {
+	return &tailSamplingHttpServerMatcher{
+		method:      operation.Method,
+		route:       operation.Route,
+		routePrefix: operation.RoutePrefix,
+	}
+}
+
+// Match returns true when:
 // - the span is a server span.
 // - it's an http span (contains http method)
 // - all the attributes specified in the matcher are present on the span and match the values.
 //
-// will return false when:
+// Match returns false when:
 // - it's not an http server span.
 // - any of the attributes specified in the matcher are not present on the span.
-// - any of the attributes specified in the matcher are presence with a different value.
+// - any of the attributes specified in the matcher are present with a different value.
 // - templated routes for spans that don't have the http.route attribute.
-func operationHttpServerMatcher(operation *commonapisampling.TailSamplingHttpServerOperationMatcher, span ptrace.Span) bool {
+func (m *tailSamplingHttpServerMatcher) Match(span ptrace.Span) bool {
 	if span.Kind() != ptrace.SpanKindServer {
 		return false
 	}
 
 	httpMethod, found := getHttpMethod(span)
 	if !found {
-		// this matcher is for http operations only, and lack of method signals no match.
 		return false
 	}
-	if operation.Method != "" && !compareHttpMethod(httpMethod, operation.Method) {
+	if m.method != "" && !compareHttpMethod(httpMethod, m.method) {
 		return false
 	}
 
-	if !matchHttpRoute(span, operation.Route, operation.RoutePrefix) {
+	if !matchHttpRoute(span, m.route, m.routePrefix) {
 		return false
 	}
 
 	return true
 }
 
-func operationKafkaConsumerMatcher(operation *commonapisampling.TailSamplingKafkaOperationMatcher, span ptrace.Span) bool {
+type tailSamplingKafkaConsumerMatcher struct{}
+
+func newTailSamplingKafkaConsumerMatcher(_ *commonapisampling.TailSamplingKafkaOperationMatcher) Matcher {
+	return &tailSamplingKafkaConsumerMatcher{}
+}
+
+func (m *tailSamplingKafkaConsumerMatcher) Match(_ ptrace.Span) bool {
 	return false
 }
 
-func operationKafkaProducerMatcher(operation *commonapisampling.TailSamplingKafkaOperationMatcher, span ptrace.Span) bool {
+type tailSamplingKafkaProducerMatcher struct{}
+
+func newTailSamplingKafkaProducerMatcher(_ *commonapisampling.TailSamplingKafkaOperationMatcher) Matcher {
+	return &tailSamplingKafkaProducerMatcher{}
+}
+
+func (m *tailSamplingKafkaProducerMatcher) Match(_ ptrace.Span) bool {
 	return false
 }

--- a/collector/processors/odigostailsamplingprocessor/matchers/tailsampling_test.go
+++ b/collector/processors/odigostailsamplingprocessor/matchers/tailsampling_test.go
@@ -143,7 +143,7 @@ func TestOperationHttpServerMatcher(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			span := spanWithAttrsAndKind(t, tt.spanKind, tt.attrs)
-			got := operationHttpServerMatcher(tt.operation, span)
+			got := newTailSamplingHttpServerMatcher(tt.operation).Match(span)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -179,7 +179,7 @@ func TestTailSamplingOperationMatcher(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			span := spanWithAttrsAndKind(t, tt.spanKind, tt.attrs)
-			got := TailSamplingOperationMatcher(tt.operation, span)
+			got := NewTailSamplingOperationMatcher(tt.operation).Match(span)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: CORE-1097

Replace the matching as functions, with matcher object with a go interface.

This is cleaner, and allows to generalize the processor, also making it easier to add additional matchers in the future

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
