### PR TITLE
CORE-1023: Add externalOnpremPullSecret helm value

### DIFF
--- a/docs/snippets/enterprise/setup/installation.mdx
+++ b/docs/snippets/enterprise/setup/installation.mdx
@@ -95,6 +95,7 @@ helm upgrade --install odigos odigos/odigos --namespace odigos-system --create-n
 ```
 
 The license token can also be provided by creating a secret in kubernetes before installing Odigos.
+
 ```yaml
 apiVersion: v1
 kind: Secret
@@ -105,6 +106,56 @@ metadata:
     odigos.io/system-object: "true"
 stringData:
   odigos-onprem-token: <TOKEN>
+```
+
+When pulling enterprise images from `registry.odigos.io`, Odigos also needs a Docker registry pull secret named `odigos-enterprise-registry`. The Helm chart can create this automatically when `onPremToken` is set, or when it can read the token from an existing `odigos-pro` secret.
+
+For GitOps tools such as Argo CD that cannot read cluster secrets during `helm template`, manage both secrets externally and set:
+
+```yaml
+externalOnpremTokenSecret: true
+externalOnpremPullSecret: true
+```
+
+Create the registry pull secret before syncing Odigos. The username is always `odigos` and the password is your enterprise token:
+
+```shell
+kubectl create secret docker-registry odigos-enterprise-registry \
+  --namespace odigos-system \
+  --docker-server=registry.odigos.io \
+  --docker-username=odigos \
+  --docker-password="$ODIGOS_TOKEN"
+kubectl label secret odigos-enterprise-registry -n odigos-system odigos.io/system-object=true
+```
+
+Or apply it declaratively:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: odigos-enterprise-registry
+  namespace: odigos-system
+  labels:
+    odigos.io/system-object: "true"
+type: kubernetes.io/dockerconfigjson
+stringData:
+  .dockerconfigjson: |
+    {
+      "auths": {
+        "registry.odigos.io": {
+          "username": "odigos",
+          "password": "<TOKEN>",
+          "auth": "<BASE64_OF_odigos:TOKEN>"
+        }
+      }
+    }
+```
+
+Generate the `auth` value with:
+
+```shell
+echo -n "odigos:$ODIGOS_TOKEN" | base64
 ```
 
 Once the Odigos pods are online, simply run the following command to launch the Odigos UI.

--- a/helm/odigos-central/templates/_helpers.tpl
+++ b/helm/odigos-central/templates/_helpers.tpl
@@ -38,7 +38,16 @@ odigos-enterprise-registry
 {{- end -}}
 
 {{- define "odigos.hasEnterpriseRegistryPullSecret" -}}
-{{- if and (include "odigos.onPremToken" .) (include "odigos.usesOdigosRegistry" .) -}}
+{{- if not (include "odigos.usesOdigosRegistry" .) -}}
+{{- else if and (.Values.externalOnpremPullSecret | default false) (include "odigos.secretExists" .) -}}
+true
+{{- else if include "odigos.onPremToken" . -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{- define "odigos.createEnterpriseRegistryPullSecret" -}}
+{{- if and (include "odigos.usesOdigosRegistry" .) (include "odigos.onPremToken" .) (not (.Values.externalOnpremPullSecret | default false)) -}}
 true
 {{- end -}}
 {{- end -}}
@@ -57,8 +66,8 @@ true
 {{- end -}}
 
 {{- define "odigos.validateEnterpriseRegistryPullSecrets" -}}
-{{- if and (include "odigos.secretExists" .) (include "odigos.usesOdigosRegistry" .) (not (include "odigos.onPremToken" .)) -}}
-{{- fail "Odigos images pull from registry.odigos.io but no on-prem token is available to the chart. Set onPremToken or ensure the odigos-central secret exists in the release namespace before install/upgrade." -}}
+{{- if and (include "odigos.secretExists" .) (include "odigos.usesOdigosRegistry" .) (not (include "odigos.onPremToken" .)) (not (.Values.externalOnpremPullSecret | default false)) -}}
+{{- fail "Odigos images pull from registry.odigos.io but no on-prem token is available to the chart. Set onPremToken, set externalOnpremPullSecret to true when providing odigos-enterprise-registry externally, or ensure the odigos-central secret exists in the release namespace before install/upgrade." -}}
 {{- end -}}
 {{- end -}}
 

--- a/helm/odigos-central/templates/enterprise-registry-pull-secret.yaml
+++ b/helm/odigos-central/templates/enterprise-registry-pull-secret.yaml
@@ -1,4 +1,4 @@
-{{- if include "odigos.hasEnterpriseRegistryPullSecret" . }}
+{{- if include "odigos.createEnterpriseRegistryPullSecret" . }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/odigos-central/values.yaml
+++ b/helm/odigos-central/values.yaml
@@ -14,6 +14,10 @@ imagePullSecrets: []
 # the existing odigos-central secret to create the enterprise registry pull secret.
 # externalOnpremTokenSecret: false
 
+# Set to true when odigos-enterprise-registry is managed externally (GitOps).
+# The chart mounts the existing pull secret but does not create it.
+# externalOnpremPullSecret: false
+
 centralBackend:
   # Resources and scheduling for the Central backend
   # -- Maximum message size in bytes for gRPC messages (empty = use default)

--- a/helm/odigos/templates/_helpers.tpl
+++ b/helm/odigos/templates/_helpers.tpl
@@ -30,7 +30,16 @@ odigos-enterprise-registry
 {{- end -}}
 
 {{- define "odigos.hasEnterpriseRegistryPullSecret" -}}
-{{- if and (include "odigos.onPremToken" .) (include "odigos.usesOdigosRegistry" .) -}}
+{{- if not (include "odigos.usesOdigosRegistry" .) -}}
+{{- else if and (.Values.externalOnpremPullSecret | default false) (include "odigos.secretExists" .) -}}
+true
+{{- else if include "odigos.onPremToken" . -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{- define "odigos.createEnterpriseRegistryPullSecret" -}}
+{{- if and (include "odigos.usesOdigosRegistry" .) (include "odigos.onPremToken" .) (not (.Values.externalOnpremPullSecret | default false)) -}}
 true
 {{- end -}}
 {{- end -}}
@@ -46,8 +55,8 @@ true
 {{- end -}}
 
 {{- define "odigos.validateEnterpriseRegistryPullSecrets" -}}
-{{- if and (include "odigos.secretExists" .) (include "odigos.usesOdigosRegistry" .) (not (include "odigos.onPremToken" .)) -}}
-{{- fail "Odigos images pull from registry.odigos.io but no on-prem token is available to the chart. Set onPremToken or ensure the odigos-pro secret exists in the release namespace before install/upgrade." -}}
+{{- if and (include "odigos.secretExists" .) (include "odigos.usesOdigosRegistry" .) (not (include "odigos.onPremToken" .)) (not (.Values.externalOnpremPullSecret | default false)) -}}
+{{- fail "Odigos images pull from registry.odigos.io but no on-prem token is available to the chart. Set onPremToken, set externalOnpremPullSecret to true when providing odigos-enterprise-registry externally, or ensure the odigos-pro secret exists in the release namespace before install/upgrade." -}}
 {{- end -}}
 {{- end -}}
 

--- a/helm/odigos/templates/enterprise-registry-pull-secret.yaml
+++ b/helm/odigos/templates/enterprise-registry-pull-secret.yaml
@@ -1,4 +1,4 @@
-{{- if include "odigos.hasEnterpriseRegistryPullSecret" . }}
+{{- if include "odigos.createEnterpriseRegistryPullSecret" . }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/odigos/values.schema.json
+++ b/helm/odigos/values.schema.json
@@ -522,9 +522,15 @@
       "required": [],
       "title": "collectorNode"
     },
+    "externalOnpremPullSecret": {
+      "default": "false",
+      "description": "Set to true if you are providing the odigos-enterprise-registry pull secret externally (not managed by this chart).\nWhen true, the chart will not create the pull secret but will still mount odigos-enterprise-registry on Odigos workloads\nwhen pulling from registry.odigos.io. Use with externalOnpremTokenSecret for GitOps installs where Helm cannot read secrets at template time.",
+      "required": [],
+      "title": "externalOnpremPullSecret"
+    },
     "externalOnpremTokenSecret": {
       "default": "false",
-      "description": "Set to true if you are providing the odigos-pro secret externally (not managed by this chart).\nWhen true, the chart will not create the odigos-pro secret but will still enable Pro features if the secret exists.\nThe chart will read the token from the existing odigos-pro secret to create the enterprise registry pull secret.\nThis is useful for GitOps workflows where secrets are managed separately.",
+      "description": "Set to true if you are providing the odigos-pro secret externally (not managed by this chart).\nWhen true, the chart will not create the odigos-pro secret but will still enable Pro features if the secret exists.\nThis is useful for GitOps workflows where secrets are managed separately.",
       "required": [],
       "title": "externalOnpremTokenSecret"
     },

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -1778,7 +1778,14 @@ sampling:
 # description: |-
 #   Set to true if you are providing the odigos-pro secret externally (not managed by this chart).
 #   When true, the chart will not create the odigos-pro secret but will still enable Pro features if the secret exists.
-#   The chart will read the token from the existing odigos-pro secret to create the enterprise registry pull secret.
 #   This is useful for GitOps workflows where secrets are managed separately.
 # @schema
 # externalOnpremTokenSecret: false
+
+# @schema
+# description: |-
+#   Set to true if you are providing the odigos-enterprise-registry pull secret externally (not managed by this chart).
+#   When true, the chart will not create the pull secret but will still mount odigos-enterprise-registry on Odigos workloads
+#   when pulling from registry.odigos.io. Use with externalOnpremTokenSecret for GitOps installs where Helm cannot read secrets at template time.
+# @schema
+# externalOnpremPullSecret: false


### PR DESCRIPTION
#### What this PR does / why we need it:
Using `externalOnpremTokenSecret: true` with the new enterprise Docker pull secret generation added in https://github.com/odigos-io/odigos/pull/4990 can cause errors like:

```
ComparisonError: Failed to load target state: failed to generate manifest for source 1 of 1: rpc error: code = Unknown desc = Manifest generation error (cached): `helm template . --name-template odigos-qa --namespace odigos --kube-version 1.34 --values <path to cached source>/apps/odigos/values-qa.yml <api versions removed> --include-crds` failed exit status 1: Error: execution error at (odigos/charts/odigos/templates/validate-enterprise-pull-secrets.yaml:1:3): Odigos images pull from registry.odigos.io but no on-prem token is available to the chart. Set onPremToken or ensure the odigos-pro secret exists in the release namespace before install/upgrade. Use --debug flag to render out invalid YAML
```

In this case, with an Argo deployment, where Argo is unable to read the token secret value (even though the secret exists). This is actually the only place where we are trying to *read* the secret value (in order to generate the Docker pull secret based off the onprem token). Other spots just assume it exists if `externalOnpremTokenSecret: true` and sets up the appropriate enterprise mounts.

This `externalOnpremPullSecret` works the same way. If it is `true`, the helm chart will assume the externally-managed Docker pull secret exists and set up the required mounts. This does put the burden on certain users to create the pull secret themselves, which is why this PR also adds documentation on how to do that.

cherry-pick:v1.30

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
fix: add externalOnpremPullSecret for enterprise Docker pull secret management
```
