### PR TITLE
CORE-1231 | chore: expose pprof port

### DIFF
--- a/helm/odigos/templates/security/deployment.yaml
+++ b/helm/odigos/templates/security/deployment.yaml
@@ -38,6 +38,8 @@ spec:
               containerPort: 8080
             - name: otlp-grpc
               containerPort: 4317
+            - name: pprof
+              containerPort: 6060
           env:
             - name: CURRENT_NS
               valueFrom:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Exposing the pprof port to the odigos-insights service

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Exposing the pprof port to the odigos-insights service
```
