### PR TITLE
chore: add pid to identifying attributes on ebpf instrumentation instances CRs

### DIFF
--- a/odiglet/pkg/ebpf/reporter.go
+++ b/odiglet/pkg/ebpf/reporter.go
@@ -3,12 +3,14 @@ package ebpf
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/odigos-io/odigos/api/k8sconsts"
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/instrumentation"
 	instance "github.com/odigos-io/odigos/k8sutils/pkg/instrumentation_instance"
 	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
+	semconv "go.opentelemetry.io/otel/semconv/v1.38.0"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -111,5 +113,11 @@ func (r *k8sReporter) updateInstrumentationInstanceStatus(ctx context.Context, k
 	return instance.UpdateInstrumentationInstanceStatus(ctx, ke.Pod, ke.ContainerName, r.client, instrumentedAppName, pid, r.client.Scheme(),
 		instance.WithHealthy(&healthy, string(reason), &msg),
 		instance.WithComponents(components),
+		instance.WithAttributes([]odigosv1.Attribute{
+			{
+				Key:   string(semconv.ProcessPIDKey),
+				Value: strconv.FormatInt(int64(pid), 10),
+			},
+		}, nil),
 	)
 }

--- a/tests/common/assert/simple-demo-instrumented-full.yaml
+++ b/tests/common/assert/simple-demo-instrumented-full.yaml
@@ -550,6 +550,8 @@ metadata:
     instrumented-app: deployment-membership
 status:
   healthy: true
+  (identifyingAttributes[?key == 'process.pid']):
+    - (value != null): true
   reason: LoadedSuccessfully
 ---
 ### Simple-demo Deployments ###


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->

Add `process.pid` identifying attributes to all the ebpf-manager created instrumentation instances - this helps the UI sort the instrumentation instances it presents.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
chore: add pid to identifying attributes on ebpf instrumentation instances CRs
```

emergency-ticket id: EMR-1911
