### PR TITLE
CORE-1140: hook collector metrics for gateway to display in the UI + new ebpf reader metrics

### DIFF
--- a/collector/receivers/odigosebpfreceiver/documentation.md
+++ b/collector/receivers/odigosebpfreceiver/documentation.md
@@ -14,14 +14,6 @@ Current number of entries in the logs resource-attributes cache. Bounded by the 
 | ---- | ----------- | ---------- | --------- |
 | {entries} | Gauge | Int | Development |
 
-### otelcol_ebpf_lost_samples
-
-The number of samples lost while reading from the eBPF perf buffer. For the ring buffer, this value is always 0.
-
-| Unit | Metric Type | Value Type | Monotonic | Stability |
-| ---- | ----------- | ---------- | --------- | --------- |
-| {samples} | Sum | Int | true | Development |
-
 ### otelcol_ebpf_memory_pressure_wait_time_total
 
 Total time spent waiting due to memory pressure. Can be compared with otelcol_process_uptime_seconds_total to calculate the percentage of time spent in memory pressure: (ebpf_memory_pressure_wait_time_total_milliseconds / (otelcol_process_uptime_seconds_total * 1000)) * 100
@@ -37,3 +29,19 @@ Total number of bytes read from the eBPF buffer (perf or ring).
 | Unit | Metric Type | Value Type | Monotonic | Stability |
 | ---- | ----------- | ---------- | --------- | --------- |
 | bytes | Sum | Int | true | Development |
+
+### otelcol_odigos_ebpf_accepted_spans
+
+Total number of spans accepted from the eBPF buffer (perf or ring).
+
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| {spans} | Sum | Int | true | Development |
+
+### otelcol_odigos_ebpf_lost_samples
+
+The number of samples lost while reading from the eBPF perf buffer. For the ring buffer, this value is always 0.
+
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| {samples} | Sum | Int | true | Development |

--- a/collector/receivers/odigosebpfreceiver/internal/metadata/generated_telemetry.go
+++ b/collector/receivers/odigosebpfreceiver/internal/metadata/generated_telemetry.go
@@ -27,9 +27,10 @@ type TelemetryBuilder struct {
 	mu                              sync.Mutex
 	registrations                   []metric.Registration
 	EbpfLogsAttrCacheSize           metric.Int64Gauge
-	EbpfLostSamples                 metric.Int64Counter
 	EbpfMemoryPressureWaitTimeTotal metric.Int64Counter
 	EbpfTotalBytesRead              metric.Int64Counter
+	OdigosEbpfAcceptedSpans         metric.Int64Counter
+	OdigosEbpfLostSamples           metric.Int64Counter
 }
 
 // TelemetryBuilderOption applies changes to default builder.
@@ -67,12 +68,6 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		metric.WithUnit("{entries}"),
 	)
 	errs = errors.Join(errs, err)
-	builder.EbpfLostSamples, err = builder.meter.Int64Counter(
-		"otelcol_ebpf_lost_samples",
-		metric.WithDescription("The number of samples lost while reading from the eBPF perf buffer. For the ring buffer, this value is always 0. [Development]"),
-		metric.WithUnit("{samples}"),
-	)
-	errs = errors.Join(errs, err)
 	builder.EbpfMemoryPressureWaitTimeTotal, err = builder.meter.Int64Counter(
 		"otelcol_ebpf_memory_pressure_wait_time_total",
 		metric.WithDescription("Total time spent waiting due to memory pressure. Can be compared with otelcol_process_uptime_seconds_total to calculate the percentage of time spent in memory pressure: (ebpf_memory_pressure_wait_time_total_milliseconds / (otelcol_process_uptime_seconds_total * 1000)) * 100 [Development]"),
@@ -83,6 +78,18 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		"otelcol_ebpf_total_bytes_read",
 		metric.WithDescription("Total number of bytes read from the eBPF buffer (perf or ring). [Development]"),
 		metric.WithUnit("bytes"),
+	)
+	errs = errors.Join(errs, err)
+	builder.OdigosEbpfAcceptedSpans, err = builder.meter.Int64Counter(
+		"otelcol_odigos_ebpf_accepted_spans",
+		metric.WithDescription("Total number of spans accepted from the eBPF buffer (perf or ring). [Development]"),
+		metric.WithUnit("{spans}"),
+	)
+	errs = errors.Join(errs, err)
+	builder.OdigosEbpfLostSamples, err = builder.meter.Int64Counter(
+		"otelcol_odigos_ebpf_lost_samples",
+		metric.WithDescription("The number of samples lost while reading from the eBPF perf buffer. For the ring buffer, this value is always 0. [Development]"),
+		metric.WithUnit("{samples}"),
 	)
 	errs = errors.Join(errs, err)
 	return &builder, errs

--- a/collector/receivers/odigosebpfreceiver/internal/metadatatest/generated_telemetrytest.go
+++ b/collector/receivers/odigosebpfreceiver/internal/metadatatest/generated_telemetrytest.go
@@ -35,22 +35,6 @@ func AssertEqualEbpfLogsAttrCacheSize(t *testing.T, tt *componenttest.Telemetry,
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualEbpfLostSamples(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
-	want := metricdata.Metrics{
-		Name:        "otelcol_ebpf_lost_samples",
-		Description: "The number of samples lost while reading from the eBPF perf buffer. For the ring buffer, this value is always 0. [Development]",
-		Unit:        "{samples}",
-		Data: metricdata.Sum[int64]{
-			Temporality: metricdata.CumulativeTemporality,
-			IsMonotonic: true,
-			DataPoints:  dps,
-		},
-	}
-	got, err := tt.GetMetric("otelcol_ebpf_lost_samples")
-	require.NoError(t, err)
-	metricdatatest.AssertEqual(t, want, got, opts...)
-}
-
 func AssertEqualEbpfMemoryPressureWaitTimeTotal(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_ebpf_memory_pressure_wait_time_total",
@@ -79,6 +63,38 @@ func AssertEqualEbpfTotalBytesRead(t *testing.T, tt *componenttest.Telemetry, dp
 		},
 	}
 	got, err := tt.GetMetric("otelcol_ebpf_total_bytes_read")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualOdigosEbpfAcceptedSpans(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_odigos_ebpf_accepted_spans",
+		Description: "Total number of spans accepted from the eBPF buffer (perf or ring). [Development]",
+		Unit:        "{spans}",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_odigos_ebpf_accepted_spans")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualOdigosEbpfLostSamples(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_odigos_ebpf_lost_samples",
+		Description: "The number of samples lost while reading from the eBPF perf buffer. For the ring buffer, this value is always 0. [Development]",
+		Unit:        "{samples}",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_odigos_ebpf_lost_samples")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }

--- a/collector/receivers/odigosebpfreceiver/internal/metadatatest/generated_telemetrytest_test.go
+++ b/collector/receivers/odigosebpfreceiver/internal/metadatatest/generated_telemetrytest_test.go
@@ -21,19 +21,23 @@ func TestSetupTelemetry(t *testing.T) {
 	require.NoError(t, err)
 	defer tb.Shutdown()
 	tb.EbpfLogsAttrCacheSize.Record(context.Background(), 1)
-	tb.EbpfLostSamples.Add(context.Background(), 1)
 	tb.EbpfMemoryPressureWaitTimeTotal.Add(context.Background(), 1)
 	tb.EbpfTotalBytesRead.Add(context.Background(), 1)
+	tb.OdigosEbpfAcceptedSpans.Add(context.Background(), 1)
+	tb.OdigosEbpfLostSamples.Add(context.Background(), 1)
 	AssertEqualEbpfLogsAttrCacheSize(t, testTel,
-		[]metricdata.DataPoint[int64]{{Value: 1}},
-		metricdatatest.IgnoreTimestamp())
-	AssertEqualEbpfLostSamples(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualEbpfMemoryPressureWaitTimeTotal(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualEbpfTotalBytesRead(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualOdigosEbpfAcceptedSpans(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualOdigosEbpfLostSamples(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 

--- a/collector/receivers/odigosebpfreceiver/logs.go
+++ b/collector/receivers/odigosebpfreceiver/logs.go
@@ -146,7 +146,7 @@ func (r *ebpfReceiver) logsReadLoop(ctx context.Context, m *ebpf.Map, attrCache 
 		// Minimum valid size is the header (offset of Data field).
 		headerSize := int(unsafe.Offsetof(logEvent{}.Data))
 		if len(record.RawSample) < headerSize {
-			r.telemetry.EbpfLostSamples.Add(ctx, 1)
+			r.telemetry.OdigosEbpfLostSamples.Add(ctx, 1)
 			r.logger.Error("short sample", zap.Int("size", len(record.RawSample)), zap.Int("headerSize", headerSize))
 			continue
 		}

--- a/collector/receivers/odigosebpfreceiver/metadata.yaml
+++ b/collector/receivers/odigosebpfreceiver/metadata.yaml
@@ -17,15 +17,6 @@ telemetry:
         value_type: int
       stability: development
 
-    ebpf_lost_samples:
-      enabled: true
-      description: "The number of samples lost while reading from the eBPF perf buffer. For the ring buffer, this value is always 0."
-      unit: "{samples}"
-      sum:
-        value_type: int
-        monotonic: true
-      stability: development
-
     ebpf_memory_pressure_wait_time_total:
       enabled: true
       description: "Total time spent waiting due to memory pressure. Can be compared with otelcol_process_uptime_seconds_total to calculate the percentage of time spent in memory pressure: (ebpf_memory_pressure_wait_time_total_milliseconds / (otelcol_process_uptime_seconds_total * 1000)) * 100"
@@ -39,6 +30,24 @@ telemetry:
       enabled: true
       description: "Total number of bytes read from the eBPF buffer (perf or ring)."
       unit: "bytes"
+      sum:
+        value_type: int
+        monotonic: true
+      stability: development
+    
+    odigos_ebpf_accepted_spans:
+      enabled: true
+      description: "Total number of spans accepted from the eBPF buffer (perf or ring)."
+      unit: "{spans}"
+      sum:
+        value_type: int
+        monotonic: true
+      stability: development
+
+    odigos_ebpf_lost_samples:
+      enabled: true
+      description: "The number of samples lost while reading from the eBPF perf buffer. For the ring buffer, this value is always 0."
+      unit: "{samples}"
       sum:
         value_type: int
         monotonic: true

--- a/collector/receivers/odigosebpfreceiver/traces.go
+++ b/collector/receivers/odigosebpfreceiver/traces.go
@@ -61,8 +61,7 @@ func (r *ebpfReceiver) tracesReadLoop(ctx context.Context, m *ebpf.Map) error {
 
 		if record.LostSamples != 0 {
 			// Record the lost samples metric
-			r.telemetry.EbpfLostSamples.Add(ctx, int64(record.LostSamples))
-			// Keep the log for debugging, but at debug level
+			r.telemetry.OdigosEbpfLostSamples.Add(ctx, int64(record.LostSamples))
 			r.logger.Debug("lost samples", zap.Int("lost", int(record.LostSamples)))
 			continue
 		}
@@ -93,9 +92,12 @@ func (r *ebpfReceiver) tracesReadLoop(ctx context.Context, m *ebpf.Map) error {
 
 		err = r.nextTraces.ConsumeTraces(ctx, td)
 		if err != nil {
+			r.telemetry.OdigosEbpfLostSamples.Add(ctx, int64(record.LostSamples))
 			r.logger.Error("err consuming traces", zap.Error(err))
 			continue
 		}
+		// If no error, we passed the span to the next consumer, meaning it was accepted
+		r.telemetry.OdigosEbpfAcceptedSpans.Add(ctx, int64(td.SpanCount()))
 	}
 }
 

--- a/frontend/graph/collectors.resolvers.go
+++ b/frontend/graph/collectors.resolvers.go
@@ -6,9 +6,7 @@ package graph
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/odigos-io/odigos/api/k8sconsts"
 	"github.com/odigos-io/odigos/frontend/graph/model"
 	"github.com/odigos-io/odigos/frontend/services/collectors"
 )
@@ -25,8 +23,7 @@ func (r *queryResolver) OdigletDaemonSetInfo(ctx context.Context) (*model.Collec
 
 // GatewayPods is the resolver for the gatewayPods field.
 func (r *queryResolver) GatewayPods(ctx context.Context) ([]*model.PodInfo, error) {
-	selector := fmt.Sprintf("%s=%s", k8sconsts.OdigosCollectorRoleLabel, string(k8sconsts.CollectorsRoleClusterGateway))
-	return collectors.GetPodsBySelector(ctx, selector)
+	return collectors.GetGatewayPodsWithMetrics(ctx, r.PromAPI)
 }
 
 // OdigletPods is the resolver for the odigletPods field.

--- a/frontend/graph/collectors.resolvers.go
+++ b/frontend/graph/collectors.resolvers.go
@@ -28,7 +28,7 @@ func (r *queryResolver) GatewayPods(ctx context.Context) ([]*model.PodInfo, erro
 
 // OdigletPods is the resolver for the odigletPods field.
 func (r *queryResolver) OdigletPods(ctx context.Context) ([]*model.PodInfo, error) {
-	return collectors.GetOdigletPodsWithMetrics(ctx, r.PromAPI)
+	return collectors.GetOdigletPodsWithNodeCollectorContainerMetrics(ctx, r.PromAPI)
 }
 
 // CollectorPod is the resolver for the collectorPod field.

--- a/frontend/services/collectors/metrics.go
+++ b/frontend/services/collectors/metrics.go
@@ -12,9 +12,9 @@ import (
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
-// GetOdigletPodsWithMetrics returns node collector (odiglet) pods enriched with per-pod collector metrics from VictoriaMetrics.
+// GetOdigletPodsWithNodeCollectorContainerMetrics returns node collector (odiglet) pods enriched with per-pod collector metrics from VictoriaMetrics.
 // If api is nil or queries fail, the pods are returned without metrics.
-func GetOdigletPodsWithMetrics(ctx context.Context, api v1.API) ([]*model.PodInfo, error) {
+func GetOdigletPodsWithNodeCollectorContainerMetrics(ctx context.Context, api v1.API) ([]*model.PodInfo, error) {
 	selector := fmt.Sprintf("%s=%s", k8sconsts.OdigosCollectorRoleLabel, string(k8sconsts.CollectorsRoleNodeCollector))
 	return getPodsWithMetrics(ctx, api, selector)
 }
@@ -41,7 +41,7 @@ func getPodsWithMetrics(ctx context.Context, api v1.API, selector string) ([]*mo
 	}
 
 	namespace := env.GetCurrentNamespace()
-	ratesByPod, err := metrics.GetCollectorPodRates(ctx, api, namespace, names, metrics.DefaultMetricsWindow)
+	ratesByPod, err := metrics.GetCollectorMetricsFromMetricsStore(ctx, api, namespace, names, metrics.DefaultMetricsWindow)
 	if err != nil {
 		return pods, nil
 	}

--- a/frontend/services/collectors/metrics.go
+++ b/frontend/services/collectors/metrics.go
@@ -12,10 +12,21 @@ import (
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
-// GetOdigletPodsWithMetrics returns odiglet pods enriched with per-pod collector metrics from Prometheus.
+// GetOdigletPodsWithMetrics returns node collector (odiglet) pods enriched with per-pod collector metrics from VictoriaMetrics.
 // If api is nil or queries fail, the pods are returned without metrics.
 func GetOdigletPodsWithMetrics(ctx context.Context, api v1.API) ([]*model.PodInfo, error) {
 	selector := fmt.Sprintf("%s=%s", k8sconsts.OdigosCollectorRoleLabel, string(k8sconsts.CollectorsRoleNodeCollector))
+	return getPodsWithMetrics(ctx, api, selector)
+}
+
+// GetGatewayPodsWithMetrics returns cluster gateway pods enriched with per-pod collector metrics from VictoriaMetrics.
+// If api is nil or queries fail, the pods are returned without metrics.
+func GetGatewayPodsWithMetrics(ctx context.Context, api v1.API) ([]*model.PodInfo, error) {
+	selector := fmt.Sprintf("%s=%s", k8sconsts.OdigosCollectorRoleLabel, string(k8sconsts.CollectorsRoleClusterGateway))
+	return getPodsWithMetrics(ctx, api, selector)
+}
+
+func getPodsWithMetrics(ctx context.Context, api v1.API, selector string) ([]*model.PodInfo, error) {
 	pods, err := GetPodsBySelector(ctx, selector)
 	if err != nil {
 		return nil, err
@@ -29,8 +40,8 @@ func GetOdigletPodsWithMetrics(ctx context.Context, api v1.API) ([]*model.PodInf
 		return pods, nil
 	}
 
-	ns := env.GetCurrentNamespace()
-	ratesByPod, err := metrics.GetDataCollectorContainerMetrics(ctx, api, ns, names, metrics.DefaultMetricsWindow)
+	namespace := env.GetCurrentNamespace()
+	ratesByPod, err := metrics.GetCollectorPodRates(ctx, api, namespace, names, metrics.DefaultMetricsWindow)
 	if err != nil {
 		return pods, nil
 	}

--- a/frontend/services/metrics/collector_metrics.go
+++ b/frontend/services/metrics/collector_metrics.go
@@ -25,6 +25,16 @@ const (
 	// Exporter success/failure counters from collector self-telemetry.
 	metricExporterSentSpans       = "otelcol_exporter_sent_spans"
 	metricExporterSendFailedSpans = "otelcol_exporter_send_failed_spans"
+
+	// Python instrumentation metrics
+	metricPythonSentSpans     = "otelcol_odigos_python_ebpf_instrumentation_sent_events"
+	metricPythonFailedSpans   = "otelcol_odigos_python_ebpf_instrumentation_output_failed_events"
+	metricPythonTooLargeSpans = "otelcol_odigos_python_ebpf_instrumentation_events_too_larger"
+
+	// NodeJS instrumentation metrics
+	metricNodeJSSentSpans     = "otelcol_odigos_nodejs_ebpf_instrumentation_sent_events"
+	metricNodeJSFailedSpans   = "otelcol_odigos_nodejs_ebpf_instrumentation_output_failed_events"
+	metricNodeJSTooLargeSpans = "otelcol_odigos_nodejs_ebpf_instrumentation_events_too_larger"
 )
 
 type PodRates struct {
@@ -66,6 +76,14 @@ func GetCollectorPodRates(ctx context.Context, api v1.API, namespace string, pod
 	// Metrics from the Odigos eBPF receiver
 	qEBPFReceiverAccepted := rateSumByPod(metricEBPFReceiverAcceptedSpans, podRegex, window)
 	qEBPFReceiverDropped := rateSumByPod(metricEBPFReceiverLostSamples, podRegex, window)
+	// Python metrics
+	qPythonSent := rateSumByPod(metricPythonSentSpans, podRegex, window)
+	qPythonFailed := rateSumByPod(metricPythonFailedSpans, podRegex, window)
+	qPythonTooLarge := rateSumByPod(metricPythonTooLargeSpans, podRegex, window)
+	// NodeJS metrics
+	qNodeJSSent := rateSumByPod(metricNodeJSSentSpans, podRegex, window)
+	qNodeJSFailed := rateSumByPod(metricNodeJSFailedSpans, podRegex, window)
+	qNodeJSTooLarge := rateSumByPod(metricNodeJSTooLargeSpans, podRegex, window)
 
 	otelReceiverAccepted, tsAcc, err := queryVector(ctx, api, qOtelReceiverAccepted, now)
 	if err != nil {
@@ -91,6 +109,30 @@ func GetCollectorPodRates(ctx context.Context, api v1.API, namespace string, pod
 	if err != nil {
 		return nil, err
 	}
+	pythonSent, tsPythonSent, err := queryVector(ctx, api, qPythonSent, now)
+	if err != nil {
+		return nil, err
+	}
+	pythonFailed, tsPythonFailed, err := queryVector(ctx, api, qPythonFailed, now)
+	if err != nil {
+		return nil, err
+	}
+	pythonTooLarge, tsPythonTooLarge, err := queryVector(ctx, api, qPythonTooLarge, now)
+	if err != nil {
+		return nil, err
+	}
+	nodeJSSent, tsNodeJSSent, err := queryVector(ctx, api, qNodeJSSent, now)
+	if err != nil {
+		return nil, err
+	}
+	nodeJSFailed, tsNodeJSFailed, err := queryVector(ctx, api, qNodeJSFailed, now)
+	if err != nil {
+		return nil, err
+	}
+	nodeJSTooLarge, tsNodeJSTooLarge, err := queryVector(ctx, api, qNodeJSTooLarge, now)
+	if err != nil {
+		return nil, err
+	}
 
 	result := make(map[string]PodRates, len(podNames))
 	for _, pod := range podNames {
@@ -99,7 +141,7 @@ func GetCollectorPodRates(ctx context.Context, api v1.API, namespace string, pod
 		}
 	}
 
-	lastScrape := maxTime(tsAcc, tsRef, tsSent, tsFail, tsEBPFAccept, tsEBPFDrop)
+	lastScrape := maxTime(tsAcc, tsRef, tsSent, tsFail, tsEBPFAccept, tsEBPFDrop, tsPythonSent, tsPythonFailed, tsPythonTooLarge, tsNodeJSSent, tsNodeJSFailed, tsNodeJSTooLarge)
 
 	for pod := range result {
 		r := result[pod]
@@ -107,8 +149,8 @@ func GetCollectorPodRates(ctx context.Context, api v1.API, namespace string, pod
 		// A single pod can receive spans through both the eBPF receiver and the OTel built-in receiver, since not all instrumentations go through eBPF.
 		// Sum both receiver sources for accepted.
 		// refused/dropped spans are aggregated under dropped.
-		r.MetricsAcceptedRps = sumByPod(pod, otelReceiverAccepted, ebpfReceiverAccepted)
-		r.MetricsDroppedRps = sumByPod(pod, ebpfReceiverDropped, otelReceiverRefused)
+		r.MetricsAcceptedRps = sumByPod(pod, otelReceiverAccepted, ebpfReceiverAccepted, pythonSent, nodeJSSent)
+		r.MetricsDroppedRps = sumByPod(pod, ebpfReceiverDropped, otelReceiverRefused, pythonFailed, pythonTooLarge, nodeJSFailed, nodeJSTooLarge)
 
 		if v, ok := expSent[pod]; ok {
 			r.ExporterSuccessRps = v

--- a/frontend/services/metrics/collector_metrics.go
+++ b/frontend/services/metrics/collector_metrics.go
@@ -10,18 +10,26 @@ import (
 )
 
 const (
-	// Accepted spans as recorded by odigostrafficmetrics processor
-	metricAcceptedSpans = "otelcol_odigos_accepted_spans"
+	// Accepted spans, from two different receivers depending on the collector role.
+	// OTel built-in receiver self-telemetry (gateway pods / OTLP receiver).
+	metricOtelReceiverAcceptedSpans = "otelcol_receiver_accepted_spans"
+	// Odigos eBPF receiver (node collector / odiglet pods).
+	metricEBPFReceiverAcceptedSpans = "otelcol_odigos_ebpf_accepted_spans"
+
+	// Refused (we also call it dropped) spans, from two different receivers depending on the collector role.
 	// Receiver drop/refuse counters from collector self-telemetry
-	metricReceiverRefusedSpans = "otelcol_receiver_refused_spans"
-	metricReceiverDroppedSpans = "otelcol_receiver_dropped_spans"
-	// Exporter success/failure counters from collector self-telemetry
+	metricOtelReceiverRefusedSpans = "otelcol_receiver_refused_spans"
+	// Samples lost while reading the eBPF buffer.
+	metricEBPFReceiverLostSamples = "otelcol_odigos_ebpf_lost_samples"
+
+	// Exporter success/failure counters from collector self-telemetry.
 	metricExporterSentSpans       = "otelcol_exporter_sent_spans"
 	metricExporterSendFailedSpans = "otelcol_exporter_send_failed_spans"
 )
 
 type PodRates struct {
 	MetricsAcceptedRps float64
+	// Spans lost/refused at the receiver itself (e.g. eBPF buffer overflow, memory limiter).
 	MetricsDroppedRps  float64
 	ExporterSuccessRps float64
 	ExporterFailedRps  float64
@@ -49,21 +57,21 @@ func GetCollectorPodRates(ctx context.Context, api v1.API, namespace string, pod
 	podRegex := buildPodRegex(podNames)
 	now := time.Now()
 
-	qAccepted := rateSumByPod(metricAcceptedSpans, podRegex, window)
-	qRefused := rateSumByPod(metricReceiverRefusedSpans, podRegex, window)
-	qDropped := rateSumByPod(metricReceiverDroppedSpans, podRegex, window)
+	// Metrics from the OTel receiver
+	qOtelReceiverAccepted := rateSumByPod(metricOtelReceiverAcceptedSpans, podRegex, window)
+	qOtelReceiverRefused := rateSumByPod(metricOtelReceiverRefusedSpans, podRegex, window)
+	// Metrics from the OTel exporter
 	qExpSent := rateSumByPod(metricExporterSentSpans, podRegex, window)
 	qExpFailed := rateSumByPod(metricExporterSendFailedSpans, podRegex, window)
+	// Metrics from the Odigos eBPF receiver
+	qEBPFReceiverAccepted := rateSumByPod(metricEBPFReceiverAcceptedSpans, podRegex, window)
+	qEBPFReceiverDropped := rateSumByPod(metricEBPFReceiverLostSamples, podRegex, window)
 
-	accepted, tsAcc, err := queryVector(ctx, api, qAccepted, now)
+	otelReceiverAccepted, tsAcc, err := queryVector(ctx, api, qOtelReceiverAccepted, now)
 	if err != nil {
 		return nil, err
 	}
-	refused, tsRef, err := queryVector(ctx, api, qRefused, now)
-	if err != nil {
-		return nil, err
-	}
-	dropped, tsDrop, err := queryVector(ctx, api, qDropped, now)
+	otelReceiverRefused, tsRef, err := queryVector(ctx, api, qOtelReceiverRefused, now)
 	if err != nil {
 		return nil, err
 	}
@@ -75,10 +83,13 @@ func GetCollectorPodRates(ctx context.Context, api v1.API, namespace string, pod
 	if err != nil {
 		return nil, err
 	}
-
-	receiverDropped := refused
-	if len(receiverDropped) == 0 {
-		receiverDropped = dropped
+	ebpfReceiverAccepted, tsEBPFAccept, err := queryVector(ctx, api, qEBPFReceiverAccepted, now)
+	if err != nil {
+		return nil, err
+	}
+	ebpfReceiverDropped, tsEBPFDrop, err := queryVector(ctx, api, qEBPFReceiverDropped, now)
+	if err != nil {
+		return nil, err
 	}
 
 	result := make(map[string]PodRates, len(podNames))
@@ -88,16 +99,17 @@ func GetCollectorPodRates(ctx context.Context, api v1.API, namespace string, pod
 		}
 	}
 
-	lastScrape := maxTime(tsAcc, tsRef, tsDrop, tsSent, tsFail)
+	lastScrape := maxTime(tsAcc, tsRef, tsSent, tsFail, tsEBPFAccept, tsEBPFDrop)
 
 	for pod := range result {
 		r := result[pod]
-		if v, ok := accepted[pod]; ok {
-			r.MetricsAcceptedRps = v
-		}
-		if v, ok := receiverDropped[pod]; ok {
-			r.MetricsDroppedRps = v
-		}
+
+		// A single pod can receive spans through both the eBPF receiver and the OTel built-in receiver, since not all instrumentations go through eBPF.
+		// Sum both receiver sources for accepted.
+		// refused/dropped spans are aggregated under dropped.
+		r.MetricsAcceptedRps = sumByPod(pod, otelReceiverAccepted, ebpfReceiverAccepted)
+		r.MetricsDroppedRps = sumByPod(pod, ebpfReceiverDropped, otelReceiverRefused)
+
 		if v, ok := expSent[pod]; ok {
 			r.ExporterSuccessRps = v
 		}

--- a/frontend/services/metrics/collector_metrics.go
+++ b/frontend/services/metrics/collector_metrics.go
@@ -47,10 +47,10 @@ type PodRates struct {
 	LastScrape         time.Time
 }
 
-// GetCollectorPodRates queries own-metrics (VictoriaMetrics via Prometheus-compatible API)
+// GetCollectorMetricsFromMetricsStore queries own-metrics (VictoriaMetrics via Prometheus-compatible API)
 // and aggregates per-pod rates for accepted/dropped spans and exporter success/failures.
 // Works for data collection and gateway pods.
-func GetCollectorPodRates(ctx context.Context, api v1.API, namespace string, podNames []string, window string) (map[string]PodRates, error) {
+func GetCollectorMetricsFromMetricsStore(ctx context.Context, api v1.API, namespace string, podNames []string, window string) (map[string]PodRates, error) {
 	if api == nil {
 		return nil, fmt.Errorf("own-metrics API is nil")
 	}
@@ -68,72 +68,61 @@ func GetCollectorPodRates(ctx context.Context, api v1.API, namespace string, pod
 	now := time.Now()
 
 	// Metrics from the OTel receiver
-	qOtelReceiverAccepted := rateSumByPod(metricOtelReceiverAcceptedSpans, podRegex, window)
-	qOtelReceiverRefused := rateSumByPod(metricOtelReceiverRefusedSpans, podRegex, window)
+	queryOtelReceiverAccepted := rateSumByPod(metricOtelReceiverAcceptedSpans, podRegex, window)
+	queryOtelReceiverRefused := rateSumByPod(metricOtelReceiverRefusedSpans, podRegex, window)
 	// Metrics from the OTel exporter
-	qExpSent := rateSumByPod(metricExporterSentSpans, podRegex, window)
-	qExpFailed := rateSumByPod(metricExporterSendFailedSpans, podRegex, window)
+	queryExpSent := rateSumByPod(metricExporterSentSpans, podRegex, window)
+	queryExpFailed := rateSumByPod(metricExporterSendFailedSpans, podRegex, window)
 	// Metrics from the Odigos eBPF receiver
-	qEBPFReceiverAccepted := rateSumByPod(metricEBPFReceiverAcceptedSpans, podRegex, window)
-	qEBPFReceiverDropped := rateSumByPod(metricEBPFReceiverLostSamples, podRegex, window)
+	queryEBPFReceiverAccepted := rateSumByPod(metricEBPFReceiverAcceptedSpans, podRegex, window)
+	queryEBPFReceiverDropped := rateSumByPod(metricEBPFReceiverLostSamples, podRegex, window)
 	// Python metrics
-	qPythonSent := rateSumByPod(metricPythonSentSpans, podRegex, window)
-	qPythonFailed := rateSumByPod(metricPythonFailedSpans, podRegex, window)
-	qPythonTooLarge := rateSumByPod(metricPythonTooLargeSpans, podRegex, window)
+	queryPythonSent := rateSumByPod(metricPythonSentSpans, podRegex, window)
+	queryPythonDropped := rateSumByPod(fmt.Sprintf("(%s|%s)", metricPythonFailedSpans, metricPythonTooLargeSpans), podRegex, window)
 	// NodeJS metrics
-	qNodeJSSent := rateSumByPod(metricNodeJSSentSpans, podRegex, window)
-	qNodeJSFailed := rateSumByPod(metricNodeJSFailedSpans, podRegex, window)
-	qNodeJSTooLarge := rateSumByPod(metricNodeJSTooLargeSpans, podRegex, window)
+	queryNodeJSSent := rateSumByPod(metricNodeJSSentSpans, podRegex, window)
+	queryNodeJSDropped := rateSumByPod(fmt.Sprintf("(%s|%s)", metricNodeJSFailedSpans, metricNodeJSTooLargeSpans), podRegex, window)
 
-	otelReceiverAccepted, tsAcc, err := queryVector(ctx, api, qOtelReceiverAccepted, now)
+	otelReceiverAccepted, tsAcc, err := queryVector(ctx, api, queryOtelReceiverAccepted, now)
 	if err != nil {
 		return nil, err
 	}
-	otelReceiverRefused, tsRef, err := queryVector(ctx, api, qOtelReceiverRefused, now)
+	otelReceiverRefused, tsRef, err := queryVector(ctx, api, queryOtelReceiverRefused, now)
 	if err != nil {
 		return nil, err
 	}
-	expSent, tsSent, err := queryVector(ctx, api, qExpSent, now)
+	expSent, tsSent, err := queryVector(ctx, api, queryExpSent, now)
 	if err != nil {
 		return nil, err
 	}
-	expFailed, tsFail, err := queryVector(ctx, api, qExpFailed, now)
+	expFailed, tsFail, err := queryVector(ctx, api, queryExpFailed, now)
 	if err != nil {
 		return nil, err
 	}
-	ebpfReceiverAccepted, tsEBPFAccept, err := queryVector(ctx, api, qEBPFReceiverAccepted, now)
+	ebpfReceiverAccepted, tsEBPFAccept, err := queryVector(ctx, api, queryEBPFReceiverAccepted, now)
 	if err != nil {
 		return nil, err
 	}
-	ebpfReceiverDropped, tsEBPFDrop, err := queryVector(ctx, api, qEBPFReceiverDropped, now)
+	ebpfReceiverDropped, tsEBPFDrop, err := queryVector(ctx, api, queryEBPFReceiverDropped, now)
 	if err != nil {
 		return nil, err
 	}
-	pythonSent, tsPythonSent, err := queryVector(ctx, api, qPythonSent, now)
+	pythonSent, tsPythonSent, err := queryVector(ctx, api, queryPythonSent, now)
 	if err != nil {
 		return nil, err
 	}
-	pythonFailed, tsPythonFailed, err := queryVector(ctx, api, qPythonFailed, now)
+	pythonDropped, tsPythonDropped, err := queryVector(ctx, api, queryPythonDropped, now)
 	if err != nil {
 		return nil, err
 	}
-	pythonTooLarge, tsPythonTooLarge, err := queryVector(ctx, api, qPythonTooLarge, now)
+	nodeJSSent, tsNodeJSSent, err := queryVector(ctx, api, queryNodeJSSent, now)
 	if err != nil {
 		return nil, err
 	}
-	nodeJSSent, tsNodeJSSent, err := queryVector(ctx, api, qNodeJSSent, now)
+	nodeJSDropped, tsNodeJSDropped, err := queryVector(ctx, api, queryNodeJSDropped, now)
 	if err != nil {
 		return nil, err
 	}
-	nodeJSFailed, tsNodeJSFailed, err := queryVector(ctx, api, qNodeJSFailed, now)
-	if err != nil {
-		return nil, err
-	}
-	nodeJSTooLarge, tsNodeJSTooLarge, err := queryVector(ctx, api, qNodeJSTooLarge, now)
-	if err != nil {
-		return nil, err
-	}
-
 	result := make(map[string]PodRates, len(podNames))
 	for _, pod := range podNames {
 		result[pod] = PodRates{
@@ -141,7 +130,7 @@ func GetCollectorPodRates(ctx context.Context, api v1.API, namespace string, pod
 		}
 	}
 
-	lastScrape := maxTime(tsAcc, tsRef, tsSent, tsFail, tsEBPFAccept, tsEBPFDrop, tsPythonSent, tsPythonFailed, tsPythonTooLarge, tsNodeJSSent, tsNodeJSFailed, tsNodeJSTooLarge)
+	lastScrape := maxTime(tsAcc, tsRef, tsSent, tsFail, tsEBPFAccept, tsEBPFDrop, tsPythonSent, tsPythonDropped, tsNodeJSSent, tsNodeJSDropped)
 
 	for pod := range result {
 		r := result[pod]
@@ -150,7 +139,7 @@ func GetCollectorPodRates(ctx context.Context, api v1.API, namespace string, pod
 		// Sum both receiver sources for accepted.
 		// refused/dropped spans are aggregated under dropped.
 		r.MetricsAcceptedRps = sumByPod(pod, otelReceiverAccepted, ebpfReceiverAccepted, pythonSent, nodeJSSent)
-		r.MetricsDroppedRps = sumByPod(pod, ebpfReceiverDropped, otelReceiverRefused, pythonFailed, pythonTooLarge, nodeJSFailed, nodeJSTooLarge)
+		r.MetricsDroppedRps = sumByPod(pod, ebpfReceiverDropped, otelReceiverRefused, pythonDropped, nodeJSDropped)
 
 		if v, ok := expSent[pod]; ok {
 			r.ExporterSuccessRps = v

--- a/frontend/services/metrics/collector_metrics.go
+++ b/frontend/services/metrics/collector_metrics.go
@@ -29,10 +29,10 @@ type PodRates struct {
 	LastScrape         time.Time
 }
 
-// GetDataCollectorContainerMetrics queries own-metrics (VictoriaMetrics via Prometheus-compatible API)
-// and aggregates per-pod rates for accepted/dropped metrics and exporter success/failures
-// for the data-collection (node) collector containers.
-func GetDataCollectorContainerMetrics(ctx context.Context, api v1.API, namespace string, podNames []string, window string) (map[string]PodRates, error) {
+// GetCollectorPodRates queries own-metrics (VictoriaMetrics via Prometheus-compatible API)
+// and aggregates per-pod rates for accepted/dropped spans and exporter success/failures.
+// Works for data collection and gateway pods.
+func GetCollectorPodRates(ctx context.Context, api v1.API, namespace string, podNames []string, window string) (map[string]PodRates, error) {
 	if api == nil {
 		return nil, fmt.Errorf("own-metrics API is nil")
 	}
@@ -49,11 +49,11 @@ func GetDataCollectorContainerMetrics(ctx context.Context, api v1.API, namespace
 	podRegex := buildPodRegex(podNames)
 	now := time.Now()
 
-	qAccepted := rateSumByPod(metricAcceptedSpans, namespace, podRegex, window)
-	qRefused := rateSumByPod(metricReceiverRefusedSpans, namespace, podRegex, window)
-	qDropped := rateSumByPod(metricReceiverDroppedSpans, namespace, podRegex, window)
-	qExpSent := rateSumByPod(metricExporterSentSpans, namespace, podRegex, window)
-	qExpFailed := rateSumByPod(metricExporterSendFailedSpans, namespace, podRegex, window)
+	qAccepted := rateSumByPod(metricAcceptedSpans, podRegex, window)
+	qRefused := rateSumByPod(metricReceiverRefusedSpans, podRegex, window)
+	qDropped := rateSumByPod(metricReceiverDroppedSpans, podRegex, window)
+	qExpSent := rateSumByPod(metricExporterSentSpans, podRegex, window)
+	qExpFailed := rateSumByPod(metricExporterSendFailedSpans, podRegex, window)
 
 	accepted, tsAcc, err := queryVector(ctx, api, qAccepted, now)
 	if err != nil {

--- a/frontend/services/metrics/utils.go
+++ b/frontend/services/metrics/utils.go
@@ -84,6 +84,15 @@ func regexpEscape(s string) string {
 	return replacer.Replace(s)
 }
 
+// sumByPod returns the sum of a pod's value across the given maps. Missing keys contribute zero.
+func sumByPod(pod string, maps ...map[string]float64) float64 {
+	var total float64
+	for _, m := range maps {
+		total += m[pod]
+	}
+	return total
+}
+
 func maxTime(times ...time.Time) time.Time {
 	var z time.Time
 	for _, t := range times {

--- a/frontend/services/metrics/utils.go
+++ b/frontend/services/metrics/utils.go
@@ -13,12 +13,15 @@ import (
 // rateSumByPod builds a PromQL query that returns per-pod rates over a window.
 // Uses VictoriaMetrics/OTel k8s labels and filters by pod only to be resilient
 // to environments where k8s.namespace.name label is not present on the series.
-// Example:
 //
-//	sum by (k8s.pod.name) (rate(<metric>{k8s.pod.name=~"<regex>"}[<win>]))
-func rateSumByPod(metric, namespace, podRegex, window string) string {
+// The metric name is matched with an optional "_total" suffix because the two  collector roles reach VictoriaMetrics through different paths:
+// node collector metrics arrive via OTLP -> original OTel name (no suffix),
+// gateway are scraped by Prometheus -> with suffix = original OTel name + _total
+
+// Only one variant exists per pod, so we don't get doubles.
+func rateSumByPod(metric, podRegex, window string) string {
 	return fmt.Sprintf(
-		`sum by (k8s.pod.name) (rate(%s{k8s.pod.name=~"%s"}[%s]))`,
+		`sum by (k8s.pod.name) (rate({__name__=~"%s(_total)?", k8s.pod.name=~"%s"}[%s]))`,
 		metric, podRegex, window,
 	)
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
1. Add new counter to ebpf receiver - accepted spans.
2. Rename existing lost samples to start with `odigos_` to show it is an odigos metric
3. Send cluster collector metrics to frontend via victoria metrics
4. New NodeJS and Python metrics

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Stream cluster collector and node collector metrics from both otel and ebpf to frontend via victoria metrics
```
