### PR TITLE
CORE-000 | fix(fs): make dotnet deprecated symlinks idempotent on upgrade

### DIFF
--- a/common/fs/copy.go
+++ b/common/fs/copy.go
@@ -248,16 +248,30 @@ func createDotnetDeprecatedDirectories(destDir string) error {
 		return err
 	}
 
-	err = os.Symlink(filepath.Join(glibcDir, dotnetSoFile), filepath.Join(glibcDirWithArch, dotnetSoFile))
-	if err != nil {
+	if err := ensureSymlink(filepath.Join(glibcDir, dotnetSoFile), filepath.Join(glibcDirWithArch, dotnetSoFile)); err != nil {
 		return err
 	}
-	err = os.Symlink(filepath.Join(muslDir, dotnetSoFile), filepath.Join(muslDirWithArch, dotnetSoFile))
-	if err != nil {
+	if err := ensureSymlink(filepath.Join(muslDir, dotnetSoFile), filepath.Join(muslDirWithArch, dotnetSoFile)); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// ensureSymlink creates a symlink at linkPath pointing to target, replacing any
+// existing symlink. os.Symlink fails with EEXIST if the link is already present,
+// so on upgrades/reinstalls (where the dotnet directories persist on the host)
+// a plain os.Symlink would error and abort the whole agents sync. Removing the
+// existing link first makes this idempotent.
+func ensureSymlink(target, linkPath string) error {
+	if _, err := os.Lstat(linkPath); err == nil {
+		if err := os.Remove(linkPath); err != nil {
+			return fmt.Errorf("failed to remove existing symlink %s: %w", linkPath, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to stat %s: %w", linkPath, err)
+	}
+	return os.Symlink(target, linkPath)
 }
 
 func getArch() string {

--- a/common/fs/copy_test.go
+++ b/common/fs/copy_test.go
@@ -278,3 +278,37 @@ func BenchmarkCopyDirectories(b *testing.B) {
 		}
 	}
 }
+
+// TestCreateDotnetDeprecatedDirectories_Idempotent reproduces the upgrade/reinstall
+// scenario: the dotnet directories already exist on the host with the arch symlinks
+// from a previous install. A second call must not fail with EEXIST.
+func TestCreateDotnetDeprecatedDirectories_Idempotent(t *testing.T) {
+	dotnetDir := filepath.Join(t.TempDir(), "dotnet")
+
+	// First call: fresh host, like the very first install.
+	if err := createDotnetDeprecatedDirectories(dotnetDir); err != nil {
+		t.Fatalf("first call failed: %v", err)
+	}
+
+	// Second call: simulates an upgrade/reinstall where the symlinks persist.
+	// Before the fix this returned "file exists" and aborted the agents sync,
+	// crash-looping the vm-agent at startup.
+	if err := createDotnetDeprecatedDirectories(dotnetDir); err != nil {
+		t.Fatalf("second call (upgrade) must be idempotent, got: %v", err)
+	}
+
+	arch := getArch()
+	soFile := "OpenTelemetry.AutoInstrumentation.Native.so"
+	for _, link := range []string{
+		filepath.Join(dotnetDir, "linux-glibc-"+arch, soFile),
+		filepath.Join(dotnetDir, "linux-musl-"+arch, soFile),
+	} {
+		fi, err := os.Lstat(link)
+		if err != nil {
+			t.Fatalf("expected symlink %s: %v", link, err)
+		}
+		if fi.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("expected %s to be a symlink", link)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

After upgrading the vm-agent, the agent crash-loops at startup and instruments nothing:

```
ERROR  fs/agents.go:75  Error creating dotnet deprecated directories
ERROR  vm-agent/main.go:79  failed to sync instrumentation files
systemd: odigos-vmagent.service: Main process exited, code=exited, status=1/FAILURE
systemd: odigos-vmagent.service: Scheduled restart job, restart counter is at 7
```

Root cause is in `createDotnetDeprecatedDirectories` it calls `os.Symlink` directly, and **`os.Symlink` returns `EEXIST` ("file exists") if the link already exists**.

This step runs as part of the non-empty / rsync path, i.e. on every host that isn't a brand-new install.

This will always fail on upgrades since the symlink already exisits


## Fix

Replace the two `os.Symlink` calls with `ensureSymlink`, which removes any existing link before creating it, making the agents sync idempotent across upgrades.

```release-note
bugfix: make dotnet deprecated-directory symlinks idempotent so the vm-agent no longer crash-loops on upgrade/reinstall.
```
