### PR TITLE
feat: add sampling config to gql workloads api

### DIFF
--- a/frontend/graph/conversions.go
+++ b/frontend/graph/conversions.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/common"
+	commonapi "github.com/odigos-io/odigos/common/api"
 	"github.com/odigos-io/odigos/common/api/sampling"
 	"github.com/odigos-io/odigos/frontend/graph/model"
 	"github.com/odigos-io/odigos/frontend/services"
@@ -750,7 +751,238 @@ func convertSamplingConfigInputToOdigosConfig(config *model.SamplingConfigInput)
 
 // containerAgentConfigToAgentConfigModel converts InstrumentationConfig container agent config (traces/head sampling) to the GraphQL K8sWorkloadContainerAgentConfig model.
 func containerAgentConfigToAgentConfigModel(c *v1alpha1.ContainerAgentConfig) *model.K8sWorkloadContainerAgentConfig {
-	return nil
+	if c == nil || c.Traces == nil {
+		return nil
+	}
+	headSampling := headSamplingConfigToModel(c.Traces.HeadSampling)
+	if headSampling == nil {
+		return &model.K8sWorkloadContainerAgentConfig{
+			Traces: &model.K8sWorkloadContainerAgentConfigTraces{},
+		}
+	}
+	return &model.K8sWorkloadContainerAgentConfig{
+		Traces: &model.K8sWorkloadContainerAgentConfigTraces{
+			HeadSampling: headSampling,
+		},
+	}
+}
+
+func headSamplingConfigToModel(cfg *sampling.HeadSamplingConfig) *model.K8sWorkloadContainerAgentConfigTracesHeadSampling {
+	if cfg == nil {
+		return nil
+	}
+	result := &model.K8sWorkloadContainerAgentConfigTracesHeadSampling{}
+	if cfg.DryRun {
+		result.DryRun = ptrBool(true)
+	}
+	if cfg.SpanMetricsMode != "" {
+		mode := headSamplingSpanMetricsModeToModel(cfg.SpanMetricsMode)
+		result.SpanMetricsMode = &mode
+	}
+	if len(cfg.NoisyOperations) > 0 {
+		result.NoisyOperations = make([]*model.K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation, 0, len(cfg.NoisyOperations))
+		for i := range cfg.NoisyOperations {
+			if op := headSamplingNoisyOperationToModel(&cfg.NoisyOperations[i]); op != nil {
+				result.NoisyOperations = append(result.NoisyOperations, op)
+			}
+		}
+	}
+	return result
+}
+
+func headSamplingSpanMetricsModeToModel(mode sampling.SpanMetricsMode) model.K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode {
+	switch mode {
+	case sampling.SpanMetricsModeAllSpans:
+		return model.K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsModeAllSpans
+	default:
+		return model.K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsModeSampledSpansOnly
+	}
+}
+
+func headSamplingNoisyOperationToModel(op *sampling.NoisyOperation) *model.K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation {
+	if op == nil {
+		return nil
+	}
+	ruleID := op.Id
+	if ruleID == "" {
+		ruleID = v1alpha1.ComputeNoisyOperationHash(&v1alpha1.NoisyOperation{
+			Name:             op.Name,
+			Disabled:         op.Disabled,
+			Operation:        op.Operation,
+			PercentageAtMost: op.PercentageAtMost,
+		})
+	}
+	return &model.K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation{
+		RuleID:           ruleID,
+		Name:             services.StringPtrIfNotEmpty(op.Name),
+		Disabled:         op.Disabled,
+		Operation:        headSamplingOperationMatcherToModel(op.Operation),
+		PercentageAtMost: op.PercentageAtMost,
+	}
+}
+
+func headSamplingOperationMatcherToModel(matcher *sampling.HeadSamplingOperationMatcher) *model.HeadSamplingOperationMatcher {
+	if matcher == nil {
+		return nil
+	}
+	result := &model.HeadSamplingOperationMatcher{}
+	if matcher.HttpServer != nil {
+		result.HTTPServer = &model.HeadSamplingHTTPServerMatcher{
+			Route:       services.StringPtrIfNotEmpty(matcher.HttpServer.Route),
+			RoutePrefix: services.StringPtrIfNotEmpty(matcher.HttpServer.RoutePrefix),
+			Method:      services.StringPtrIfNotEmpty(matcher.HttpServer.Method),
+		}
+	}
+	if matcher.HttpClient != nil {
+		result.HTTPClient = &model.HeadSamplingHTTPClientMatcher{
+			ServerAddress:       services.StringPtrIfNotEmpty(matcher.HttpClient.ServerAddress),
+			TemplatedPath:       services.StringPtrIfNotEmpty(matcher.HttpClient.TemplatedPath),
+			TemplatedPathPrefix: services.StringPtrIfNotEmpty(matcher.HttpClient.TemplatedPathPrefix),
+			Method:              services.StringPtrIfNotEmpty(matcher.HttpClient.Method),
+		}
+	}
+	return result
+}
+
+// containerCollectorConfigToModel converts InstrumentationConfig workload collector config (tail sampling) to the GraphQL model.
+func containerCollectorConfigToModel(c *commonapi.ContainerCollectorConfig) *model.K8sWorkloadContainerCollectorConfig {
+	if c == nil {
+		return nil
+	}
+	tailSampling := tailSamplingSourceConfigToModel(c.TailSampling)
+	if tailSampling == nil {
+		return &model.K8sWorkloadContainerCollectorConfig{}
+	}
+	return &model.K8sWorkloadContainerCollectorConfig{
+		TailSampling: tailSampling,
+	}
+}
+
+func tailSamplingSourceConfigToModel(cfg *sampling.TailSamplingSourceConfig) *model.K8sWorkloadContainerCollectorConfigTailSampling {
+	if cfg == nil {
+		return nil
+	}
+	result := &model.K8sWorkloadContainerCollectorConfigTailSampling{}
+	if len(cfg.NoisyOperations) > 0 {
+		result.NoisyOperations = make([]*model.K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation, 0, len(cfg.NoisyOperations))
+		for i := range cfg.NoisyOperations {
+			if op := tailSamplingNoisyOperationToModel(&cfg.NoisyOperations[i]); op != nil {
+				result.NoisyOperations = append(result.NoisyOperations, op)
+			}
+		}
+	}
+	if len(cfg.HighlyRelevantOperations) > 0 {
+		result.HighlyRelevantOperations = make([]*model.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation, 0, len(cfg.HighlyRelevantOperations))
+		for i := range cfg.HighlyRelevantOperations {
+			if op := tailSamplingHighlyRelevantOperationToModel(&cfg.HighlyRelevantOperations[i]); op != nil {
+				result.HighlyRelevantOperations = append(result.HighlyRelevantOperations, op)
+			}
+		}
+	}
+	if len(cfg.CostReductionRules) > 0 {
+		result.CostReductionRules = make([]*model.K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule, 0, len(cfg.CostReductionRules))
+		for i := range cfg.CostReductionRules {
+			if rule := tailSamplingCostReductionRuleToModel(&cfg.CostReductionRules[i]); rule != nil {
+				result.CostReductionRules = append(result.CostReductionRules, rule)
+			}
+		}
+	}
+	return result
+}
+
+func tailSamplingNoisyOperationToModel(op *sampling.NoisyOperation) *model.K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation {
+	if op == nil {
+		return nil
+	}
+	ruleID := op.Id
+	if ruleID == "" {
+		ruleID = v1alpha1.ComputeNoisyOperationHash(&v1alpha1.NoisyOperation{
+			Name:             op.Name,
+			Disabled:         op.Disabled,
+			Operation:        op.Operation,
+			PercentageAtMost: op.PercentageAtMost,
+		})
+	}
+	return &model.K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation{
+		RuleID:           ruleID,
+		Name:             services.StringPtrIfNotEmpty(op.Name),
+		Disabled:         op.Disabled,
+		Operation:        headSamplingOperationMatcherToModel(op.Operation),
+		PercentageAtMost: op.PercentageAtMost,
+	}
+}
+
+func tailSamplingHighlyRelevantOperationToModel(op *sampling.HighlyRelevantOperation) *model.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation {
+	if op == nil {
+		return nil
+	}
+	ruleID := op.Id
+	if ruleID == "" {
+		ruleID = v1alpha1.ComputeHighlyRelevantOperationHash(&v1alpha1.HighlyRelevantOperation{
+			Name:              op.Name,
+			Disabled:          op.Disabled,
+			Error:             op.Error,
+			DurationAtLeastMs: op.DurationAtLeastMs,
+			Operation:         op.Operation,
+			PercentageAtLeast: op.PercentageAtLeast,
+		})
+	}
+	return &model.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation{
+		RuleID:            ruleID,
+		Name:              services.StringPtrIfNotEmpty(op.Name),
+		Disabled:          op.Disabled,
+		Error:             op.Error,
+		DurationAtLeastMs: op.DurationAtLeastMs,
+		Operation:         tailSamplingOperationMatcherToModel(op.Operation),
+		PercentageAtLeast: op.PercentageAtLeast,
+	}
+}
+
+func tailSamplingCostReductionRuleToModel(rule *sampling.CostReductionRule) *model.K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule {
+	if rule == nil {
+		return nil
+	}
+	ruleID := rule.Id
+	if ruleID == "" {
+		ruleID = v1alpha1.ComputeCostReductionRuleHash(&v1alpha1.CostReductionRule{
+			Name:             rule.Name,
+			Disabled:         rule.Disabled,
+			Operation:        rule.Operation,
+			PercentageAtMost: rule.PercentageAtMost,
+		})
+	}
+	return &model.K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule{
+		RuleID:           ruleID,
+		Name:             services.StringPtrIfNotEmpty(rule.Name),
+		Disabled:         rule.Disabled,
+		Operation:        tailSamplingOperationMatcherToModel(rule.Operation),
+		PercentageAtMost: rule.PercentageAtMost,
+	}
+}
+
+func tailSamplingOperationMatcherToModel(matcher *sampling.TailSamplingOperationMatcher) *model.TailSamplingOperationMatcher {
+	if matcher == nil {
+		return nil
+	}
+	result := &model.TailSamplingOperationMatcher{}
+	if matcher.HttpServer != nil {
+		result.HTTPServer = &model.TailSamplingHTTPServerMatcher{
+			Route:       services.StringPtrIfNotEmpty(matcher.HttpServer.Route),
+			RoutePrefix: services.StringPtrIfNotEmpty(matcher.HttpServer.RoutePrefix),
+			Method:      services.StringPtrIfNotEmpty(matcher.HttpServer.Method),
+		}
+	}
+	if matcher.KafkaConsumer != nil {
+		result.KafkaConsumer = &model.TailSamplingKafkaMatcher{
+			KafkaTopic: services.StringPtrIfNotEmpty(matcher.KafkaConsumer.KafkaTopic),
+		}
+	}
+	if matcher.KafkaProducer != nil {
+		result.KafkaProducer = &model.TailSamplingKafkaMatcher{
+			KafkaTopic: services.StringPtrIfNotEmpty(matcher.KafkaProducer.KafkaTopic),
+		}
+	}
+	return result
 }
 
 func convertMetricsSourcesToModel(ms *common.MetricsSourceConfiguration, pc *provenanceCollector) *model.MetricsSourceConfig {

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -747,6 +747,7 @@ type ComplexityRoot struct {
 	K8sWorkloadContainer struct {
 		AgentConfig      func(childComplexity int) int
 		AgentEnabled     func(childComplexity int) int
+		CollectorConfig  func(childComplexity int) int
 		ContainerName    func(childComplexity int) int
 		Instrumentations func(childComplexity int) int
 		Overrides        func(childComplexity int) int
@@ -762,19 +763,53 @@ type ComplexityRoot struct {
 	}
 
 	K8sWorkloadContainerAgentConfigTracesHeadSampling struct {
-		Checks             func(childComplexity int) int
-		FallbackPercentage func(childComplexity int) int
+		DryRun          func(childComplexity int) int
+		NoisyOperations func(childComplexity int) int
+		SpanMetricsMode func(childComplexity int) int
 	}
 
-	K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck struct {
-		Conditions func(childComplexity int) int
-		Percentage func(childComplexity int) int
+	K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation struct {
+		Disabled         func(childComplexity int) int
+		Name             func(childComplexity int) int
+		Operation        func(childComplexity int) int
+		PercentageAtMost func(childComplexity int) int
+		RuleID           func(childComplexity int) int
 	}
 
-	K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition struct {
-		Key      func(childComplexity int) int
-		Operator func(childComplexity int) int
-		Value    func(childComplexity int) int
+	K8sWorkloadContainerCollectorConfig struct {
+		TailSampling func(childComplexity int) int
+	}
+
+	K8sWorkloadContainerCollectorConfigTailSampling struct {
+		CostReductionRules       func(childComplexity int) int
+		HighlyRelevantOperations func(childComplexity int) int
+		NoisyOperations          func(childComplexity int) int
+	}
+
+	K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule struct {
+		Disabled         func(childComplexity int) int
+		Name             func(childComplexity int) int
+		Operation        func(childComplexity int) int
+		PercentageAtMost func(childComplexity int) int
+		RuleID           func(childComplexity int) int
+	}
+
+	K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation struct {
+		Disabled          func(childComplexity int) int
+		DurationAtLeastMs func(childComplexity int) int
+		Error             func(childComplexity int) int
+		Name              func(childComplexity int) int
+		Operation         func(childComplexity int) int
+		PercentageAtLeast func(childComplexity int) int
+		RuleID            func(childComplexity int) int
+	}
+
+	K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation struct {
+		Disabled         func(childComplexity int) int
+		Name             func(childComplexity int) int
+		Operation        func(childComplexity int) int
+		PercentageAtMost func(childComplexity int) int
+		RuleID           func(childComplexity int) int
 	}
 
 	K8sWorkloadContainerOverrides struct {
@@ -4708,6 +4743,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.K8sWorkloadContainer.AgentEnabled(childComplexity), true
 
+	case "K8sWorkloadContainer.collectorConfig":
+		if e.complexity.K8sWorkloadContainer.CollectorConfig == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadContainer.CollectorConfig(childComplexity), true
+
 	case "K8sWorkloadContainer.containerName":
 		if e.complexity.K8sWorkloadContainer.ContainerName == nil {
 			break
@@ -4750,54 +4792,208 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.K8sWorkloadContainerAgentConfigTraces.HeadSampling(childComplexity), true
 
-	case "K8sWorkloadContainerAgentConfigTracesHeadSampling.checks":
-		if e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSampling.Checks == nil {
+	case "K8sWorkloadContainerAgentConfigTracesHeadSampling.dryRun":
+		if e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSampling.DryRun == nil {
 			break
 		}
 
-		return e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSampling.Checks(childComplexity), true
+		return e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSampling.DryRun(childComplexity), true
 
-	case "K8sWorkloadContainerAgentConfigTracesHeadSampling.fallbackPercentage":
-		if e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSampling.FallbackPercentage == nil {
+	case "K8sWorkloadContainerAgentConfigTracesHeadSampling.noisyOperations":
+		if e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSampling.NoisyOperations == nil {
 			break
 		}
 
-		return e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSampling.FallbackPercentage(childComplexity), true
+		return e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSampling.NoisyOperations(childComplexity), true
 
-	case "K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck.conditions":
-		if e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck.Conditions == nil {
+	case "K8sWorkloadContainerAgentConfigTracesHeadSampling.spanMetricsMode":
+		if e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSampling.SpanMetricsMode == nil {
 			break
 		}
 
-		return e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck.Conditions(childComplexity), true
+		return e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSampling.SpanMetricsMode(childComplexity), true
 
-	case "K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck.percentage":
-		if e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck.Percentage == nil {
+	case "K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation.disabled":
+		if e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation.Disabled == nil {
 			break
 		}
 
-		return e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck.Percentage(childComplexity), true
+		return e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation.Disabled(childComplexity), true
 
-	case "K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition.key":
-		if e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition.Key == nil {
+	case "K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation.name":
+		if e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation.Name == nil {
 			break
 		}
 
-		return e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition.Key(childComplexity), true
+		return e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation.Name(childComplexity), true
 
-	case "K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition.operator":
-		if e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition.Operator == nil {
+	case "K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation.operation":
+		if e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation.Operation == nil {
 			break
 		}
 
-		return e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition.Operator(childComplexity), true
+		return e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation.Operation(childComplexity), true
 
-	case "K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition.value":
-		if e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition.Value == nil {
+	case "K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation.percentageAtMost":
+		if e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation.PercentageAtMost == nil {
 			break
 		}
 
-		return e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition.Value(childComplexity), true
+		return e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation.PercentageAtMost(childComplexity), true
+
+	case "K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation.ruleId":
+		if e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation.RuleID == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation.RuleID(childComplexity), true
+
+	case "K8sWorkloadContainerCollectorConfig.tailSampling":
+		if e.complexity.K8sWorkloadContainerCollectorConfig.TailSampling == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadContainerCollectorConfig.TailSampling(childComplexity), true
+
+	case "K8sWorkloadContainerCollectorConfigTailSampling.costReductionRules":
+		if e.complexity.K8sWorkloadContainerCollectorConfigTailSampling.CostReductionRules == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadContainerCollectorConfigTailSampling.CostReductionRules(childComplexity), true
+
+	case "K8sWorkloadContainerCollectorConfigTailSampling.highlyRelevantOperations":
+		if e.complexity.K8sWorkloadContainerCollectorConfigTailSampling.HighlyRelevantOperations == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadContainerCollectorConfigTailSampling.HighlyRelevantOperations(childComplexity), true
+
+	case "K8sWorkloadContainerCollectorConfigTailSampling.noisyOperations":
+		if e.complexity.K8sWorkloadContainerCollectorConfigTailSampling.NoisyOperations == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadContainerCollectorConfigTailSampling.NoisyOperations(childComplexity), true
+
+	case "K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule.disabled":
+		if e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule.Disabled == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule.Disabled(childComplexity), true
+
+	case "K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule.name":
+		if e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule.Name == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule.Name(childComplexity), true
+
+	case "K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule.operation":
+		if e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule.Operation == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule.Operation(childComplexity), true
+
+	case "K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule.percentageAtMost":
+		if e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule.PercentageAtMost == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule.PercentageAtMost(childComplexity), true
+
+	case "K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule.ruleId":
+		if e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule.RuleID == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule.RuleID(childComplexity), true
+
+	case "K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation.disabled":
+		if e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation.Disabled == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation.Disabled(childComplexity), true
+
+	case "K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation.durationAtLeastMs":
+		if e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation.DurationAtLeastMs == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation.DurationAtLeastMs(childComplexity), true
+
+	case "K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation.error":
+		if e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation.Error == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation.Error(childComplexity), true
+
+	case "K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation.name":
+		if e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation.Name == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation.Name(childComplexity), true
+
+	case "K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation.operation":
+		if e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation.Operation == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation.Operation(childComplexity), true
+
+	case "K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation.percentageAtLeast":
+		if e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation.PercentageAtLeast == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation.PercentageAtLeast(childComplexity), true
+
+	case "K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation.ruleId":
+		if e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation.RuleID == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation.RuleID(childComplexity), true
+
+	case "K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation.disabled":
+		if e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation.Disabled == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation.Disabled(childComplexity), true
+
+	case "K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation.name":
+		if e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation.Name == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation.Name(childComplexity), true
+
+	case "K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation.operation":
+		if e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation.Operation == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation.Operation(childComplexity), true
+
+	case "K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation.percentageAtMost":
+		if e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation.PercentageAtMost == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation.PercentageAtMost(childComplexity), true
+
+	case "K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation.ruleId":
+		if e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation.RuleID == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation.RuleID(childComplexity), true
 
 	case "K8sWorkloadContainerOverrides.containerName":
 		if e.complexity.K8sWorkloadContainerOverrides.ContainerName == nil {
@@ -28749,6 +28945,8 @@ func (ec *executionContext) fieldContext_K8sWorkload_containers(_ context.Contex
 				return ec.fieldContext_K8sWorkloadContainer_overrides(ctx, field)
 			case "agentConfig":
 				return ec.fieldContext_K8sWorkloadContainer_agentConfig(ctx, field)
+			case "collectorConfig":
+				return ec.fieldContext_K8sWorkloadContainer_collectorConfig(ctx, field)
 			case "instrumentations":
 				return ec.fieldContext_K8sWorkloadContainer_instrumentations(ctx, field)
 			}
@@ -30676,6 +30874,51 @@ func (ec *executionContext) fieldContext_K8sWorkloadContainer_agentConfig(_ cont
 	return fc, nil
 }
 
+func (ec *executionContext) _K8sWorkloadContainer_collectorConfig(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainer) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainer_collectorConfig(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CollectorConfig, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.K8sWorkloadContainerCollectorConfig)
+	fc.Result = res
+	return ec.marshalOK8sWorkloadContainerCollectorConfig2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerCollectorConfig(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadContainer_collectorConfig(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadContainer",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "tailSampling":
+				return ec.fieldContext_K8sWorkloadContainerCollectorConfig_tailSampling(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type K8sWorkloadContainerCollectorConfig", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _K8sWorkloadContainer_instrumentations(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainer) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_K8sWorkloadContainer_instrumentations(ctx, field)
 	if err != nil {
@@ -30804,10 +31047,12 @@ func (ec *executionContext) fieldContext_K8sWorkloadContainerAgentConfigTraces_h
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "checks":
-				return ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSampling_checks(ctx, field)
-			case "fallbackPercentage":
-				return ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSampling_fallbackPercentage(ctx, field)
+			case "dryRun":
+				return ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSampling_dryRun(ctx, field)
+			case "spanMetricsMode":
+				return ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSampling_spanMetricsMode(ctx, field)
+			case "noisyOperations":
+				return ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSampling_noisyOperations(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type K8sWorkloadContainerAgentConfigTracesHeadSampling", field.Name)
 		},
@@ -30815,8 +31060,8 @@ func (ec *executionContext) fieldContext_K8sWorkloadContainerAgentConfigTraces_h
 	return fc, nil
 }
 
-func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSampling_checks(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerAgentConfigTracesHeadSampling) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSampling_checks(ctx, field)
+func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSampling_dryRun(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerAgentConfigTracesHeadSampling) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSampling_dryRun(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -30829,7 +31074,7 @@ func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSampling_c
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Checks, nil
+		return obj.DryRun, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -30838,32 +31083,26 @@ func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSampling_c
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.([]*model.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck)
+	res := resTmp.(*bool)
 	fc.Result = res
-	return ec.marshalOK8sWorkloadContainerAgentConfigTracesHeadSamplingCheck2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerAgentConfigTracesHeadSamplingCheckᚄ(ctx, field.Selections, res)
+	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSampling_checks(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSampling_dryRun(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "K8sWorkloadContainerAgentConfigTracesHeadSampling",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "conditions":
-				return ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck_conditions(ctx, field)
-			case "percentage":
-				return ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck_percentage(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck", field.Name)
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
 }
 
-func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSampling_fallbackPercentage(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerAgentConfigTracesHeadSampling) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSampling_fallbackPercentage(ctx, field)
+func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSampling_spanMetricsMode(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerAgentConfigTracesHeadSampling) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSampling_spanMetricsMode(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -30876,7 +31115,708 @@ func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSampling_f
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.FallbackPercentage, nil
+		return obj.SpanMetricsMode, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode)
+	fc.Result = res
+	return ec.marshalOK8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSampling_spanMetricsMode(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadContainerAgentConfigTracesHeadSampling",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSampling_noisyOperations(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerAgentConfigTracesHeadSampling) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSampling_noisyOperations(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NoisyOperations, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation)
+	fc.Result = res
+	return ec.marshalOK8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperationᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSampling_noisyOperations(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadContainerAgentConfigTracesHeadSampling",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "ruleId":
+				return ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation_ruleId(ctx, field)
+			case "name":
+				return ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation_name(ctx, field)
+			case "disabled":
+				return ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation_disabled(ctx, field)
+			case "operation":
+				return ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation_operation(ctx, field)
+			case "percentageAtMost":
+				return ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation_percentageAtMost(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation_ruleId(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation_ruleId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RuleID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation_ruleId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation_name(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation_disabled(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation_disabled(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Disabled, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation_disabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation_operation(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation_operation(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Operation, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.HeadSamplingOperationMatcher)
+	fc.Result = res
+	return ec.marshalOHeadSamplingOperationMatcher2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐHeadSamplingOperationMatcher(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation_operation(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "httpServer":
+				return ec.fieldContext_HeadSamplingOperationMatcher_httpServer(ctx, field)
+			case "httpClient":
+				return ec.fieldContext_HeadSamplingOperationMatcher_httpClient(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type HeadSamplingOperationMatcher", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation_percentageAtMost(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation_percentageAtMost(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PercentageAtMost, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*float64)
+	fc.Result = res
+	return ec.marshalOFloat2ᚖfloat64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation_percentageAtMost(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfig_tailSampling(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerCollectorConfig) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerCollectorConfig_tailSampling(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TailSampling, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.K8sWorkloadContainerCollectorConfigTailSampling)
+	fc.Result = res
+	return ec.marshalOK8sWorkloadContainerCollectorConfigTailSampling2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerCollectorConfigTailSampling(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadContainerCollectorConfig_tailSampling(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadContainerCollectorConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "noisyOperations":
+				return ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSampling_noisyOperations(ctx, field)
+			case "highlyRelevantOperations":
+				return ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSampling_highlyRelevantOperations(ctx, field)
+			case "costReductionRules":
+				return ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSampling_costReductionRules(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type K8sWorkloadContainerCollectorConfigTailSampling", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfigTailSampling_noisyOperations(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerCollectorConfigTailSampling) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSampling_noisyOperations(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NoisyOperations, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation)
+	fc.Result = res
+	return ec.marshalOK8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerCollectorConfigTailSamplingNoisyOperationᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadContainerCollectorConfigTailSampling_noisyOperations(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadContainerCollectorConfigTailSampling",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "ruleId":
+				return ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation_ruleId(ctx, field)
+			case "name":
+				return ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation_name(ctx, field)
+			case "disabled":
+				return ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation_disabled(ctx, field)
+			case "operation":
+				return ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation_operation(ctx, field)
+			case "percentageAtMost":
+				return ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation_percentageAtMost(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfigTailSampling_highlyRelevantOperations(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerCollectorConfigTailSampling) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSampling_highlyRelevantOperations(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.HighlyRelevantOperations, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation)
+	fc.Result = res
+	return ec.marshalOK8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperationᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadContainerCollectorConfigTailSampling_highlyRelevantOperations(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadContainerCollectorConfigTailSampling",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "ruleId":
+				return ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_ruleId(ctx, field)
+			case "name":
+				return ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_name(ctx, field)
+			case "disabled":
+				return ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_disabled(ctx, field)
+			case "error":
+				return ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_error(ctx, field)
+			case "durationAtLeastMs":
+				return ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_durationAtLeastMs(ctx, field)
+			case "operation":
+				return ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_operation(ctx, field)
+			case "percentageAtLeast":
+				return ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_percentageAtLeast(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfigTailSampling_costReductionRules(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerCollectorConfigTailSampling) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSampling_costReductionRules(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CostReductionRules, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule)
+	fc.Result = res
+	return ec.marshalOK8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerCollectorConfigTailSamplingCostReductionRuleᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadContainerCollectorConfigTailSampling_costReductionRules(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadContainerCollectorConfigTailSampling",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "ruleId":
+				return ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule_ruleId(ctx, field)
+			case "name":
+				return ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule_name(ctx, field)
+			case "disabled":
+				return ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule_disabled(ctx, field)
+			case "operation":
+				return ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule_operation(ctx, field)
+			case "percentageAtMost":
+				return ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule_percentageAtMost(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule_ruleId(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule_ruleId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RuleID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule_ruleId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule_name(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule_disabled(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule_disabled(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Disabled, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule_disabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule_operation(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule_operation(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Operation, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.TailSamplingOperationMatcher)
+	fc.Result = res
+	return ec.marshalOTailSamplingOperationMatcher2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐTailSamplingOperationMatcher(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule_operation(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "httpServer":
+				return ec.fieldContext_TailSamplingOperationMatcher_httpServer(ctx, field)
+			case "kafkaConsumer":
+				return ec.fieldContext_TailSamplingOperationMatcher_kafkaConsumer(ctx, field)
+			case "kafkaProducer":
+				return ec.fieldContext_TailSamplingOperationMatcher_kafkaProducer(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TailSamplingOperationMatcher", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule_percentageAtMost(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule_percentageAtMost(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PercentageAtMost, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -30893,9 +31833,9 @@ func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSampling_f
 	return ec.marshalNFloat2float64(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSampling_fallbackPercentage(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule_percentageAtMost(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "K8sWorkloadContainerAgentConfigTracesHeadSampling",
+		Object:     "K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -30906,8 +31846,8 @@ func (ec *executionContext) fieldContext_K8sWorkloadContainerAgentConfigTracesHe
 	return fc, nil
 }
 
-func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck_conditions(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck_conditions(ctx, field)
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_ruleId(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_ruleId(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -30920,7 +31860,51 @@ func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSamplingCh
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Conditions, nil
+		return obj.RuleID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_ruleId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_name(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -30929,34 +31913,204 @@ func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSamplingCh
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.([]*model.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalOK8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionᚄ(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck_conditions(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck",
+		Object:     "K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_disabled(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_disabled(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Disabled, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_disabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_error(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_error(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Error, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_error(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_durationAtLeastMs(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_durationAtLeastMs(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DurationAtLeastMs, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_durationAtLeastMs(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_operation(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_operation(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Operation, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.TailSamplingOperationMatcher)
+	fc.Result = res
+	return ec.marshalOTailSamplingOperationMatcher2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐTailSamplingOperationMatcher(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_operation(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "key":
-				return ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition_key(ctx, field)
-			case "operator":
-				return ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition_operator(ctx, field)
-			case "value":
-				return ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition_value(ctx, field)
+			case "httpServer":
+				return ec.fieldContext_TailSamplingOperationMatcher_httpServer(ctx, field)
+			case "kafkaConsumer":
+				return ec.fieldContext_TailSamplingOperationMatcher_kafkaConsumer(ctx, field)
+			case "kafkaProducer":
+				return ec.fieldContext_TailSamplingOperationMatcher_kafkaProducer(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type TailSamplingOperationMatcher", field.Name)
 		},
 	}
 	return fc, nil
 }
 
-func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck_percentage(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck_percentage(ctx, field)
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_percentageAtLeast(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_percentageAtLeast(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -30969,26 +32123,23 @@ func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSamplingCh
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Percentage, nil
+		return obj.PercentageAtLeast, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(float64)
+	res := resTmp.(*float64)
 	fc.Result = res
-	return ec.marshalNFloat2float64(ctx, field.Selections, res)
+	return ec.marshalOFloat2ᚖfloat64(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck_percentage(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_percentageAtLeast(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck",
+		Object:     "K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -30999,8 +32150,8 @@ func (ec *executionContext) fieldContext_K8sWorkloadContainerAgentConfigTracesHe
 	return fc, nil
 }
 
-func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition_key(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition_key(ctx, field)
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation_ruleId(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation_ruleId(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -31013,7 +32164,7 @@ func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSamplingCh
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Key, nil
+		return obj.RuleID, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -31027,24 +32178,24 @@ func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSamplingCh
 	}
 	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNID2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition_key(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation_ruleId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition",
+		Object:     "K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	return fc, nil
 }
 
-func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition_operator(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition_operator(ctx, field)
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation_name(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation_name(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -31057,38 +32208,35 @@ func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSamplingCh
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Operator, nil
+		return obj.Name, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(model.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNK8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition_operator(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition",
+		Object:     "K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator does not have child fields")
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
 }
 
-func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition_value(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition_value(ctx, field)
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation_disabled(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation_disabled(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -31101,7 +32249,7 @@ func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSamplingCh
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Value, nil
+		return obj.Disabled, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -31113,19 +32261,107 @@ func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSamplingCh
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(bool)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition_value(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation_disabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
-		Object:     "K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition",
+		Object:     "K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation_operation(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation_operation(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Operation, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.HeadSamplingOperationMatcher)
+	fc.Result = res
+	return ec.marshalOHeadSamplingOperationMatcher2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐHeadSamplingOperationMatcher(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation_operation(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "httpServer":
+				return ec.fieldContext_HeadSamplingOperationMatcher_httpServer(ctx, field)
+			case "httpClient":
+				return ec.fieldContext_HeadSamplingOperationMatcher_httpClient(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type HeadSamplingOperationMatcher", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation_percentageAtMost(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation_percentageAtMost(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PercentageAtMost, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*float64)
+	fc.Result = res
+	return ec.marshalOFloat2ᚖfloat64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation_percentageAtMost(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
 		},
 	}
 	return fc, nil
@@ -59462,6 +60698,8 @@ func (ec *executionContext) _K8sWorkloadContainer(ctx context.Context, sel ast.S
 			out.Values[i] = ec._K8sWorkloadContainer_overrides(ctx, field, obj)
 		case "agentConfig":
 			out.Values[i] = ec._K8sWorkloadContainer_agentConfig(ctx, field, obj)
+		case "collectorConfig":
+			out.Values[i] = ec._K8sWorkloadContainer_collectorConfig(ctx, field, obj)
 		case "instrumentations":
 			out.Values[i] = ec._K8sWorkloadContainer_instrumentations(ctx, field, obj)
 		default:
@@ -59570,10 +60808,188 @@ func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSampling(c
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("K8sWorkloadContainerAgentConfigTracesHeadSampling")
-		case "checks":
-			out.Values[i] = ec._K8sWorkloadContainerAgentConfigTracesHeadSampling_checks(ctx, field, obj)
-		case "fallbackPercentage":
-			out.Values[i] = ec._K8sWorkloadContainerAgentConfigTracesHeadSampling_fallbackPercentage(ctx, field, obj)
+		case "dryRun":
+			out.Values[i] = ec._K8sWorkloadContainerAgentConfigTracesHeadSampling_dryRun(ctx, field, obj)
+		case "spanMetricsMode":
+			out.Values[i] = ec._K8sWorkloadContainerAgentConfigTracesHeadSampling_spanMetricsMode(ctx, field, obj)
+		case "noisyOperations":
+			out.Values[i] = ec._K8sWorkloadContainerAgentConfigTracesHeadSampling_noisyOperations(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var k8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperationImplementors = []string{"K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation"}
+
+func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation(ctx context.Context, sel ast.SelectionSet, obj *model.K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, k8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperationImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation")
+		case "ruleId":
+			out.Values[i] = ec._K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation_ruleId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "name":
+			out.Values[i] = ec._K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation_name(ctx, field, obj)
+		case "disabled":
+			out.Values[i] = ec._K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation_disabled(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "operation":
+			out.Values[i] = ec._K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation_operation(ctx, field, obj)
+		case "percentageAtMost":
+			out.Values[i] = ec._K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation_percentageAtMost(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var k8sWorkloadContainerCollectorConfigImplementors = []string{"K8sWorkloadContainerCollectorConfig"}
+
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfig(ctx context.Context, sel ast.SelectionSet, obj *model.K8sWorkloadContainerCollectorConfig) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, k8sWorkloadContainerCollectorConfigImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("K8sWorkloadContainerCollectorConfig")
+		case "tailSampling":
+			out.Values[i] = ec._K8sWorkloadContainerCollectorConfig_tailSampling(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var k8sWorkloadContainerCollectorConfigTailSamplingImplementors = []string{"K8sWorkloadContainerCollectorConfigTailSampling"}
+
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfigTailSampling(ctx context.Context, sel ast.SelectionSet, obj *model.K8sWorkloadContainerCollectorConfigTailSampling) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, k8sWorkloadContainerCollectorConfigTailSamplingImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("K8sWorkloadContainerCollectorConfigTailSampling")
+		case "noisyOperations":
+			out.Values[i] = ec._K8sWorkloadContainerCollectorConfigTailSampling_noisyOperations(ctx, field, obj)
+		case "highlyRelevantOperations":
+			out.Values[i] = ec._K8sWorkloadContainerCollectorConfigTailSampling_highlyRelevantOperations(ctx, field, obj)
+		case "costReductionRules":
+			out.Values[i] = ec._K8sWorkloadContainerCollectorConfigTailSampling_costReductionRules(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var k8sWorkloadContainerCollectorConfigTailSamplingCostReductionRuleImplementors = []string{"K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule"}
+
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule(ctx context.Context, sel ast.SelectionSet, obj *model.K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, k8sWorkloadContainerCollectorConfigTailSamplingCostReductionRuleImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule")
+		case "ruleId":
+			out.Values[i] = ec._K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule_ruleId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "name":
+			out.Values[i] = ec._K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule_name(ctx, field, obj)
+		case "disabled":
+			out.Values[i] = ec._K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule_disabled(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "operation":
+			out.Values[i] = ec._K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule_operation(ctx, field, obj)
+		case "percentageAtMost":
+			out.Values[i] = ec._K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule_percentageAtMost(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -59600,24 +61016,40 @@ func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSampling(c
 	return out
 }
 
-var k8sWorkloadContainerAgentConfigTracesHeadSamplingCheckImplementors = []string{"K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck"}
+var k8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperationImplementors = []string{"K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation"}
 
-func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck(ctx context.Context, sel ast.SelectionSet, obj *model.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, k8sWorkloadContainerAgentConfigTracesHeadSamplingCheckImplementors)
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation(ctx context.Context, sel ast.SelectionSet, obj *model.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, k8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperationImplementors)
 
 	out := graphql.NewFieldSet(fields)
 	deferred := make(map[string]*graphql.FieldSet)
 	for i, field := range fields {
 		switch field.Name {
 		case "__typename":
-			out.Values[i] = graphql.MarshalString("K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck")
-		case "conditions":
-			out.Values[i] = ec._K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck_conditions(ctx, field, obj)
-		case "percentage":
-			out.Values[i] = ec._K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck_percentage(ctx, field, obj)
+			out.Values[i] = graphql.MarshalString("K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation")
+		case "ruleId":
+			out.Values[i] = ec._K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_ruleId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "name":
+			out.Values[i] = ec._K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_name(ctx, field, obj)
+		case "disabled":
+			out.Values[i] = ec._K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_disabled(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "error":
+			out.Values[i] = ec._K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_error(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "durationAtLeastMs":
+			out.Values[i] = ec._K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_durationAtLeastMs(ctx, field, obj)
+		case "operation":
+			out.Values[i] = ec._K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_operation(ctx, field, obj)
+		case "percentageAtLeast":
+			out.Values[i] = ec._K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation_percentageAtLeast(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -59641,32 +61073,33 @@ func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSamplingCh
 	return out
 }
 
-var k8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionImplementors = []string{"K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition"}
+var k8sWorkloadContainerCollectorConfigTailSamplingNoisyOperationImplementors = []string{"K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation"}
 
-func (ec *executionContext) _K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition(ctx context.Context, sel ast.SelectionSet, obj *model.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, k8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionImplementors)
+func (ec *executionContext) _K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation(ctx context.Context, sel ast.SelectionSet, obj *model.K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, k8sWorkloadContainerCollectorConfigTailSamplingNoisyOperationImplementors)
 
 	out := graphql.NewFieldSet(fields)
 	deferred := make(map[string]*graphql.FieldSet)
 	for i, field := range fields {
 		switch field.Name {
 		case "__typename":
-			out.Values[i] = graphql.MarshalString("K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition")
-		case "key":
-			out.Values[i] = ec._K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition_key(ctx, field, obj)
+			out.Values[i] = graphql.MarshalString("K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation")
+		case "ruleId":
+			out.Values[i] = ec._K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation_ruleId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "operator":
-			out.Values[i] = ec._K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition_operator(ctx, field, obj)
+		case "name":
+			out.Values[i] = ec._K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation_name(ctx, field, obj)
+		case "disabled":
+			out.Values[i] = ec._K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation_disabled(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "value":
-			out.Values[i] = ec._K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition_value(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
+		case "operation":
+			out.Values[i] = ec._K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation_operation(ctx, field, obj)
+		case "percentageAtMost":
+			out.Values[i] = ec._K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation_percentageAtMost(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -67179,34 +68612,44 @@ func (ec *executionContext) marshalNK8sWorkloadContainer2ᚖgithubᚗcomᚋodigo
 	return ec._K8sWorkloadContainer(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalNK8sWorkloadContainerAgentConfigTracesHeadSamplingCheck2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerAgentConfigTracesHeadSamplingCheck(ctx context.Context, sel ast.SelectionSet, v *model.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck) graphql.Marshaler {
+func (ec *executionContext) marshalNK8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation(ctx context.Context, sel ast.SelectionSet, v *model.K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
 		}
 		return graphql.Null
 	}
-	return ec._K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck(ctx, sel, v)
+	return ec._K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalNK8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition(ctx context.Context, sel ast.SelectionSet, v *model.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition) graphql.Marshaler {
+func (ec *executionContext) marshalNK8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule(ctx context.Context, sel ast.SelectionSet, v *model.K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
 		}
 		return graphql.Null
 	}
-	return ec._K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition(ctx, sel, v)
+	return ec._K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule(ctx, sel, v)
 }
 
-func (ec *executionContext) unmarshalNK8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator(ctx context.Context, v any) (model.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator, error) {
-	var res model.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator
-	err := res.UnmarshalGQL(v)
-	return res, graphql.ErrorOnPath(ctx, err)
+func (ec *executionContext) marshalNK8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation(ctx context.Context, sel ast.SelectionSet, v *model.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalNK8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator(ctx context.Context, sel ast.SelectionSet, v model.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator) graphql.Marshaler {
-	return v
+func (ec *executionContext) marshalNK8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation(ctx context.Context, sel ast.SelectionSet, v *model.K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNK8sWorkloadId2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadID(ctx context.Context, sel ast.SelectionSet, v *model.K8sWorkloadID) graphql.Marshaler {
@@ -70369,7 +71812,7 @@ func (ec *executionContext) marshalOK8sWorkloadContainerAgentConfigTracesHeadSam
 	return ec._K8sWorkloadContainerAgentConfigTracesHeadSampling(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalOK8sWorkloadContainerAgentConfigTracesHeadSamplingCheck2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerAgentConfigTracesHeadSamplingCheckᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck) graphql.Marshaler {
+func (ec *executionContext) marshalOK8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperationᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
@@ -70396,7 +71839,7 @@ func (ec *executionContext) marshalOK8sWorkloadContainerAgentConfigTracesHeadSam
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNK8sWorkloadContainerAgentConfigTracesHeadSamplingCheck2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerAgentConfigTracesHeadSamplingCheck(ctx, sel, v[i])
+			ret[i] = ec.marshalNK8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -70416,7 +71859,37 @@ func (ec *executionContext) marshalOK8sWorkloadContainerAgentConfigTracesHeadSam
 	return ret
 }
 
-func (ec *executionContext) marshalOK8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition) graphql.Marshaler {
+func (ec *executionContext) unmarshalOK8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode(ctx context.Context, v any) (*model.K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var res = new(model.K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode)
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOK8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode(ctx context.Context, sel ast.SelectionSet, v *model.K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return v
+}
+
+func (ec *executionContext) marshalOK8sWorkloadContainerCollectorConfig2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerCollectorConfig(ctx context.Context, sel ast.SelectionSet, v *model.K8sWorkloadContainerCollectorConfig) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._K8sWorkloadContainerCollectorConfig(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOK8sWorkloadContainerCollectorConfigTailSampling2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerCollectorConfigTailSampling(ctx context.Context, sel ast.SelectionSet, v *model.K8sWorkloadContainerCollectorConfigTailSampling) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._K8sWorkloadContainerCollectorConfigTailSampling(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOK8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerCollectorConfigTailSamplingCostReductionRuleᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
@@ -70443,7 +71916,101 @@ func (ec *executionContext) marshalOK8sWorkloadContainerAgentConfigTracesHeadSam
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNK8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition(ctx, sel, v[i])
+			ret[i] = ec.marshalNK8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalOK8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperationᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNK8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalOK8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerCollectorConfigTailSamplingNoisyOperationᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNK8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐK8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -940,6 +940,7 @@ type K8sWorkloadContainer struct {
 	AgentEnabled     *K8sWorkloadAgentEnabledContainer                `json:"agentEnabled,omitempty"`
 	Overrides        *K8sWorkloadContainerOverrides                   `json:"overrides,omitempty"`
 	AgentConfig      *K8sWorkloadContainerAgentConfig                 `json:"agentConfig,omitempty"`
+	CollectorConfig  *K8sWorkloadContainerCollectorConfig             `json:"collectorConfig,omitempty"`
 	Instrumentations []*K8sWorkloadPodContainerProcessInstrumentation `json:"instrumentations,omitempty"`
 }
 
@@ -952,19 +953,53 @@ type K8sWorkloadContainerAgentConfigTraces struct {
 }
 
 type K8sWorkloadContainerAgentConfigTracesHeadSampling struct {
-	Checks             []*K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck `json:"checks,omitempty"`
-	FallbackPercentage float64                                                   `json:"fallbackPercentage"`
+	DryRun          *bool                                                              `json:"dryRun,omitempty"`
+	SpanMetricsMode *K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode  `json:"spanMetricsMode,omitempty"`
+	NoisyOperations []*K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation `json:"noisyOperations,omitempty"`
 }
 
-type K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck struct {
-	Conditions []*K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition `json:"conditions,omitempty"`
-	Percentage float64                                                            `json:"percentage"`
+type K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation struct {
+	RuleID           string                        `json:"ruleId"`
+	Name             *string                       `json:"name,omitempty"`
+	Disabled         bool                          `json:"disabled"`
+	Operation        *HeadSamplingOperationMatcher `json:"operation,omitempty"`
+	PercentageAtMost *float64                      `json:"percentageAtMost,omitempty"`
 }
 
-type K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition struct {
-	Key      string                                                                  `json:"key"`
-	Operator K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator `json:"operator"`
-	Value    string                                                                  `json:"value"`
+type K8sWorkloadContainerCollectorConfig struct {
+	TailSampling *K8sWorkloadContainerCollectorConfigTailSampling `json:"tailSampling,omitempty"`
+}
+
+type K8sWorkloadContainerCollectorConfigTailSampling struct {
+	NoisyOperations          []*K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation          `json:"noisyOperations,omitempty"`
+	HighlyRelevantOperations []*K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation `json:"highlyRelevantOperations,omitempty"`
+	CostReductionRules       []*K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule       `json:"costReductionRules,omitempty"`
+}
+
+type K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule struct {
+	RuleID           string                        `json:"ruleId"`
+	Name             *string                       `json:"name,omitempty"`
+	Disabled         bool                          `json:"disabled"`
+	Operation        *TailSamplingOperationMatcher `json:"operation,omitempty"`
+	PercentageAtMost float64                       `json:"percentageAtMost"`
+}
+
+type K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation struct {
+	RuleID            string                        `json:"ruleId"`
+	Name              *string                       `json:"name,omitempty"`
+	Disabled          bool                          `json:"disabled"`
+	Error             bool                          `json:"error"`
+	DurationAtLeastMs *int                          `json:"durationAtLeastMs,omitempty"`
+	Operation         *TailSamplingOperationMatcher `json:"operation,omitempty"`
+	PercentageAtLeast *float64                      `json:"percentageAtLeast,omitempty"`
+}
+
+type K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation struct {
+	RuleID           string                        `json:"ruleId"`
+	Name             *string                       `json:"name,omitempty"`
+	Disabled         bool                          `json:"disabled"`
+	Operation        *HeadSamplingOperationMatcher `json:"operation,omitempty"`
+	PercentageAtMost *float64                      `json:"percentageAtMost,omitempty"`
 }
 
 type K8sWorkloadContainerOverrides struct {
@@ -2410,48 +2445,44 @@ func (e K8sResourceKind) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
-type K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator string
+type K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode string
 
 const (
-	K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperatorEquals    K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator = "equals"
-	K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperatorNotEquals K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator = "notEquals"
-	K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperatorEndWith   K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator = "endWith"
-	K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperatorStartWith K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator = "startWith"
+	K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsModeSampledSpansOnly K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode = "sampled_spans_only"
+	K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsModeAllSpans         K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode = "all_spans"
 )
 
-var AllK8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator = []K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator{
-	K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperatorEquals,
-	K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperatorNotEquals,
-	K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperatorEndWith,
-	K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperatorStartWith,
+var AllK8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode = []K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode{
+	K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsModeSampledSpansOnly,
+	K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsModeAllSpans,
 }
 
-func (e K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator) IsValid() bool {
+func (e K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode) IsValid() bool {
 	switch e {
-	case K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperatorEquals, K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperatorNotEquals, K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperatorEndWith, K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperatorStartWith:
+	case K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsModeSampledSpansOnly, K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsModeAllSpans:
 		return true
 	}
 	return false
 }
 
-func (e K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator) String() string {
+func (e K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode) String() string {
 	return string(e)
 }
 
-func (e *K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator) UnmarshalGQL(v any) error {
+func (e *K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode) UnmarshalGQL(v any) error {
 	str, ok := v.(string)
 	if !ok {
 		return fmt.Errorf("enums must be strings")
 	}
 
-	*e = K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator(str)
+	*e = K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode(str)
 	if !e.IsValid() {
-		return fmt.Errorf("%s is not a valid K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator", str)
+		return fmt.Errorf("%s is not a valid K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode", str)
 	}
 	return nil
 }
 
-func (e K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator) MarshalGQL(w io.Writer) {
+func (e K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 

--- a/frontend/graph/workload.graphqls
+++ b/frontend/graph/workload.graphqls
@@ -235,59 +235,88 @@ type K8sWorkloadContainerOverrides {
   runtimeInfo: K8sWorkloadRuntimeInfoContainer
 }
 
-# operators to use to compare the attributes of a span with a value for head sampling.
-enum K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator {
-  equals
-  notEquals
-  endWith
-  startWith
-}
-
-# a single condition to check for head sampling.
-# a condition checks one attribute of a span for head sampling.
-# multiple conditions can be combined to form a single check which is used to determine the sampling decision.
-type K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition {
-  # attribute key to check.
-  key: String!
-
-  # operator to use to compare the attribute value
-  # one of: 'equals', 'notEquals', 'endWith', 'startWith'
-  operator: K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckConditionOperator!
-
-  # value to compare the attribute value to.
-  # for example: '/healthz' for 'url.path' and 'GET' for 'http.request.method'
-  value: String!
-}
-
-type K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck {
-  # all the conditions that must evaluate to true for this check to be used.
-  # for example: 'url.path', 'equals', '/healthz' and 'http.request.method', 'equals', 'GET'
-  conditions: [K8sWorkloadContainerAgentConfigTracesHeadSamplingCheckCondition!]
-
-  # percentage to keep traces if all conditions evaluate to true.
-  percentage: Float!
-}
-
-# configuration for head sampling to apply on traces in instrumentation agent.
-type K8sWorkloadContainerAgentConfigTracesHeadSampling {
-  # these are tested one by one, and the first one that evaluates to true is used to determine the sampling decision.
-  checks: [K8sWorkloadContainerAgentConfigTracesHeadSamplingCheck!]
-
-  # if none of the checks above evaluate to true, this fraction of traces will be kept.
-  # defaults to 100% (all traces are kept).
-  fallbackPercentage: Float!
-}
-
 # traces configuration for the instrumentation agent.
 type K8sWorkloadContainerAgentConfigTraces {
-  # configuration for head sampling to apply on traces.
   headSampling: K8sWorkloadContainerAgentConfigTracesHeadSampling
+}
+
+# head sampling configuration applied by the instrumentation agent on root spans.
+type K8sWorkloadContainerAgentConfigTracesHeadSampling {
+  # when true, sampling decisions are evaluated but traces are not dropped.
+  dryRun: Boolean
+
+  # controls the tradeoff between span-metrics accuracy and resource usage.
+  spanMetricsMode: K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode
+
+  # operation matchers with per-rule sampling percentages.
+  noisyOperations: [K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation!]
+}
+
+enum K8sWorkloadContainerAgentConfigTracesHeadSamplingSpanMetricsMode {
+  sampled_spans_only
+  all_spans
+}
+
+# a single noisy-operation rule in the effective head-sampling config for a container.
+type K8sWorkloadContainerAgentConfigTracesHeadSamplingNoisyOperation {
+  ruleId: ID!
+  name: String
+  disabled: Boolean!
+  operation: HeadSamplingOperationMatcher
+  # percentage (0-100) of matching traces to keep. unset defaults to 0% (drop all).
+  percentageAtMost: Float
 }
 
 # configuration for the instrumentation agent.
 type K8sWorkloadContainerAgentConfig {
   # configuration for traces.
   traces: K8sWorkloadContainerAgentConfigTraces
+}
+
+# collector configuration for a workload container (odigos collector pipeline).
+type K8sWorkloadContainerCollectorConfig {
+  tailSampling: K8sWorkloadContainerCollectorConfigTailSampling
+}
+
+# tail sampling rules applied by the collector for this container.
+type K8sWorkloadContainerCollectorConfigTailSampling {
+  noisyOperations: [K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation!]
+  highlyRelevantOperations: [K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation!]
+  costReductionRules: [K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule!]
+}
+
+# a noisy-operation rule in the effective tail-sampling config for a container.
+type K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation {
+  ruleId: ID!
+  name: String
+  disabled: Boolean!
+  operation: HeadSamplingOperationMatcher
+  # percentage (0-100) of matching traces to keep. unset defaults to 0% (drop all).
+  percentageAtMost: Float
+}
+
+# a highly-relevant-operation rule in the effective tail-sampling config for a container.
+type K8sWorkloadContainerCollectorConfigTailSamplingHighlyRelevantOperation {
+  ruleId: ID!
+  name: String
+  disabled: Boolean!
+  # if true, only spans with SpanStatus set to Error are considered.
+  error: Boolean!
+  # if set, only operations with duration in ms larger than this value are considered.
+  durationAtLeastMs: Int
+  operation: TailSamplingOperationMatcher
+  # percentage (0-100) of matching traces to keep. unset defaults to 100% (keep all).
+  percentageAtLeast: Float
+}
+
+# a cost-reduction rule in the effective tail-sampling config for a container.
+type K8sWorkloadContainerCollectorConfigTailSamplingCostReductionRule {
+  ruleId: ID!
+  name: String
+  disabled: Boolean!
+  operation: TailSamplingOperationMatcher
+  # percentage (0-100) of matching traces to keep.
+  percentageAtMost: Float!
 }
 
 # show all info for a specific workload container (not container instance)
@@ -305,6 +334,9 @@ type K8sWorkloadContainer {
 
   # configuration for the instrumentation agent for this container.
   agentConfig: K8sWorkloadContainerAgentConfig
+
+  # configuration for the odigos collector pipeline for this container.
+  collectorConfig: K8sWorkloadContainerCollectorConfig
 
   # this part is a summary of all the instrumentations that were found in any process of this container.
   instrumentations: [K8sWorkloadPodContainerProcessInstrumentation!]

--- a/frontend/graph/workload.resolvers.go
+++ b/frontend/graph/workload.resolvers.go
@@ -395,6 +395,16 @@ func (r *k8sWorkloadResolver) Containers(ctx context.Context, obj *model.K8sWork
 		containerByName[container.ContainerName].AgentConfig = containerAgentConfigToAgentConfigModel(container)
 	}
 
+	for i := range ic.Spec.WorkloadCollectorConfig {
+		collectorConfig := &ic.Spec.WorkloadCollectorConfig[i]
+		if _, ok := containerByName[collectorConfig.ContainerName]; !ok {
+			containerByName[collectorConfig.ContainerName] = &model.K8sWorkloadContainer{
+				ContainerName: collectorConfig.ContainerName,
+			}
+		}
+		containerByName[collectorConfig.ContainerName].CollectorConfig = containerCollectorConfigToModel(collectorConfig)
+	}
+
 	for _, container := range ic.Status.RuntimeDetailsByContainer {
 		if _, ok := containerByName[container.ContainerName]; !ok {
 			containerByName[container.ContainerName] = &model.K8sWorkloadContainer{

--- a/frontend/graph/workload_populate.go
+++ b/frontend/graph/workload_populate.go
@@ -161,6 +161,15 @@ func (r *queryResolver) populateWorkloadFields(ctx context.Context, l *loaders.L
 			containerByName[container.ContainerName].AgentEnabled = agentEnabledContainersToModel(container)
 			containerByName[container.ContainerName].AgentConfig = containerAgentConfigToAgentConfigModel(container)
 		}
+		for i := range ic.Spec.WorkloadCollectorConfig {
+			collectorConfig := &ic.Spec.WorkloadCollectorConfig[i]
+			if _, ok := containerByName[collectorConfig.ContainerName]; !ok {
+				containerByName[collectorConfig.ContainerName] = &model.K8sWorkloadContainer{
+					ContainerName: collectorConfig.ContainerName,
+				}
+			}
+			containerByName[collectorConfig.ContainerName].CollectorConfig = containerCollectorConfigToModel(collectorConfig)
+		}
 		for _, container := range ic.Status.RuntimeDetailsByContainer {
 			if _, ok := containerByName[container.ContainerName]; !ok {
 				containerByName[container.ContainerName] = &model.K8sWorkloadContainer{


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: PLAT-1099

To support showing the sampling config per workload in the ui, add relevant config to gql and to resolvers.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
