### PR TITLE
CORE-1030: Support GKE Autopilot

### DIFF
--- a/api/k8sconsts/node.go
+++ b/api/k8sconsts/node.go
@@ -3,4 +3,9 @@ package k8sconsts
 const (
 	NodeNameEnvVar = "NODE_NAME"
 	NodeIPEnvVar   = "NODE_IP"
+
+	GKEAutopilotEnvVar = "GKE_AUTOPILOT"
+
+	// GKEManagedNodeNamePrefix is the prefix for node names on GKE Autopilot clusters.
+	GKEManagedNodeNamePrefix = "gk3-"
 )

--- a/docs/snippets/enterprise/setup/system-requirements.mdx
+++ b/docs/snippets/enterprise/setup/system-requirements.mdx
@@ -20,7 +20,7 @@ This allows users to maintain observability on nodes that meet the requirements 
 - [K3s](https://k3s.io)
 - [Red Hat OpenShift](https://catalog.redhat.com/software/container-stacks/detail/675201b3ade18c062e2efc0b) (see [how to install on OpenShift](../setup/installation-options#openshift-installation))
 - [Amazon Elastic Kubernetes Service (EKS)](https://aws.amazon.com/eks/)
-- [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine)
+- [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine) (see [how to install on GKE](/enterprise/setup/installation-options#gke-installation))
 - [Azure Kubernetes Service (AKS)](https://azure.microsoft.com/en-us/products/kubernetes-service)
 
 ## Resource Requirements

--- a/docs/snippets/oss/setup/system-requirements.mdx
+++ b/docs/snippets/oss/setup/system-requirements.mdx
@@ -12,7 +12,7 @@ Odigos requires Kubernetes version 1.21.12 or higher.
 - [K3s](https://k3s.io)
 - [Red Hat OpenShift](https://catalog.redhat.com/software/container-stacks/detail/675201b3ade18c062e2efc0b) (see [how to install on OpenShift](../setup/installation-options#openshift-installation))
 - [Amazon Elastic Kubernetes Service (EKS)](https://aws.amazon.com/eks/)
-- [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine)
+- [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine) (see [how to install on GKE](../setup/installation-options#gke-installation))
 - [Azure Kubernetes Service (AKS)](https://azure.microsoft.com/en-us/products/kubernetes-service)
 
 ## Resource Requirements

--- a/docs/snippets/shared/setup/installation-options.mdx
+++ b/docs/snippets/shared/setup/installation-options.mdx
@@ -166,3 +166,123 @@ you will need to modify the YAML of the oc route with `spec.tls.termination: edg
 Check the OpenShift documentation or run `oc expose -h` for more
 information on configuring OpenShift routes according to your
 cluster's requirements.
+
+## GKE Installation
+
+Installing on Google Kubernetes Engine (GKE) requires additional settings
+that can be configured based on your cluster type:
+
+<Tabs>
+  <Tab title="Odigos CLI">
+       For GKE Standard clusters:
+
+       ```shell
+       odigos install --set gke.enabled=true
+       ```
+
+       For GKE Autopilot clusters:
+
+       ```shell
+       odigos install --set gke.enabled=true --set gke.autopilot=true
+       ```
+  </Tab>
+  <Tab title="Helm Chart">
+       For GKE Standard clusters, set `gke.enabled=true` in `values.yaml`:
+
+       ```yaml
+       gke:
+         enabled: true
+       ```
+
+       Or pass it as a flag during installation:
+
+       ```shell
+       helm install odigos odigos/odigos --set gke.enabled=true
+       ```
+
+       For GKE Autopilot clusters, also set `gke.autopilot=true`:
+
+       ```yaml
+       gke:
+         enabled: true
+         autopilot: true
+       ```
+
+       Or pass both flags during installation:
+
+       ```shell
+       helm install odigos odigos/odigos --set gke.enabled=true --set gke.autopilot=true
+       ```
+  </Tab>
+</Tabs>
+
+GKE installation with `gke.enabled=true` does the following:
+
+* Configures a `ResourceQuota` for `system-node-critical` pods, which is required for odiglet on GKE
+
+### GKE Autopilot
+
+GKE Autopilot restricts privileged workloads by default. Odiglet requires
+elevated permissions for eBPF-based instrumentation, so it must be allowlisted
+before it can run on Autopilot clusters.
+
+Allowlist synchronization requires GKE version `1.32.2-gke.1652000` or later.
+
+When `gke.autopilot=true`, the Helm chart:
+
+* Creates an `AllowlistSynchronizer` that syncs the Odigos odiglet allowlist from the [Google-managed partner repository](https://cloud.google.com/kubernetes-engine/docs/how-to/run-autopilot-partner-workloads)
+* Skips node label setup in the odiglet init phase, where Autopilot nodes cannot be modified. Autopilot is auto-detected by the `gk3-` node name prefix; set `gke.autopilot=true` to force this behavior
+
+#### Node label limitations
+
+On standard clusters, odiglet sets `odigos.io/odiglet-oss-installed=true` (or
+`odigos.io/odiglet-enterprise-installed=true` for enterprise) on each node after
+preparing it for instrumentation. Autopilot does not allow modifying node labels,
+so odiglet skips this step.
+
+Without the label:
+
+* **Instrumented pod scheduling with hostPath or CSI mount methods** — For
+  `k8s-host-path` and `k8s-csi-driver` mount methods, the instrumentor webhook
+  adds required node affinity matching the odiglet installed label so pods only
+  schedule on nodes where odiglet has prepared `/var/odigos`. Without the label
+  on Autopilot nodes, newly instrumented pods may remain Pending and fail to
+  schedule. The default `k8s-virtual-device` mount method does not rely on this
+  label and is recommended on Autopilot.
+* **Karpenter integration** — Odiglet normally removes the `odigos.io/needs-init`
+  startup taint when it sets the node label. This step is also skipped on
+  Autopilot, so the Karpenter integration workflow is not supported.
+
+#### Manually create the AllowlistSynchronizer
+
+If you do not set `gke.autopilot=true`, create the `AllowlistSynchronizer` yourself
+before odiglet pods are scheduled. See the [GKE documentation for running Autopilot
+partner workloads](https://cloud.google.com/kubernetes-engine/docs/how-to/run-autopilot-partner-workloads)
+for more details.
+
+Apply the following manifest to install all Odigos allowlists from the partner
+repository:
+
+```yaml
+apiVersion: auto.gke.io/v1
+kind: AllowlistSynchronizer
+metadata:
+  name: odigos-allowlist-synchronizer
+spec:
+  allowlistPaths:
+    - "Odigos/Odigos/*"
+```
+
+```shell
+kubectl apply -f allowlist-synchronizer.yaml
+```
+
+After the allowlist is installed, verify that it is ready before odiglet pods start:
+
+```shell
+kubectl wait --for=condition=Ready allowlistsynchronizer/odigos-allowlist-synchronizer --timeout=60s
+kubectl get workloadallowlist
+```
+
+For more information on privileged workload allowlisting in Autopilot, see the
+[GKE documentation on running Autopilot partner workloads](https://cloud.google.com/kubernetes-engine/docs/how-to/run-autopilot-partner-workloads).

--- a/helm/odigos/templates/gke/allowlist-synchronizer.yaml
+++ b/helm/odigos/templates/gke/allowlist-synchronizer.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.gke.autopilot }}
+# Installs the Odigos WorkloadAllowlist from the Google-managed partner repository.
+# https://cloud.google.com/kubernetes-engine/docs/how-to/run-autopilot-partner-workloads
+apiVersion: auto.gke.io/v1
+kind: AllowlistSynchronizer
+metadata:
+  name: odigos-allowlist-synchronizer
+  labels:
+    odigos.io/system-object: "true"
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+spec:
+  allowlistPaths:
+    - "Odigos/Odigos/*"
+{{- end }}

--- a/helm/odigos/templates/odiglet/daemonset.yaml
+++ b/helm/odigos/templates/odiglet/daemonset.yaml
@@ -113,6 +113,10 @@ spec:
                 resourceFieldRef:
                   containerName: init
                   resource: limits.cpu
+            {{- if .Values.gke.autopilot }}
+            - name: GKE_AUTOPILOT
+              value: "true"
+            {{- end }}
           resources:
 {{ toYaml .Values.odiglet.initContainerResources | indent 12 }}
       {{- end }}

--- a/helm/odigos/values.schema.json
+++ b/helm/odigos/values.schema.json
@@ -532,6 +532,12 @@
       "additionalProperties": false,
       "description": "GKE-specific configuration.",
       "properties": {
+        "autopilot": {
+          "default": "false",
+          "description": "GKE Autopilot settings. When enabled, installs an AllowlistSynchronizer for the Odigos\nodiglet allowlist and skips node label setup in the odiglet init phase.\nAutopilot is auto-detected by the gk3- node name prefix; set this to true to force both behaviors.",
+          "required": [],
+          "title": "autopilot"
+        },
         "enabled": {
           "default": false,
           "title": "enabled",

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -1206,6 +1206,13 @@ openshift:
 # @schema
 gke:
   enabled: false
+  # @schema
+  # description: |-
+  #   GKE Autopilot settings. When enabled, installs an AllowlistSynchronizer for the Odigos
+  #   odiglet allowlist and skips node label setup in the odiglet init phase.
+  #   Autopilot is auto-detected by the gk3- node name prefix; set this to true to force both behaviors.
+  # @schema
+  autopilot: false
 
 # @schema
 # description: |-

--- a/k8sutils/pkg/node/node.go
+++ b/k8sutils/pkg/node/node.go
@@ -3,6 +3,8 @@ package node
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -15,6 +17,15 @@ import (
 	"github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 )
+
+// IsGKEManagedNode reports whether to skip node label setup on GKE Autopilot.
+// Autopilot is auto-detected by the gk3- node name prefix, or can be forced via GKE_AUTOPILOT=true.
+func IsGKEManagedNode(nodeName string) bool {
+	if forced, err := strconv.ParseBool(env.GetEnvVarOrDefault(k8sconsts.GKEAutopilotEnvVar, "false")); err == nil && forced {
+		return true
+	}
+	return strings.HasPrefix(nodeName, k8sconsts.GKEManagedNodeNamePrefix)
+}
 
 func DetermineNodeOdigletInstalledLabelByTier() string {
 	odigosTier := env.GetOdigosTierFromEnv()

--- a/odiglet/odiglet.go
+++ b/odiglet/odiglet.go
@@ -268,7 +268,9 @@ func OdigletInitPhase(clientset *kubernetes.Clientset) {
 		os.Exit(-1)
 	}
 
-	if err := k8snode.PrepareNodeForOdigosInstallation(clientset, nn); err != nil {
+	if k8snode.IsGKEManagedNode(nn) {
+		logger.Info("Skipping node label setup for GKE Autopilot")
+	} else if err := k8snode.PrepareNodeForOdigosInstallation(clientset, nn); err != nil {
 		logger.Error("Failed to prepare node for Odigos installation", "err", err)
 		os.Exit(-1)
 	} else {


### PR DESCRIPTION
#### What this PR does / why we need it:
This adds support for GKE Autopilot based on our approval as an Autopilot partner https://docs.cloud.google.com/kubernetes-engine/docs/how-to/run-autopilot-partner-workloads and https://docs.cloud.google.com/kubernetes-engine/docs/resources/autopilot-partners

It adds a `gke.autopilot` flag that installs an AllowlistSynchronizer (GKE CRD) that will automatically install our Autopilot allowlist to support Odiglet's elevated permissions.

It also disables the odiglet's "node label" init phase, since we can't modify nodes on GKE Autopilot. This means hostpath mount method won't necessarily always work (if an injected pod gets scheduled on a different Autopilot node than the odiglet -- though not sure this is even possible with how Autopilot scales nodes).

Keeping a downstream copy of our git-on-borg (googlesource git repo) here: https://github.com/odigos-io/gke-ap-allowlist, which we could automate to submit new allowlists upstream. We will need a new allowlist if the odiglet daemonset definition changes

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Add GKE Autopilot which disables odiglet node labeling and gke.autopilot flag to install AllowlistSynchronizer
```

cherry-pick:v1.28
