### PR TITLE
fix: no instrumentation when OTEL_RESOURCE_ATTRIBUTES is set to non odigos

### DIFF
--- a/instrumentor/controllers/agentenabled/podswebhook/otelresource.go
+++ b/instrumentor/controllers/agentenabled/podswebhook/otelresource.go
@@ -15,6 +15,10 @@ import (
 const (
 	otelServiceNameEnvVarName        = "OTEL_SERVICE_NAME"
 	otelResourceAttributesEnvVarName = "OTEL_RESOURCE_ATTRIBUTES"
+
+	// used when OTEL_RESOURCE_ATTRIBUTES is already set,
+	// so we can pass our values without overwriting or modifying the existing environment variable.
+	odigosResourceAttributesEnvVarName = "ODIGOS_RESOURCE_ATTRIBUTES"
 )
 
 type resourceAttribute struct {
@@ -126,9 +130,14 @@ func InjectOtelResourceAndServiceNameEnvVars(existingEnvNames EnvVarNamesMap, co
 	// OTEL_SERVICE_NAME
 	existingEnvNames = InjectConstEnvVarToPodContainer(existingEnvNames, container, otelServiceNameEnvVarName, serviceName)
 
-	// OTEL_RESOURCE_ATTRIBUTES
+	// OTEL_RESOURCE_ATTRIBUTES or ODIGOS_RESOURCE_ATTRIBUTES
 	resourceAttributes := getResourceAttributes(pw, container.Name, ownerReferences)
 	resourceAttributesEnvValue := getResourceAttributesEnvVarValue(resourceAttributes)
-	existingEnvNames = InjectConstEnvVarToPodContainer(existingEnvNames, container, otelResourceAttributesEnvVarName, resourceAttributesEnvValue)
+
+	if _, exists := existingEnvNames[otelResourceAttributesEnvVarName]; !exists {
+		existingEnvNames = InjectConstEnvVarToPodContainer(existingEnvNames, container, otelResourceAttributesEnvVarName, resourceAttributesEnvValue)
+	} else {
+		existingEnvNames = InjectConstEnvVarToPodContainer(existingEnvNames, container, odigosResourceAttributesEnvVarName, resourceAttributesEnvValue)
+	}
 	return existingEnvNames
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

fixes: CORE-1168

if `OTEL_RESOURCE_ATTRIBUTES` is already set by the user, odigos skips populating it and then relevant values (like container name) can become missing in the agent.

in this case, this PR will make it so we populate `ODIGOS_RESOURCE_ATTRIBUTES' instead. the agents should try both.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
