### PR TITLE
feat: filter out unsupported head sampling rules

### DIFF
--- a/distros/distro/oteldistribution.go
+++ b/distros/distro/oteldistribution.go
@@ -168,6 +168,9 @@ type AgentMetrics struct {
 type HeadSampling struct {
 	// if true, the distro supports head sampling for health checks.
 	Supported bool `yaml:"supported,omitempty"`
+
+	// if true, the distro supports HTTP query params sampling.
+	HttpQueryParamsSupported bool `yaml:"httpQueryParamsSupported,omitempty"`
 }
 
 type HeadersCollection struct {

--- a/distros/yamls/nodejs-community.yaml
+++ b/distros/yamls/nodejs-community.yaml
@@ -28,6 +28,7 @@ spec:
   traces:
     headSampling:
       supported: true
+      httpQueryParamsSupported: true
     headersCollection:
       supported: true
     traceVerbosity:

--- a/instrumentor/controllers/agentenabled/dynamicconfig/traces/sampling.go
+++ b/instrumentor/controllers/agentenabled/dynamicconfig/traces/sampling.go
@@ -232,6 +232,10 @@ func calculateKubeletHealthProbesSamplingRules(effectiveConfig *common.OdigosCon
 	return noisyOperations
 }
 
+func noisyOperationContainsHttpQueryParams(noisyOperation *commonapisampling.NoisyOperation) bool {
+	return noisyOperation != nil && noisyOperation.Operation != nil && noisyOperation.Operation.HttpServer != nil && len(noisyOperation.Operation.HttpServer.QueryParams) > 0
+}
+
 func CalculateSamplingCategoryRulesForContainer(samplingRules *[]odigosv1.Sampling, language common.ProgrammingLanguage,
 	pw k8sconsts.PodWorkload, containerName string, distro *distro.OtelDistro, workloadObj workload.Workload, effectiveConfig *common.OdigosConfiguration) ([]apisampling.NoisyOperation, []apisampling.HighlyRelevantOperation, []apisampling.CostReductionRule) {
 
@@ -239,9 +243,21 @@ func CalculateSamplingCategoryRulesForContainer(samplingRules *[]odigosv1.Sampli
 	var filteredRelevantOps []apisampling.HighlyRelevantOperation
 	var filteredCostRules []apisampling.CostReductionRule
 
+	distroSupportsHttpQueryParams := distro.Traces != nil && distro.Traces.HeadSampling != nil && distro.Traces.HeadSampling.HttpQueryParamsSupported
+
 	// compute auto sampling rules
 	if isK8sHealthProbesSamplingEnabled(effectiveConfig) {
-		filteredNoisyOps = append(filteredNoisyOps, calculateKubeletHealthProbesSamplingRules(effectiveConfig, workloadObj, containerName)...)
+		kubeletHealthProbesSamplingRules := calculateKubeletHealthProbesSamplingRules(effectiveConfig, workloadObj, containerName)
+		for _, rule := range kubeletHealthProbesSamplingRules {
+			ruleContainsHttpQueryParams := noisyOperationContainsHttpQueryParams(&rule)
+			if ruleContainsHttpQueryParams && !distroSupportsHttpQueryParams {
+				// filter out rule which are not supported by the distro.
+				// in the future, we should somehow communicate this to the user, and not just silently ignore it.
+				// for now, we just silently ignore it.
+				continue
+			}
+			filteredNoisyOps = append(filteredNoisyOps, rule)
+		}
 	}
 
 	for _, samplingRule := range *samplingRules {
@@ -250,13 +266,24 @@ func CalculateSamplingCategoryRulesForContainer(samplingRules *[]odigosv1.Sampli
 
 		for _, noisyOp := range samplingRule.Spec.NoisyOperations {
 			if scope.SourceScopeMatchesContainer(noisyOp.SourceScopes, pw, language) {
-				filteredNoisyOps = append(filteredNoisyOps, apisampling.NoisyOperation{
+
+				noisyOperationCommonApi := apisampling.NoisyOperation{
 					Id:               odigosv1.ComputeNoisyOperationHash(&noisyOp),
 					Name:             noisyOp.Name,
 					Disabled:         noisyOp.Disabled,
 					Operation:        noisyOp.Operation,
 					PercentageAtMost: noisyOp.PercentageAtMost,
-				})
+				}
+
+				ruleContainsHttpQueryParams := noisyOperationContainsHttpQueryParams(&noisyOperationCommonApi)
+				if ruleContainsHttpQueryParams && !distroSupportsHttpQueryParams {
+					// filter out rule which are not supported by the distro.
+					// in the future, we should somehow communicate this to the user, and not just silently ignore it.
+					// for now, we just silently ignore it.
+					continue
+				}
+
+				filteredNoisyOps = append(filteredNoisyOps, noisyOperationCommonApi)
 			}
 		}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: CORE-1149

https://github.com/odigos-io/odigos/pull/5184 added support for query params in head-sampling rules, but currently only nodejs supports it.
if the distro does not support the feature, it will silently be ignored, which can cause sampling to be applied where it should not. 

This PR adds the support indication to the distro, and filter out rules when they are not supported. in the future we should indicate to the user somehow that the rule is skipped due to not supported

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Avoid adding head sampling rules for query params to distros that do not support this feature
```
