### PR TITLE
test(actions): re-enable RenameAttribute in v2 actions e2e (PLAT-1260)

### DIFF
--- a/frontend/webapp/cypress/constants/index.ts
+++ b/frontend/webapp/cypress/constants/index.ts
@@ -71,15 +71,12 @@ export const SELECTED_ENTITIES = {
     AUTOFILL_FIELD: 'JAEGER_URL',
     AUTOFILL_VALUE: `jaeger.${NAMESPACES.DESTINATIONS}:4317`,
   },
-  // NOTE: two action types are temporarily excluded because the dynamic
-  // (catalog-driven) action form can't create them yet:
-  //   - 'RenameAttribute': the generic `keyValuePairs` renderer emits an array of
-  //     `{ key, value }` rows while the kit still treats `renames` as an object map,
-  //     which crashes on save (PLAT-1260).
+  // NOTE: one action type is temporarily excluded because the dynamic
+  // (catalog-driven) action form can't create it yet:
   //   - 'ExtractAttribute': the dynamic table sends `dataFormat: ""` for an unselected
   //     optional enum, which the GraphQL server rejects with a 400 (PLAT-1261).
-  // Re-add each here (and restore its case in 05-actions.cy.ts) once its ticket lands.
-  ACTIONS: ['K8sAttributesResolver', 'AddClusterInfo', 'DeleteAttribute', 'PiiMasking'],
+  // Re-add it here (and restore its case in 05-actions.cy.ts) once its ticket lands.
+  ACTIONS: ['K8sAttributesResolver', 'AddClusterInfo', 'DeleteAttribute', 'RenameAttribute', 'PiiMasking'],
   INSTRUMENTATION_RULES: ['PayloadCollection', 'CodeAttributes'],
 };
 


### PR DESCRIPTION
## Summary

Re-enables `RenameAttribute` in the v2 actions e2e suite now that the ui-kit fix for [PLAT-1260](https://linear.app/odigos/issue/PLAT-1260) has landed.

The dynamic (catalog-driven) action form used to render `renames` via the generic `keyValuePairs` renderer, which emits an array of `{ key, value }` rows — while the kit modeled `renames` as an object map `{ [oldKey]: newKey }`. On save this threw `TypeError: v.trim is not a function` before `CreateAction` fired, so the action could never be created and `RenameAttribute` was temporarily excluded from e2e coverage. The ui-kit now (de)serializes the array shape into the object map (dedicated `KeyValueField`), so the action creates cleanly.

- Re-add `'RenameAttribute'` to `SELECTED_ENTITIES.ACTIONS` in `cypress/constants/index.ts`.
- Trim the stale exclusion comment (only `ExtractAttribute` / PLAT-1261 remains excluded).
- The `RenameAttribute` case in `05-actions.cy.ts` was already restored (key/value table path), so no test-body change is needed.

`totalEntities` is derived from `SELECTED_ENTITIES.ACTIONS.length`, so all create/update/delete/CRD-count assertions scale automatically.

> Note: touches the same `ACTIONS` array/comment as #5176 (PLAT-1261); whichever merges second will need a trivial conflict resolution.

## Test plan

- [ ] `05-actions.cy.ts` passes with 5 actions (K8sAttributesResolver, AddClusterInfo, DeleteAttribute, RenameAttribute, PiiMasking) created / updated / deleted.

Made with [Cursor](https://cursor.com)