### PR TITLE
CORE-1023: Fix Helm pull secret generation with non-default registry

### DIFF
--- a/helm/odigos/templates/_helpers.tpl
+++ b/helm/odigos/templates/_helpers.tpl
@@ -45,7 +45,9 @@ true
 {{- end -}}
 
 {{- define "odigos.usesOdigosRegistry" -}}
-{{- eq (include "utils.imagePrefix" (dict "Values" .Values)) "registry.odigos.io" -}}
+{{- if eq (include "utils.imagePrefix" (dict "Values" .Values)) "registry.odigos.io" -}}
+true
+{{- end -}}
 {{- end -}}
 
 {{- define "odigos.enterpriseRegistryPullSecretToMount" -}}
@@ -62,9 +64,8 @@ true
 
 {{- define "odigos.enterpriseRegistryDockerConfigJson" -}}
 {{- $token := include "odigos.onPremToken" . -}}
-{{- $registry := include "utils.imagePrefix" (dict "Values" .Values) -}}
 {{- $auth := printf "odigos:%s" $token | b64enc -}}
-{{- dict "auths" (dict $registry (dict "username" "odigos" "password" $token "auth" $auth)) | toJson -}}
+{{- dict "auths" (dict "registry.odigos.io" (dict "username" "odigos" "password" $token "auth" $auth)) | toJson -}}
 {{- end -}}
 
 {{- define "utils.imageName" -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

## Summary

Fix enterprise registry pull secret (`odigos-enterprise-registry`) being incorrectly created and mounted when `imagePrefix` is set to a custom registry.

When `onPremToken` was set alongside a non-default `imagePrefix` (e.g. a mirrored private registry on OpenShift), the chart still created and mounted `odigos-enterprise-registry`, and the secret's `.dockerconfigjson` auth was keyed to the custom registry with `username: odigos` instead of `registry.odigos.io`.

**Root cause:** Two bugs in `helm/odigos/templates/_helpers.tpl`:

1. **`usesOdigosRegistry` boolean trap** — The helper used `eq` directly as its return value, which produces the string `"false"`. In Helm/Go templates, non-empty strings are truthy, so `"false"` passed checks like `and (include "odigos.usesOdigosRegistry" .) ...`, causing create/mount logic to run even when images pull from a custom registry.
2. **Wrong registry in docker config** — `enterpriseRegistryDockerConfigJson` used `utils.imagePrefix` as the auth host instead of hardcoding `registry.odigos.io`.

**Fix:**
- `usesOdigosRegistry` now returns `"true"` or empty (consistent with other helpers like `secretExists`).
- `enterpriseRegistryDockerConfigJson` always targets `registry.odigos.io`, matching `odigos-central` and the Go runtime path in `k8sutils/pkg/pro/pullsecret.go`.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
fix: enterprise pull secret should not be generated for custom registries
```

cherry-pick:v1.30
