### PR TITLE
CORE-1100: push victoria metrics image to the odigos gcr

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,7 +282,7 @@ jobs:
         env:
           SOURCE_IMAGE: victoriametrics/victoria-metrics:${{ env.VICTORIA_METRICS_VERSION }}
           DOCKERHUB_DEST_IMAGE: ${{ env.DOCKERHUB_ORG }}/victoriametrics
-          GCR_DEST_IMAGE: us-central1-docker.pkg.dev/odigos-cloud/components/victoriametrics
+          GCR_DEST_IMAGE: us-central1-docker.pkg.dev/odigos-cloud/components/victoria-metrics
         run: |
           crane copy ${SOURCE_IMAGE} ${DOCKERHUB_DEST_IMAGE}:${{ env.TAG }}
           crane copy ${SOURCE_IMAGE} ${DOCKERHUB_DEST_IMAGE}:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ permissions:
 
 env:
   DOCKERHUB_ORG: "keyval"
+  VICTORIA_METRICS_VERSION: "v1.144.0"
 
 jobs:
   package-helm:
@@ -276,6 +277,17 @@ jobs:
         run: |
           crane copy ${SOURCE_IMAGE}:${{ env.TAG }} ${DEST_IMAGE}:${{ env.TAG }}
           crane copy ${SOURCE_IMAGE}:latest ${DEST_IMAGE}:latest
+
+      - name: Copy VictoriaMetrics image to Docker Hub and GCR
+        env:
+          SOURCE_IMAGE: victoriametrics/victoria-metrics:${{ env.VICTORIA_METRICS_VERSION }}
+          DOCKERHUB_DEST_IMAGE: ${{ env.DOCKERHUB_ORG }}/victoriametrics
+          GCR_DEST_IMAGE: us-central1-docker.pkg.dev/odigos-cloud/components/victoriametrics
+        run: |
+          crane copy ${SOURCE_IMAGE} ${DOCKERHUB_DEST_IMAGE}:${{ env.TAG }}
+          crane copy ${SOURCE_IMAGE} ${DOCKERHUB_DEST_IMAGE}:latest
+          crane copy ${SOURCE_IMAGE} ${GCR_DEST_IMAGE}:${{ env.TAG }}
+          crane copy ${SOURCE_IMAGE} ${GCR_DEST_IMAGE}:latest
 
       - name: Set notification messages
         run: |

--- a/docs/snippets/oss/setup/docker-registry.mdx
+++ b/docs/snippets/oss/setup/docker-registry.mdx
@@ -23,6 +23,7 @@ docker pull registry.odigos.io/odigos-ui:$VERSION
 docker pull registry.odigos.io/odigos-autoscaler:$VERSION
 docker pull registry.odigos.io/odigos-odiglet:$VERSION
 docker pull registry.odigos.io/odigos-collector:$VERSION
+docker pull registry.odigos.io/odigos-victoria-metrics:$VERSION
 ```
 
 If you are using the [k8s-init-container](../instrumentations/configuration/mount-method#3-InitContainer) mount method
@@ -52,6 +53,7 @@ docker pull --platform $PLATFORM registry.odigos.io/odigos-ui:$VERSION
 docker pull --platform $PLATFORM registry.odigos.io/odigos-autoscaler:$VERSION
 docker pull --platform $PLATFORM registry.odigos.io/odigos-odiglet:$VERSION
 docker pull --platform $PLATFORM registry.odigos.io/odigos-collector:$VERSION
+docker pull --platform $PLATFORM registry.odigos.io/odigos-victoria-metrics:$VERSION
 ```
 
 ### Step 3: Tag the Images
@@ -64,6 +66,7 @@ docker tag registry.odigos.io/odigos-ui:$VERSION $CUSTOM_DOCKER_REGISTRY/odigos-
 docker tag registry.odigos.io/odigos-autoscaler:$VERSION $CUSTOM_DOCKER_REGISTRY/odigos-autoscaler:$VERSION
 docker tag registry.odigos.io/odigos-odiglet:$VERSION $CUSTOM_DOCKER_REGISTRY/odigos-odiglet:$VERSION
 docker tag registry.odigos.io/odigos-collector:$VERSION $CUSTOM_DOCKER_REGISTRY/odigos-collector:$VERSION
+docker tag registry.odigos.io/odigos-collector:$VERSION $CUSTOM_DOCKER_REGISTRY/odigos-victoria-metrics:$VERSION
 ```
 
 
@@ -78,6 +81,7 @@ docker push $CUSTOM_DOCKER_REGISTRY/odigos-ui:$VERSION
 docker push $CUSTOM_DOCKER_REGISTRY/odigos-autoscaler:$VERSION
 docker push $CUSTOM_DOCKER_REGISTRY/odigos-odiglet:$VERSION
 docker push $CUSTOM_DOCKER_REGISTRY/odigos-collector:$VERSION
+docker push $CUSTOM_DOCKER_REGISTRY/odigos-victoria-metrics:$VERSION
 ```
 
 ### Step 5: Configure Access for Private Registries
@@ -99,6 +103,8 @@ If your Docker registry is private, configure your Kubernetes cluster to pull im
 > kubectl patch deployment odigos-autoscaler -n $ODIGOS_NAMESPACE \
 > --type='json' -p='[{"op": "add", "path": "/spec/template/spec/imagePullSecrets", "value": [{"name": '$IMAGE_PULL_SECRET'}]}]'
 > kubectl patch deployment odigos-gateway -n $ODIGOS_NAMESPACE \
+> --type='json' -p='[{"op": "add", "path": "/spec/template/spec/imagePullSecrets", "value": [{"name": '$IMAGE_PULL_SECRET'}]}]'
+> kubectl patch deployment odigos-victoriametrics -n $ODIGOS_NAMESPACE \
 > --type='json' -p='[{"op": "add", "path": "/spec/template/spec/imagePullSecrets", "value": [{"name": '$IMAGE_PULL_SECRET'}]}]'
 > kubectl patch daemonset odiglet -n $ODIGOS_NAMESPACE \
 > --type='json' -p='[{"op": "add", "path": "/spec/template/spec/imagePullSecrets", "value": [{"name": '$IMAGE_PULL_SECRET'}]}]'

--- a/helm/odigos/templates/metricsstore/deployment.yaml
+++ b/helm/odigos/templates/metricsstore/deployment.yaml
@@ -16,7 +16,8 @@ spec:
     spec:
       containers:
       - name: vm
-        image: victoriametrics/victoria-metrics:v1.103.0
+        {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
+        image: {{ template "utils.imageName" (dict "Values" .Values "Component" "victoria-metrics" "Tag" $imageTag) }}
         args:
           - "-httpListenAddr=0.0.0.0:8428"
           - "-storageDataPath=/vm-data"


### PR DESCRIPTION
So customers which use a private repo can pull them from the odigos repo directly instead of dockerhub

#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
VictoriaMetrics image is now available on the odigos image repository
```
