### PR TITLE
CORE-00 | refactor: Remove redundant dotnet fix in the upgrade flow

### DIFF
--- a/common/fs/agents.go
+++ b/common/fs/agents.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -60,20 +59,6 @@ func CopyAgentsDirectoryToHost(srcDir, dstDir string, optionalRsyncPath *string)
 			logger.Error("rsync failed", "err", err)
 			return err
 		}
-	}
-
-	// temporary workaround for dotnet.
-	// dotnet used to have directories containing the arch suffix (linux-glibc-arm64).
-	// this works will with virtual device that knows the arch it is running on.
-	// however, the webhook cannot know in advance which arch the pod is going to run on.
-	// thus, the directory names are renamed so they do not contain the arch suffix (linux-glibc)
-	// which can be used by the webhook.
-	// The following link is a temporary support for the deprecated dotnet virtual devices.
-	// TODO: remove this once we delete the virtual devices.
-	err = createDotnetDeprecatedDirectories(path.Join(dstDir, "dotnet"))
-	if err != nil {
-		logger.Error("Error creating dotnet deprecated directories", "err", err)
-		return err
 	}
 
 	logger.Info("Odigos agents directory copied to host", "elapsed", time.Since(startTime))

--- a/common/fs/copy.go
+++ b/common/fs/copy.go
@@ -8,7 +8,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	commonlogger "github.com/odigos-io/odigos/common/logger"
@@ -228,42 +227,4 @@ func findHashVersionFiles(filePath string) ([]string, error) {
 		return nil, err
 	}
 	return matches, nil
-}
-
-func createDotnetDeprecatedDirectories(destDir string) error {
-	var err error
-	arch := getArch()
-	dotnetSoFile := "OpenTelemetry.AutoInstrumentation.Native.so"
-	glibcDir := filepath.Join(destDir, "linux-glibc")
-	muslDir := filepath.Join(destDir, "linux-musl")
-	glibcDirWithArch := filepath.Join(destDir, "linux-glibc-"+arch)
-	muslDirWithArch := filepath.Join(destDir, "linux-musl-"+arch)
-
-	err = os.MkdirAll(glibcDirWithArch, os.ModePerm)
-	if err != nil {
-		return err
-	}
-	err = os.MkdirAll(muslDirWithArch, os.ModePerm)
-	if err != nil {
-		return err
-	}
-
-	err = os.Symlink(filepath.Join(glibcDir, dotnetSoFile), filepath.Join(glibcDirWithArch, dotnetSoFile))
-	if err != nil {
-		return err
-	}
-	err = os.Symlink(filepath.Join(muslDir, dotnetSoFile), filepath.Join(muslDirWithArch, dotnetSoFile))
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func getArch() string {
-	if runtime.GOARCH == "arm64" {
-		return "arm64"
-	}
-
-	return "x64"
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Remove redundant dotnet fix in the upgrade flow.
This is no longer needed.
#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
refactor: Remove redundant dotnet fix in the upgrade flow
```
