### PR TITLE
CORE-1201: add new ebpf core metrics to victoria metrics and collection metrics

### DIFF
--- a/autoscaler/controllers/nodecollector/collectorconfig/ownmetrics-victoriametrics.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/ownmetrics-victoriametrics.go
@@ -24,6 +24,9 @@ const (
 	// keep only the eBPF instrumentation counters (java, python, nodejs) exposed by the odiglet.
 	ebpfInstrumentationMetricsRegexPattern = "odigos_(java|python|nodejs)_ebpf_instrumentation_.*"
 
+	// keep the ebpf-core shared-buffer event counters (emitted by the go/java greatwall instrumentations for example)
+	ebpfCoreEventsRegexPattern = "odigos_ebpf_events_(sent|send_failed)_.*"
+
 	// the cluster collector's own-metrics OTLP http receiver listens on this port.
 	clusterCollectorOwnMetricsOtlpHttpPort = 44318
 )
@@ -34,6 +37,8 @@ func odigletMetricsReceiverConfig(odigosNamespace string) config.GenericMap {
 		odigosNamespace,
 		k8sconsts.OdigletMetricsServerPort,
 	)
+
+	keepRegex := fmt.Sprintf("%s|%s", ebpfInstrumentationMetricsRegexPattern, ebpfCoreEventsRegexPattern)
 
 	return config.GenericMap{
 		odigletMetricsReceiverName: config.GenericMap{
@@ -51,7 +56,7 @@ func odigletMetricsReceiverConfig(odigosNamespace string) config.GenericMap {
 						"metric_relabel_configs": []config.GenericMap{
 							{
 								"source_labels": []string{"__name__"},
-								"regex":         ebpfInstrumentationMetricsRegexPattern,
+								"regex":         keepRegex,
 								"action":        "keep",
 							},
 						},

--- a/frontend/services/metrics/collector_metrics.go
+++ b/frontend/services/metrics/collector_metrics.go
@@ -36,9 +36,9 @@ const (
 	metricNodeJSFailedSpans   = "odigos_nodejs_ebpf_instrumentation_output_failed_events"
 	metricNodeJSTooLargeSpans = "odigos_nodejs_ebpf_instrumentation_events_too_larger"
 
-	// eBPF core metrics. rateSumByPod appends an optional `(_total)?`, so omit the suffix here.
-	metricEBPFCoreSentEvents   = "ebpf_events_sent"
-	metricEBPFCoreFailedEvents = "ebpf_events_send_failed"
+	// eBPF core metrics
+	metricEBPFCoreSentEvents   = "odigos_ebpf_events_sent"
+	metricEBPFCoreFailedEvents = "odigos_ebpf_events_send_failed"
 )
 
 type PodRates struct {

--- a/frontend/services/metrics/collector_metrics.go
+++ b/frontend/services/metrics/collector_metrics.go
@@ -35,6 +35,10 @@ const (
 	metricNodeJSSentSpans     = "odigos_nodejs_ebpf_instrumentation_sent_events"
 	metricNodeJSFailedSpans   = "odigos_nodejs_ebpf_instrumentation_output_failed_events"
 	metricNodeJSTooLargeSpans = "odigos_nodejs_ebpf_instrumentation_events_too_larger"
+
+	// eBPF core metrics. rateSumByPod appends an optional `(_total)?`, so omit the suffix here.
+	metricEBPFCoreSentEvents   = "ebpf_events_sent"
+	metricEBPFCoreFailedEvents = "ebpf_events_send_failed"
 )
 
 type PodRates struct {
@@ -82,6 +86,9 @@ func GetCollectorMetricsFromMetricsStore(ctx context.Context, api v1.API, namesp
 	// NodeJS metrics
 	queryNodeJSSent := rateSumByPod(metricNodeJSSentSpans, podRegex, window)
 	queryNodeJSDropped := rateSumByPod(fmt.Sprintf("(%s|%s)", metricNodeJSFailedSpans, metricNodeJSTooLargeSpans), podRegex, window)
+	// eBPF core (go/c++ shared-buffer) metrics
+	queryEBPFCoreSent := rateSumByPod(metricEBPFCoreSentEvents, podRegex, window)
+	queryEBPFCoreFailed := rateSumByPod(metricEBPFCoreFailedEvents, podRegex, window)
 
 	otelReceiverAccepted, tsAcc, err := queryVector(ctx, api, queryOtelReceiverAccepted, now)
 	if err != nil {
@@ -123,6 +130,14 @@ func GetCollectorMetricsFromMetricsStore(ctx context.Context, api v1.API, namesp
 	if err != nil {
 		return nil, err
 	}
+	ebpfCoreSent, tsEBPFCoreSent, err := queryVector(ctx, api, queryEBPFCoreSent, now)
+	if err != nil {
+		return nil, err
+	}
+	ebpfCoreFailed, tsEBPFCoreFailed, err := queryVector(ctx, api, queryEBPFCoreFailed, now)
+	if err != nil {
+		return nil, err
+	}
 	result := make(map[string]PodRates, len(podNames))
 	for _, pod := range podNames {
 		result[pod] = PodRates{
@@ -130,7 +145,7 @@ func GetCollectorMetricsFromMetricsStore(ctx context.Context, api v1.API, namesp
 		}
 	}
 
-	lastScrape := maxTime(tsAcc, tsRef, tsSent, tsFail, tsEBPFAccept, tsEBPFDrop, tsPythonSent, tsPythonDropped, tsNodeJSSent, tsNodeJSDropped)
+	lastScrape := maxTime(tsAcc, tsRef, tsSent, tsFail, tsEBPFAccept, tsEBPFDrop, tsPythonSent, tsPythonDropped, tsNodeJSSent, tsNodeJSDropped, tsEBPFCoreSent, tsEBPFCoreFailed)
 
 	for pod := range result {
 		r := result[pod]
@@ -138,8 +153,8 @@ func GetCollectorMetricsFromMetricsStore(ctx context.Context, api v1.API, namesp
 		// A single pod can receive spans through both the eBPF receiver and the OTel built-in receiver, since not all instrumentations go through eBPF.
 		// Sum both receiver sources for accepted.
 		// refused/dropped spans are aggregated under dropped.
-		r.MetricsAcceptedRps = sumByPod(pod, otelReceiverAccepted, ebpfReceiverAccepted, pythonSent, nodeJSSent)
-		r.MetricsDroppedRps = sumByPod(pod, ebpfReceiverDropped, otelReceiverRefused, pythonDropped, nodeJSDropped)
+		r.MetricsAcceptedRps = sumByPod(pod, otelReceiverAccepted, ebpfReceiverAccepted, pythonSent, nodeJSSent, ebpfCoreSent)
+		r.MetricsDroppedRps = sumByPod(pod, ebpfReceiverDropped, otelReceiverRefused, pythonDropped, nodeJSDropped, ebpfCoreFailed)
 
 		if v, ok := expSent[pod]; ok {
 			r.ExporterSuccessRps = v


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
ebpf core, which is used by the go and java instrumentations, is now emitting two new and relevant metrics that can be used for calculating span drop %:
`odigos_ebpf_events_sent`
and
`odigos_ebpf_events_send_failed`

as of this current moment the `odigos_` part has been freshly added, so we wait for this to be updated in the OSS and enterprise repos:
https://github.com/odigos-io/ebpf-core/pull/27


#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Add ebpf core metrics to victoria metrics
```
