### PR TITLE
test(actions): re-enable ExtractAttribute + RenameAttribute in v2 actions e2e (PLAT-1261, PLAT-1260)

### DIFF
--- a/frontend/webapp/cypress/constants/index.ts
+++ b/frontend/webapp/cypress/constants/index.ts
@@ -71,13 +71,7 @@ export const SELECTED_ENTITIES = {
     AUTOFILL_FIELD: 'JAEGER_URL',
     AUTOFILL_VALUE: `jaeger.${NAMESPACES.DESTINATIONS}:4317`,
   },
-  // NOTE: one action type is temporarily excluded because the dynamic
-  // (catalog-driven) action form can't create it yet:
-  //   - 'RenameAttribute': the generic `keyValuePairs` renderer emits an array of
-  //     `{ key, value }` rows while the kit still treats `renames` as an object map,
-  //     which crashes on save (PLAT-1260).
-  // Re-add it here (and restore its case in 05-actions.cy.ts) once its ticket lands.
-  ACTIONS: ['K8sAttributesResolver', 'AddClusterInfo', 'DeleteAttribute', 'PiiMasking', 'ExtractAttribute'],
+  ACTIONS: ['K8sAttributesResolver', 'AddClusterInfo', 'DeleteAttribute', 'PiiMasking', 'ExtractAttribute', 'RenameAttribute'],
   INSTRUMENTATION_RULES: ['PayloadCollection', 'CodeAttributes'],
 };
 

--- a/frontend/webapp/cypress/constants/index.ts
+++ b/frontend/webapp/cypress/constants/index.ts
@@ -71,15 +71,13 @@ export const SELECTED_ENTITIES = {
     AUTOFILL_FIELD: 'JAEGER_URL',
     AUTOFILL_VALUE: `jaeger.${NAMESPACES.DESTINATIONS}:4317`,
   },
-  // NOTE: two action types are temporarily excluded because the dynamic
-  // (catalog-driven) action form can't create them yet:
+  // NOTE: one action type is temporarily excluded because the dynamic
+  // (catalog-driven) action form can't create it yet:
   //   - 'RenameAttribute': the generic `keyValuePairs` renderer emits an array of
   //     `{ key, value }` rows while the kit still treats `renames` as an object map,
   //     which crashes on save (PLAT-1260).
-  //   - 'ExtractAttribute': the dynamic table sends `dataFormat: ""` for an unselected
-  //     optional enum, which the GraphQL server rejects with a 400 (PLAT-1261).
-  // Re-add each here (and restore its case in 05-actions.cy.ts) once its ticket lands.
-  ACTIONS: ['K8sAttributesResolver', 'AddClusterInfo', 'DeleteAttribute', 'PiiMasking'],
+  // Re-add it here (and restore its case in 05-actions.cy.ts) once its ticket lands.
+  ACTIONS: ['K8sAttributesResolver', 'AddClusterInfo', 'DeleteAttribute', 'PiiMasking', 'ExtractAttribute'],
   INSTRUMENTATION_RULES: ['PayloadCollection', 'CodeAttributes'],
 };
 


### PR DESCRIPTION
## Summary

Re-enables `ExtractAttribute` and `RenameAttribute` in the v2 actions e2e suite now that both ui-kit fixes have landed ([PLAT-1261](https://linear.app/odigos/issue/PLAT-1261), [PLAT-1260](https://linear.app/odigos/issue/PLAT-1260)).

Both action types were temporarily excluded because the dynamic (catalog-driven) action form couldn't create them:
- **ExtractAttribute (PLAT-1261):** the dynamic table sent `dataFormat: ""` for an unselected optional `ExtractionDataFormat` enum, which the GraphQL server rejected with an HTTP 400. The ui-kit `prepareFormData` fix now omits `dataFormat` entirely when no value is selected.
- **RenameAttribute (PLAT-1260):** the generic `keyValuePairs` renderer emitted an array of `{ key, value }` rows while the kit modeled `renames` as an object map, throwing `TypeError: v.trim is not a function` on save. The ui-kit now (de)serializes the array shape into the object map (dedicated `KeyValueField`).

Changes:
- Re-add `'ExtractAttribute'` and `'RenameAttribute'` to `SELECTED_ENTITIES.ACTIONS` in `cypress/constants/index.ts`.
- Drop the now-empty exclusion comment (no action types remain excluded).
- Both cases in `05-actions.cy.ts` were already restored, so no test-body change is needed.

`totalEntities` is derived from `SELECTED_ENTITIES.ACTIONS.length`, so all create/update/delete/CRD-count assertions scale automatically.

## Test plan

- [ ] `05-actions.cy.ts` passes with 6 actions (K8sAttributesResolver, AddClusterInfo, DeleteAttribute, PiiMasking, ExtractAttribute, RenameAttribute) created / updated / deleted.

```release-note
NONE
```