### PR TITLE
fix(docs): resolve broken links reported by check-links

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           args: >-
             -v -n "*.md" "**/*.md" "**/*.mdx"
+            --exclude-path "docs/snippets"
             --exclude "http://localhost*"
             --exclude "^https://logs-prod.*"
             --exclude ".*your-account.*"
@@ -36,6 +37,8 @@ jobs:
             --exclude "https://github.com/odigos-io/ui-kit"
             --exclude "http://host:port*"
             --exclude "https://www.npmjs.com/*"
+            --exclude "^https://join\\.slack\\.com/.*"
+            --exclude "^https://github\\.com/odigos-io/odigos-enterprise.*"
             --timeout 30
             --max-concurrency 2
             --retry-wait-time 15

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,7 +174,7 @@ make deploy-ui
 
 First - make sure you clone the [nodejs agent](https://github.com/odigos-io/opentelemetry-node) repos in the same directory as the odigos repo. e.g. `../opentelemetry-node` should exist alongside the odigos repo in your local filesystem.
 
-See the [Odigos docs](https://docs.odigos.io/intro) for the full steps on debugging Odigos locally.
+See the [Odigos docs](https://docs.odigos.io/quickstart/introduction) for the full steps on debugging Odigos locally.
 
 ### How to Build and run Odigos Frontend Locally
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Manage and configure collectors via a convenient web UI.
 ## Installation
 
 Installing Odigos takes less than 5 minutes and requires no code changes.<br />
-Download our [CLI](https://docs.odigos.io/installation) and run the following command:
+Download our [CLI](https://docs.odigos.io/setup/installation) and run the following command:
 
 ```bash
 odigos install

--- a/docs/central/overview.mdx
+++ b/docs/central/overview.mdx
@@ -9,7 +9,7 @@ sidebarTitle: 'Overview'
   Odigos team to inquire about access to the Enterprise version.
 </Note>
 
-Odigos Central is a centralized management layer for multi-cluster observability. Instead of configuring instrumentation, [sampling rules](../enterprise/pipeline/sampling/rules/overview), and destinations separately in each Kubernetes cluster, Odigos Central provides a **single pane of glass** to manage all your clusters from one place.
+Odigos Central is a centralized management layer for multi-cluster observability. Instead of configuring instrumentation, [sampling rules](/enterprise/pipeline/sampling/rules/overview), and destinations separately in each Kubernetes cluster, Odigos Central provides a **single pane of glass** to manage all your clusters from one place.
 
 ## Why Use Odigos Central?
 

--- a/docs/vmagent/overview.mdx
+++ b/docs/vmagent/overview.mdx
@@ -13,15 +13,15 @@ import EnterpriseVMAgent from '../../../snippets/enterprise/vmagent/enterprise-v
 - Instrument [systemd](https://systemd.io/) services and Linux processes
 - Automatic OpenTelemetry instrumentation via eBPF with no code changes
 - Distributed traces with seamless context propagation
-- Continuous CPU profiling (eBPF) with export to [Pyroscope](./instrumentations/profiling/export-pyroscope) or other OTLP Profiles backends
+- Continuous CPU profiling (eBPF) with export to [Pyroscope](/vmagent/instrumentations/profiling/export-pyroscope) or other OTLP Profiles backends
 
 ## Key concepts
 
 - **Sources**: The systemd services or Linux processes you instrument with the VM Agent. 
-See [Add Sources](./setup/configuration/add-sources) to get started.
+See [Add Sources](/vmagent/setup/configuration/add-sources) to get started.
 - **Destinations**: The backends that receive your telemetry data. 
-See [Add Destinations](./setup/configuration/add-destinations) to get started.
+See [Add Destinations](/vmagent/setup/configuration/add-destinations) to get started.
 - **Actions**: Processors that transform, filter, or enrich telemetry before it is sent to destinations. 
-See [Actions overview](./setup/configuration/actions/overview) to add and manage actions.
+See [Actions overview](/vmagent/setup/configuration/actions/overview) to add and manage actions.
 - **Instrumentation rules**: Rules that control how telemetry is recorded from your sources—for example, which attributes, headers, or payloads are collected and how custom instrumentations behave. 
-See [Instrumentation rules overview](./setup/configuration/instrumentation-rules/overview) to add and manage rules.
+See [Instrumentation rules overview](/vmagent/setup/configuration/instrumentation-rules/overview) to add and manage rules.

--- a/docs/vmagent/setup/configuration/actions/overview.mdx
+++ b/docs/vmagent/setup/configuration/actions/overview.mdx
@@ -15,16 +15,16 @@ Actions modify OpenTelemetry Signals produced by your sources before it is expor
 
 ## Action types
 
-The VM Agent supports three kinds of actions. Each type has a dedicated page with configuration steps for [odictl](../odictl) and YAML:
+The VM Agent supports three kinds of actions. Each type has a dedicated page with configuration steps for [odictl](/vmagent/setup/configuration/odictl) and YAML:
 
 ### Processor addition
 
-Add an OpenTelemetry Collector processor to transform, filter, or enrich signals (e.g., add or delete attributes, batch, sample, mask PII). Processors defined in the [Odigos collector builder config](https://github.com/odigos-io/odigos/blob/main/collector/builder-config.yaml#L61) are supported; for each processor's configuration options, see the [OpenTelemetry Collector Contrib documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor). See [Processor addition](./processor-addition) for configuration steps.
+Add an OpenTelemetry Collector processor to transform, filter, or enrich signals (e.g., add or delete attributes, batch, sample, mask PII). Processors defined in the [Odigos collector builder config](https://github.com/odigos-io/odigos/blob/main/collector/builder-config.yaml#L61) are supported; for each processor's configuration options, see the [OpenTelemetry Collector Contrib documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor). See [Processor addition](/vmagent/setup/configuration/actions/processor-addition) for configuration steps.
 
 ### Span metrics
 
-Convert tracing spans into aggregated metrics (e.g., request counts, latency histograms) to reduce volume and simplify dashboards and alerts. See [Span metrics](./span-metrics) for configuration steps.
+Convert tracing spans into aggregated metrics (e.g., request counts, latency histograms) to reduce volume and simplify dashboards and alerts. See [Span metrics](/vmagent/setup/configuration/actions/span-metrics) for configuration steps.
 
 ### URL templatization
 
-Replace variable parts of URLs with parameter placeholders (e.g., `/users/123` → `/users/{id}`) before recording in signals to control cardinality and group traffic by endpoint pattern. See [URL templatization](./url-templatization) for configuration steps.
+Replace variable parts of URLs with parameter placeholders (e.g., `/users/123` → `/users/{id}`) before recording in signals to control cardinality and group traffic by endpoint pattern. See [URL templatization](/vmagent/setup/configuration/actions/url-templatization) for configuration steps.

--- a/docs/vmagent/setup/configuration/actions/processor-addition.mdx
+++ b/docs/vmagent/setup/configuration/actions/processor-addition.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Processor Addition"
 description: "Add OpenTelemetry Collector processors to transform, filter, or enrich OpenTelemetry signals in the VM Agent"
 ---
 
-[Processor addition](./overview#processor-addition) lets you add an OpenTelemetry Collector processor to transform, filter, or enrich signals (e.g., add or delete attributes, batch, sample, mask PII). Processors defined in the [Odigos collector builder config](https://github.com/odigos-io/odigos/blob/main/collector/builder-config.yaml#L61) are supported.
+[Processor addition](/vmagent/setup/configuration/actions/overview#processor-addition) lets you add an OpenTelemetry Collector processor to transform, filter, or enrich signals (e.g., add or delete attributes, batch, sample, mask PII). Processors defined in the [Odigos collector builder config](https://github.com/odigos-io/odigos/blob/main/collector/builder-config.yaml#L61) are supported.
 
 There are two ways to add a processor addition action: using `odictl` or using YAML files.
 

--- a/docs/vmagent/setup/configuration/actions/span-metrics.mdx
+++ b/docs/vmagent/setup/configuration/actions/span-metrics.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Span Metrics"
 description: "Convert tracing spans into aggregated metrics in the Odigos VM Agent"
 ---
 
-[Span metrics](./overview#span-metrics) is a processor that turns tracing spans into aggregated metrics (e.g., request counts, latency histograms), reducing export volume and making it easier to build dashboards and alerts.
+[Span metrics](/vmagent/setup/configuration/actions/overview#span-metrics) is a processor that turns tracing spans into aggregated metrics (e.g., request counts, latency histograms), reducing export volume and making it easier to build dashboards and alerts.
 
 There are two ways to add a span metrics action: using `odictl` or using YAML files.
 

--- a/docs/vmagent/setup/configuration/actions/url-templatization.mdx
+++ b/docs/vmagent/setup/configuration/actions/url-templatization.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "URL Templatization"
 description: "Replace dynamic URL parts with parameter placeholders in VM Agent OpenTelemetry signals"
 ---
 
-[URL templatization](./overview#url-templatization) replaces variable parts of URLs with parameter placeholders before the URL is recorded in OpenTelemetry signals (e.g., `/users/123` → `/users/{id}`), keeping cardinality under control and making it easier to group traffic by endpoint pattern.
+[URL templatization](/vmagent/setup/configuration/actions/overview#url-templatization) replaces variable parts of URLs with parameter placeholders before the URL is recorded in OpenTelemetry signals (e.g., `/users/123` → `/users/{id}`), keeping cardinality under control and making it easier to group traffic by endpoint pattern.
 
 There are two ways to add a URL templatization action: using `odictl` or using YAML files.
 

--- a/docs/vmagent/setup/configuration/add-destinations.mdx
+++ b/docs/vmagent/setup/configuration/add-destinations.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Destinations"
 description: "Add destinations to the Odigos VM Agent so telemetry can be sent to your backends."
 ---
 
-There are two ways to add [destinations](../../../overview#key-concepts) to the Odigos VM Agent: use `odictl` or use YAML files.
+There are two ways to add [destinations](/vmagent/overview#key-concepts) to the Odigos VM Agent: use `odictl` or use YAML files.
 
 <Tabs>
   <Tab title="odictl">
@@ -44,10 +44,10 @@ There are two ways to add [destinations](../../../overview#key-concepts) to the 
       />
     </Step>
     <Step title="Configure destination">
-      Set each field according to your destination type. See [Destinations](../../../../enterprise/backends-overview) 
+      Set each field according to your destination type. See [Destinations](/enterprise/backends-overview) 
       for field details and requirements.
 
-      <Frame caption="Example of an [OTLP http](../../../../enterprise/backends-overview) destination">
+      <Frame caption="Example of an [OTLP http](/enterprise/backends-overview) destination">
         <img 
           src="../../../images/vmagent/destination/odictl-destination-configure.png" 
           alt="Configure Destination"
@@ -114,7 +114,7 @@ There are two ways to add [destinations](../../../overview#key-concepts) to the 
       </Step>
       <Step title="Add the destination configuration">
 
-        Set each field according to your destination type. See [Destinations](../../../../enterprise/backends-overview) for field details and requirements.
+        Set each field according to your destination type. See [Destinations](/enterprise/backends-overview) for field details and requirements.
 
 
         For example:
@@ -130,9 +130,9 @@ There are two ways to add [destinations](../../../overview#key-concepts) to the 
           signals:
             - TRACES
         ```
-        <Info>The above is an example of an [OTLP http](../../../../enterprise/backends-overview) destination.</Info>
+        <Info>The above is an example of an [OTLP http](/enterprise/backends-overview) destination.</Info>
 
-        For continuous CPU profiling, add a [Pyroscope](../../../../enterprise/backends/pyroscope) destination with `signals: [PROFILES]`. See [Export to Pyroscope](../../instrumentations/profiling/export-pyroscope).
+        For continuous CPU profiling, add a [Pyroscope](/enterprise/backends/pyroscope) destination with `signals: [PROFILES]`. See [Export to Pyroscope](/vmagent/instrumentations/profiling/export-pyroscope).
 
         <Note>You can define multiple destinations in a single YAML file, and you can organize destinations across multiple YAML files.</Note>
 

--- a/docs/vmagent/setup/configuration/add-sources.mdx
+++ b/docs/vmagent/setup/configuration/add-sources.mdx
@@ -4,9 +4,9 @@ sidebarTitle: "Sources"
 description: "Add or instrument sources in the Odigos VM Agent so the agent can collect their telemetry."
 ---
 
-There are two ways to add [sources](../../../overview#key-concepts) to the Odigos VM Agent: use `odictl` or use YAML files.
+There are two ways to add [sources](/vmagent/overview#key-concepts) to the Odigos VM Agent: use `odictl` or use YAML files.
 
-<Tip>It is recommended to [add a destination](./add-destinations) before adding a source.</Tip>
+<Tip>It is recommended to [add a destination](/vmagent/setup/configuration/add-destinations) before adding a source.</Tip>
 
 <Tabs>
   <Tab title="odictl">

--- a/docs/vmagent/setup/configuration/instrumentation-rules/custom-instrumentation.mdx
+++ b/docs/vmagent/setup/configuration/instrumentation-rules/custom-instrumentation.mdx
@@ -4,12 +4,12 @@ sidebarTitle: "Custom Instrumentation"
 description: "Define custom eBPF-based instrumentations for arbitrary functions in your Java, Go, or C++ application or its dependencies using the VM Agent."
 ---
 
-[Custom instrumentation](./overview#custom-instrumentation) lets you define custom eBPF-based instrumentations for specific functions or methods in your application or its dependencies. Unlike automatic instrumentation, which covers common frameworks and libraries, custom instrumentation targets the exact code you choose—for example, a business-critical function or an internal helper that you want to see as a span in your traces. The VM Agent supports **Java**, **Go**, and **C++**. For Go, you can instrument either a **function** (by package and function name) or a **receiver method** (by package, receiver type, and method name); you must use one form or the other, not both. For C++, you target a function by its **signature**. 
+[Custom instrumentation](/vmagent/setup/configuration/instrumentation-rules/overview#custom-instrumentation) lets you define custom eBPF-based instrumentations for specific functions or methods in your application or its dependencies. Unlike automatic instrumentation, which covers common frameworks and libraries, custom instrumentation targets the exact code you choose—for example, a business-critical function or an internal helper that you want to see as a span in your traces. The VM Agent supports **Java**, **Go**, and **C++**. For Go, you can instrument either a **function** (by package and function name) or a **receiver method** (by package, receiver type, and method name); you must use one form or the other, not both. For C++, you target a function by its **signature**. 
 
 There are two ways to add a custom instrumentation rule: using `odictl` or using YAML files.
 
 <Tip>
-Prefer to find hot functions visually instead of typing class and method names? Use the odictl profiling view to instrument a function straight from a CPU profile. See [Instrument from Profiles](./instrument-from-profiles).
+Prefer to find hot functions visually instead of typing class and method names? Use the odictl profiling view to instrument a function straight from a CPU profile. See [Instrument from Profiles](/vmagent/setup/configuration/instrumentation-rules/instrument-from-profiles).
 </Tip>
 
 <Tabs>

--- a/docs/vmagent/setup/configuration/instrumentation-rules/instrument-from-profiles.mdx
+++ b/docs/vmagent/setup/configuration/instrumentation-rules/instrument-from-profiles.mdx
@@ -4,24 +4,24 @@ sidebarTitle: "Instrument from Profiles"
 description: "Create custom instrumentation rules from a function in the odictl continuous profiling view."
 ---
 
-The odictl [profiling view](../../../instrumentations/profiling/view-in-odictl) lets you turn a profiled function into a [custom instrumentation](./custom-instrumentation) rule with a single keystroke. Instead of typing a class, package, or method name by hand, you highlight a hot function in the profile and press `i`—`odictl` generates the matching `CustomInstrumentation` rule for you.
+The odictl [profiling view](/vmagent/instrumentations/profiling/view-in-odictl) lets you turn a profiled function into a [custom instrumentation](/vmagent/setup/configuration/instrumentation-rules/custom-instrumentation) rule with a single keystroke. Instead of typing a class, package, or method name by hand, you highlight a hot function in the profile and press `i`—`odictl` generates the matching `CustomInstrumentation` rule for you.
 
 This UI-driven flow supports **Java**, **Go**, and **C++**.
 
 <Note>
-This page covers the profile-driven, UI-only workflow. To define a rule manually (entering class/method or package/function yourself) or with YAML files, see [Custom Instrumentation](./custom-instrumentation).
+This page covers the profile-driven, UI-only workflow. To define a rule manually (entering class/method or package/function yourself) or with YAML files, see [Custom Instrumentation](/vmagent/setup/configuration/instrumentation-rules/custom-instrumentation).
 </Note>
 
 ## Before you start
 
-- Profiling must be enabled and collecting data. See [View profiles in odictl](../../../instrumentations/profiling/view-in-odictl).
-- A [source](../add-sources) must be enabled for the service you want to instrument.
+- Profiling must be enabled and collecting data. See [View profiles in odictl](/vmagent/instrumentations/profiling/view-in-odictl).
+- A [source](/vmagent/setup/configuration/add-sources) must be enabled for the service you want to instrument.
 
 ## Create a rule from a profile
 
 <Steps>
   <Step title="Open the profiling view and select a function">
-    From the main `odictl` dashboard, press <Badge color="blue">Shift+P</Badge> to open the [profiling view](../../../instrumentations/profiling/view-in-odictl). Use `Tab` to move between the three panes—**Services**, **Filter modules**, and **Functions**—and the arrow keys to move within the focused pane.
+    From the main `odictl` dashboard, press <Badge color="blue">Shift+P</Badge> to open the [profiling view](/vmagent/instrumentations/profiling/view-in-odictl). Use `Tab` to move between the three panes—**Services**, **Filter modules**, and **Functions**—and the arrow keys to move within the focused pane.
 
     1. In the **Services** pane, select a service. Its runtime (Java, Go, or C++) determines the modules shown.
     2. In the **Filter modules** pane, adjust the module or type filter if needed.
@@ -64,7 +64,7 @@ This page covers the profile-driven, UI-only workflow. To define a rule manually
     - **Go** — the package and function name, or the package, receiver type, and method name.
     - **C++** — the function signature.
 
-    For the underlying field reference, see [Custom Instrumentation](./custom-instrumentation).
+    For the underlying field reference, see [Custom Instrumentation](/vmagent/setup/configuration/instrumentation-rules/custom-instrumentation).
 
     <img
       src="../../../../images/vmagent/profiling/odictl_profiling_instrumentation_rule.png"
@@ -78,7 +78,7 @@ This page covers the profile-driven, UI-only workflow. To define a rule manually
     />
 
     <Note>
-    The rule name and config are generated automatically from the profile—you don't enter the class, package, or method by hand. To author a rule manually instead, see [Custom Instrumentation](./custom-instrumentation).
+    The rule name and config are generated automatically from the profile—you don't enter the class, package, or method by hand. To author a rule manually instead, see [Custom Instrumentation](/vmagent/setup/configuration/instrumentation-rules/custom-instrumentation).
     </Note>
   </Step>
   <Step title="Verify the new span">
@@ -92,6 +92,6 @@ To stop instrumenting a function, reopen the profiling view (`Shift+P`), highlig
 
 ## Related
 
-- [View profiles in odictl](../../../instrumentations/profiling/view-in-odictl) — open and navigate the profiling view.
-- [Custom Instrumentation](./custom-instrumentation) — define rules manually with `odictl` or YAML.
-- [Instrumentation rules overview](./overview) — all rule types and their benefits.
+- [View profiles in odictl](/vmagent/instrumentations/profiling/view-in-odictl) — open and navigate the profiling view.
+- [Custom Instrumentation](/vmagent/setup/configuration/instrumentation-rules/custom-instrumentation) — define rules manually with `odictl` or YAML.
+- [Instrumentation rules overview](/vmagent/setup/configuration/instrumentation-rules/overview) — all rule types and their benefits.

--- a/docs/vmagent/setup/configuration/instrumentation-rules/overview.mdx
+++ b/docs/vmagent/setup/configuration/instrumentation-rules/overview.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Overview"
 description: "What Odigos VM Agent instrumentation rules are, their benefits, and rule types: code attributes, headers collection, payload collection, and custom instrumentation."
 ---
 
-Instrumentation rules control how telemetry is recorded from your [sources](../../../overview#key-concepts). You can apply rules to specific sources and instrumentation libraries to control which attributes, headers, and payloads are collected and how custom instrumentations behave.
+Instrumentation rules control how telemetry is recorded from your [sources](/vmagent/overview#key-concepts). You can apply rules to specific sources and instrumentation libraries to control which attributes, headers, and payloads are collected and how custom instrumentations behave.
 
 ## Benefits
 
@@ -15,11 +15,11 @@ Instrumentation rules control how telemetry is recorded from your [sources](../.
 
 ## Rule types
 
-You can manage instrumentation rules via [odictl](../odictl) or YAML.
+You can manage instrumentation rules via [odictl](/vmagent/setup/configuration/odictl) or YAML.
 
 ### Custom instrumentation
 
-Define custom eBPF-based instrumentations for arbitrary functions in your application or its dependencies. Use custom instrumentation with Java, Go, and C++ applications to instrument application-specific code. See [Custom Instrumentation](./custom-instrumentation) for configuration, or [Instrument from Profiles](./instrument-from-profiles) to create a rule directly from a function in the odictl profiling view.
+Define custom eBPF-based instrumentations for arbitrary functions in your application or its dependencies. Use custom instrumentation with Java, Go, and C++ applications to instrument application-specific code. See [Custom Instrumentation](/vmagent/setup/configuration/instrumentation-rules/custom-instrumentation) for configuration, or [Instrument from Profiles](/vmagent/setup/configuration/instrumentation-rules/instrument-from-profiles) to create a rule directly from a function in the odictl profiling view.
 
 ### Code attributes
 

--- a/docs/vmagent/setup/configuration/odictl.mdx
+++ b/docs/vmagent/setup/configuration/odictl.mdx
@@ -121,7 +121,7 @@ or the mouse wheel to scroll through the logs.
 ## Sources Panel
 
 Sources is where you define the systemd services or Linux processes on the host system that you want to instrument with
-the Odigos VM Agent. See [Add Sources](./add-sources) to learn how.
+the Odigos VM Agent. See [Add Sources](/vmagent/setup/configuration/add-sources) to learn how.
 
 <img 
   src="../../../images/vmagent/odictl/odictl-sources-screen.png" 
@@ -136,8 +136,8 @@ the Odigos VM Agent. See [Add Sources](./add-sources) to learn how.
 
 ## Destinations Panel
 
-[Destinations](../../../../enterprise/backends-overview) are backends that accept data from the Odigos VM Agent.
-Odigos lets you [add as many destinations](./add-destinations) as you like, enabling you to
+[Destinations](/enterprise/backends-overview) are backends that accept data from the Odigos VM Agent.
+Odigos lets you [add as many destinations](/vmagent/setup/configuration/add-destinations) as you like, enabling you to
 execute different use cases such as:
 
 - Using different backends for different types of OpenTelemetry signals
@@ -161,8 +161,8 @@ Actions let you modify OpenTelemetry data from Odigos Sources before it is expor
 implements actions using OpenTelemetry Collector processors—components that transform, filter, or enrich telemetry
 before it is sent to your destinations.
 
-See [Actions overview](./actions/overview) to add or edit actions. For action types and processor options, see
-[Odigos Actions](../../../../enterprise/pipeline/actions/introduction).
+See [Actions overview](/vmagent/setup/configuration/actions/overview) to add or edit actions. For action types and processor options, see
+[Odigos Actions](/enterprise/pipeline/actions/introduction).
 
 <img 
   src="../../../images/vmagent/odictl/odictl-actions-screen.png" 
@@ -340,7 +340,7 @@ Java instrumentation subsection targets Java-specific behavior.
 
 <Accordion title="Profiling" icon="gauge-high" defaultOpen="false">
 
-Enables **continuous CPU profiling** (eBPF, OTLP Profiles) on **odigos-otelcol**. This is separate from Go **pprof** (see **Pprof** below). See [Continuous Profiling](../../instrumentations/profiling/overview) for the full setup.
+Enables **continuous CPU profiling** (eBPF, OTLP Profiles) on **odigos-otelcol**. This is separate from Go **pprof** (see **Pprof** below). See [Continuous Profiling](/vmagent/instrumentations/profiling/overview) for the full setup.
 
 | Field | Description |
 |-------|-------------|
@@ -372,7 +372,7 @@ Instrumentation Rules control how telemetry is recorded from your instrumented s
 specific sources and instrumentation libraries, letting you control what attributes, headers, or payloads are collected
 and how custom instrumentations behave.
 
-For rule types and configuration options, see [Instrumentation rules overview](./instrumentation-rules/overview).
+For rule types and configuration options, see [Instrumentation rules overview](/vmagent/setup/configuration/instrumentation-rules/overview).
 
 <img 
   src="../../../images/vmagent/odictl/odictl-rules-screen.png" 

--- a/docs/vmagent/setup/configuration/overview.mdx
+++ b/docs/vmagent/setup/configuration/overview.mdx
@@ -10,25 +10,25 @@ Configuration defines where telemetry comes from (sources), where it is sent (de
 
 You can configure the Odigos VM Agent in two ways:
 
-- **[odictl](./odictl)** — A terminal user interface (TUI) that you use to add and manage sources, destinations, and actions interactively.
+- **[odictl](/vmagent/setup/configuration/odictl)** — A terminal user interface (TUI) that you use to add and manage sources, destinations, and actions interactively.
 - **YAML** — Each configuration task (sources, destinations, actions) can be done via YAML; the pages linked below include a YAML tab with examples.
 
 ## Configuration tasks
 
 <CardGroup cols={2}>
-  <Card title="Add sources" icon="server" href="./add-sources">
+  <Card title="Add sources" icon="server" href="/vmagent/setup/configuration/add-sources">
     Instrument systemd services or Linux processes so the VM Agent collects their telemetry.
   </Card>
-  <Card title="Add destinations" icon="location-dot" href="./add-destinations">
+  <Card title="Add destinations" icon="location-dot" href="/vmagent/setup/configuration/add-destinations">
     Define where telemetry is sent (for example, OTLP endpoints or supported backends).
   </Card>
-  <Card title="Add actions" icon="wand-magic-sparkles" href="./actions/overview">
+  <Card title="Add actions" icon="wand-magic-sparkles" href="/vmagent/setup/configuration/actions/overview">
     Transform, filter, or enrich telemetry before it is sent to destinations.
   </Card>
-  <Card title="Instrumentation rules" icon="list-check" href="./instrumentation-rules/overview">
+  <Card title="Instrumentation rules" icon="list-check" href="/vmagent/setup/configuration/instrumentation-rules/overview">
     Control how telemetry is recorded from your sources (attributes, headers, payloads and custom instrumentation rules).
   </Card>
-  <Card title="Continuous profiling" icon="gauge-high" href="../../instrumentations/profiling/overview">
+  <Card title="Continuous profiling" icon="gauge-high" href="/vmagent/instrumentations/profiling/overview">
     Enable eBPF CPU profiling on the collector and export OTLP Profiles to Pyroscope.
   </Card>
   <Card title="Connect to Odigos Central" icon="server" href="/central/adding-connections/vmagent">
@@ -37,7 +37,7 @@ You can configure the Odigos VM Agent in two ways:
 </CardGroup>
 
 <Tip>
-Add a [destination](./add-destinations) first, then [sources](./add-sources), then [actions](./actions/overview) and [instrumentation rules](./instrumentation-rules/overview) as needed.
+Add a [destination](/vmagent/setup/configuration/add-destinations) first, then [sources](/vmagent/setup/configuration/add-sources), then [actions](/vmagent/setup/configuration/actions/overview) and [instrumentation rules](/vmagent/setup/configuration/instrumentation-rules/overview) as needed.
 </Tip>
 
-For definitions of sources, destinations, and actions, see [Key concepts](../../overview#key-concepts) in the VM Agent overview.
+For definitions of sources, destinations, and actions, see [Key concepts](/vmagent/overview#key-concepts) in the VM Agent overview.

--- a/docs/vmagent/setup/system-requirements.mdx
+++ b/docs/vmagent/setup/system-requirements.mdx
@@ -12,4 +12,4 @@ import KernelVersion from '../../../snippets/shared/ebpf-kernel-version-note.mdx
 - A Linux host running a RHEL-compatible distribution (DNF), a Debian-based distribution (APT), or any Linux system 
 supporting RPM packages.
 - At least one process or application on the host that is written in a 
-[supported language](../../../enterprise/instrumentations/overview).
+[supported language](/enterprise/instrumentations/overview).

--- a/helm/README.md
+++ b/helm/README.md
@@ -10,7 +10,7 @@ helm repo add odigos https://odigos-io.github.io/odigos --force-update
 
 ## Migration
 
-If you have been previously using chart repository at [odigos-charts](https://github.com/odigos-io/odigos-charts) you will get an error "Error: repository name (odigos) already exists, please specify a different name".
+If you have been previously using the `odigos-charts` chart repository you will get an error "Error: repository name (odigos) already exists, please specify a different name".
 To update to new repository location run:
 
 ```sh


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### What this PR does / why we need it:

The `check-links` workflow was failing (171 errors) on the `v1.31.0-rc0` release candidate ([run](https://github.com/odigos-io/odigos/actions/runs/28590100314/attempts/1)). This PR fixes all reported broken links so the check passes. The failures fell into a few categories:

**1. Relative extensionless links in VM Agent / Central docs pages**

`docs/central/overview.mdx` and the `docs/vmagent/**` pages used relative links like `./odictl`, `../../overview#key-concepts`, and `../../../../enterprise/backends-overview`. lychee reports these as `Cannot find file` (it doesn't append `.mdx`), and a few had one `../` too many, so they would also 404 in Mintlify. These are converted to the repo's standard absolute Mintlify paths (e.g. `/vmagent/setup/configuration/odictl`, `/vmagent/overview#key-concepts`, `/enterprise/backends-overview`). Every converted target was verified to exist. Relative image `src` links were left untouched.

**2. Snippet fragments excluded from the checker**

Files under `docs/snippets/**` are Mintlify fragments imported into host pages. Their internal links are intentionally relative so they resolve in the context of the *importing* page (e.g. a shared snippet imported into both `/oss/...` and `/enterprise/...`). lychee checks them standalone and produces false `Cannot find file` errors, so `docs/snippets` is now excluded via `--exclude-path`.

**3. Genuine external 404s**

- `README.md`: `https://docs.odigos.io/installation` → `https://docs.odigos.io/setup/installation`
- `CONTRIBUTING.md`: `https://docs.odigos.io/intro` → `https://docs.odigos.io/quickstart/introduction`
- `helm/README.md`: removed the dead `odigos-charts` repo link (repo no longer exists), keeping the text.

**4. Checker-only false positives excluded in the workflow**

- `https://join.slack.com/...` invite links return `403` to bots but are valid for users.
- `https://github.com/odigos-io/odigos-enterprise/...` (referenced in `operator/DEVELOPMENT.md`) is a private repo that always returns `404` to the checker.

Verified locally with lychee `v0.20.1` using the updated workflow arguments: **0 errors** (343 total, 328 successful, 15 excluded).

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
NONE
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e937712-6655-4647-af79-e9586fd74ee2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e937712-6655-4647-af79-e9586fd74ee2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

emergency-ticket id: EMR-2003
