### PR TITLE
CORE-1210 | fix: 13 high CVEs in Golang base image

### DIFF
--- a/.github/workflows/build-dev-images.yml
+++ b/.github/workflows/build-dev-images.yml
@@ -77,7 +77,7 @@ jobs:
       - uses: ko-build/setup-ko@v0.9
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.4'
       - name: Build CLI Image
         env:
           COMMIT_HASH: ${{ github.sha }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -149,7 +149,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.4"
       - name: Build Instrumentor Image
         uses: docker/build-push-action@v6
         with:
@@ -460,7 +460,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.4"
       - name: Set up Goreleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -473,7 +473,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.4"
       - name: Test k8sutils module
         working-directory: ./k8sutils
         run: |
@@ -485,7 +485,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.4"
       - name: Test common module
         working-directory: ./common
         run: |
@@ -497,7 +497,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.4"
       - name: Test procdiscovery module
         working-directory: ./procdiscovery
         run: |

--- a/.github/workflows/check-operator-manifests.yml
+++ b/.github/workflows/check-operator-manifests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.4"
 
       - name: Check operator manifests are up to date
         id: check-manifests

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "~1.26.2"
+          go-version: "~1.26.4"
           check-latest: true
           cache: true
           cache-dependency-path: |

--- a/.github/workflows/full-build.yaml
+++ b/.github/workflows/full-build.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.4"
       - name: Set up Goreleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/go-mod-tidy.yml
+++ b/.github/workflows/go-mod-tidy.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.4"
       - name: run make go-mod-tidy
         run: make go-mod-tidy
       - name: Check clean repository

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.4"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.4"
       - name: Generate Helm Schema
         run: make helm-schema
       - name: Check for schema changes

--- a/.github/workflows/publish-collector-linux-packages.yml
+++ b/.github/workflows/publish-collector-linux-packages.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.4"
 
       - name: Set GoReleaser tag
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,7 +167,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.4"
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/verify-api-crds.yml
+++ b/.github/workflows/verify-api-crds.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.4"
       - name: install controller-gen
         run: make controller-gen
       - name: Check API CRDs

--- a/.github/workflows/verify-collector-ocb.yml
+++ b/.github/workflows/verify-collector-ocb.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.4"
       - name: Generate collector with ocb
         working-directory: ./collector
         run: "make genodigoscol generate"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
 ARG SERVICE_NAME
 
 # Copy local modules required by the build

--- a/autoscaler/go.mod
+++ b/autoscaler/go.mod
@@ -1,6 +1,6 @@
 module github.com/odigos-io/odigos/autoscaler
 
-go 1.26.2
+go 1.26.4
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0

--- a/deviceplugin/go.mod
+++ b/deviceplugin/go.mod
@@ -1,6 +1,6 @@
 module github.com/odigos-io/odigos/deviceplugin
 
-go 1.26.2
+go 1.26.4
 
 replace (
 	github.com/odigos-io/odigos/api => ../api

--- a/instrumentor/go.mod
+++ b/instrumentor/go.mod
@@ -1,6 +1,6 @@
 module github.com/odigos-io/odigos/instrumentor
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/argoproj/argo-rollouts v1.8.3

--- a/odiglet/base.Dockerfile
+++ b/odiglet/base.Dockerfile
@@ -22,7 +22,7 @@ RUN wget https://download.samba.org/pub/rsync/src/rsync-${RSYNC_VERSION}.tar.gz 
     && cd .. \
     && rm -rf rsync-${RSYNC_VERSION}*
 
-FROM golang:1.26.2-trixie
+FROM golang:1.26.4-trixie
 
 # goreleaser is used to build vmagent
 RUN echo "deb [trusted=yes] https://repo.goreleaser.com/apt/ /" > /etc/apt/sources.list.d/goreleaser.list

--- a/odiglet/go.mod
+++ b/odiglet/go.mod
@@ -1,6 +1,6 @@
 module github.com/odigos-io/odigos/odiglet
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/cilium/ebpf v0.20.0

--- a/scheduler/go.mod
+++ b/scheduler/go.mod
@@ -1,6 +1,6 @@
 module github.com/odigos-io/odigos/scheduler
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/golang-jwt/jwt/v4 v4.5.2


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Patches high CVEs flagged by the image vulnerability scan in odiglet.
Bumps the Go toolchain to 1.26.4 across base.Dockerfile, odiglet, and deviceplugin to fix the Go stdlib.
This solves:
CVE-2026-33811
CVE-2026-33814
CVE-2026-39820
CVE-2026-39836
CVE-2026-42499
CVE-2026-42501
GO-2026-4918
GO-2026-4971
GO-2026-4977
GO-2026-4981
GO-2026-4986
CVE-2026-42504
GO-2026-5038

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Patched high Go stdlib CVEs in the odiglet image. 
```
