### PR TITLE
refactor: CORE-1045 - Make the upgrade flow more generic, allow passing different path for rsync bin

### DIFF
--- a/common/fs/agents.go
+++ b/common/fs/agents.go
@@ -19,10 +19,11 @@ import (
 )
 
 const (
-	chrootDir      = "/host"
-	semanagePath   = "/sbin/semanage"
-	restoreconPath = "/sbin/restorecon"
-	keeplistPath   = "/tmp/keeplist"
+	chrootDir        = "/host"
+	semanagePath     = "/sbin/semanage"
+	restoreconPath   = "/sbin/restorecon"
+	keeplistPath     = "/tmp/keeplist"
+	rsyncDefaultPath = "rsync"
 )
 
 func CopyAgentsDirectoryToHost(srcDir, dstDir string, optionalRsyncPath *string) error {
@@ -43,7 +44,8 @@ func CopyAgentsDirectoryToHost(srcDir, dstDir string, optionalRsyncPath *string)
 		}
 	} else {
 		logger.Info("Odigos agents directory is not empty, syncing files with rsync")
-		updatedFilesToKeepMap, err := removeChangedFilesFromKeepMap(getCriticalFiles(dstDir), srcDir, dstDir)
+		criticalFiles := getCriticalFiles(dstDir)
+		updatedFilesToKeepMap, err := removeChangedFilesFromKeepMap(criticalFiles, srcDir, dstDir)
 
 		if err != nil {
 			logger.Error("Error getting changed files", "err", err)
@@ -274,7 +276,7 @@ func runSingleRsyncSync(srcDir, dstDir, excludeFile string, optionalRsyncPath *s
 	// --whole-file: disables delta-transfer algorithm (lower CPU, better for local copying)
 	// --inplace: update files in-place without temp files (avoids disk pressure)
 	// --exclude-from: skip deleting or overwriting files listed in keeplist.txt
-	rsyncPath := "rsync"
+	rsyncPath := rsyncDefaultPath
 	if optionalRsyncPath != nil {
 		rsyncPath = *optionalRsyncPath
 	}
@@ -300,34 +302,33 @@ func runSingleRsyncSync(srcDir, dstDir, excludeFile string, optionalRsyncPath *s
 // criticalFiles lists paths relative to the agents directory root that must be
 // preserved during upgrades because they may be memory-mapped by running processes.
 // The path is relative to the srcDir.
-
-func getCriticalFiles(basePath string) map[string]struct{} {
-	criticalFiles := make(map[string]struct{})
-	criticalFiles[filepath.Join(basePath, "nodejs-ebpf", "build", "Release", "dtrace-injector-native.node")] = struct{}{}
-	criticalFiles[filepath.Join(basePath, "nodejs-ebpf", "build", "Release", "obj.target", "dtrace-injector-native.node")] = struct{}{}
-	criticalFiles[filepath.Join(basePath, "nodejs-ebpf", "build", "Release", ".deps", "Release", "dtrace-injector-native.node.d")] = struct{}{}
-	criticalFiles[filepath.Join(basePath, "nodejs-ebpf", "build", "Release", ".deps", "Release", "obj.target", "dtrace-injector-native.node.d")] = struct{}{}
-	criticalFiles[filepath.Join(basePath, "java-ebpf", "tracing_probes.so")] = struct{}{}
-	criticalFiles[filepath.Join(basePath, "java-ext-ebpf", "end_span_usdt.so")] = struct{}{}
-	criticalFiles[filepath.Join(basePath, "java-ext-ebpf", "javaagent.jar")] = struct{}{}
-	criticalFiles[filepath.Join(basePath, "java-ext-ebpf", "otel_agent_extension.jar")] = struct{}{}
-	criticalFiles[filepath.Join(basePath, "python-ebpf", "pythonUSDT.abi3.so")] = struct{}{}
-	criticalFiles[filepath.Join(basePath, "loader", "loader.so")] = struct{}{}
+func getCriticalFiles(bp string) map[string]struct{} {
+	cf := make(map[string]struct{})
+	cf[filepath.Join(bp, "nodejs-ebpf", "build", "Release", "dtrace-injector-native.node")] = struct{}{}
+	cf[filepath.Join(bp, "nodejs-ebpf", "build", "Release", "obj.target", "dtrace-injector-native.node")] = struct{}{}
+	cf[filepath.Join(bp, "nodejs-ebpf", "build", "Release", ".deps", "Release", "dtrace-injector-native.node.d")] = struct{}{}
+	cf[filepath.Join(bp, "nodejs-ebpf", "build", "Release", ".deps", "Release", "obj.target", "dtrace-injector-native.node.d")] = struct{}{}
+	cf[filepath.Join(bp, "java-ebpf", "tracing_probes.so")] = struct{}{}
+	cf[filepath.Join(bp, "java-ext-ebpf", "end_span_usdt.so")] = struct{}{}
+	cf[filepath.Join(bp, "java-ext-ebpf", "javaagent.jar")] = struct{}{}
+	cf[filepath.Join(bp, "java-ext-ebpf", "otel_agent_extension.jar")] = struct{}{}
+	cf[filepath.Join(bp, "python-ebpf", "pythonUSDT.abi3.so")] = struct{}{}
+	cf[filepath.Join(bp, "loader", "loader.so")] = struct{}{}
 	// Python dependency shared objects - special handling:
 	// These shared objects (.so files) are loaded by Python processes and mapped into process memory.
 	// They cannot be replaced while loaded, so we must keep them in the host filesystem to avoid removal.
 	// These files are versioned and renamed when their respective library versions change.
-	criticalFiles[filepath.Join(basePath, "python", "google", "_upb", "_message.abi3.so")] = struct{}{}                     // Google protobuf library
-	criticalFiles[filepath.Join(basePath, "python", "wrapt", "_wrappers.cpython-311-aarch64-linux-gnu.so")] = struct{}{}    // Wrapt library on arm64
-	criticalFiles[filepath.Join(basePath, "python", "wrapt", "_wrappers.cpython-311-x86_64-linux-gnu.so")] = struct{}{}     // Wrapt library on x86_64
-	criticalFiles[filepath.Join(basePath, "python3.8", "google", "_upb", "_message.abi3.so")] = struct{}{}                  // Google protobuf library [python 3.8 distro]
-	criticalFiles[filepath.Join(basePath, "python3.8", "wrapt", "_wrappers.cpython-311-aarch64-linux-gnu.so")] = struct{}{} // Wrapt library on arm64 [python 3.8 distro]
-	criticalFiles[filepath.Join(basePath, "python3.8", "wrapt", "_wrappers.cpython-311-x86_64-linux-gnu.so")] = struct{}{}  // Wrapt library on x86_64 [python 3.8 distro]
+	cf[filepath.Join(bp, "python", "google", "_upb", "_message.abi3.so")] = struct{}{}                     // Google protobuf library
+	cf[filepath.Join(bp, "python", "wrapt", "_wrappers.cpython-311-aarch64-linux-gnu.so")] = struct{}{}    // Wrapt library on arm64
+	cf[filepath.Join(bp, "python", "wrapt", "_wrappers.cpython-311-x86_64-linux-gnu.so")] = struct{}{}     // Wrapt library on x86_64
+	cf[filepath.Join(bp, "python3.8", "google", "_upb", "_message.abi3.so")] = struct{}{}                  // Google protobuf library [python 3.8 distro]
+	cf[filepath.Join(bp, "python3.8", "wrapt", "_wrappers.cpython-311-aarch64-linux-gnu.so")] = struct{}{} // Wrapt library on arm64 [python 3.8 distro]
+	cf[filepath.Join(bp, "python3.8", "wrapt", "_wrappers.cpython-311-x86_64-linux-gnu.so")] = struct{}{}  // Wrapt library on x86_64 [python 3.8 distro]
 	// PHP native extension loaded by the PHP runtime via dlopen().
 	// Must be preserved during upgrades to avoid crashing running PHP-FPM processes.
-	criticalFiles[filepath.Join(basePath, "php", "8.1", "opentelemetry.so")] = struct{}{}
-	criticalFiles[filepath.Join(basePath, "php", "8.2", "opentelemetry.so")] = struct{}{}
-	criticalFiles[filepath.Join(basePath, "php", "8.3", "opentelemetry.so")] = struct{}{}
-	criticalFiles[filepath.Join(basePath, "php", "8.4", "opentelemetry.so")] = struct{}{}
-	return criticalFiles
+	cf[filepath.Join(bp, "php", "8.1", "opentelemetry.so")] = struct{}{}
+	cf[filepath.Join(bp, "php", "8.2", "opentelemetry.so")] = struct{}{}
+	cf[filepath.Join(bp, "php", "8.3", "opentelemetry.so")] = struct{}{}
+	cf[filepath.Join(bp, "php", "8.4", "opentelemetry.so")] = struct{}{}
+	return cf
 }

--- a/common/fs/agents.go
+++ b/common/fs/agents.go
@@ -25,7 +25,7 @@ const (
 	keeplistPath   = "/tmp/keeplist"
 )
 
-func CopyAgentsDirectoryToHost(srcDir, dstDir string) error {
+func CopyAgentsDirectoryToHost(srcDir, dstDir string, optionalRsyncPath *string) error {
 	logger := commonlogger.LoggerCompat().With("subsystem", "agents")
 	startTime := time.Now()
 	empty, err := isDirEmptyOrNotExist(dstDir)
@@ -43,7 +43,7 @@ func CopyAgentsDirectoryToHost(srcDir, dstDir string) error {
 		}
 	} else {
 		logger.Info("Odigos agents directory is not empty, syncing files with rsync")
-		updatedFilesToKeepMap, err := removeChangedFilesFromKeepMap(criticalFiles, srcDir, dstDir)
+		updatedFilesToKeepMap, err := removeChangedFilesFromKeepMap(getCriticalFiles(dstDir), srcDir, dstDir)
 
 		if err != nil {
 			logger.Error("Error getting changed files", "err", err)
@@ -54,7 +54,7 @@ func CopyAgentsDirectoryToHost(srcDir, dstDir string) error {
 			return err
 		}
 
-		if err := runSingleRsyncSync(srcDir, dstDir, keeplistPath); err != nil {
+		if err := runSingleRsyncSync(srcDir, dstDir, keeplistPath, optionalRsyncPath); err != nil {
 			logger.Error("rsync failed", "err", err)
 			return err
 		}
@@ -173,18 +173,18 @@ func isDirEmptyOrNotExist(dir string) (bool, error) {
 	return false, err
 }
 
-func removeChangedFilesFromKeepMap(filesToKeepMap map[string]struct{}, containerDir string, hostDir string) (map[string]struct{}, error) {
+func removeChangedFilesFromKeepMap(filesToKeepMap map[string]struct{}, srcDir string, dstDir string) (map[string]struct{}, error) {
 	logger := commonlogger.LoggerCompat().With("subsystem", "agents")
 	updatedFilesToKeepMap := make(map[string]struct{})
 
-	for hostPath := range filesToKeepMap {
-		// Convert host path to container path
-		containerPath := strings.Replace(hostPath, hostDir, containerDir, 1)
+	for dstPath := range filesToKeepMap {
+		// Convert destination path to source path
+		srcPath := strings.Replace(dstPath, dstDir, srcDir, 1)
 
 		// Find and preserve existing hash version files for this base file
-		existingHashVersionFiles, err := findHashVersionFiles(hostPath)
+		existingHashVersionFiles, err := findHashVersionFiles(dstPath)
 		if err != nil {
-			logger.Error("Error finding existing hash version files", "err", err, "basePath", hostPath)
+			logger.Error("Error finding existing hash version files", "err", err, "basePath", dstPath)
 		} else {
 			// Add all existing hash version files to the keep map
 			for _, hashVersionFile := range existingHashVersionFiles {
@@ -194,39 +194,39 @@ func removeChangedFilesFromKeepMap(filesToKeepMap map[string]struct{}, container
 		}
 
 		// If either file doesn't exist, mark as changed and remove from filesToKeepMap
-		_, hostErr := os.Stat(hostPath)
-		_, containerErr := os.Stat(containerPath)
+		_, dstErr := os.Stat(dstPath)
+		_, srcErr := os.Stat(srcPath)
 
-		if hostErr != nil || containerErr != nil {
-			logger.Info("File marked for recreate (missing)", "file", hostPath)
+		if dstErr != nil || srcErr != nil {
+			logger.Info("File marked for recreate (missing)", "file", dstPath)
 			continue
 		}
 
 		// Compare file hashes
-		hostHash, err := fileHash(hostPath)
+		dstHash, err := fileHash(dstPath)
 		if err != nil {
-			return nil, fmt.Errorf("error calculating hash for host file %s: %v", hostPath, err)
+			return nil, fmt.Errorf("error calculating hash for destination file %s: %v", dstPath, err)
 		}
 
-		containerHash, err := fileHash(containerPath)
+		srcHash, err := fileHash(srcPath)
 		if err != nil {
-			return nil, fmt.Errorf("error calculating hash for container file %s: %v", containerPath, err)
+			return nil, fmt.Errorf("error calculating hash for source file %s: %v", srcPath, err)
 		}
 
-		// If the hashes are different, keep the old version of the file in the host with the new name <ORIGINAL_FILE_NAME_{12_CHARS_OF_HASH}>
+		// If the hashes are different, keep the old version of the file in the destination with the new name <ORIGINAL_FILE_NAME_{12_CHARS_OF_HASH}>
 		// and ensure the renamed file is added to filesToKeepMap to protect it from deletion.
-		if hostHash != containerHash {
-			newHostPath, err := renameWithHashSuffix(hostPath, hostHash)
+		if dstHash != srcHash {
+			newDstPath, err := renameWithHashSuffix(dstPath, dstHash)
 			if err != nil {
 				return nil, fmt.Errorf("error renaming file: %v", err)
 			}
 
-			updatedFilesToKeepMap[newHostPath] = struct{}{}
+			updatedFilesToKeepMap[newDstPath] = struct{}{}
 
-			continue // original file is renamed, recreate hostPath and keep NewHostPath
+			continue // original file is renamed, recreate dstPath and keep newDstPath
 		}
 
-		updatedFilesToKeepMap[hostPath] = struct{}{}
+		updatedFilesToKeepMap[dstPath] = struct{}{}
 	}
 
 	return updatedFilesToKeepMap, nil
@@ -265,7 +265,7 @@ func writeKeeplist(dstDir, file string, keeps map[string]struct{}) error {
 
 // runSingleRsyncSync performs a single-threaded rsync from srcDir to dstDir using the given exclude file.
 // This is used when the destination already contains files and we want to sync changes while keeping versioned files.
-func runSingleRsyncSync(srcDir, dstDir, excludeFile string) error {
+func runSingleRsyncSync(srcDir, dstDir, excludeFile string, optionalRsyncPath *string) error {
 	logger := commonlogger.LoggerCompat().With("subsystem", "agents")
 	// rsync flags:
 	// -a: archive mode (preserves permissions, symlinks, modification times, etc.)
@@ -274,13 +274,17 @@ func runSingleRsyncSync(srcDir, dstDir, excludeFile string) error {
 	// --whole-file: disables delta-transfer algorithm (lower CPU, better for local copying)
 	// --inplace: update files in-place without temp files (avoids disk pressure)
 	// --exclude-from: skip deleting or overwriting files listed in keeplist.txt
+	rsyncPath := "rsync"
+	if optionalRsyncPath != nil {
+		rsyncPath = *optionalRsyncPath
+	}
 	args := []string{
 		"-av", "--delete", "--whole-file", "--inplace",
 		fmt.Sprintf("--exclude-from=%s", excludeFile),
 		srcDir + "/", dstDir + "/",
 	}
 
-	cmd := exec.CommandContext(context.Background(), "rsync", args...)
+	cmd := exec.CommandContext(context.Background(), rsyncPath, args...)
 	var _, stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
@@ -291,4 +295,39 @@ func runSingleRsyncSync(srcDir, dstDir, excludeFile string) error {
 
 	logger.Info("rsync completed")
 	return nil
+}
+
+// criticalFiles lists paths relative to the agents directory root that must be
+// preserved during upgrades because they may be memory-mapped by running processes.
+// The path is relative to the srcDir.
+
+func getCriticalFiles(basePath string) map[string]struct{} {
+	criticalFiles := make(map[string]struct{})
+	criticalFiles[filepath.Join(basePath, "nodejs-ebpf", "build", "Release", "dtrace-injector-native.node")] = struct{}{}
+	criticalFiles[filepath.Join(basePath, "nodejs-ebpf", "build", "Release", "obj.target", "dtrace-injector-native.node")] = struct{}{}
+	criticalFiles[filepath.Join(basePath, "nodejs-ebpf", "build", "Release", ".deps", "Release", "dtrace-injector-native.node.d")] = struct{}{}
+	criticalFiles[filepath.Join(basePath, "nodejs-ebpf", "build", "Release", ".deps", "Release", "obj.target", "dtrace-injector-native.node.d")] = struct{}{}
+	criticalFiles[filepath.Join(basePath, "java-ebpf", "tracing_probes.so")] = struct{}{}
+	criticalFiles[filepath.Join(basePath, "java-ext-ebpf", "end_span_usdt.so")] = struct{}{}
+	criticalFiles[filepath.Join(basePath, "java-ext-ebpf", "javaagent.jar")] = struct{}{}
+	criticalFiles[filepath.Join(basePath, "java-ext-ebpf", "otel_agent_extension.jar")] = struct{}{}
+	criticalFiles[filepath.Join(basePath, "python-ebpf", "pythonUSDT.abi3.so")] = struct{}{}
+	criticalFiles[filepath.Join(basePath, "loader", "loader.so")] = struct{}{}
+	// Python dependency shared objects - special handling:
+	// These shared objects (.so files) are loaded by Python processes and mapped into process memory.
+	// They cannot be replaced while loaded, so we must keep them in the host filesystem to avoid removal.
+	// These files are versioned and renamed when their respective library versions change.
+	criticalFiles[filepath.Join(basePath, "python", "google", "_upb", "_message.abi3.so")] = struct{}{}                     // Google protobuf library
+	criticalFiles[filepath.Join(basePath, "python", "wrapt", "_wrappers.cpython-311-aarch64-linux-gnu.so")] = struct{}{}    // Wrapt library on arm64
+	criticalFiles[filepath.Join(basePath, "python", "wrapt", "_wrappers.cpython-311-x86_64-linux-gnu.so")] = struct{}{}     // Wrapt library on x86_64
+	criticalFiles[filepath.Join(basePath, "python3.8", "google", "_upb", "_message.abi3.so")] = struct{}{}                  // Google protobuf library [python 3.8 distro]
+	criticalFiles[filepath.Join(basePath, "python3.8", "wrapt", "_wrappers.cpython-311-aarch64-linux-gnu.so")] = struct{}{} // Wrapt library on arm64 [python 3.8 distro]
+	criticalFiles[filepath.Join(basePath, "python3.8", "wrapt", "_wrappers.cpython-311-x86_64-linux-gnu.so")] = struct{}{}  // Wrapt library on x86_64 [python 3.8 distro]
+	// PHP native extension loaded by the PHP runtime via dlopen().
+	// Must be preserved during upgrades to avoid crashing running PHP-FPM processes.
+	criticalFiles[filepath.Join(basePath, "php", "8.1", "opentelemetry.so")] = struct{}{}
+	criticalFiles[filepath.Join(basePath, "php", "8.2", "opentelemetry.so")] = struct{}{}
+	criticalFiles[filepath.Join(basePath, "php", "8.3", "opentelemetry.so")] = struct{}{}
+	criticalFiles[filepath.Join(basePath, "php", "8.4", "opentelemetry.so")] = struct{}{}
+	return criticalFiles
 }

--- a/common/fs/copy.go
+++ b/common/fs/copy.go
@@ -14,37 +14,6 @@ import (
 	commonlogger "github.com/odigos-io/odigos/common/logger"
 )
 
-// criticalFiles lists paths relative to the agents directory root that must be
-// preserved during upgrades because they may be memory-mapped by running processes.
-var criticalFiles = map[string]struct{}{
-	"/var/odigos/nodejs-ebpf/build/Release/dtrace-injector-native.node":                            {},
-	"/var/odigos/nodejs-ebpf/build/Release/obj.target/dtrace-injector-native.node":                 {},
-	"/var/odigos/nodejs-ebpf/build/Release/.deps/Release/dtrace-injector-native.node.d":            {},
-	"/var/odigos/nodejs-ebpf/build/Release/.deps/Release/obj.target/dtrace-injector-native.node.d": {},
-	"/var/odigos/java-ebpf/tracing_probes.so":                                                      {},
-	"/var/odigos/java-ext-ebpf/end_span_usdt.so":                                                   {},
-	"/var/odigos/java-ext-ebpf/javaagent.jar":                                                      {},
-	"/var/odigos/java-ext-ebpf/otel_agent_extension.jar":                                           {},
-	"/var/odigos/python-ebpf/pythonUSDT.abi3.so":                                                   {},
-	"/var/odigos/loader/loader.so":                                                                 {},
-	// Python dependency shared objects - special handling:
-	// These shared objects (.so files) are loaded by Python processes and mapped into process memory.
-	// They cannot be replaced while loaded, so we must keep them in the host filesystem to avoid removal.
-	// These files are versioned and renamed when their respective library versions change.
-	"/var/odigos/python/google/_upb/_message.abi3.so":                        {}, // Google protobuf library
-	"/var/odigos/python/wrapt/_wrappers.cpython-311-aarch64-linux-gnu.so":    {}, // Wrapt library on arm64
-	"/var/odigos/python/wrapt/_wrappers.cpython-311-x86_64-linux-gnu.so":     {}, // Wrapt library on x86_64
-	"/var/odigos/python3.8/google/_upb/_message.abi3.so":                     {}, // Google protobuf library [python 3.8 distro]
-	"/var/odigos/python3.8/wrapt/_wrappers.cpython-311-aarch64-linux-gnu.so": {}, // Wrapt library on arm64 [python 3.8 distro]
-	"/var/odigos/python3.8/wrapt/_wrappers.cpython-311-x86_64-linux-gnu.so":  {}, // Wrapt library on x86_64 [python 3.8 distro]
-	// PHP native extension loaded by the PHP runtime via dlopen().
-	// Must be preserved during upgrades to avoid crashing running PHP-FPM processes.
-	"/var/odigos/php/8.1/opentelemetry.so": {},
-	"/var/odigos/php/8.2/opentelemetry.so": {},
-	"/var/odigos/php/8.3/opentelemetry.so": {},
-	"/var/odigos/php/8.4/opentelemetry.so": {},
-}
-
 func CopyDirectories(srcDir, dstDir string, excludes map[string]bool) error {
 	if err := os.MkdirAll(dstDir, 0o755); err != nil {
 		return fmt.Errorf("create destination dir: %w", err)
@@ -201,66 +170,6 @@ func copyFile(src, dst string, srcInfo os.FileInfo) error {
 	// size+mtime comparison, avoiding unnecessary I/O.
 	mtime := srcInfo.ModTime()
 	return os.Chtimes(dst, mtime, mtime)
-}
-
-func fileExists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
-}
-
-func ProcessCriticalFiles(files map[string]struct{}, stagingDir, targetDir string) (map[string]bool, error) {
-	excludes := make(map[string]bool)
-
-	for relPath := range files {
-		targetPath := filepath.Join(targetDir, relPath)
-		stagingPath := filepath.Join(stagingDir, relPath)
-
-		// Preserve all existing hash-versioned files for this base file.
-		hvFiles, _ := findHashVersionFiles(targetPath)
-		for _, hvf := range hvFiles {
-			rel, err := filepath.Rel(targetDir, hvf)
-			if err == nil {
-				excludes[rel] = true
-			}
-		}
-
-		targetExists := fileExists(targetPath)
-		stagingExists := fileExists(stagingPath)
-
-		if !targetExists || !stagingExists {
-			continue
-		}
-
-		targetHash, err := fileHash(targetPath)
-		if err != nil {
-			return nil, fmt.Errorf("hash target %s: %w", relPath, err)
-		}
-		stagingHash, err := fileHash(stagingPath)
-		if err != nil {
-			return nil, fmt.Errorf("hash staging %s: %w", relPath, err)
-		}
-
-		if targetHash == stagingHash {
-			// Unchanged -- exclude from sync to avoid unnecessary I/O.
-			excludes[relPath] = true
-			continue
-		}
-
-		// Changed -- rename old version so running processes keep their
-		// memory-mapped file, then let sync copy the new version.
-		renamed, err := renameWithHashSuffix(targetPath, targetHash)
-		if err != nil {
-			return nil, fmt.Errorf("rename critical file %s: %w", relPath, err)
-		}
-		if renamed != "" {
-			rel, err := filepath.Rel(targetDir, renamed)
-			if err == nil {
-				excludes[rel] = true
-			}
-		}
-	}
-
-	return excludes, nil
 }
 
 func renameWithHashSuffix(filePath, hash string) (string, error) {

--- a/common/fs/copy_test.go
+++ b/common/fs/copy_test.go
@@ -117,51 +117,48 @@ func TestCopyDirectories_RespectsExcludes(t *testing.T) {
 	}
 }
 
-func TestProcessCriticalFiles_RenamesChangedFile(t *testing.T) {
-	staging := t.TempDir()
-	target := t.TempDir()
+func TestRemoveChangedFilesFromKeepMap_RenamesChangedFile(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
 
 	relPath := "loader/loader.so"
-	stagingFile := filepath.Join(staging, relPath)
-	targetFile := filepath.Join(target, relPath)
+	srcFile := filepath.Join(srcDir, relPath)
+	dstFile := filepath.Join(dstDir, relPath)
 
-	if err := os.MkdirAll(filepath.Dir(stagingFile), 0755); err != nil {
-		t.Fatalf("mkdir staging: %v", err)
+	if err := os.MkdirAll(filepath.Dir(srcFile), 0755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
 	}
-	if err := os.MkdirAll(filepath.Dir(targetFile), 0755); err != nil {
-		t.Fatalf("mkdir target: %v", err)
+	if err := os.MkdirAll(filepath.Dir(dstFile), 0755); err != nil {
+		t.Fatalf("mkdir destination: %v", err)
 	}
-	if err := os.WriteFile(stagingFile, []byte("new-version"), 0644); err != nil {
-		t.Fatalf("write staging: %v", err)
+	if err := os.WriteFile(srcFile, []byte("new-version"), 0644); err != nil {
+		t.Fatalf("write source: %v", err)
 	}
-	if err := os.WriteFile(targetFile, []byte("old-version"), 0644); err != nil {
-		t.Fatalf("write target: %v", err)
+	if err := os.WriteFile(dstFile, []byte("old-version"), 0644); err != nil {
+		t.Fatalf("write destination: %v", err)
 	}
 
-	oldCriticalFiles := criticalFiles
-	criticalFiles = map[string]struct{}{relPath: {}}
-	defer func() { criticalFiles = oldCriticalFiles }()
+	filesToKeepMap := map[string]struct{}{dstFile: {}}
 
-	excludes, err := ProcessCriticalFiles(criticalFiles, staging, target)
+	keep, err := removeChangedFilesFromKeepMap(filesToKeepMap, srcDir, dstDir)
 	if err != nil {
-		t.Fatalf("processCriticalFiles failed: %v", err)
+		t.Fatalf("removeChangedFilesFromKeepMap failed: %v", err)
 	}
 
-	// The original target file should be renamed (no longer at original path)
-	if _, err := os.Stat(targetFile); !os.IsNotExist(err) {
-		t.Fatalf("original target file should have been renamed")
+	// The original destination file should be renamed (no longer at original path)
+	if _, err := os.Stat(dstFile); !os.IsNotExist(err) {
+		t.Fatalf("original destination file should have been renamed")
 	}
 
-	// The renamed file should be in the excludes map
-	if len(excludes) == 0 {
-		t.Fatalf("expected excludes to contain renamed file")
+	// The renamed file should be in the keep map
+	if len(keep) == 0 {
+		t.Fatalf("expected keep map to contain renamed file")
 	}
 
 	// Verify the renamed file exists on disk
-	for rel := range excludes {
-		renamedPath := filepath.Join(target, rel)
-		if _, err := os.Stat(renamedPath); err != nil {
-			t.Fatalf("renamed file %s does not exist: %v", renamedPath, err)
+	for dstPath := range keep {
+		if _, err := os.Stat(dstPath); err != nil {
+			t.Fatalf("renamed file %s does not exist: %v", dstPath, err)
 		}
 	}
 }

--- a/odiglet/odiglet.go
+++ b/odiglet/odiglet.go
@@ -256,7 +256,7 @@ func OdigletInitPhase(clientset *kubernetes.Clientset) {
 	// Logger already initialized in main() before calling OdigletInitPhase.
 	logger := commonlogger.LoggerCompat().With("subsystem", "init")
 
-	err := fs.CopyAgentsDirectoryToHost(k8sconsts.OdigletContainerAgentDirectory, k8sconsts.OdigosAgentsDirectory)
+	err := fs.CopyAgentsDirectoryToHost(k8sconsts.OdigletContainerAgentDirectory, k8sconsts.OdigosAgentsDirectory, nil)
 	if err != nil {
 		logger.Error("Failed to copy agents directory to host", "err", err)
 		os.Exit(-1)


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->

The upgrade entry point will now requires files to keep / copy and also optional rsync binary path

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
