### PR TITLE
CORE-1210 | chore: update grpc health probe version to reduce cves

### DIFF
--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -131,7 +131,7 @@ RUN if [ "$RHEL" = "true" ] ; then \
 
 
 # Download grpc_health_probe this is used by the deviceplugin container to check if the deviceplugin is healthy
-ARG GRPC_HEALTH_PROBE_VERSION=v0.4.48
+ARG GRPC_HEALTH_PROBE_VERSION=v0.4.52
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
         GRPC_ARCH="arm64"; \
     else \


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
The grpc_health_probe binary bundled in the odiglet image is downloaded as a prebuilt release, not compiled by us. The pinned v0.4.48 was built with go1.26.2, which still embeds the Go stdlib CVEs (CVE-2026-33811, CVE-2026-33814, CVE-2026-39820, CVE-2026-39836, CVE-2026-42499, CVE-2026-42501, CVE-2026-42504, GO-2026-4918/4971/4977/4981/4986/5038, etc.) even after the Go toolchain bump to 1.26.4 (#5130). This PR bumps it to v0.4.52, which upstream built with go1.26.4, so the last go1.26.2 binary in the odiglet image is eliminated.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Fixed remaining Go stdlib CVEs in the odiglet image by upgrading the bundled grpc_health_probe to v0.4.52 (built with Go 1.26.4).
```
