### PR TITLE
chore: optimize Dockerfile for frontend build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,7 +4,8 @@ COPY frontend/webapp/package.json frontend/webapp/yarn.lock ./
 COPY frontend/webapp/.yalc* ./.yalc/
 
 # This allows us to deploy the UI to local clusters with the yalc-linked version of the UI kit.
-RUN if [ -d .yalc ] && [ "$(ls -A .yalc 2>/dev/null)" ]; then \
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn \
+    if [ -d .yalc ] && [ "$(ls -A .yalc 2>/dev/null)" ]; then \
       echo "Using yalc"; \
       npm install -g yalc; \
       yarn install; \
@@ -21,7 +22,29 @@ RUN yarn build
 
 FROM --platform=$BUILDPLATFORM golang:1.26.2 AS backend
 WORKDIR /app
-COPY . .
+# Copy only the go.mod/go.sum of the frontend module and its locally-replaced
+# deps first. This lets `go mod download` be cached independently of source
+# changes, so editing source doesn't re-download the (large) dependency tree.
+COPY frontend/go.mod frontend/go.sum ./frontend/
+COPY api/go.mod api/go.sum ./api/
+COPY common/go.mod common/go.sum ./common/
+COPY config/go.mod config/go.sum ./config/
+COPY destinations/go.mod destinations/go.sum ./destinations/
+COPY k8sutils/go.mod k8sutils/go.sum ./k8sutils/
+COPY odigosauth/go.mod odigosauth/go.sum ./odigosauth/
+RUN --mount=type=cache,target=/go/pkg/mod cd frontend && go mod download
+
+# Copy the source for the frontend module and the modules it replaces locally
+# (see the `replace` directives in frontend/go.mod and its transitive deps).
+# Scoping the copy to just these modules means unrelated changes elsewhere in
+# the monorepo no longer bust the build cache.
+COPY api ./api
+COPY common ./common
+COPY config ./config
+COPY destinations ./destinations
+COPY k8sutils ./k8sutils
+COPY odigosauth ./odigosauth
+COPY frontend ./frontend
 # Strip the webapp source tree but keep embed.go — the frontend/webapp Go
 # package embeds the built bundle (//go:embed all:out) and the server package
 # imports it, so deleting it breaks the build.
@@ -31,8 +54,12 @@ WORKDIR /app/frontend
 ARG TARGETARCH
 ARG LD_FLAGS
 ARG RHEL=false
-RUN CGO_ENABLED=0 GOARCH=$TARGETARCH go build -ldflags="${LD_FLAGS}" -o odigos-ui
-RUN if [ "$RHEL" = "true" ] ; then \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build,id=go-build-$TARGETARCH \
+    CGO_ENABLED=0 GOARCH=$TARGETARCH go build -ldflags="${LD_FLAGS}" -o odigos-ui
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build,id=go-build-$TARGETARCH \
+    if [ "$RHEL" = "true" ] ; then \
       make licenses ; \
     fi
 


### PR DESCRIPTION
- Added caching for Yarn and Go module downloads to improve build performance.
- Updated Dockerfile to copy only necessary Go module files before downloading dependencies, reducing unnecessary rebuilds.
- Enhanced build commands with cache mounts for better efficiency during the build process.

```release-note
chore: optimize Dockerfile for frontend build
```

emergency-ticket id: EMR-1959
