### PR TITLE
fix: normalize runtime versions with prerelease suffixes for distro checks

### DIFF
--- a/common/lang_detection.go
+++ b/common/lang_detection.go
@@ -58,11 +58,18 @@ func MapOdigosToSemConv(odigosPrograminglang ProgrammingLanguage) string {
 }
 
 func GetVersion(versionString string) *version.Version {
-	runtimeVersion, err := version.NewVersion(versionString)
+	return ParseRuntimeVersion(versionString)
+}
+
+// ParseRuntimeVersion parses a runtime version for semver constraint checks.
+// Leading "v" and prerelease/build suffixes (e.g. "v1.2.3-0", "1.2.3+build") are normalized
+// to the core release (1.2.3) so they compare correctly against supported version ranges.
+func ParseRuntimeVersion(versionString string) *version.Version {
+	v, err := version.NewVersion(versionString)
 	if err != nil {
 		return nil
 	}
-	return runtimeVersion
+	return v.Core()
 }
 
 func MajorMinorStringOnly(v *version.Version) (string, error) {

--- a/common/lang_detection_test.go
+++ b/common/lang_detection_test.go
@@ -1,0 +1,49 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRuntimeVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		wantNil  bool
+		wantCore string
+	}{
+		{input: "1.22.0", wantCore: "1.22.0"},
+		{input: "v18.0.0", wantCore: "18.0.0"},
+		{input: "v1.2.3-0", wantCore: "1.2.3"},
+		{input: "1.2.3-0", wantCore: "1.2.3"},
+		{input: "1.2.3+build", wantCore: "1.2.3"},
+		{input: "not-a-version", wantNil: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			got := ParseRuntimeVersion(tt.input)
+			if tt.wantNil {
+				require.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			require.Equal(t, tt.wantCore, got.String())
+		})
+	}
+}
+
+func TestParseRuntimeVersion_satisfiesConstraintWithPrereleaseSuffix(t *testing.T) {
+	t.Parallel()
+
+	v := ParseRuntimeVersion("v1.22.0-0")
+	require.NotNil(t, v)
+
+	constraint, err := version.NewConstraint(">= 1.19")
+	require.NoError(t, err)
+	require.True(t, constraint.Check(v))
+}

--- a/distros/oteldistributions.go
+++ b/distros/oteldistributions.go
@@ -89,8 +89,8 @@ func (g *Getter) ResolveDistroNameForVersion(defaultDistroName string, runtimeVe
 		return defaultDistroName
 	}
 
-	detectedVersion, err := version.NewVersion(runtimeVersion)
-	if err != nil {
+	detectedVersion := common.ParseRuntimeVersion(runtimeVersion)
+	if detectedVersion == nil {
 		return defaultDistroName
 	}
 

--- a/instrumentor/controllers/agentenabled/distroresolver/distroresolver.go
+++ b/instrumentor/controllers/agentenabled/distroresolver/distroresolver.go
@@ -155,8 +155,8 @@ func ResolveDistroForContainer(
 				AgentEnabledMessage: fmt.Sprintf("failed to parse supported versions constraint: %s", d.RuntimeEnvironments[0].SupportedVersions),
 			}
 		}
-		detectedVersion, err := version.NewVersion(runtimeDetails.RuntimeVersion)
-		if err != nil {
+		detectedVersion := common.ParseRuntimeVersion(runtimeDetails.RuntimeVersion)
+		if detectedVersion == nil {
 			return nil, &odigosv1.AgentDisabledInfo{
 				AgentEnabledReason:  odigosv1.AgentEnabledReasonUnsupportedRuntimeVersion,
 				AgentEnabledMessage: fmt.Sprintf("failed to parse runtime version: %s", runtimeDetails.RuntimeVersion),

--- a/instrumentor/controllers/agentenabled/distroresolver/distroresolver_test.go
+++ b/instrumentor/controllers/agentenabled/distroresolver/distroresolver_test.go
@@ -90,6 +90,23 @@ func TestResolveDistroForContainer_wildcardDistroSkipsRuntimeSemver(t *testing.T
 	require.Equal(t, obiDistroName, d.Name)
 }
 
+func TestResolveDistroForContainer_prereleaseRuntimeVersionAccepted(t *testing.T) {
+	g := mustNewCommunityGetter(t)
+	config := &common.OdigosConfiguration{}
+	rt := &odigosv1.RuntimeDetailsByContainer{
+		Language:       common.GoProgrammingLanguage,
+		RuntimeVersion: "v1.22.0-0",
+	}
+	dpl := map[common.ProgrammingLanguage]string{
+		common.GoProgrammingLanguage: "golang-community",
+	}
+
+	d, info := ResolveDistroForContainer(config, rt, dpl, g, nil, "c1")
+	require.Nil(t, info, "prerelease suffix on runtime version should not fail supported version check")
+	require.NotNil(t, d)
+	require.Equal(t, "golang-community", d.Name)
+}
+
 func TestResolveDistroForContainer_nonWildcardEnforcesRuntimeSemver(t *testing.T) {
 	g := mustNewCommunityGetter(t)
 	config := &common.OdigosConfiguration{}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: CORE-1133

<img width="623" height="57" alt="image" src="https://github.com/user-attachments/assets/2ebc33fc-b5a6-4690-9254-019157aecc75" />


Runtime version checks for distro selection and supported-version validation were failing for versions with prerelease suffixes (e.g. v1.22.0-0, 1.2.3-0). Semver treats prerelease versions as lower than the corresponding release, so a valid runtime like v1.22.0-0 could be incorrectly rejected against constraints such as >= 1.19.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Fixed instrumentation being disabled for workloads whose detected runtime version includes a prerelease suffix (e.g. `v1.22.0-0`).
```
