### PR TITLE
CORE-1151 | bugfix: an issue with the informer when configuring https proxy in gateway

### DIFF
--- a/collector/extension/odigosconfigk8sextension/informer.go
+++ b/collector/extension/odigosconfigk8sextension/informer.go
@@ -3,6 +3,8 @@ package odigosconfigk8sextension
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -43,6 +45,15 @@ func (o *OdigosWorkloadConfig) startInformer(ctx context.Context) error {
 		o.logger.Warn("not running in-cluster, instrumentation config cache will be empty", zap.Error(err))
 		return nil
 	}
+
+	// HTTPS_PROXY on the gateway [collectorGateway.httpsProxyAddress]
+	// is intended for exporting to external destinations,
+	// not for reaching the in-cluster Kubernetes API server. Routing list/watch
+	// through a customer forward proxy gets the request blocked (e.g. CONNECT
+	// rejected with "URLBlocked") and the informer never syncs. Mirrors the
+	// bypass applied in collector/providers/odigosk8scmprovider/provider.go
+	// (PR #3305).
+	restConfig.Proxy = func(*http.Request) (*url.URL, error) { return nil, nil }
 
 	client, err := dynamic.NewForConfig(restConfig)
 	if err != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
When the cluster gateway is configured with collectorGateway.httpsProxyAddress, the autoscaler injects HTTPS_PROXY + NO_PROXY=ui.odigos-system:4317 onto the gateway pod. The new odigosconfigk8sextension informer (wired into the gateway in v1.25.0, #4703) builds its own in-cluster client from rest.InClusterConfig() without disabling the proxy, so its list/watch on instrumentationconfigs is sent through the customer's forward proxy. The proxy rejects the tunnel (e.g. 403 URLBlocked at T-Mobile), the informer cache never syncs, the health endpoint returns 503, and liveness/readiness fail → the gateway CrashLoops. Any customer setting httpsProxyAddress on v1.25.0+ has a non-Ready gateway and zero telemetry flowing through it.

Error observed:
```
E0610 06:47:30.663737       1 reflector.go:204] "Failed to watch" err="failed to list odigos.io/v1alpha1, Resource=instrumentationconfigs: Get \"https://10.96.0.1:443/apis/odigos.io/v1alpha1/instrumentationconfigs?limit=500&resourceVersion=0\": URLBlocked" logger="UnhandledError" reflector="k8s.io/client-go@v0.35.2/tools/cache/reflector.go:289" type="odigos.io/v1alpha1, Resource=instrumentationconfigs"
```

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Fix cluster gateway CrashLoopBackOff when `collectorGateway.httpsProxyAddress` is set: the instrumentationconfigs informer no longer routes its list/watch through the customer forward proxy.
```

cherry-pick: v1.28, v1.27