### PR TITLE
feat(collector): add ebpf logs metrics | RUN-811 (#5110)

### DIFF
--- a/collector/receivers/odigosebpfreceiver/documentation.md
+++ b/collector/receivers/odigosebpfreceiver/documentation.md
@@ -37,3 +37,19 @@ Total number of bytes read from the eBPF buffer (perf or ring).
 | Unit | Metric Type | Value Type | Monotonic | Stability |
 | ---- | ----------- | ---------- | --------- | --------- |
 | bytes | Sum | Int | true | Development |
+
+### otelcol_odigos_ebpf_logs_with_context
+
+Total number of captured log records emitted with trace context (trace_id/span_id) attached.
+
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| {logs} | Sum | Int | true | Development |
+
+### otelcol_odigos_ebpf_logs_without_context
+
+Total number of captured log records emitted without trace context (no active span for the writing thread).
+
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| {logs} | Sum | Int | true | Development |

--- a/collector/receivers/odigosebpfreceiver/internal/metadata/generated_telemetry.go
+++ b/collector/receivers/odigosebpfreceiver/internal/metadata/generated_telemetry.go
@@ -30,6 +30,8 @@ type TelemetryBuilder struct {
 	EbpfLostSamples                 metric.Int64Counter
 	EbpfMemoryPressureWaitTimeTotal metric.Int64Counter
 	EbpfTotalBytesRead              metric.Int64Counter
+	OdigosEbpfLogsWithContext       metric.Int64Counter
+	OdigosEbpfLogsWithoutContext    metric.Int64Counter
 }
 
 // TelemetryBuilderOption applies changes to default builder.
@@ -83,6 +85,18 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		"otelcol_ebpf_total_bytes_read",
 		metric.WithDescription("Total number of bytes read from the eBPF buffer (perf or ring). [Development]"),
 		metric.WithUnit("bytes"),
+	)
+	errs = errors.Join(errs, err)
+	builder.OdigosEbpfLogsWithContext, err = builder.meter.Int64Counter(
+		"otelcol_odigos_ebpf_logs_with_context",
+		metric.WithDescription("Total number of captured log records emitted with trace context (trace_id/span_id) attached. [Development]"),
+		metric.WithUnit("{logs}"),
+	)
+	errs = errors.Join(errs, err)
+	builder.OdigosEbpfLogsWithoutContext, err = builder.meter.Int64Counter(
+		"otelcol_odigos_ebpf_logs_without_context",
+		metric.WithDescription("Total number of captured log records emitted without trace context (no active span for the writing thread). [Development]"),
+		metric.WithUnit("{logs}"),
 	)
 	errs = errors.Join(errs, err)
 	return &builder, errs

--- a/collector/receivers/odigosebpfreceiver/internal/metadatatest/generated_telemetrytest.go
+++ b/collector/receivers/odigosebpfreceiver/internal/metadatatest/generated_telemetrytest.go
@@ -82,3 +82,35 @@ func AssertEqualEbpfTotalBytesRead(t *testing.T, tt *componenttest.Telemetry, dp
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
+
+func AssertEqualOdigosEbpfLogsWithContext(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_odigos_ebpf_logs_with_context",
+		Description: "Total number of captured log records emitted with trace context (trace_id/span_id) attached. [Development]",
+		Unit:        "{logs}",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_odigos_ebpf_logs_with_context")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualOdigosEbpfLogsWithoutContext(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_odigos_ebpf_logs_without_context",
+		Description: "Total number of captured log records emitted without trace context (no active span for the writing thread). [Development]",
+		Unit:        "{logs}",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_odigos_ebpf_logs_without_context")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}

--- a/collector/receivers/odigosebpfreceiver/internal/metadatatest/generated_telemetrytest_test.go
+++ b/collector/receivers/odigosebpfreceiver/internal/metadatatest/generated_telemetrytest_test.go
@@ -24,6 +24,8 @@ func TestSetupTelemetry(t *testing.T) {
 	tb.EbpfLostSamples.Add(context.Background(), 1)
 	tb.EbpfMemoryPressureWaitTimeTotal.Add(context.Background(), 1)
 	tb.EbpfTotalBytesRead.Add(context.Background(), 1)
+	tb.OdigosEbpfLogsWithContext.Add(context.Background(), 1)
+	tb.OdigosEbpfLogsWithoutContext.Add(context.Background(), 1)
 	AssertEqualEbpfLogsAttrCacheSize(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
@@ -34,6 +36,12 @@ func TestSetupTelemetry(t *testing.T) {
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualEbpfTotalBytesRead(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualOdigosEbpfLogsWithContext(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualOdigosEbpfLogsWithoutContext(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 

--- a/collector/receivers/odigosebpfreceiver/logs.go
+++ b/collector/receivers/odigosebpfreceiver/logs.go
@@ -164,6 +164,14 @@ func (r *ebpfReceiver) logsReadLoop(ctx context.Context, m *ebpf.Map, attrCache 
 
 		ld := logEventToPdata(event)
 
+		// Track how many captured logs carry trace context vs none, so the
+		// log↔trace correlation rate is observable without querying the backend.
+		if event.HasContext == 1 {
+			r.telemetry.OdigosEbpfLogsWithContext.Add(ctx, 1)
+		} else {
+			r.telemetry.OdigosEbpfLogsWithoutContext.Add(ctx, 1)
+		}
+
 		// Add resource attributes from packed attrs if available
 		if packedAttrs != "" && ld.ResourceLogs().Len() > 0 {
 			resourceAttrs := ld.ResourceLogs().At(0).Resource().Attributes()

--- a/collector/receivers/odigosebpfreceiver/metadata.yaml
+++ b/collector/receivers/odigosebpfreceiver/metadata.yaml
@@ -43,3 +43,21 @@ telemetry:
         value_type: int
         monotonic: true
       stability: development
+    
+    odigos_ebpf_logs_with_context:
+      enabled: true
+      description: "Total number of captured log records emitted with trace context (trace_id/span_id) attached."
+      unit: "{logs}"
+      sum:
+        value_type: int
+        monotonic: true
+      stability: development
+
+    odigos_ebpf_logs_without_context:
+      enabled: true
+      description: "Total number of captured log records emitted without trace context (no active span for the writing thread)."
+      unit: "{logs}"
+      sum:
+        value_type: int
+        monotonic: true
+      stability: development


### PR DESCRIPTION
Add metrics for logs outputted through ebpflogreceiver

feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below. If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Add metrics for logs outputted through ebpflogreceiver
```