### PR TITLE
CI: renew ECR public domain

### DIFF
--- a/.github/workflows/build-dev-images.yml
+++ b/.github/workflows/build-dev-images.yml
@@ -4,25 +4,25 @@ on:
   workflow_call: # Workflow trigger
     inputs:
       target_tag:
-        description: 'The tag to use when pushing the images to the registry'
+        description: "The tag to use when pushing the images to the registry"
         required: false
         type: string
       registry:
-        description: 'The registry to push images to'
+        description: "The registry to push images to"
         required: false
         type: string
-        default: public.ecr.aws/y2v0v6s7
+        default: public.ecr.aws/y7i2a5w6
   workflow_dispatch: # Manual trigger
     inputs:
       target_tag:
-        description: 'The tag to use when pushing the images to the registry'
+        description: "The tag to use when pushing the images to the registry"
         required: false
         type: string
       registry:
-        description: 'The registry to push images to'
+        description: "The registry to push images to"
         required: false
         type: string
-        default: public.ecr.aws/y2v0v6s7
+        default: public.ecr.aws/y7i2a5w6
 
 permissions:
   id-token: write
@@ -37,7 +37,7 @@ jobs:
       # If none is provided (as in pull_request), it defaults to github.sha for target_tag
       TARGET_TAG: ${{ (inputs.target_tag || github.event.inputs.target_tag) || github.sha }}
       # For REGISTRY, it falls back to the default value provided here if no input is available.
-      REGISTRY: ${{ (inputs.registry || github.event.inputs.registry) || 'public.ecr.aws/y2v0v6s7' }}
+      REGISTRY: ${{ (inputs.registry || github.event.inputs.registry) || 'public.ecr.aws/y7i2a5w6' }}
       # TF_REGION: us-east-1
 
     steps:
@@ -66,35 +66,33 @@ jobs:
           make build-images TAG=${COMMIT_HASH}
 
           # Tag images for public ECR
-          docker tag ${DOCKER_REGISTRY}/odigos-collector:${COMMIT_HASH} public.ecr.aws/y2v0v6s7/odigos-collector:${COMMIT_HASH}
-          docker tag ${DOCKER_REGISTRY}/odigos-instrumentor:${COMMIT_HASH} public.ecr.aws/y2v0v6s7/odigos-instrumentor:${COMMIT_HASH}
-          docker tag ${DOCKER_REGISTRY}/odigos-ui:${COMMIT_HASH} public.ecr.aws/y2v0v6s7/odigos-ui:${COMMIT_HASH}
-          docker tag ${DOCKER_REGISTRY}/odigos-scheduler:${COMMIT_HASH} public.ecr.aws/y2v0v6s7/odigos-scheduler:${COMMIT_HASH}
-          docker tag ${DOCKER_REGISTRY}/odigos-autoscaler:${COMMIT_HASH} public.ecr.aws/y2v0v6s7/odigos-autoscaler:${COMMIT_HASH}
-          docker tag ${DOCKER_REGISTRY}/odigos-odiglet:${COMMIT_HASH} public.ecr.aws/y2v0v6s7/odigos-odiglet:${COMMIT_HASH}
-
+          docker tag ${DOCKER_REGISTRY}/odigos-collector:${COMMIT_HASH} public.ecr.aws/y7i2a5w6/odigos-collector:${COMMIT_HASH}
+          docker tag ${DOCKER_REGISTRY}/odigos-instrumentor:${COMMIT_HASH} public.ecr.aws/y7i2a5w6/odigos-instrumentor:${COMMIT_HASH}
+          docker tag ${DOCKER_REGISTRY}/odigos-ui:${COMMIT_HASH} public.ecr.aws/y7i2a5w6/odigos-ui:${COMMIT_HASH}
+          docker tag ${DOCKER_REGISTRY}/odigos-scheduler:${COMMIT_HASH} public.ecr.aws/y7i2a5w6/odigos-scheduler:${COMMIT_HASH}
+          docker tag ${DOCKER_REGISTRY}/odigos-autoscaler:${COMMIT_HASH} public.ecr.aws/y7i2a5w6/odigos-autoscaler:${COMMIT_HASH}
+          docker tag ${DOCKER_REGISTRY}/odigos-odiglet:${COMMIT_HASH} public.ecr.aws/y7i2a5w6/odigos-odiglet:${COMMIT_HASH}
 
       - uses: ko-build/setup-ko@v0.9
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
         with:
-          go-version: '1.26.2'
+          go-version: "1.26.2"
       - name: Build CLI Image
         env:
           COMMIT_HASH: ${{ github.sha }}
           DOCKER_REGISTRY: registry.odigos.io
         run: |
           make build-cli-image TAG=${COMMIT_HASH}
-          docker tag ${DOCKER_REGISTRY}/odigos-cli:${COMMIT_HASH} public.ecr.aws/y2v0v6s7/odigos-cli:${COMMIT_HASH}
-
+          docker tag ${DOCKER_REGISTRY}/odigos-cli:${COMMIT_HASH} public.ecr.aws/y7i2a5w6/odigos-cli:${COMMIT_HASH}
 
       - name: Push Docker Images to ECR
         env:
           COMMIT_HASH: ${{ github.sha }}
         run: |
-          docker push public.ecr.aws/y2v0v6s7/odigos-collector:${COMMIT_HASH}
-          docker push public.ecr.aws/y2v0v6s7/odigos-instrumentor:${COMMIT_HASH}
-          docker push public.ecr.aws/y2v0v6s7/odigos-ui:${COMMIT_HASH}
-          docker push public.ecr.aws/y2v0v6s7/odigos-scheduler:${COMMIT_HASH}
-          docker push public.ecr.aws/y2v0v6s7/odigos-autoscaler:${COMMIT_HASH}
-          docker push public.ecr.aws/y2v0v6s7/odigos-odiglet:${COMMIT_HASH}
-          docker push public.ecr.aws/y2v0v6s7/odigos-cli:${COMMIT_HASH}
+          docker push public.ecr.aws/y7i2a5w6/odigos-collector:${COMMIT_HASH}
+          docker push public.ecr.aws/y7i2a5w6/odigos-instrumentor:${COMMIT_HASH}
+          docker push public.ecr.aws/y7i2a5w6/odigos-ui:${COMMIT_HASH}
+          docker push public.ecr.aws/y7i2a5w6/odigos-scheduler:${COMMIT_HASH}
+          docker push public.ecr.aws/y7i2a5w6/odigos-autoscaler:${COMMIT_HASH}
+          docker push public.ecr.aws/y7i2a5w6/odigos-odiglet:${COMMIT_HASH}
+          docker push public.ecr.aws/y7i2a5w6/odigos-cli:${COMMIT_HASH}

--- a/tests/chaos/network-latency/leader-election/chainsaw-test.yaml
+++ b/tests/chaos/network-latency/leader-election/chainsaw-test.yaml
@@ -20,7 +20,7 @@ spec:
             content: |
               # The pwd is the directory of this file, so we have to walk up to the project root to find the helm chart
               P="../../../.."
-              helm upgrade --install odigos $P/helm/odigos --create-namespace --namespace odigos-test --set image.tag="$COMMIT_HASH" --set imagePrefix=public.ecr.aws/y2v0v6s7 --wait --timeout 5m
+              helm upgrade --install odigos $P/helm/odigos --create-namespace --namespace odigos-test --set image.tag="$COMMIT_HASH" --set imagePrefix=public.ecr.aws/y7i2a5w6 --wait --timeout 5m
               kubectl label namespace odigos-test odigos.io/system-object="true"
 
     - name: Verify Odigos Installation

--- a/tests/e2e/data-streams/chainsaw-test.yaml
+++ b/tests/e2e/data-streams/chainsaw-test.yaml
@@ -6,22 +6,22 @@ spec:
   description: This e2e test runs a data streams scenario
   skipDelete: true
   steps:
-    - name: '[1 - Setup] Prepare destination 1'
+    - name: "[1 - Setup] Prepare destination 1"
       try:
         - apply:
             file: ../../common/apply/simple-trace-db-deployment.yaml
-    - name: '[1 - Setup] Prepare destination 2'
+    - name: "[1 - Setup] Prepare destination 2"
       try:
         - apply:
             file: ../../common/apply/simple-trace-db-deployment-2.yaml
 
-    - name: '[1 - Setup] Install Odigos'
+    - name: "[1 - Setup] Install Odigos"
       try:
         - script:
             timeout: 4m
             content: |
               if [ "$MODE" = "cross-cloud-tests" ]; then
-                ../../../cli/odigos install --ns odigos-test --set image.tag="$COMMIT_HASH" --set imagePrefix=public.ecr.aws/y2v0v6s7
+                ../../../cli/odigos install --ns odigos-test --set image.tag="$COMMIT_HASH" --set imagePrefix=public.ecr.aws/y7i2a5w6
               else
                 ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test
               fi
@@ -31,24 +31,24 @@ spec:
         - assert:
             file: ../../common/assert/odigos-installed.yaml
 
-    - name: '[1 - Setup] Verify Node Odiglet label has been added'
+    - name: "[1 - Setup] Verify Node Odiglet label has been added"
       try:
         - assert:
             file: ../../common/assert/node-odiglet-label.yaml
 
-    - name: '[1 - Setup] Assert Trace DB 1 is up'
+    - name: "[1 - Setup] Assert Trace DB 1 is up"
       try:
         - assert:
             timeout: 1m
             file: ../../common/assert/simple-trace-db-running.yaml
 
-    - name: '[1 - Setup] Assert Trace DB 2 is up'
+    - name: "[1 - Setup] Assert Trace DB 2 is up"
       try:
         - assert:
             timeout: 1m
             file: ../../common/assert/simple-trace-db-running-2.yaml
 
-    - name: '[1 - Setup] Install - Simple Demo Apps'
+    - name: "[1 - Setup] Install - Simple Demo Apps"
       try:
         - apply:
             file: ../../common/apply/install-simple-demo.yaml
@@ -56,31 +56,31 @@ spec:
             timeout: 3m
             file: ../../common/assert/simple-demo-installed.yaml
 
-    - name: '[2 - Workload Instrumentation] Instrument Deployments using Sources'
+    - name: "[2 - Workload Instrumentation] Instrument Deployments using Sources"
       try:
         - apply:
             file: 01-sources.yaml
 
-    - name: '[2 - Workload Instrumentation] Assert Runtime Detected'
+    - name: "[2 - Workload Instrumentation] Assert Runtime Detected"
       try:
         - assert:
             timeout: 2m
             file: ../../common/assert/simple-demo-runtime-detected.yaml
 
-    - name: '[2 - Workload Instrumentation] Add Destinations for data streams'
+    - name: "[2 - Workload Instrumentation] Add Destinations for data streams"
       try:
         - apply:
             file: ../../common/apply/add-simple-trace-db-destination-stream-1.yaml
         - apply:
             file: ../../common/apply/add-simple-trace-db-destination-stream-2.yaml
 
-    - name: '[2 - Workload Instrumentation] Odigos pipeline ready'
+    - name: "[2 - Workload Instrumentation] Odigos pipeline ready"
       try:
         - assert:
             timeout: 1m
             file: ../../common/assert/pipeline-ready.yaml
 
-    - name: '[2 - Workload Instrumentation] Simple-demo instrumented after destination added'
+    - name: "[2 - Workload Instrumentation] Simple-demo instrumented after destination added"
       try:
         - assert:
             file: ../../common/assert/simple-demo-instrumented.yaml
@@ -109,7 +109,7 @@ spec:
               ## This sleep here to ensure configuration is updated in the collector because of the debounce mechanism
               sleep 5
 
-    - name: '[2 - Workload Instrumentation] Generate Traffic'
+    - name: "[2 - Workload Instrumentation] Generate Traffic"
       try:
         - apply:
             file: ../../common/apply/generate-traffic-job.yaml

--- a/tests/e2e/helm-chart/chainsaw-test.yaml
+++ b/tests/e2e/helm-chart/chainsaw-test.yaml
@@ -31,7 +31,7 @@ spec:
               if [ "$MODE" = "cross-cloud-tests" ]; then
                 helm upgrade --install odigos $P/helm/odigos --create-namespace --namespace odigos-test \
                   --set image.tag="$COMMIT_HASH" \
-                  --set imagePrefix=public.ecr.aws/y2v0v6s7 \
+                  --set imagePrefix=public.ecr.aws/y7i2a5w6 \
                   --set nodeSelector."kubernetes\.io/os"=linux \
                   --set collectorNode.memoryLimit=560 \
                   --set collectorNode.limitCPUm=550
@@ -126,7 +126,6 @@ spec:
         - assert:
             timeout: 3m
             file: ../../common/assert/simple-demo-runtime-detected.yaml
-
 
     - name: Odigos pipeline ready
       try:

--- a/tests/e2e/helm-upgrade/chainsaw-test.yaml
+++ b/tests/e2e/helm-upgrade/chainsaw-test.yaml
@@ -114,7 +114,7 @@ spec:
                 helm upgrade odigos $P/helm/odigos \
                   --namespace odigos-test \
                   --set image.tag="$COMMIT_HASH" \
-                  --set imagePrefix=public.ecr.aws/y2v0v6s7 \
+                  --set imagePrefix=public.ecr.aws/y7i2a5w6 \
                   --set nodeSelector."kubernetes\.io/os"=linux
               else
                 helm upgrade odigos $P/helm/odigos \

--- a/tests/e2e/instrumentation-rollback-stability-window/chainsaw-test.yaml
+++ b/tests/e2e/instrumentation-rollback-stability-window/chainsaw-test.yaml
@@ -19,7 +19,7 @@ spec:
               # The pwd is the directory of this file, so we have to walk up to the project root to find the helm chart
               P="../../.."
               if [ "$MODE" = "cross-cloud-tests" ]; then
-                helm upgrade --install odigos $P/helm/odigos --create-namespace --namespace odigos-test --set image.tag="$COMMIT_HASH" --set imagePrefix=public.ecr.aws/y2v0v6s7 --set nodeSelector."kubernetes\.io/os"=linux --set autoRollback.graceTime=3m --set autoRollback.stabilityWindowTime=2m
+                helm upgrade --install odigos $P/helm/odigos --create-namespace --namespace odigos-test --set image.tag="$COMMIT_HASH" --set imagePrefix=public.ecr.aws/y7i2a5w6 --set nodeSelector."kubernetes\.io/os"=linux --set autoRollback.graceTime=3m --set autoRollback.stabilityWindowTime=2m
               else
                 helm upgrade --install odigos $P/helm/odigos --create-namespace --namespace odigos-test --set image.tag=e2e-test  --set nodeSelector."kubernetes\.io/os"=linux --set autoRollback.graceTime=3m --set autoRollback.stabilityWindowTime=2m
               fi

--- a/tests/e2e/instrumentation-rollback/chainsaw-test.yaml
+++ b/tests/e2e/instrumentation-rollback/chainsaw-test.yaml
@@ -19,7 +19,7 @@ spec:
               # The pwd is the directory of this file, so we have to walk up to the project root to find the helm chart
               P="../../.."
               if [ "$MODE" = "cross-cloud-tests" ]; then
-                helm upgrade --install odigos $P/helm/odigos --create-namespace --namespace odigos-test --set image.tag="$COMMIT_HASH" --set imagePrefix=public.ecr.aws/y2v0v6s7 --set nodeSelector."kubernetes\.io/os"=linux --set autoRollback.graceTime=90s
+                helm upgrade --install odigos $P/helm/odigos --create-namespace --namespace odigos-test --set image.tag="$COMMIT_HASH" --set imagePrefix=public.ecr.aws/y7i2a5w6 --set nodeSelector."kubernetes\.io/os"=linux --set autoRollback.graceTime=90s
               else
                 helm upgrade --install odigos $P/helm/odigos --create-namespace --namespace odigos-test --set image.tag=e2e-test  --set nodeSelector."kubernetes\.io/os"=linux --set autoRollback.graceTime=90s
               fi

--- a/tests/e2e/mount-method/chainsaw-test.yaml
+++ b/tests/e2e/mount-method/chainsaw-test.yaml
@@ -6,23 +6,23 @@ spec:
   description: This e2e test runs a multi-apps scenario testing both init-container and CSI driver mount methods
   skipDelete: true
   steps:
-    - name: '[1 - Setup] Install - Simple Demo Apps'
+    - name: "[1 - Setup] Install - Simple Demo Apps"
       try:
         - apply:
             file: ../../common/apply/install-simple-demo.yaml
 
-    - name: '[1 - Setup] Prepare destination'
+    - name: "[1 - Setup] Prepare destination"
       try:
         - apply:
             file: ../../common/apply/simple-trace-db-deployment.yaml
 
-    - name: '[1 - Setup] Install Odigos'
+    - name: "[1 - Setup] Install Odigos"
       try:
         - script:
             timeout: 4m
             content: |
               if [ "$MODE" = "cross-cloud-tests" ]; then
-                ../../../cli/odigos install --ns odigos-test --set image.tag="$COMMIT_HASH" --set imagePrefix=public.ecr.aws/y2v0v6s7 --set instrumentor.mountMethod=k8s-init-container
+                ../../../cli/odigos install --ns odigos-test --set image.tag="$COMMIT_HASH" --set imagePrefix=public.ecr.aws/y7i2a5w6 --set instrumentor.mountMethod=k8s-init-container
               else
                 ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test --set instrumentor.mountMethod=k8s-init-container
               fi
@@ -32,20 +32,19 @@ spec:
             timeout: 3m
             file: ../../common/assert/odigos-installed-no-device-plugin.yaml
 
-    - name: '[1 - Setup] Assert - Simple Demo Apps Installed'
+    - name: "[1 - Setup] Assert - Simple Demo Apps Installed"
       try:
         - assert:
             timeout: 3m
             file: ../../common/assert/simple-demo-installed.yaml
 
-
-    - name: '[1 - Setup] Assert config set successfully'
+    - name: "[1 - Setup] Assert config set successfully"
       try:
         - script:
             timeout: 30s
             content: ../../common/assert_config_value.sh -k mountMethod -v k8s-init-container
 
-    - name: '[1 - Setup] Wait for odiglet to be rolled out'
+    - name: "[1 - Setup] Wait for odiglet to be rolled out"
       try:
         - script:
             timeout: 5m
@@ -55,44 +54,42 @@ spec:
 
     ## After setting mount method, device-plugin container removed from odiglet pod spec
     ## so we need to wait for odiglet to be ready
-    - name: '[1 - Setup] Odiglet ready'
+    - name: "[1 - Setup] Odiglet ready"
       try:
         - assert:
             file: odiglet-ready.yaml
 
     # mount method is k8s-init-container, so node is not labeled by odigos.
 
-    - name: '[1 - Setup]Assert Trace DB is up'
+    - name: "[1 - Setup]Assert Trace DB is up"
       try:
         - assert:
             timeout: 1m
             file: ../../common/assert/simple-trace-db-running.yaml
 
-    - name: '[1 - Setup] Add Destination'
+    - name: "[1 - Setup] Add Destination"
       try:
         - apply:
             file: ../../common/apply/add-simple-trace-db-destination.yaml
 
-    - name: '[2 - Workload Instrumentation] Instrument default ns workloads'
+    - name: "[2 - Workload Instrumentation] Instrument default ns workloads"
       try:
         - apply:
             file: ../../common/apply/instrument-default-ns.yaml
 
-    - name: '[2 - Workload Instrumentation] Assert Runtime Detected'
+    - name: "[2 - Workload Instrumentation] Assert Runtime Detected"
       try:
         - assert:
             timeout: 2m
             file: ../../common/assert/simple-demo-runtime-detected.yaml
 
-
-    - name: '[2 - Workload Instrumentation] Odigos pipeline ready'
+    - name: "[2 - Workload Instrumentation] Odigos pipeline ready"
       try:
         - assert:
             timeout: 1m
             file: ../../common/assert/pipeline-ready.yaml
 
-
-    - name: '[2 - Workload Instrumentation] Simple-demo instrumented after destination added'
+    - name: "[2 - Workload Instrumentation] Simple-demo instrumented after destination added"
       try:
         - assert:
             file: simple-demo-instrumented.yaml
@@ -100,7 +97,7 @@ spec:
             timeout: 2m
             content: ../../common/wait_for_rollout.sh
 
-    - name: '[2 - Workload Instrumentation] Generate Traffic'
+    - name: "[2 - Workload Instrumentation] Generate Traffic"
       try:
         - apply:
             file: ../../common/apply/generate-traffic-job.yaml
@@ -111,7 +108,7 @@ spec:
         - delete:
             file: ../../common/apply/generate-traffic-job.yaml
 
-    - name: '[2 - Workload Instrumentation] Wait For Trace'
+    - name: "[2 - Workload Instrumentation] Wait For Trace"
       try:
         - script:
             timeout: 1m
@@ -129,8 +126,7 @@ spec:
               java_pod_name=$(kubectl get pods -n default -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep ^frontend)
               kubectl logs $java_pod_name -n default
 
-
-    - name: '[3 - CSI Driver Test] Upgrade to CSI driver mount method'
+    - name: "[3 - CSI Driver Test] Upgrade to CSI driver mount method"
       try:
         - script:
             timeout: 3m
@@ -138,13 +134,13 @@ spec:
               # Upgrade existing installation to CSI driver mount method
               ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test --set instrumentor.mountMethod=k8s-csi-driver
 
-    - name: '[3 - CSI Driver Test] Assert config changed successfully'
+    - name: "[3 - CSI Driver Test] Assert config changed successfully"
       try:
         - script:
             timeout: 30s
             content: ../../common/assert_config_value.sh -k mountMethod -v k8s-csi-driver
 
-    - name: '[3 - CSI Driver Test] Wait for odiglet rollout with CSI driver'
+    - name: "[3 - CSI Driver Test] Wait for odiglet rollout with CSI driver"
       try:
         - script:
             timeout: 5m
@@ -152,13 +148,13 @@ spec:
               # Wait for DaemonSet to update with CSI driver container
               kubectl rollout status daemonset/odiglet -n odigos-test --timeout=5m
 
-    - name: '[3 - CSI Driver Test] Verify odiglet pods ready with CSI driver'
+    - name: "[3 - CSI Driver Test] Verify odiglet pods ready with CSI driver"
       try:
         - assert:
             timeout: 2m
             file: odiglet-ready-with-csi-driver.yaml
 
-    - name: '[3 - CSI Driver Test] Restart trace DB for fresh data'
+    - name: "[3 - CSI Driver Test] Restart trace DB for fresh data"
       try:
         - script:
             timeout: 2m
@@ -166,7 +162,7 @@ spec:
               kubectl delete pod -l app=simple-trace-db -n traces
               kubectl wait --for=condition=Ready pod -l app=simple-trace-db -n traces --timeout=2m
 
-    - name: '[3 - CSI Driver Test] Restart instrumented workloads to get CSI volumes'
+    - name: "[3 - CSI Driver Test] Restart instrumented workloads to get CSI volumes"
       try:
         - script:
             timeout: 3m
@@ -189,13 +185,13 @@ spec:
               kubectl rollout status deployment/pricing --timeout=3m
               kubectl rollout status deployment/geolocation --timeout=3m
 
-    - name: '[3 - CSI Driver Test] Verify CSI volumes are mounted correctly'
+    - name: "[3 - CSI Driver Test] Verify CSI volumes are mounted correctly"
       try:
         - assert:
             timeout: 2m
             file: simple-demo-instrumented-with-csi.yaml
 
-    - name: '[3 - CSI Driver Test] Generate Traffic with CSI driver'
+    - name: "[3 - CSI Driver Test] Generate Traffic with CSI driver"
       try:
         - apply:
             file: ../../common/apply/generate-traffic-job.yaml
@@ -206,7 +202,7 @@ spec:
         - delete:
             file: ../../common/apply/generate-traffic-job.yaml
 
-    - name: '[3 - CSI Driver Test] Wait For CSI Trace'
+    - name: "[3 - CSI Driver Test] Wait For CSI Trace"
       try:
         - script:
             timeout: 1m
@@ -219,7 +215,7 @@ spec:
                 sleep 1
               done
 
-    - name: 'Uninstall Odigos'
+    - name: "Uninstall Odigos"
       try:
         - script:
             timeout: 2m

--- a/tests/e2e/source/chainsaw-test.yaml
+++ b/tests/e2e/source/chainsaw-test.yaml
@@ -6,23 +6,23 @@ spec:
   description: This e2e test runs a multi-apps scenario with Source instrumentation
   skipDelete: true
   steps:
-    - name: '[1 - Setup] Prepare destination'
+    - name: "[1 - Setup] Prepare destination"
       try:
         - apply:
             file: ../../common/apply/simple-trace-db-deployment.yaml
 
-    - name: '[1 - Setup] Install - Simple Demo Apps'
+    - name: "[1 - Setup] Install - Simple Demo Apps"
       try:
         - apply:
             file: ../../common/apply/install-simple-demo.yaml
 
-    - name: '[1 - Setup] Install Odigos'
+    - name: "[1 - Setup] Install Odigos"
       try:
         - script:
             timeout: 4m
             content: |
               if [ "$MODE" = "cross-cloud-tests" ]; then
-                ../../../cli/odigos install --ns odigos-test --set image.tag="$COMMIT_HASH" --set imagePrefix=public.ecr.aws/y2v0v6s7
+                ../../../cli/odigos install --ns odigos-test --set image.tag="$COMMIT_HASH" --set imagePrefix=public.ecr.aws/y7i2a5w6
               else
                 ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test
               fi
@@ -33,49 +33,46 @@ spec:
             timeout: 3m
             file: ../../common/assert/odigos-installed.yaml
 
-    - name: '[1 - Setup] Verify Node Odiglet label has been added'
+    - name: "[1 - Setup] Verify Node Odiglet label has been added"
       try:
         - assert:
             file: ../../common/assert/node-odiglet-label.yaml
 
-    - name: '[1 - Setup]Assert Trace DB is up'
+    - name: "[1 - Setup]Assert Trace DB is up"
       try:
         - assert:
             timeout: 1m
             file: ../../common/assert/simple-trace-db-running.yaml
 
-    - name: '[1 - Setup] Assert - Simple Demo Apps Installed'
+    - name: "[1 - Setup] Assert - Simple Demo Apps Installed"
       try:
         - assert:
             timeout: 3m
             file: ../../common/assert/simple-demo-installed.yaml
 
-    - name: '[1 - Setup] Add Destination'
+    - name: "[1 - Setup] Add Destination"
       try:
         - apply:
             file: ../../common/apply/add-simple-trace-db-destination.yaml
 
-
-    - name: '[2 - Workload Instrumentation] Instrument Deployments using Sources with otelServiceName field set'
+    - name: "[2 - Workload Instrumentation] Instrument Deployments using Sources with otelServiceName field set"
       try:
         - apply:
             file: 01-sources.yaml
 
-    - name: '[2 - Workload Instrumentation] Assert Runtime Detected'
+    - name: "[2 - Workload Instrumentation] Assert Runtime Detected"
       try:
         - assert:
             timeout: 2m
             file: ../../common/assert/simple-demo-runtime-detected.yaml
 
-
-    - name: '[2 - Workload Instrumentation] Odigos pipeline ready'
+    - name: "[2 - Workload Instrumentation] Odigos pipeline ready"
       try:
         - assert:
             timeout: 1m
             file: ../../common/assert/pipeline-ready.yaml
 
-
-    - name: '[2 - Workload Instrumentation] Simple-demo instrumented after destination added'
+    - name: "[2 - Workload Instrumentation] Simple-demo instrumented after destination added"
       try:
         - assert:
             file: ../../common/assert/simple-demo-instrumented.yaml
@@ -86,7 +83,7 @@ spec:
             timeout: 70s
             content: ../../common/wait_for_rollout.sh
 
-    - name: '[2 - Workload Instrumentation] Shipping (C++) instrumented with OBI container override'
+    - name: "[2 - Workload Instrumentation] Shipping (C++) instrumented with OBI container override"
       try:
         - assert:
             timeout: 4m
@@ -96,7 +93,7 @@ spec:
             name: odiglet
             namespace: odigos-test
 
-    - name: '[2 - Workload Instrumentation] Generate Traffic'
+    - name: "[2 - Workload Instrumentation] Generate Traffic"
       try:
         - apply:
             file: ../../common/apply/generate-traffic-job.yaml
@@ -107,7 +104,7 @@ spec:
         - delete:
             file: ../../common/apply/generate-traffic-job.yaml
 
-    - name: '[2 - Workload Instrumentation] Wait For Trace'
+    - name: "[2 - Workload Instrumentation] Wait For Trace"
       try:
         - script:
             timeout: 1m
@@ -125,7 +122,7 @@ spec:
               java_pod_name=$(kubectl get pods -n default -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep ^frontend)
               kubectl logs $java_pod_name -n default
 
-    - name: '[2 - Workload Instrumentation] Wait For Shipping Trace (OBI)'
+    - name: "[2 - Workload Instrumentation] Wait For Shipping Trace (OBI)"
       try:
         - script:
             timeout: 3m
@@ -146,7 +143,7 @@ spec:
             name: odiglet
             namespace: odigos-test
 
-    - name: '[2 - Workload Instrumentation] Verify Trace - Context Propagation'
+    - name: "[2 - Workload Instrumentation] Verify Trace - Context Propagation"
       try:
         - script:
             timeout: 3m
@@ -168,7 +165,7 @@ spec:
             name: odiglet
             namespace: odigos-test
 
-    - name: '[2 - Workload Instrumentation] Verify Trace - Span Attributes'
+    - name: "[2 - Workload Instrumentation] Verify Trace - Span Attributes"
       try:
         - script:
             timeout: 3m
@@ -179,7 +176,7 @@ spec:
             name: odiglet
             namespace: odigos-test
 
-    - name: '[2 - Workload Instrumentation] Verify collector metrics are collected by the UI'
+    - name: "[2 - Workload Instrumentation] Verify collector metrics are collected by the UI"
       try:
         - script:
             timeout: 5m
@@ -192,14 +189,14 @@ spec:
                 sleep 5
               done
 
-    - name: '[2 - Workload Instrumentation] Verify collector metrics survive UI pod restart'
+    - name: "[2 - Workload Instrumentation] Verify collector metrics survive UI pod restart"
       try:
         - script:
             timeout: 8m
             content: |
               ../../common/assert_collector_metrics_survive_ui_restart.sh odigos-test
 
-    - name: '[3 - Workload Uninstrumentation] Uninstrument individual deployments'
+    - name: "[3 - Workload Uninstrumentation] Uninstrument individual deployments"
       try:
         - script:
             timeout: 3m
@@ -213,14 +210,13 @@ spec:
                 sleep 5
               done
 
-    - name: '[3 - Workload Uninstrumentation] Assert workloads updated after uninstrumentation'
+    - name: "[3 - Workload Uninstrumentation] Assert workloads updated after uninstrumentation"
       try:
         - assert:
             timeout: 2m
             file: 02-workloads.yaml
 
-
-    - name: 'Uninstall Odigos'
+    - name: "Uninstall Odigos"
       try:
         - script:
             timeout: 2m

--- a/tests/e2e/webhooks/chainsaw-test.yaml
+++ b/tests/e2e/webhooks/chainsaw-test.yaml
@@ -11,7 +11,7 @@ spec:
         - script:
             content: |
               if [ "$MODE" = "cross-cloud-tests" ]; then
-                ../../../cli/odigos install --ns odigos-test --set image.tag="$COMMIT_HASH" --set imagePrefix=public.ecr.aws/y2v0v6s7
+                ../../../cli/odigos install --ns odigos-test --set image.tag="$COMMIT_HASH" --set imagePrefix=public.ecr.aws/y7i2a5w6
               else
                 ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test
               fi
@@ -194,14 +194,14 @@ spec:
             check:
               ($error != null): true
               (contains($stderr, 'Invalid value')): true
-    - name: '[Migration] - Old startlangdetection finalizer is removed and migrated to new combined one'
+    - name: "[Migration] - Old startlangdetection finalizer is removed and migrated to new combined one"
       try:
         - apply:
             file: migration-01-source-with-old-finalizer.yaml
         - assert:
             timeout: 2m
             file: migration-01-assert-source-with-old-finalizer.yaml
-    - name: '[Migration] - Old deleteinstrumentationconfig finalizer is removed and migrated to new combined one'
+    - name: "[Migration] - Old deleteinstrumentationconfig finalizer is removed and migrated to new combined one"
       try:
         - apply:
             file: migration-02-source-with-old-finalizer.yaml


### PR DESCRIPTION
In effort to fully migrate to the new AWS account, this PR changes the default image registry from `public.ecr.aws/y2v0v6s7` to `public.ecr.aws/y7i2a5w6` across multiple workflows and test files.

```release-note
NONE
```

emergency-ticket id: EMR-1945
