### PR TITLE
CORE-1158 | feat: support applying actions to the profiles signal

### DIFF
--- a/autoscaler/controllers/actions/deleteattribute_controller.go
+++ b/autoscaler/controllers/actions/deleteattribute_controller.go
@@ -144,6 +144,23 @@ func deleteAttributeConfig(cfg []string, signals []common.ObservabilitySignal) (
 					Statements: ottlDeleteKeyStatements,
 				},
 			}
+
+		case common.ProfilesObservabilitySignal:
+			// resource, scope and profile are the only OTTL contexts the transformprocessor accepts for profiles.
+			config.ProfileStatements = []OttlStatementConfig{
+				{
+					Context:    "resource",
+					Statements: ottlDeleteKeyStatements,
+				},
+				{
+					Context:    "scope",
+					Statements: ottlDeleteKeyStatements,
+				},
+				{
+					Context:    "profile",
+					Statements: ottlDeleteKeyStatements,
+				},
+			}
 		}
 	}
 	return config, nil

--- a/autoscaler/controllers/actions/profiles_actions_test.go
+++ b/autoscaler/controllers/actions/profiles_actions_test.go
@@ -1,0 +1,149 @@
+package actions
+
+// In-process end-to-end: drive real Actions through convertActionToProcessor, the OrderHint
+// filter/sort, bucketing and both the gateway and node render, asserting the rendered configs.
+// Ties together what the unit tests cover in isolation, including OrderHint ordering and the fact
+// that the tier-1 actions are cluster-gateway scoped.
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	actionsv1 "github.com/odigos-io/odigos/api/actions/v1alpha1"
+	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	commonconf "github.com/odigos-io/odigos/autoscaler/controllers/common"
+	"github.com/odigos-io/odigos/autoscaler/controllers/nodecollector/collectorconfig"
+	"github.com/odigos-io/odigos/common"
+	"github.com/odigos-io/odigos/common/config"
+	"github.com/odigos-io/odigos/common/pipelinegen"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pyroscopeDest is a Pyroscope-typed destination so the real Pyroscope configer registers a
+// "profiles/pyroscope-<id>" pipeline via addProfilesPipeline.
+type pyroscopeDest struct{ id string }
+
+func (d pyroscopeDest) GetID() string                   { return d.id }
+func (d pyroscopeDest) GetType() common.DestinationType { return common.PyroscopeDestinationType }
+func (d pyroscopeDest) GetConfig() map[string]string {
+	return map[string]string{"PYROSCOPE_URL": "pyroscope.example.com:4040"}
+}
+func (d pyroscopeDest) GetSignals() []common.ObservabilitySignal {
+	return []common.ObservabilitySignal{common.ProfilesObservabilitySignal}
+}
+
+func mkAction(name string, spec odigosv1.ActionSpec) *odigosv1.Action {
+	return &odigosv1.Action{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "odigos.io/v1alpha1", Kind: "Action"},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "odigos-system", UID: types.UID(name + "-uid")},
+		Spec:       spec,
+	}
+}
+
+func TestE2E_ProfilesActions_ActionToRenderedConfig(t *testing.T) {
+	ctx := context.Background()
+	str := func(s string) *string { return &s }
+	// Each action selects PROFILES *and* TRACES, so a single generated processor config carries both
+	// profile_statements and trace_statements — the shared-across-pipelines case.
+	sigs := []common.ObservabilitySignal{common.ProfilesObservabilitySignal, common.TracesObservabilitySignal}
+
+	actions := []*odigosv1.Action{
+		mkAction("add-cluster", odigosv1.ActionSpec{ActionName: "add cluster info", Signals: sigs,
+			AddClusterInfo: &actionsv1.AddClusterInfoConfig{ClusterAttributes: []actionsv1.OtelAttributeWithValue{
+				{AttributeName: "k8s.cluster.name", AttributeStringValue: str("prod-eu")}}}}),
+		mkAction("rename-attr", odigosv1.ActionSpec{ActionName: "rename attr", Signals: sigs,
+			RenameAttribute: &actionsv1.RenameAttributeConfig{Renames: map[string]string{"old.name": "new.name"}}}),
+		mkAction("delete-attr", odigosv1.ActionSpec{ActionName: "delete attr", Signals: sigs,
+			DeleteAttribute: &actionsv1.DeleteAttributeConfig{AttributeNamesToDelete: []string{"secret.token"}}}),
+	}
+
+	// 1) Real reconciler conversion: Action -> Processor CRD.
+	procList := &odigosv1.ProcessorList{}
+	for _, a := range actions {
+		p, err := convertActionToProcessor(ctx, nil, a)
+		require.NoError(t, err, "convertActionToProcessor(%s)", a.Name)
+		procList.Items = append(procList.Items, *p)
+	}
+
+	// 2) Production filter+sort by OrderHint, per collector role. All three tier-1 actions declare
+	// only the ClusterGateway role, so the gateway gets all three (ordered) and the node gets none.
+	gwProcs := commonconf.FilterAndSortProcessorsByOrderHint(procList, odigosv1.CollectorsGroupRoleClusterGateway)
+	nodeProcs := commonconf.FilterAndSortProcessorsByOrderHint(procList, odigosv1.CollectorsGroupRoleNodeCollector)
+	require.Len(t, gwProcs, 3)
+	require.Len(t, nodeProcs, 0)
+
+	// 3) Bucketing: all three are admitted to profiles, ordered by OrderHint (delete -100, rename -50,
+	// addclusterinfo 1), and also to traces — with no cross-contamination.
+	results := config.CrdProcessorToConfig(commonconf.ToProcessorConfigurerArray(gwProcs))
+	require.Empty(t, results.Errs)
+	wantOrder := []string{"transform/delete-attr", "transform/rename-attr", "resource/add-cluster"}
+	assert.Equal(t, wantOrder, results.ProfilesProcessors)
+	assert.Len(t, results.TracesProcessors, 3)
+
+	// --- GATEWAY render ---
+	gwOpts := pipelinegen.GatewayConfigOptions{OdigosNamespace: "odigos-system"}
+	gw, err, statuses, signals := pipelinegen.CalculateGatewayConfig(
+		[]config.ExporterConfigurer{pyroscopeDest{id: "p1"}},
+		commonconf.ToProcessorConfigurerArray(gwProcs),
+		func(c *config.Config, _ []string, _ []string) error { return nil },
+		nil, &gwOpts)
+	require.NoError(t, err)
+	require.NoError(t, statuses.Destination["p1"])
+	require.Contains(t, signals, common.ProfilesObservabilitySignal)
+
+	// Profiles flow through the router: the "profiles/in" root pipeline runs the processors once
+	// (OrderHint order, after resource/odigos-version) and exports to odigosrouterconnector/profiles.
+	root, ok := gw.Service.Pipelines["profiles/in"]
+	require.True(t, ok)
+	assert.Equal(t, append([]string{"resource/odigos-version"}, wantOrder...), root.Processors, "profiles root processor order")
+	assert.Equal(t, []string{"odigosrouterconnector/profiles"}, root.Exporters)
+	// The destination pipeline receives from its forward connector, no batch.
+	dest, ok := gw.Service.Pipelines["profiles/pyroscope-p1"]
+	require.True(t, ok)
+	assert.Contains(t, dest.Receivers, "forward/profiles/pyroscope-p1")
+	assert.NotContains(t, dest.Processors, "batch")
+	// The transform processors carry profile_statements with exactly the collector-safe contexts.
+	assertProfileStatementContexts(t, gw.Processors, "transform/rename-attr")
+	assertProfileStatementContexts(t, gw.Processors, "transform/delete-attr")
+
+	// --- NODE render --- gateway-scoped actions => node profiles pipeline is unchanged (built-in chain).
+	on := true
+	nodeResults := config.CrdProcessorToConfig(commonconf.ToProcessorConfigurerArray(nodeProcs))
+	require.Empty(t, nodeResults.ProfilesProcessors)
+	nodeCfg, err := config.MergeConfigs(map[string]config.Config{
+		"processors": nodeResults.ProcessorsConfig,
+		"profiling":  collectorconfig.ProfilingPipelineConfig("odigos-system", &common.ProfilingConfiguration{Enabled: &on}, nodeResults.ProfilesProcessors),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		commonconf.ProfilingNodeFilterProcessor,
+		commonconf.ProfilingNodeK8sAttributesProcessor,
+		commonconf.ProfilingNodeOdigosProfilesProcessor,
+		commonconf.ProfilingNodeSymbolizeProcessor,
+		commonconf.ProfilingNodeServiceNameProcessor,
+	}, nodeCfg.Service.Pipelines["profiles"].Processors)
+}
+
+// assertProfileStatementContexts asserts the processor carries profile_statements over exactly the
+// resource/scope/profile contexts — the only ones the transformprocessor accepts for profiles.
+// The config has been through a JSON round-trip (Processor CRD RawExtension -> GetConfig), so the
+// statements are generic maps rather than typed OttlStatementConfig structs.
+func assertProfileStatementContexts(t *testing.T, procs config.GenericMap, key string) {
+	t.Helper()
+	m, ok := procs[key].(config.GenericMap)
+	require.True(t, ok, "processor %q config missing/not a map", key)
+	ps, ok := m["profile_statements"].([]interface{})
+	require.True(t, ok, "processor %q missing profile_statements (got %T)", key, m["profile_statements"])
+	got := make([]string, len(ps))
+	for i, s := range ps {
+		sm, ok := s.(map[string]interface{})
+		require.True(t, ok, "profile_statements[%d] not a map: %T", i, s)
+		got[i], _ = sm["context"].(string)
+	}
+	assert.Equal(t, []string{"resource", "scope", "profile"}, got, "processor %q profile_statements contexts", key)
+}

--- a/autoscaler/controllers/actions/profiles_statements_test.go
+++ b/autoscaler/controllers/actions/profiles_statements_test.go
@@ -1,0 +1,74 @@
+package actions
+
+import (
+	"testing"
+
+	"github.com/odigos-io/odigos/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// profilesCapableContexts are the only OTTL contexts the transformprocessor accepts for the
+// profiles signal in the pinned collector build; emitting any other context fails collector startup.
+var profilesCapableContexts = []string{"resource", "scope", "profile"}
+
+func contexts(stmts []OttlStatementConfig) []string {
+	out := make([]string, len(stmts))
+	for i, s := range stmts {
+		out[i] = s.Context
+	}
+	return out
+}
+
+func TestRenameAttributeConfig_Profiles(t *testing.T) {
+	cfg, err := renameAttributeConfig(
+		map[string]string{"old.attr": "new.attr"},
+		[]common.ObservabilitySignal{common.ProfilesObservabilitySignal},
+	)
+	require.NoError(t, err)
+
+	// Only profile_statements is populated for a PROFILES-only action.
+	assert.Empty(t, cfg.TraceStatements)
+	assert.Empty(t, cfg.MetricStatements)
+	assert.Empty(t, cfg.LogStatements)
+	require.NotEmpty(t, cfg.ProfileStatements)
+
+	assert.Equal(t, profilesCapableContexts, contexts(cfg.ProfileStatements))
+	// Each context carries the same set/delete_key statement pair the other signals use.
+	for _, s := range cfg.ProfileStatements {
+		assert.Equal(t, []string{
+			`set(attributes["new.attr"], attributes["old.attr"])`,
+			`delete_key(attributes, "old.attr")`,
+		}, s.Statements)
+	}
+}
+
+func TestDeleteAttributeConfig_Profiles(t *testing.T) {
+	cfg, err := deleteAttributeConfig(
+		[]string{"drop.me"},
+		[]common.ObservabilitySignal{common.ProfilesObservabilitySignal},
+	)
+	require.NoError(t, err)
+
+	assert.Empty(t, cfg.TraceStatements)
+	assert.Empty(t, cfg.MetricStatements)
+	assert.Empty(t, cfg.LogStatements)
+	require.NotEmpty(t, cfg.ProfileStatements)
+
+	assert.Equal(t, profilesCapableContexts, contexts(cfg.ProfileStatements))
+	for _, s := range cfg.ProfileStatements {
+		assert.Equal(t, []string{`delete_key(attributes, "drop.me")`}, s.Statements)
+	}
+}
+
+// Profiles combines cleanly with the existing signals without cross-populating the other buckets.
+func TestRenameAttributeConfig_ProfilesWithOtherSignals(t *testing.T) {
+	cfg, err := renameAttributeConfig(
+		map[string]string{"a": "b"},
+		[]common.ObservabilitySignal{common.TracesObservabilitySignal, common.ProfilesObservabilitySignal},
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, cfg.TraceStatements)
+	require.NotEmpty(t, cfg.ProfileStatements)
+	assert.Equal(t, profilesCapableContexts, contexts(cfg.ProfileStatements))
+}

--- a/autoscaler/controllers/actions/renameattribute_controller.go
+++ b/autoscaler/controllers/actions/renameattribute_controller.go
@@ -148,6 +148,23 @@ func renameAttributeConfig(cfg map[string]string, signals []common.Observability
 					Statements: ottlStatements,
 				},
 			}
+
+		case common.ProfilesObservabilitySignal:
+			// resource, scope and profile are the only OTTL contexts the transformprocessor accepts for profiles.
+			config.ProfileStatements = []OttlStatementConfig{
+				{
+					Context:    "resource",
+					Statements: ottlStatements,
+				},
+				{
+					Context:    "scope",
+					Statements: ottlStatements,
+				},
+				{
+					Context:    "profile",
+					Statements: ottlStatements,
+				},
+			}
 		}
 	}
 	return config, nil

--- a/autoscaler/controllers/actions/types.go
+++ b/autoscaler/controllers/actions/types.go
@@ -26,8 +26,9 @@ type OttlStatementConfig struct {
 }
 
 type TransformProcessorConfig struct {
-	ErrorMode        string                `json:"error_mode"`
-	TraceStatements  []OttlStatementConfig `json:"trace_statements,omitempty"`
-	MetricStatements []OttlStatementConfig `json:"metric_statements,omitempty"`
-	LogStatements    []OttlStatementConfig `json:"log_statements,omitempty"`
+	ErrorMode         string                `json:"error_mode"`
+	TraceStatements   []OttlStatementConfig `json:"trace_statements,omitempty"`
+	MetricStatements  []OttlStatementConfig `json:"metric_statements,omitempty"`
+	LogStatements     []OttlStatementConfig `json:"log_statements,omitempty"`
+	ProfileStatements []OttlStatementConfig `json:"profile_statements,omitempty"`
 }

--- a/autoscaler/controllers/nodecollector/collectorconfig/profiles.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/profiles.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ProfilingPipelineConfig builds the node collector profiles domain when profiling is enabled.
-func ProfilingPipelineConfig(odigosNamespace string, profiling *common.ProfilingConfiguration) config.Config {
+func ProfilingPipelineConfig(odigosNamespace string, profiling *common.ProfilingConfiguration, manifestProcessorNames []string) config.Config {
 	if !common.ProfilingPipelineActive(profiling) {
 		return config.Config{}
 	}
@@ -40,6 +40,7 @@ func ProfilingPipelineConfig(odigosNamespace string, profiling *common.Profiling
 		pipelineProcessors = append(pipelineProcessors, commonconf.ProfilingNodeSymbolizeProcessor)
 	}
 	pipelineProcessors = append(pipelineProcessors, commonconf.ProfilingNodeServiceNameProcessor)
+	pipelineProcessors = append(pipelineProcessors, manifestProcessorNames...)
 
 	return config.Config{
 		Receivers: config.GenericMap{

--- a/autoscaler/controllers/nodecollector/collectorconfig/profiles_test.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/profiles_test.go
@@ -12,20 +12,20 @@ import (
 )
 
 func TestProfilingPipelineConfig_Disabled(t *testing.T) {
-	got := ProfilingPipelineConfig("odigos-system", nil)
+	got := ProfilingPipelineConfig("odigos-system", nil, nil)
 	assert.Empty(t, got.Receivers)
 	assert.Empty(t, got.Processors)
 	assert.Empty(t, got.Exporters)
 	assert.Empty(t, got.Service.Pipelines)
 
 	off := false
-	got = ProfilingPipelineConfig("odigos-system", &common.ProfilingConfiguration{Enabled: &off})
+	got = ProfilingPipelineConfig("odigos-system", &common.ProfilingConfiguration{Enabled: &off}, nil)
 	assert.Empty(t, got.Service.Pipelines)
 }
 
 func TestProfilingPipelineConfig_Enabled(t *testing.T) {
 	on := true
-	got := ProfilingPipelineConfig("odigos-system", &common.ProfilingConfiguration{Enabled: &on})
+	got := ProfilingPipelineConfig("odigos-system", &common.ProfilingConfiguration{Enabled: &on}, nil)
 	require.Contains(t, got.Receivers, commonconf.ProfilingReceiver)
 	require.Contains(t, got.Processors, commonconf.ProfilingNodeFilterProcessor)
 	require.Contains(t, got.Processors, commonconf.ProfilingNodeK8sAttributesProcessor)
@@ -57,6 +57,26 @@ func TestProfilingPipelineConfig_Enabled(t *testing.T) {
 	assert.Equal(t, k8sconsts.OdigosConfigK8sExtensionType, odigosProfilesCfg["odigos_config_extension"])
 }
 
+func TestProfilingPipelineConfig_UserProcessorsAppended(t *testing.T) {
+	on := true
+	userProcessors := []string{"resource/addclusterinfo", "transform/rename"}
+	got := ProfilingPipelineConfig("odigos-system", &common.ProfilingConfiguration{Enabled: &on}, userProcessors)
+
+	pl, ok := got.Service.Pipelines["profiles"]
+	require.True(t, ok)
+	// User processors run after the built-in enrichment chain (native symbolization is on by
+	// default, so the symbolize processor is present) and before export.
+	assert.Equal(t, []string{
+		commonconf.ProfilingNodeFilterProcessor,
+		commonconf.ProfilingNodeK8sAttributesProcessor,
+		commonconf.ProfilingNodeOdigosProfilesProcessor,
+		commonconf.ProfilingNodeSymbolizeProcessor,
+		commonconf.ProfilingNodeServiceNameProcessor,
+		"resource/addclusterinfo",
+		"transform/rename",
+	}, pl.Processors)
+}
+
 // TestProfilingPipelineConfig_NativeSymbolizationDisabled drops the symbolize
 // processor when a user explicitly opts out (profiling.symbolization.native: false).
 func TestProfilingPipelineConfig_NativeSymbolizationDisabled(t *testing.T) {
@@ -64,7 +84,7 @@ func TestProfilingPipelineConfig_NativeSymbolizationDisabled(t *testing.T) {
 	got := ProfilingPipelineConfig("odigos-system", &common.ProfilingConfiguration{
 		Enabled:       &on,
 		Symbolization: &common.ProfilingSymbolizationConfiguration{Native: &off},
-	})
+	}, nil)
 	require.NotContains(t, got.Processors, commonconf.ProfilingNodeSymbolizeProcessor)
 
 	pl := got.Service.Pipelines["profiles"]

--- a/autoscaler/controllers/nodecollector/configmap.go
+++ b/autoscaler/controllers/nodecollector/configmap.go
@@ -294,7 +294,7 @@ func calculateCollectorConfigDomains(
 	}
 
 	if odigoscommon.ProfilingPipelineActive(profiling) {
-		configDomains["profiling"] = collectorconfig.ProfilingPipelineConfig(odigosNamespace, profiling)
+		configDomains["profiling"] = collectorconfig.ProfilingPipelineConfig(odigosNamespace, profiling, processorsResults.ProfilesProcessors)
 	}
 
 	mergedConfig, err := config.MergeConfigs(configDomains)

--- a/collector/connectors/odigosrouterconnector/connector.go
+++ b/collector/connectors/odigosrouterconnector/connector.go
@@ -7,12 +7,16 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/connector"
+	"go.opentelemetry.io/collector/connector/xconnector"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/xconsumer"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/pprofile"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	collectorpipeline "go.opentelemetry.io/collector/pipeline"
+	xpipeline "go.opentelemetry.io/collector/pipeline/xpipeline"
 	"go.uber.org/zap"
 
 	odigoscollector "github.com/odigos-io/odigos/common/collector"
@@ -37,10 +41,17 @@ type logsConfig struct {
 	logger      *zap.Logger
 }
 
+type profilesConfig struct {
+	consumers   xconnector.ProfilesRouterAndConsumer
+	defaultCons xconsumer.Profiles
+	logger      *zap.Logger
+}
+
 type routerConnector struct {
-	tracesConfig  tracesConfig
-	metricsConfig metricsConfig
-	logsConfig    logsConfig
+	tracesConfig   tracesConfig
+	metricsConfig  metricsConfig
+	logsConfig     logsConfig
+	profilesConfig profilesConfig
 
 	configExtensionID     *component.ID
 	odigosConfigExtension odigoscollector.OdigosConfigExtension
@@ -149,6 +160,34 @@ func createLogsConnector(
 
 	return &routerConnector{
 		logsConfig:        logsConfig{consumers: tr, defaultCons: defaultLogsConsumer, logger: set.Logger},
+		configExtensionID: config.OdigosConfigExtension,
+	}, nil
+}
+
+func createProfilesConnector(
+	ctx context.Context,
+	set connector.Settings,
+	cfg component.Config,
+	next xconsumer.Profiles,
+) (xconnector.Profiles, error) {
+
+	tr, ok := next.(xconnector.ProfilesRouterAndConsumer)
+	if !ok {
+		return nil, errors.New("expected consumer to be a connector router")
+	}
+
+	config := cfg.(*Config)
+
+	defaultProfilesConsumer, err := tr.Consumer(
+		collectorpipeline.NewIDWithName(xpipeline.SignalProfiles, consts.DefaultDataStream),
+	)
+	if err != nil {
+		set.Logger.Warn("failed to get default profiles consumer")
+		defaultProfilesConsumer = nil
+	}
+
+	return &routerConnector{
+		profilesConfig:    profilesConfig{consumers: tr, defaultCons: defaultProfilesConsumer, logger: set.Logger},
 		configExtensionID: config.OdigosConfigExtension,
 	}, nil
 }
@@ -318,6 +357,59 @@ func (r *routerConnector) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 		if cfg.defaultCons != nil {
 			if err := cfg.defaultCons.ConsumeLogs(ctx, defaultLogs); err != nil {
 				cfg.logger.Debug("failed to send logs to the default pipeline", zap.Error(err))
+			}
+		}
+	}
+
+	return errs
+}
+
+func (r *routerConnector) ConsumeProfiles(ctx context.Context, pd pprofile.Profiles) error {
+	cfg := r.profilesConfig
+	profilesByConsumer := make(map[xconsumer.Profiles]pprofile.Profiles)
+	defaultProfiles := pprofile.NewProfiles()
+	var errs error
+
+	rProfiles := pd.ResourceProfiles()
+	for i := 0; i < rProfiles.Len(); i++ {
+		rp := rProfiles.At(i)
+		pipelines := r.resolveDataStreams(rp.Resource())
+
+		if len(pipelines) == 0 {
+			rp.CopyTo(defaultProfiles.ResourceProfiles().AppendEmpty())
+			continue
+		}
+
+		for _, pipeline := range pipelines {
+			pipelineID := collectorpipeline.NewIDWithName(xpipeline.SignalProfiles, pipeline)
+			consumer, err := cfg.consumers.Consumer(pipelineID)
+			if err != nil {
+				continue
+			}
+
+			batch, ok := profilesByConsumer[consumer]
+			if !ok {
+				batch = pprofile.NewProfiles()
+			}
+			rp.CopyTo(batch.ResourceProfiles().AppendEmpty())
+			profilesByConsumer[consumer] = batch
+		}
+	}
+
+	for cons, batch := range profilesByConsumer {
+		if batch.ResourceProfiles().Len() == 0 {
+			continue
+		}
+		if err := cons.ConsumeProfiles(ctx, batch); err != nil {
+			errs = errors.Join(errs, err)
+		}
+	}
+
+	// Fallback, if any profiles unmatched
+	if defaultProfiles.ResourceProfiles().Len() > 0 {
+		if cfg.defaultCons != nil {
+			if err := cfg.defaultCons.ConsumeProfiles(ctx, defaultProfiles); err != nil {
+				cfg.logger.Debug("failed to send profiles to the default pipeline", zap.Error(err))
 			}
 		}
 	}

--- a/collector/connectors/odigosrouterconnector/factory.go
+++ b/collector/connectors/odigosrouterconnector/factory.go
@@ -2,18 +2,19 @@ package odigosrouterconnector
 
 import (
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/connector"
+	"go.opentelemetry.io/collector/connector/xconnector"
 )
 
 var typeStr = component.MustNewType("odigosrouterconnector")
 
-func NewFactory() connector.Factory {
-	return connector.NewFactory(
+func NewFactory() xconnector.Factory {
+	return xconnector.NewFactory(
 		component.Type(typeStr),
 		createDefaultConfig,
-		connector.WithTracesToTraces(createTracesConnector, component.StabilityLevelAlpha),
-		connector.WithMetricsToMetrics(createMetricsConnector, component.StabilityLevelAlpha),
-		connector.WithLogsToLogs(createLogsConnector, component.StabilityLevelAlpha),
+		xconnector.WithTracesToTraces(createTracesConnector, component.StabilityLevelAlpha),
+		xconnector.WithMetricsToMetrics(createMetricsConnector, component.StabilityLevelAlpha),
+		xconnector.WithLogsToLogs(createLogsConnector, component.StabilityLevelAlpha),
+		xconnector.WithProfilesToProfiles(createProfilesConnector, component.StabilityLevelAlpha),
 	)
 }
 

--- a/collector/connectors/odigosrouterconnector/go.mod
+++ b/collector/connectors/odigosrouterconnector/go.mod
@@ -10,10 +10,14 @@ require (
 	go.opentelemetry.io/collector/confmap v1.57.0
 	go.opentelemetry.io/collector/connector v0.151.0
 	go.opentelemetry.io/collector/connector/connectortest v0.151.0
+	go.opentelemetry.io/collector/connector/xconnector v0.151.0
 	go.opentelemetry.io/collector/consumer v1.57.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.151.0
+	go.opentelemetry.io/collector/consumer/xconsumer v0.151.0
 	go.opentelemetry.io/collector/pdata v1.57.0
+	go.opentelemetry.io/collector/pdata/pprofile v0.151.0
 	go.opentelemetry.io/collector/pipeline v1.57.0
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.151.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.28.0
 )
@@ -37,13 +41,9 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/collector/connector/xconnector v0.151.0 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.151.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.57.0 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.151.0 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.151.0 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.151.0 // indirect
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.151.0 // indirect
 	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.44.0 // indirect

--- a/common/config/genericotlp.go
+++ b/common/config/genericotlp.go
@@ -140,7 +140,7 @@ func (g *GenericOTLP) ModifyConfig(dest ExporterConfigurer, currentConfig *Confi
 	}
 
 	if isProfilingEnabled(dest) {
-		addProfilesPipeline(currentConfig, "generic", dest.GetID(), genericOtlpExporterName)
+		pipelineNames = append(pipelineNames, addProfilesPipeline(currentConfig, "generic", dest.GetID(), genericOtlpExporterName))
 	}
 
 	return pipelineNames, nil

--- a/common/config/otlphttp.go
+++ b/common/config/otlphttp.go
@@ -195,7 +195,7 @@ func (g *OTLPHttp) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) 
 	}
 
 	if isProfilingEnabled(dest) {
-		addProfilesPipeline(currentConfig, "otlphttp", dest.GetID(), otlpHttpExporterName)
+		pipelineNames = append(pipelineNames, addProfilesPipeline(currentConfig, "otlphttp", dest.GetID(), otlpHttpExporterName))
 	}
 
 	return pipelineNames, nil

--- a/common/config/processor.go
+++ b/common/config/processor.go
@@ -10,6 +10,7 @@ type CrdProcessorResults struct {
 	TracesProcessorsPostSpanMetrics []string
 	MetricsProcessors               []string
 	LogsProcessors                  []string
+	ProfilesProcessors              []string
 	Errs                            map[string]error
 }
 
@@ -21,6 +22,7 @@ func CrdProcessorToConfig(processors []ProcessorConfigurer) CrdProcessorResults 
 		TracesProcessorsPostSpanMetrics: []string{},
 		MetricsProcessors:               []string{},
 		LogsProcessors:                  []string{},
+		ProfilesProcessors:              []string{},
 		Errs:                            make(map[string]error),
 	}
 
@@ -54,6 +56,9 @@ func CrdProcessorToConfig(processors []ProcessorConfigurer) CrdProcessorResults 
 		}
 		if isLoggingEnabled(processor) {
 			results.LogsProcessors = append(results.LogsProcessors, processorKey)
+		}
+		if isProfilingEnabled(processor) {
+			results.ProfilesProcessors = append(results.ProfilesProcessors, processorKey)
 		}
 	}
 	if len(results.Errs) != 0 {

--- a/common/config/processor_test.go
+++ b/common/config/processor_test.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/odigos-io/odigos/common"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeProcessor struct {
+	id        string
+	pType     string
+	signals   []common.ObservabilitySignal
+	config    GenericMap
+	orderHint int
+}
+
+func (f fakeProcessor) GetSignals() []common.ObservabilitySignal { return f.signals }
+func (f fakeProcessor) GetType() string                          { return f.pType }
+func (f fakeProcessor) GetID() string                            { return f.id }
+func (f fakeProcessor) GetConfig() (GenericMap, error)           { return f.config, nil }
+func (f fakeProcessor) GetOrderHint() int                        { return f.orderHint }
+
+func TestCrdProcessorToConfig_ProfilesBucketing(t *testing.T) {
+	profiles := []common.ObservabilitySignal{common.ProfilesObservabilitySignal}
+	traces := []common.ObservabilitySignal{common.TracesObservabilitySignal}
+
+	processors := []ProcessorConfigurer{
+		fakeProcessor{id: "addclusterinfo", pType: "resource", signals: profiles, config: GenericMap{}},
+		fakeProcessor{id: "rename", pType: "transform", signals: profiles, config: GenericMap{}},
+		// Not selecting PROFILES: must not be bucketed into profiles.
+		fakeProcessor{id: "traces-only", pType: "resource", signals: traces, config: GenericMap{}},
+	}
+
+	results := CrdProcessorToConfig(processors)
+
+	// Profiles is bucketed like the other signals: any processor selecting PROFILES is included.
+	assert.ElementsMatch(t,
+		[]string{"resource/addclusterinfo", "transform/rename"},
+		results.ProfilesProcessors,
+		"every processor selecting PROFILES should be wired into profiles pipelines",
+	)
+	assert.NotContains(t, results.ProfilesProcessors, "resource/traces-only")
+}
+
+func TestCrdProcessorToConfig_ProfilesNotSelected(t *testing.T) {
+	// A profiles-capable type that did NOT select the PROFILES signal must not be bucketed.
+	processors := []ProcessorConfigurer{
+		fakeProcessor{
+			id:      "rename-traces-only",
+			pType:   "transform",
+			signals: []common.ObservabilitySignal{common.TracesObservabilitySignal},
+			config:  GenericMap{},
+		},
+	}
+
+	results := CrdProcessorToConfig(processors)
+
+	assert.Empty(t, results.ProfilesProcessors)
+	assert.Equal(t, []string{"transform/rename-traces-only"}, results.TracesProcessors)
+}

--- a/common/config/profiles_gateway_test.go
+++ b/common/config/profiles_gateway_test.go
@@ -1,0 +1,107 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/odigos-io/odigos/common"
+	"github.com/odigos-io/odigos/common/config"
+	"github.com/odigos-io/odigos/common/pipelinegen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// configurableProcessor is a ProcessorConfigurer mock that lets a test set the type and signals.
+type configurableProcessor struct {
+	id      string
+	pType   string
+	signals []common.ObservabilitySignal
+}
+
+func (p configurableProcessor) GetID() string   { return p.id }
+func (p configurableProcessor) GetType() string { return p.pType }
+func (p configurableProcessor) GetConfig() (config.GenericMap, error) {
+	return config.GenericMap{}, nil
+}
+func (p configurableProcessor) GetSignals() []common.ObservabilitySignal { return p.signals }
+func (p configurableProcessor) GetOrderHint() int                        { return 0 }
+
+// profilesDestination is a Pyroscope-typed destination so the real Pyroscope configer registers a
+// "profiles/pyroscope-<id>" pipeline via addProfilesPipeline.
+type profilesDestination struct{ id string }
+
+func (d profilesDestination) GetID() string                   { return d.id }
+func (d profilesDestination) GetType() common.DestinationType { return common.PyroscopeDestinationType }
+func (d profilesDestination) GetConfig() map[string]string {
+	return map[string]string{"PYROSCOPE_URL": "pyroscope.example.com:4040"}
+}
+func (d profilesDestination) GetSignals() []common.ObservabilitySignal {
+	return []common.ObservabilitySignal{common.ProfilesObservabilitySignal}
+}
+
+// TestGatewayProfilesProcessorsWired renders a full gateway config and asserts profiles flow through
+// the same router path as traces/metrics/logs: a "profiles/in" root pipeline runs the processors once
+// and exports to odigosrouterconnector/profiles, and the destination pipeline receives from its
+// forward connector (no batch — unsupported for profiles).
+func TestGatewayProfilesProcessorsWired(t *testing.T) {
+	profilesSig := []common.ObservabilitySignal{common.ProfilesObservabilitySignal}
+
+	processors := []config.ProcessorConfigurer{
+		configurableProcessor{id: "addcluster", pType: "resource", signals: profilesSig},
+		configurableProcessor{id: "rename", pType: "transform", signals: profilesSig},
+		configurableProcessor{ // traces-only: must not leak into profiles
+			id: "traces-only", pType: "resource",
+			signals: []common.ObservabilitySignal{common.TracesObservabilitySignal},
+		},
+	}
+
+	gatewayOptions := pipelinegen.GatewayConfigOptions{OdigosNamespace: "odigos-system"}
+
+	rendered, err, statuses, signals := pipelinegen.CalculateGatewayConfig(
+		[]config.ExporterConfigurer{profilesDestination{id: "p1"}},
+		processors,
+		func(c *config.Config, _ []string, _ []string) error { return nil },
+		nil, &gatewayOptions,
+	)
+	require.NoError(t, err)
+	require.NoError(t, statuses.Destination["p1"])
+	require.Contains(t, signals, common.ProfilesObservabilitySignal)
+
+	// Root pipeline: otlp -> [resource/odigos-version, processors] -> odigosrouterconnector/profiles.
+	root, ok := rendered.Service.Pipelines["profiles/in"]
+	require.True(t, ok, "expected profiles/in root pipeline")
+	assert.Equal(t, []string{"otlp"}, root.Receivers)
+	assert.Contains(t, root.Processors, "resource/addcluster")
+	assert.Contains(t, root.Processors, "transform/rename")
+	assert.NotContains(t, root.Processors, "resource/traces-only")
+	assert.Equal(t, []string{"odigosrouterconnector/profiles"}, root.Exporters)
+
+	// Destination pipeline: receives from its forward connector, exports, no batch processor.
+	dest, ok := rendered.Service.Pipelines["profiles/pyroscope-p1"]
+	require.True(t, ok)
+	assert.Contains(t, dest.Receivers, "forward/profiles/pyroscope-p1")
+	assert.NotContains(t, dest.Processors, "batch")
+}
+
+// TestGatewayNoProfilesProcessorsWhenNoneSelected: with no PROFILES action, the profiles root pipeline
+// carries only resource/odigos-version (no user processors).
+func TestGatewayNoProfilesProcessorsWhenNoneSelected(t *testing.T) {
+	processors := []config.ProcessorConfigurer{
+		configurableProcessor{
+			id: "rename", pType: "transform",
+			signals: []common.ObservabilitySignal{common.TracesObservabilitySignal},
+		},
+	}
+	gatewayOptions := pipelinegen.GatewayConfigOptions{OdigosNamespace: "odigos-system"}
+
+	rendered, err, _, _ := pipelinegen.CalculateGatewayConfig(
+		[]config.ExporterConfigurer{profilesDestination{id: "p1"}},
+		processors,
+		nil, nil, &gatewayOptions,
+	)
+	require.NoError(t, err)
+
+	root, ok := rendered.Service.Pipelines["profiles/in"]
+	require.True(t, ok)
+	assert.Equal(t, []string{"resource/odigos-version"}, root.Processors)
+	assert.NotContains(t, root.Processors, "transform/rename")
+}

--- a/common/config/pyroscope.go
+++ b/common/config/pyroscope.go
@@ -57,7 +57,7 @@ func (p *Pyroscope) ModifyConfig(dest ExporterConfigurer, currentConfig *Config)
 		},
 	}
 
-	addProfilesPipeline(currentConfig, "pyroscope", dest.GetID(), exporterName)
+	profilesPipelineName := addProfilesPipeline(currentConfig, "pyroscope", dest.GetID(), exporterName)
 
-	return nil, nil
+	return []string{profilesPipelineName}, nil
 }

--- a/common/config/root.go
+++ b/common/config/root.go
@@ -127,22 +127,15 @@ func isProfilingEnabled(dest SignalSpecific) bool {
 	return isSignalExists(dest, common.ProfilesObservabilitySignal)
 }
 
-// addProfilesPipeline registers a direct profiles pipeline that consumes from
-// the gateway "otlp" receiver and exports via the supplied exporter.
-//
-// Profile pipelines deliberately bypass the data-stream router connector that
-// traces/metrics/logs flow through. The router connector and per-data-stream
-// pipelines do not yet support the profiles signal, so the OTel collector fans
-// the gateway OTLP receiver out to this pipeline directly. Callers must not
-// include the registered name in the destinationPipelineNames slice they
-// return from ModifyConfig; doing so would cause the gateway builder to wire
-// a forward connector that has no upstream producer.
-func addProfilesPipeline(currentConfig *Config, prefix, destID, exporterName string) {
+// addProfilesPipeline registers a "profiles/<prefix>-<id>" destination pipeline (exporter only) and
+// returns its name. Like traces/metrics/logs destination pipelines, its receiver (the forward
+// connector) is attached by the gateway builder, so it flows through the odigosrouterconnector.
+func addProfilesPipeline(currentConfig *Config, prefix, destID, exporterName string) string {
 	name := fmt.Sprintf("profiles/%s-%s", prefix, destID)
 	currentConfig.Service.Pipelines[name] = Pipeline{
-		Receivers: []string{"otlp"},
 		Exporters: []string{exporterName},
 	}
+	return name
 }
 
 func addProtocol(s string) string {

--- a/common/pipelinegen/config_builder.go
+++ b/common/pipelinegen/config_builder.go
@@ -142,8 +142,11 @@ func CalculateGatewayConfig(
 			pipeline := currentConfig.Service.Pipelines[pipelineName]
 			// add the forward connector as a receiver to the pipeline
 			pipeline.Receivers = append(pipeline.Receivers, connectorName)
-			// every destination pipeline should have a generic batch processor
-			pipeline.Processors = append(pipeline.Processors, consts.GenericBatchProcessorConfigKey)
+			// every destination pipeline should have a generic batch processor, except profiles:
+			// the batch processor does not support the profiles signal in the pinned collector build.
+			if !strings.HasPrefix(pipelineName, "profiles/") {
+				pipeline.Processors = append(pipeline.Processors, consts.GenericBatchProcessorConfigKey)
+			}
 
 			// track which signals are enabled based on the destination pipeline names
 			switch {
@@ -162,18 +165,6 @@ func CalculateGatewayConfig(
 		}
 
 		status.Destination[dest.GetID()] = nil // mark this destination as success
-	}
-	// Profile destinations (e.g. Pyroscope) register their pipelines directly under
-	// "profiles/<id>" and intentionally return no destination pipeline names from
-	// ModifyConfig — so they bypass the forward-connector loop above. Detect them
-	// by scanning registered pipelines so PROFILES is reflected in enabledSignals.
-	if !profilesEnabled {
-		for pipelineName := range currentConfig.Service.Pipelines {
-			if strings.HasPrefix(pipelineName, "profiles/") {
-				profilesEnabled = true
-				break
-			}
-		}
 	}
 
 	// track which signals are enabled
@@ -212,6 +203,7 @@ func CalculateGatewayConfig(
 		tracesPostForwardProcessors,
 		processorsResults.MetricsProcessors,
 		processorsResults.LogsProcessors,
+		processorsResults.ProfilesProcessors,
 		enabledSignals,
 		gatewayOptions)
 
@@ -247,7 +239,7 @@ func CalculateGatewayConfig(
 }
 
 func insertRootPipelinesToConfig(currentConfig *config.Config,
-	tracesProcessors, tracesPostForwardProcessors, metricsProcessors, logsProcessors []string,
+	tracesProcessors, tracesPostForwardProcessors, metricsProcessors, logsProcessors, profilesProcessors []string,
 	signals []common.ObservabilitySignal, gatewayOptions *GatewayConfigOptions) {
 	if slices.Contains(signals, common.TracesObservabilitySignal) {
 		if traceAggregationNeeded(gatewayOptions) {
@@ -264,6 +256,10 @@ func insertRootPipelinesToConfig(currentConfig *config.Config,
 
 	if slices.Contains(signals, common.LogsObservabilitySignal) {
 		applyRootPipelineForSignal(currentConfig, common.LogsObservabilitySignal, logsProcessors, gatewayOptions.OdigosConfigExtensionName)
+	}
+
+	if slices.Contains(signals, common.ProfilesObservabilitySignal) {
+		applyRootPipelineForSignal(currentConfig, common.ProfilesObservabilitySignal, profilesProcessors, gatewayOptions.OdigosConfigExtensionName)
 	}
 }
 

--- a/common/pipelinegen/datastreams.go
+++ b/common/pipelinegen/datastreams.go
@@ -24,9 +24,10 @@ type Destination struct {
 // when building the telemetry configuration.
 // and also to be single source of truth for the root pipelines
 var telemetryRootPipelinesBySignal = map[common.ObservabilitySignal]string{
-	common.TracesObservabilitySignal:  strings.ToLower(string(common.TracesObservabilitySignal)) + "/in",
-	common.MetricsObservabilitySignal: strings.ToLower(string(common.MetricsObservabilitySignal)) + "/in",
-	common.LogsObservabilitySignal:    strings.ToLower(string(common.LogsObservabilitySignal)) + "/in",
+	common.TracesObservabilitySignal:   strings.ToLower(string(common.TracesObservabilitySignal)) + "/in",
+	common.MetricsObservabilitySignal:  strings.ToLower(string(common.MetricsObservabilitySignal)) + "/in",
+	common.LogsObservabilitySignal:     strings.ToLower(string(common.LogsObservabilitySignal)) + "/in",
+	common.ProfilesObservabilitySignal: strings.ToLower(string(common.ProfilesObservabilitySignal)) + "/in",
 }
 
 func GetTelemetryRootPipelineName(signal common.ObservabilitySignal) string {
@@ -37,5 +38,6 @@ func GetSignalsRootPipelineNames() []string {
 		GetTelemetryRootPipelineName(common.TracesObservabilitySignal),
 		GetTelemetryRootPipelineName(common.MetricsObservabilitySignal),
 		GetTelemetryRootPipelineName(common.LogsObservabilitySignal),
+		GetTelemetryRootPipelineName(common.ProfilesObservabilitySignal),
 	}
 }

--- a/common/pipelinegen/pipeline_builder.go
+++ b/common/pipelinegen/pipeline_builder.go
@@ -8,7 +8,7 @@ import (
 	"github.com/odigos-io/odigos/common/consts"
 )
 
-// BuildDataStreamPipelines constructs data stream pipelines for logs, metrics, traces.
+// BuildDataStreamPipelines constructs data stream pipelines for logs, metrics, traces, profiles.
 // Each pipeline receives from its routing connector and exports to all destinations relevant to the data stream.
 func buildDataStreamPipelines(
 	dataStreams []DataStreams,
@@ -17,13 +17,17 @@ func buildDataStreamPipelines(
 	pipelines := make(map[string]config.Pipeline)
 
 	for _, dataStream := range dataStreams {
-		for _, signal := range []string{"logs", "metrics", "traces"} {
+		for _, signal := range []string{"logs", "metrics", "traces", "profiles"} {
 			pipelineName := fmt.Sprintf("%s/%s", signal, dataStream.Name)
 
 			pipeline := config.Pipeline{
-				Receivers:  []string{fmt.Sprintf("odigosrouterconnector/%s", signal)},
-				Processors: []string{consts.GenericBatchProcessorConfigKey}, // every group pipeline should have a generic batch processor
-				Exporters:  []string{},
+				Receivers: []string{fmt.Sprintf("odigosrouterconnector/%s", signal)},
+				Exporters: []string{},
+			}
+			// every group pipeline should have a generic batch processor, except profiles:
+			// the batch processor does not support the profiles signal in the pinned collector build.
+			if signal != "profiles" {
+				pipeline.Processors = []string{consts.GenericBatchProcessorConfigKey}
 			}
 
 			// Add forward connectors for each destination in the group to route telemetry data


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Explain why this change is needed and what it does. -->

**Problem**

While looking at profiles samples in a customer env, we couldn't tell whether a sample came from an Odigos-instrumented source or another agent. 

**What changed**
Profiles now go through the **same pipeline-building path as traces / metrics /logs**

- **Same router topology.** using the `odigosrouterconnector` 

This PR includes the collector change (`odigosrouterconnector` profiles support) alongside the config generation, so the generated config and the collector that runs it.

```
GATEWAY — profiles built identically to traces / metrics / logs (minus `batch`):

  profiles/in        otlp ─► resource/odigos-version ─► [action processors] ─► odigosrouterconnector/profiles
                                                         (run ONCE at root)                 │ routes per data-stream
  profiles/<stream>  odigosrouterconnector/profiles ─► forward/profiles/<dest> …            ▼
  profiles/<dest>    forward/profiles/<dest> ─► otlphttp/<dest>     fan-out ─► Pyroscope-1, Pyroscope-2, Odigos-UI
```

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!-- If yes, a release note is required. Otherwise, write NONE. -->
```release-note
Support applying AddClusterInfo, RenameAttribute, and DeleteAttribute actions to the profiles signal.
```