### PR TITLE
Cherry-pick: CORE-1023: Push all images to private registry (#5025) (v1.29.0)

### DIFF
--- a/.github/workflows/promote-rc-to-stable.yml
+++ b/.github/workflows/promote-rc-to-stable.yml
@@ -115,12 +115,9 @@ jobs:
       - name: Retag existing images to stable
         run: |
             # Define which images go to which registries
-            GCR_IMAGE_NAMES=("odigos-agents" "odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-ui" "odigos-operator" "odigos-enterprise-central-backend" "odigos-enterprise-central-proxy" "odigos-enterprise-central-ui" "odigos-enterprise-agents" "odigos-enterprise-instrumentor" "odigos-enterprise-odiglet")
-
-            # Enterprise images are currently published to both the public and private registries.
-            # To publish them only to the private registry, remove them from GCR_IMAGE_NAMES above
-            # and from the EXTENDED_IMAGE_NAMES loop below.
-            GCR_PRIVATE_IMAGE_NAMES=("odigos-enterprise-central-backend" "odigos-enterprise-central-proxy" "odigos-enterprise-central-ui" "odigos-enterprise-agents" "odigos-enterprise-instrumentor" "odigos-enterprise-odiglet")
+            # All non-RHEL component images (OSS + enterprise). Each is promoted in components
+            # and mirrored to components-private.
+            GCR_IMAGE_NAMES=("odigos-agents" "odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-ui" "odigos-operator" "odigos-cli" "odigos-victoria-metrics" "odigos-enterprise-central-backend" "odigos-enterprise-central-proxy" "odigos-enterprise-central-ui" "odigos-enterprise-agents" "odigos-enterprise-instrumentor" "odigos-enterprise-odiglet")
 
             GHCR_IMAGE_NAMES=("odigos-agents" "odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-ui" "odigos-operator")
 
@@ -144,15 +141,14 @@ jobs:
                 fi
               done
 
-              # Process GCR private images
-              for IMAGE_NAME in "${GCR_PRIVATE_IMAGE_NAMES[@]}"; do
-                REPO=${GCR_PRIVATE_REPO}
-                echo "Copying ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.RC_TAG }} to ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.STABLE_TAG }}"
-                if ! crane copy ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.RC_TAG }} ${REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.STABLE_TAG }}; then
-                  echo "ERROR: Failed to copy ${REPO}/${IMAGE_NAME}${SUFFIX}"
-                  FAILED_COPIES+=("${REPO}/${IMAGE_NAME}${SUFFIX}")
+              # Mirror all GCR images into the private registry (components-private).
+              for IMAGE_NAME in "${GCR_IMAGE_NAMES[@]}"; do
+                echo "Mirroring ${GCR_REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.STABLE_TAG }} to ${GCR_PRIVATE_REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.STABLE_TAG }}"
+                if ! crane copy ${GCR_REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.STABLE_TAG }} ${GCR_PRIVATE_REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.STABLE_TAG }}; then
+                  echo "ERROR: Failed to mirror ${GCR_PRIVATE_REPO}/${IMAGE_NAME}${SUFFIX}"
+                  FAILED_COPIES+=("${GCR_PRIVATE_REPO}/${IMAGE_NAME}${SUFFIX}")
                 else
-                  echo "Successfully copied ${REPO}/${IMAGE_NAME}${SUFFIX}"
+                  echo "Successfully mirrored ${GCR_PRIVATE_REPO}/${IMAGE_NAME}${SUFFIX}"
                 fi
               done
 
@@ -182,18 +178,34 @@ jobs:
             done
 
             # Handle extended tag variants for agents and odiglet (e.g. v1.0.0-rc1-extended -> v1.0.0-extended).
-            # To publish extended images only to the private registry, drop ${GCR_REPO} from the loop below.
-            EXTENDED_IMAGE_NAMES=("odigos-enterprise-agents" "odigos-enterprise-odiglet")
+            EXTENDED_IMAGE_NAMES=("odigos-agents" "odigos-odiglet" "odigos-enterprise-agents" "odigos-enterprise-odiglet")
+            ENTERPRISE_EXTENDED_IMAGE_NAMES=("odigos-enterprise-agents" "odigos-enterprise-odiglet")
             for IMAGE_NAME in "${EXTENDED_IMAGE_NAMES[@]}"; do
-              for REPO in "${GCR_REPO}" "${GCR_PRIVATE_REPO}" "${DOCKERHUB_REPO}"; do
-                echo "Copying ${REPO}/${IMAGE_NAME}:${{ env.RC_TAG }}-extended to ${REPO}/${IMAGE_NAME}:${{ env.STABLE_TAG }}-extended"
-                if ! crane copy ${REPO}/${IMAGE_NAME}:${{ env.RC_TAG }}-extended ${REPO}/${IMAGE_NAME}:${{ env.STABLE_TAG }}-extended; then
-                  echo "ERROR: Failed to copy ${REPO}/${IMAGE_NAME} extended"
-                  FAILED_COPIES+=("${REPO}/${IMAGE_NAME}-extended")
-                else
-                  echo "Successfully copied ${REPO}/${IMAGE_NAME} extended"
-                fi
-              done
+              echo "Copying ${GCR_REPO}/${IMAGE_NAME}:${{ env.RC_TAG }}-extended to ${GCR_REPO}/${IMAGE_NAME}:${{ env.STABLE_TAG }}-extended"
+              if ! crane copy ${GCR_REPO}/${IMAGE_NAME}:${{ env.RC_TAG }}-extended ${GCR_REPO}/${IMAGE_NAME}:${{ env.STABLE_TAG }}-extended; then
+                echo "ERROR: Failed to copy ${GCR_REPO}/${IMAGE_NAME} extended"
+                FAILED_COPIES+=("${GCR_REPO}/${IMAGE_NAME}-extended")
+              else
+                echo "Successfully copied ${GCR_REPO}/${IMAGE_NAME} extended"
+              fi
+
+              echo "Mirroring ${GCR_REPO}/${IMAGE_NAME}:${{ env.STABLE_TAG }}-extended to ${GCR_PRIVATE_REPO}/${IMAGE_NAME}:${{ env.STABLE_TAG }}-extended"
+              if ! crane copy ${GCR_REPO}/${IMAGE_NAME}:${{ env.STABLE_TAG }}-extended ${GCR_PRIVATE_REPO}/${IMAGE_NAME}:${{ env.STABLE_TAG }}-extended; then
+                echo "ERROR: Failed to mirror ${GCR_PRIVATE_REPO}/${IMAGE_NAME} extended"
+                FAILED_COPIES+=("${GCR_PRIVATE_REPO}/${IMAGE_NAME}-extended")
+              else
+                echo "Successfully mirrored ${GCR_PRIVATE_REPO}/${IMAGE_NAME} extended"
+              fi
+            done
+
+            for IMAGE_NAME in "${ENTERPRISE_EXTENDED_IMAGE_NAMES[@]}"; do
+              echo "Copying ${DOCKERHUB_REPO}/${IMAGE_NAME}:${{ env.RC_TAG }}-extended to ${DOCKERHUB_REPO}/${IMAGE_NAME}:${{ env.STABLE_TAG }}-extended"
+              if ! crane copy ${DOCKERHUB_REPO}/${IMAGE_NAME}:${{ env.RC_TAG }}-extended ${DOCKERHUB_REPO}/${IMAGE_NAME}:${{ env.STABLE_TAG }}-extended; then
+                echo "ERROR: Failed to copy ${DOCKERHUB_REPO}/${IMAGE_NAME} extended"
+                FAILED_COPIES+=("${DOCKERHUB_REPO}/${IMAGE_NAME}-extended")
+              else
+                echo "Successfully copied ${DOCKERHUB_REPO}/${IMAGE_NAME} extended"
+              fi
             done
 
             # Check if any copies failed

--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -252,6 +252,7 @@ jobs:
           provenance: false
           tags: |
             us-central1-docker.pkg.dev/odigos-cloud/components/odigos-${{ matrix.service }}:${{ env.ODIGOS_TAG }}
+            us-central1-docker.pkg.dev/odigos-cloud/components-private/odigos-${{ matrix.service }}:${{ env.ODIGOS_TAG }}
             keyval/odigos-${{ matrix.service }}:${{ env.ODIGOS_TAG }}
             ghcr.io/odigos-io/odigos-${{ matrix.service }}:${{ env.ODIGOS_TAG }}
           build-args: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,24 +270,30 @@ jobs:
       - name: Install crane
         uses: imjasonh/setup-crane@v0.4
 
-      - name: Copy CLI image to Docker Hub
+      - name: Copy CLI image to Docker Hub and private GCR
         env:
           SOURCE_IMAGE: us-central1-docker.pkg.dev/odigos-cloud/components/odigos-cli
           DEST_IMAGE: ${{ env.DOCKERHUB_ORG }}/odigos-cli
+          GCR_PRIVATE_DEST_IMAGE: us-central1-docker.pkg.dev/odigos-cloud/components-private/odigos-cli
         run: |
           crane copy ${SOURCE_IMAGE}:${{ env.TAG }} ${DEST_IMAGE}:${{ env.TAG }}
           crane copy ${SOURCE_IMAGE}:latest ${DEST_IMAGE}:latest
+          crane copy ${SOURCE_IMAGE}:${{ env.TAG }} ${GCR_PRIVATE_DEST_IMAGE}:${{ env.TAG }}
+          crane copy ${SOURCE_IMAGE}:latest ${GCR_PRIVATE_DEST_IMAGE}:latest
 
       - name: Copy VictoriaMetrics image to Docker Hub and GCR
         env:
           SOURCE_IMAGE: victoriametrics/victoria-metrics:${{ env.VICTORIA_METRICS_VERSION }}
           DOCKERHUB_DEST_IMAGE: ${{ env.DOCKERHUB_ORG }}/odigos-victoria-metrics
           GCR_DEST_IMAGE: us-central1-docker.pkg.dev/odigos-cloud/components/odigos-victoria-metrics
+          GCR_PRIVATE_DEST_IMAGE: us-central1-docker.pkg.dev/odigos-cloud/components-private/odigos-victoria-metrics
         run: |
           crane copy ${SOURCE_IMAGE} ${DOCKERHUB_DEST_IMAGE}:${{ env.TAG }}
           crane copy ${SOURCE_IMAGE} ${DOCKERHUB_DEST_IMAGE}:latest
           crane copy ${SOURCE_IMAGE} ${GCR_DEST_IMAGE}:${{ env.TAG }}
           crane copy ${SOURCE_IMAGE} ${GCR_DEST_IMAGE}:latest
+          crane copy ${SOURCE_IMAGE} ${GCR_PRIVATE_DEST_IMAGE}:${{ env.TAG }}
+          crane copy ${SOURCE_IMAGE} ${GCR_PRIVATE_DEST_IMAGE}:latest
 
       - name: Set notification messages
         run: |


### PR DESCRIPTION
#### What this PR does / why we need it:
This pushes all images to `components-private`, so they can be served by the same registry handler and eventually all be behind auth



#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below. If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```


