### PR TITLE
CORE-1092: Fix flakey instrumentationconfig test

### DIFF
--- a/instrumentor/controllers/sourceinstrumentation/instrumentationconfig_controller_test.go
+++ b/instrumentor/controllers/sourceinstrumentation/instrumentationconfig_controller_test.go
@@ -60,19 +60,23 @@ var _ = Describe("deleteInstrumentationConfig InstrumentationConfig controller",
 			})
 		})
 
-		When("InstrumentationConfig is deleted after source removal", func() {
+		When("InstrumentationConfig is deleted when no source applies", func() {
 			It("Does not recreate InstrumentationConfig", func() {
 				namespace = testutil.NewMockNamespace()
 				Expect(k8sClient.Create(ctx, namespace)).Should(Succeed())
+
+				source := testutil.NewMockSource(namespace, false)
+				Expect(k8sClient.Create(ctx, source)).Should(Succeed())
 
 				deployment = testutil.NewMockTestDeployment(namespace, "test-deployment")
 				Expect(k8sClient.Create(ctx, deployment)).Should(Succeed())
 
 				instrumentationConfig = testutil.NewMockInstrumentationConfig(deployment)
-				Expect(k8sClient.Create(ctx, instrumentationConfig)).Should(Succeed())
+				testutil.AssertInstrumentationConfigCreated(ctx, k8sClient, instrumentationConfig)
 
-				Expect(k8sClient.Delete(ctx, instrumentationConfig)).Should(Succeed())
+				Expect(k8sClient.Delete(ctx, source)).Should(Succeed())
 				testutil.AssertInstrumentationConfigDeleted(ctx, k8sClient, instrumentationConfig)
+				testutil.AssertInstrumentationConfigNotCreated(ctx, k8sClient, instrumentationConfig)
 			})
 		})
 


### PR DESCRIPTION
#### What this PR does / why we need it:
https://github.com/odigos-io/odigos/pull/5013/changes#diff-45a3b7934924f07757976d0ab1a74df3424bfd76e50b426582fe4cb851d3a1f0 introduced a test to check that the changes to sourceinstrumentation controller don't cause an IC to be created when it shouldn't (ie, that it's deleted during uninstrumentation). However that test is flakey, trying to `Delete` the IC manually which can lead to failures like this one if the manual `Delete` happens after the IC controller has actually deleted it (which it should) (https://github.com/odigos-io/odigos/actions/runs/28055342075/job/83056121301?pr=4990)

This rewrites it to check that the IC doesn't get recreated after source deletion, which is a more logical flow

cherry-pick:v1.30

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
