### PR TITLE
Cherry pick/v1.28.0/upgrade python dep

### DIFF
--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -41,7 +41,7 @@ ADD --chmod=644 https://github.com/open-telemetry/opentelemetry-java-instrumenta
 
 # python-community/python-community3.8
 COPY --from=public.ecr.aws/odigos/agents/python-community:v1.0.73-py3.8 /instrumentations/python3.8 /instrumentations/python3.8
-COPY --from=public.ecr.aws/odigos/agents/python-community:v1.0.87 /instrumentations/python /instrumentations/python
+COPY --from=public.ecr.aws/odigos/agents/python-community:v1.0.88 /instrumentations/python /instrumentations/python
 
 # nodejs-community
 COPY --from=public.ecr.aws/odigos/agents/nodejs-community:v0.9.1 /instrumentations/opentelemetry-node /instrumentations/opentelemetry-node

--- a/odiglet/debug.Dockerfile
+++ b/odiglet/debug.Dockerfile
@@ -63,7 +63,7 @@ RUN chmod 644 /instrumentations/java/javaagent.jar
 
 # python-community/python-community3.8
 COPY --from=public.ecr.aws/odigos/agents/python-community:v1.0.73-py3.8 /instrumentations/python3.8 /instrumentations/python3.8
-COPY --from=public.ecr.aws/odigos/agents/python-community:v1.0.87 /instrumentations/python /instrumentations/python
+COPY --from=public.ecr.aws/odigos/agents/python-community:v1.0.88 /instrumentations/python /instrumentations/python
 
 # nodejs-community
 COPY --from=public.ecr.aws/odigos/agents/nodejs-community:v0.9.1 /instrumentations/opentelemetry-node /instrumentations/opentelemetry-node


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Cherry pick the python instrumentation with the kafka fix into 1.28.0.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Python instrumentation upgrade - fixes Kafka context errors
```

emergency-ticket id: EMR-1880
