### PR TITLE
CORE-1150: scrape odiglet metrics by the data collection and send to the gateway

### DIFF
--- a/autoscaler/controllers/clustercollector/configmap.go
+++ b/autoscaler/controllers/clustercollector/configmap.go
@@ -403,4 +403,3 @@ func isOdigosTrafficMetricsProcessorRelevant(name string, destinationPipelines [
 	}
 	return false
 }
-

--- a/autoscaler/controllers/nodecollector/collectorconfig/ownmetrics-victoriametrics.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/ownmetrics-victoriametrics.go
@@ -1,0 +1,112 @@
+package collectorconfig
+
+import (
+	"fmt"
+
+	"github.com/odigos-io/odigos/api/k8sconsts"
+	"github.com/odigos-io/odigos/common/config"
+	semconv "go.opentelemetry.io/otel/semconv/v1.5.0"
+)
+
+const (
+	odigletMetricsReceiverName = "prometheus/odiglet-metrics"
+	odigletMetricsExporterName = "otlp_http/odiglet-metrics-out"
+	odigletMetricsPipelineName = "metrics/odiglet-metrics"
+
+	// Adds "odiglet" as a pod name so we can filter out the odiglet's own metrics in the UI
+	odigletMetricsPodNameProcessorName = "resource/odiglet-pod-name"
+
+	// keep only the eBPF instrumentation counters (java, python, nodejs) exposed by the odiglet.
+	ebpfInstrumentationMetricsRegexPattern = "odigos_(java|python|nodejs)_ebpf_instrumentation_.*"
+
+	// the cluster collector's own-metrics OTLP http receiver listens on this port.
+	clusterCollectorOwnMetricsOtlpHttpPort = 44318
+)
+
+func odigletMetricsReceiverConfig(odigosNamespace string) config.GenericMap {
+	odigletMetricsTarget := fmt.Sprintf("%s.%s:%d",
+		k8sconsts.OdigletLocalTrafficServiceName,
+		odigosNamespace,
+		k8sconsts.OdigletMetricsServerPort,
+	)
+
+	return config.GenericMap{
+		odigletMetricsReceiverName: config.GenericMap{
+			"config": config.GenericMap{
+				"scrape_configs": []config.GenericMap{
+					{
+						"job_name":           "odiglet",
+						"scrape_interval":    "10s",
+						"enable_compression": false,
+						"static_configs": []config.GenericMap{
+							{
+								"targets": []string{odigletMetricsTarget},
+							},
+						},
+						"metric_relabel_configs": []config.GenericMap{
+							{
+								"source_labels": []string{"__name__"},
+								"regex":         ebpfInstrumentationMetricsRegexPattern,
+								"action":        "keep",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func odigletMetricsExporterConfig(odigosNamespace string) config.GenericMap {
+	endpoint := fmt.Sprintf("http://%s.%s:%d",
+		k8sconsts.OdigosClusterCollectorServiceName,
+		odigosNamespace,
+		clusterCollectorOwnMetricsOtlpHttpPort,
+	)
+
+	return config.GenericMap{
+		odigletMetricsExporterName: config.GenericMap{
+			"endpoint": endpoint,
+			"retry_on_failure": config.GenericMap{
+				"enabled": false,
+			},
+			"tls": config.GenericMap{
+				"insecure": true,
+			},
+		},
+	}
+}
+
+func odigletMetricsProcessorConfig() config.GenericMap {
+	return config.GenericMap{
+		odigletMetricsPodNameProcessorName: config.GenericMap{
+			"attributes": []config.GenericMap{{
+				"key":    string(semconv.K8SPodNameKey),
+				"value":  "${POD_NAME}",
+				"action": "upsert",
+			}},
+		},
+	}
+}
+
+func odigletMetricsPipeline() map[string]config.Pipeline {
+	return map[string]config.Pipeline{
+		odigletMetricsPipelineName: {
+			Receivers:  []string{odigletMetricsReceiverName},
+			Processors: []string{odigletMetricsPodNameProcessorName},
+			Exporters:  []string{odigletMetricsExporterName},
+		},
+	}
+}
+
+// Assembles a metrics config to be added to the node collector, which scrapes the odiglet for metrics
+func OdigletMetricsConfig(odigosNamespace string) config.Config {
+	return config.Config{
+		Receivers:  odigletMetricsReceiverConfig(odigosNamespace),
+		Exporters:  odigletMetricsExporterConfig(odigosNamespace),
+		Processors: odigletMetricsProcessorConfig(),
+		Service: config.Service{
+			Pipelines: odigletMetricsPipeline(),
+		},
+	}
+}

--- a/autoscaler/controllers/nodecollector/configmap.go
+++ b/autoscaler/controllers/nodecollector/configmap.go
@@ -260,6 +260,11 @@ func calculateCollectorConfigDomains(
 			return nil, "", errors.Join(err, errors.New("failed to calculate own metrics config"))
 		}
 		configDomains["own_metrics"] = ownMetricsConfig
+
+		// scrape the odiglet's prometheus /metrics endpoint and forward to the cluster collector.
+		// the cluster collector decides (via its own SendToOdigosMetricsStore setting) whether
+		// to forward these to the odigos metrics store (Victoria Metrics).
+		configDomains["odiglet_metrics"] = collectorconfig.OdigletMetricsConfig(odigosNamespace)
 	}
 
 	// traces

--- a/frontend/services/metrics/collector_metrics.go
+++ b/frontend/services/metrics/collector_metrics.go
@@ -18,6 +18,16 @@ const (
 	// Exporter success/failure counters from collector self-telemetry
 	metricExporterSentSpans       = "otelcol_exporter_sent_spans"
 	metricExporterSendFailedSpans = "otelcol_exporter_send_failed_spans"
+
+	// Python instrumentation metrics.
+	metricPythonSentSpans     = "odigos_python_ebpf_instrumentation_sent_events"
+	metricPythonFailedSpans   = "odigos_python_ebpf_instrumentation_output_failed_events"
+	metricPythonTooLargeSpans = "odigos_python_ebpf_instrumentation_events_too_larger"
+
+	// NodeJS instrumentation metrics
+	metricNodeJSSentSpans     = "odigos_nodejs_ebpf_instrumentation_sent_events"
+	metricNodeJSFailedSpans   = "odigos_nodejs_ebpf_instrumentation_output_failed_events"
+	metricNodeJSTooLargeSpans = "odigos_nodejs_ebpf_instrumentation_events_too_larger"
 )
 
 type PodRates struct {


### PR DESCRIPTION
Does what it says on the tin. Sends odiglet metrics through the data collection to the gateway.

#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
