### PR TITLE
CORE-1128 | feat: Collector to support journald module for systemd LOGS in the VM

### DIFF
--- a/collector/builder-config.yaml
+++ b/collector/builder-config.yaml
@@ -105,6 +105,7 @@ receivers:
   - gomod: github.com/odigos-io/odigos/collector/receivers/odigosebpfreceiver v0.148.0
   - gomod: go.opentelemetry.io/ebpf-profiler v0.0.202614
     import: go.opentelemetry.io/ebpf-profiler/collector
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver v0.148.0
 
 # https://github.com/open-telemetry/opentelemetry-collector/issues/8127
 excludes:

--- a/collector/odigosotelcol/components.go
+++ b/collector/odigosotelcol/components.go
@@ -76,6 +76,7 @@ import (
 	transformprocessor "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor"
 	filelogreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver"
 	hostmetricsreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver"
+	journaldreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver"
 	k8sclusterreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver"
 	kubeletstatsreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver"
 	prometheusreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
@@ -173,6 +174,7 @@ func components() (otelcol.Factories, error) {
 		prometheusreceiver.NewFactory(),
 		odigosebpfreceiver.NewFactory(),
 		collector.NewFactory(),
+		journaldreceiver.NewFactory(),
 	)
 	if err != nil {
 		return otelcol.Factories{}, err
@@ -187,6 +189,7 @@ func components() (otelcol.Factories, error) {
 		prometheusreceiver.NewFactory().Type():   "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.148.0",
 		odigosebpfreceiver.NewFactory().Type():   "github.com/odigos-io/odigos/collector/receivers/odigosebpfreceiver v0.148.0",
 		collector.NewFactory().Type():            "go.opentelemetry.io/ebpf-profiler v0.0.202614",
+		journaldreceiver.NewFactory().Type():     "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver v0.148.0",
 	})
 
 	factories.Exporters, err = otelcol.MakeFactoryMap[exporter.Factory](

--- a/collector/odigosotelcol/go.mod
+++ b/collector/odigosotelcol/go.mod
@@ -91,6 +91,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.148.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.148.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.148.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver v0.148.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.148.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.148.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.148.0

--- a/collector/odigosotelcol/go.sum
+++ b/collector/odigosotelcol/go.sum
@@ -1281,6 +1281,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiv
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.148.0/go.mod h1:swrd8aXbWH+oToLfhR58RR72oAMUpPIf4yGd7RXLiEA=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.148.0 h1:3B3ViGXW394qi1HM3KxyVKc3jBMG+9KoZGCbEfnGGdU=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.148.0/go.mod h1:k7xBk5UyH7TEX4Rl/kAbZ6aaWvlu5hvcyXeCLq55n68=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver v0.148.0 h1:/Qxzdyg+LmZNBx2qZ5G2mK+GQjA/nEpZsDLEtmh2pVc=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver v0.148.0/go.mod h1:lNoQarFu91nFtiFN9F5dnG4BGNnrwpx6d4cyXw4P9VA=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.148.0 h1:bEwLtv5eCm+hSZPv4XNkwgQUG8WEjdN3yzPOboIe8x8=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.148.0/go.mod h1:SCUvudQdlfYNPJFoqcN4/HldgLJrN8AZ5lqxkZDYx2k=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.148.0 h1:KtiSxz2B7woF4XXYBCvZJUPwS8+ucO11NjPAvZgXhoE=


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
The otel collector will now support module journald so we can use it in the VM agent to support LOGS signal destinations.
#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Odigos collector distro to support journald receiver
```
