### PR TITLE
revert: enterprise ui image

### DIFF
--- a/helm/odigos/templates/ui/deployment.yaml
+++ b/helm/odigos/templates/ui/deployment.yaml
@@ -44,11 +44,7 @@ spec:
       containers:
       - name: ui
         {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
-        {{- if include "odigos.secretExists" . }}
-        image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-ui" "Tag" $imageTag) }}
-        {{- else }}
         image: {{ template "utils.imageName" (dict "Values" .Values "Component" "ui" "Tag" $imageTag) }}
-        {{- end }}
         args:
           - --namespace=$(CURRENT_NS)
           - --address=0.0.0.0


### PR DESCRIPTION
#### What this PR does / why we need it:

revert enterprise ui changes from helm which breaks the main branch

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```

emergency-ticket id: EMR-1867
