### PR TITLE
CORE-1001 | OSS prerequisites for enterprise UI MCP (helm toggle + access mode + diagnose + ci)

### DIFF
--- a/.github/workflows/promote-rc-to-stable.yml
+++ b/.github/workflows/promote-rc-to-stable.yml
@@ -117,7 +117,7 @@ jobs:
             # Define which images go to which registries
             # All non-RHEL component images (OSS + enterprise). Each is promoted in components
             # and mirrored to components-private.
-            GCR_IMAGE_NAMES=("odigos-agents" "odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-ui" "odigos-operator" "odigos-cli" "odigos-victoria-metrics" "odigos-enterprise-central-backend" "odigos-enterprise-central-proxy" "odigos-enterprise-central-ui" "odigos-enterprise-agents" "odigos-enterprise-instrumentor" "odigos-enterprise-odiglet")
+            GCR_IMAGE_NAMES=("odigos-agents" "odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-ui" "odigos-operator" "odigos-cli" "odigos-victoria-metrics" "odigos-enterprise-central-backend" "odigos-enterprise-central-proxy" "odigos-enterprise-central-ui" "odigos-enterprise-ui" "odigos-enterprise-agents" "odigos-enterprise-instrumentor" "odigos-enterprise-odiglet")
 
             GHCR_IMAGE_NAMES=("odigos-agents" "odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-ui" "odigos-operator")
 

--- a/common/odigos_config.go
+++ b/common/odigos_config.go
@@ -95,6 +95,17 @@ const (
 	UiModeReadonly UiMode = "readonly"
 )
 
+// McpAccessMode controls whether the Odigos MCP server may run write (mutating)
+// tools. It is independent of UiMode: read-only is the default, and an operator
+// raises it to read-write to let an agent change the cluster.
+// +kubebuilder:validation:Enum=read-only;read-write
+type McpAccessMode string
+
+const (
+	McpAccessModeReadOnly  McpAccessMode = "read-only"
+	McpAccessModeReadWrite McpAccessMode = "read-write"
+)
+
 // +kubebuilder:object:generate=true
 // ResourceDetectorConfig holds the configuration for a single resource detector.
 type ResourceDetectorConfig struct {
@@ -596,6 +607,8 @@ type OdigosConfiguration struct {
 	UiMode                    UiMode                         `json:"uiMode,omitempty" yaml:"uiMode"`
 	UiPaginationLimit         int                            `json:"uiPaginationLimit,omitempty" yaml:"uiPaginationLimit"`
 	UiRemoteUrl               string                         `json:"uiRemoteUrl,omitempty" yaml:"uiRemoteUrl"`
+	McpAccessMode             McpAccessMode                  `json:"mcpAccessMode,omitempty" yaml:"mcpAccessMode"`
+	McpEnabled                *bool                          `json:"mcpEnabled,omitempty" yaml:"mcpEnabled"`
 	CentralBackendURL         string                         `json:"centralBackendURL,omitempty" yaml:"centralBackendURL"`
 	ClusterName               string                         `json:"clusterName,omitempty" yaml:"clusterName"`
 	MountMethod               *MountMethod                   `json:"mountMethod,omitempty" yaml:"mountMethod"`

--- a/frontend/kube/cache.go
+++ b/frontend/kube/cache.go
@@ -91,6 +91,12 @@ func SetupK8sCache(ctx context.Context, kubeConfig string, kubeContext string, o
 		&odigosv1.Sampling{}: {
 			Field: nsSelector,
 		},
+		&odigosv1.Action{}: {
+			Field: nsSelector,
+		},
+		&odigosv1.InstrumentationRule{}: {
+			Field: nsSelector,
+		},
 	}
 
 	// if argo rollout is available, add it to the cache as well

--- a/frontend/services/odigos_config.go
+++ b/frontend/services/odigos_config.go
@@ -66,6 +66,16 @@ func GetLocalUIConfig(ctx context.Context, c client.Client) (*common.OdigosConfi
 	return getOdigosConfigFromConfigMap(ctx, c, consts.OdigosLocalUiConfigName)
 }
 
+// SetMcpAccessMode persists the MCP access mode in the local UI config, which the
+// odigos-configuration controller merges into the effective config. Stored here
+// (rather than written to the effective config directly) because the effective
+// config is generated and would overwrite a direct edit.
+func SetMcpAccessMode(ctx context.Context, c client.Client, mode common.McpAccessMode) error {
+	return upsertLocalUiConfig(ctx, c, func(cfg *common.OdigosConfiguration) {
+		cfg.McpAccessMode = mode
+	})
+}
+
 // upsertLocalUiConfig applies a mutation to the odigos-local-ui-config ConfigMap,
 // creating it with proper owner references if it does not yet exist.
 func upsertLocalUiConfig(ctx context.Context, c client.Client, mutate func(cfg *common.OdigosConfiguration)) error {

--- a/helm/odigos/templates/odigos-configuration-cm.yaml
+++ b/helm/odigos/templates/odigos-configuration-cm.yaml
@@ -40,6 +40,10 @@ data:
     {{- if .Values.ui.uiMode }}
     uiMode: {{ .Values.ui.uiMode }}
     {{- end }}
+    {{- if .Values.ui.mcpAccessMode }}
+    mcpAccessMode: {{ .Values.ui.mcpAccessMode }}
+    {{- end }}
+    mcpEnabled: {{ dig "mcp" "enabled" true .Values.ui }}
     {{- if .Values.ui.uiPaginationLimit }}
     uiPaginationLimit: {{ .Values.ui.uiPaginationLimit }}
     {{- end }}

--- a/helm/odigos/templates/ui/deployment.yaml
+++ b/helm/odigos/templates/ui/deployment.yaml
@@ -43,8 +43,10 @@ spec:
       {{- end }}
       containers:
       - name: ui
-        {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
-        image: {{ template "utils.imageName" (dict "Values" .Values "Component" "ui" "Tag" $imageTag) }}
+        {{- $imageTag := .Values.image.tag | default .Chart.AppVersion }}
+        {{- $isEnterprise := not (empty (include "odigos.secretExists" .)) }}
+        {{- $uiComponent := ternary "enterprise-ui" "ui" $isEnterprise }}
+        image: {{ template "utils.imageName" (dict "Values" .Values "Component" $uiComponent "Tag" $imageTag) }}
         args:
           - --namespace=$(CURRENT_NS)
           - --address=0.0.0.0
@@ -64,9 +66,8 @@ spec:
           {{- end }}
           - name: GOMEMLIMIT
             value: {{ include "odigos.gomemlimitFromResources" (dict "Resources" .Values.ui.resources) }}
-          {{- if include "odigos.secretExists" . }}
-          # Consumed by the enterprise UI's odigosauth.AssertEnterpriseOdigosToken()
-          # at startup. The community UI image ignores this env var.
+          {{- if $isEnterprise }}
+          # Consumed by the enterprise UI at startup; ignored by the community image.
           - name: ODIGOS_ONPREM_TOKEN
             valueFrom:
               secretKeyRef:

--- a/helm/odigos/values.schema.json
+++ b/helm/odigos/values.schema.json
@@ -2177,6 +2177,26 @@
           "required": [],
           "title": "logLevel"
         },
+        "mcp": {
+          "additionalProperties": false,
+          "description": "Mount the embedded MCP server at /mcp on the enterprise UI. Enterprise-only — the gate is rendered only when an onPremToken/odigos-pro secret is present (the same condition that selects the enterprise UI image); it has no effect on the community image. Served on the UI port; reachable in-cluster via the ui Service.",
+          "properties": {
+            "enabled": {
+              "default": true,
+              "title": "enabled",
+              "type": "boolean"
+            }
+          },
+          "required": [],
+          "title": "mcp",
+          "type": "object"
+        },
+        "mcpAccessMode": {
+          "default": "read-only",
+          "description": "mcpAccessMode: 'read-only' or 'read-write'\n - Controls whether the MCP server may run write (mutating) tools.\n - Defaults to 'read-only', so an agent cannot change the cluster until\n   an operator opts in to 'read-write'.",
+          "required": [],
+          "title": "mcpAccessMode"
+        },
         "nodeSelector": {
           "default": "",
           "description": "Override the global nodeSelector (values.nodeSelector) for this component",

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -607,6 +607,13 @@ scheduler:
 # @schema
 ui:
   # @schema
+  # description: Mount the embedded MCP server at /mcp on the enterprise UI. Enterprise-only — the gate is rendered only when an onPremToken/odigos-pro secret is present (the same condition that selects the enterprise UI image); it has no effect on the community image. Served on the UI port; reachable in-cluster via the ui Service.
+  # type: object
+  # @schema
+  mcp:
+    enabled: true
+
+  # @schema
   # description: Log level for UI. Defaults to info.
   # @schema
   logLevel: "info"
@@ -666,6 +673,15 @@ ui:
   #    - If not set, the UI will be in default mode.
   # @schema
   uiMode: 'default'
+
+  # @schema
+  # description: |-
+  #   mcpAccessMode: 'read-only' or 'read-write'
+  #    - Controls whether the MCP server may run write (mutating) tools.
+  #    - Defaults to 'read-only', so an agent cannot change the cluster until
+  #      an operator opts in to 'read-write'.
+  # @schema
+  mcpAccessMode: 'read-only'
 
   # @schema
   # description: |-

--- a/k8sutils/pkg/diagnose/profiles.go
+++ b/k8sutils/pkg/diagnose/profiles.go
@@ -114,6 +114,12 @@ var servicesProfilingMetadata = map[string]ProfilingPodConfig{
 			k8sconsts.OdigosCollectorRoleLabel: string(k8sconsts.CollectorsRoleClusterGateway),
 		}.AsSelector(),
 	},
+	"ui": {
+		Port: k8sconsts.DefaultPprofEndpointPort,
+		Selector: labels.Set{
+			"app": k8sconsts.UIAppLabelValue,
+		}.AsSelector(),
+	},
 }
 
 // FetchServiceProfiles collects pprof profiles for a single Odigos service (e.g. "odiglet").

--- a/scheduler/controllers/odigosconfiguration/odigosconfiguration_controller.go
+++ b/scheduler/controllers/odigosconfiguration/odigosconfiguration_controller.go
@@ -218,6 +218,14 @@ func mergeConfigs(baseConfig *common.OdigosConfiguration, addtionalConfig *commo
 		baseConfig.ClusterName = addtionalConfig.ClusterName
 	}
 
+	if addtionalConfig.McpAccessMode != "" {
+		baseConfig.McpAccessMode = addtionalConfig.McpAccessMode
+	}
+
+	if addtionalConfig.McpEnabled != nil {
+		baseConfig.McpEnabled = addtionalConfig.McpEnabled
+	}
+
 	if addtionalConfig.AgentEnvVarsInjectionMethod != nil {
 		baseConfig.AgentEnvVarsInjectionMethod = addtionalConfig.AgentEnvVarsInjectionMethod
 	}


### PR DESCRIPTION
### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->

Consolidates the small OSS changes that the enterprise UI MCP image depends on into a single review

### What's included
| area | change |
|---|---|
| **helm** | `ui.mcp.enabled` toggle + enterprise UI image selection + regenerated `values.schema.json` |
| **helm/config** | `mcpAccessMode` (`read-only`/`read-write`) on `OdigosConfiguration` |
| **diagnose** | collect pprof from the UI pod |
| **ci** | promote `odigos-enterprise-ui` image to stable + private registry |

### Verification
- `common` + `frontend/services` build clean with the new `McpAccessMode` type/field.
- able to build both oss and enterprise UI with the help of https://github.com/odigos-io/odigos-enterprise/pull/2871

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
None
```


---
### Also in this PR (MCP enablement, end-to-end)
- **`McpEnabled` flag** added to `OdigosConfiguration` (`*bool`, nil = enabled) alongside `mcpAccessMode` — the MCP enable flag flows through config, not a deployment env var (no `ODIGOS_MCP_ENABLED`). Helm `ui.mcp.enabled` feeds it into the ConfigMap.
- **Scheduler merges both** `McpAccessMode` and `McpEnabled` in `odigosconfiguration_controller.go`. ⚠️ The effective-config is produced by the scheduler/autoscaler round-trip — reconcilers built **before** these fields drop them on marshal, so **scheduler + autoscaler must be built from this PR** or the UI sees no `mcpAccessMode` and falls back to read-only.
- **Informer cache** now watches `Action` and `InstrumentationRule` (`frontend/kube/cache.go`), so the enterprise MCP `list/get` tools for those read from the cache like sources/destinations/sampling.
