### PR TITLE
feat: add attribute to document url-templatization outcome

### DIFF
--- a/collector/processors/odigosurltemplateprocessor/processor.go
+++ b/collector/processors/odigosurltemplateprocessor/processor.go
@@ -312,7 +312,7 @@ func splitPathToSegments(path string) ([]string, bool) {
 // calculateTemplatedUrlFromAttrWithRules calculates a templated URL using the given rules.
 // returns the templated path and a method indicating how it was produced.
 // a nil method means templatization was skipped and the route attribute should not be set.
-func (p *urlTemplateProcessor) calculateTemplatedUrlFromAttrWithRules(attr pcommon.Map, config workloadUrlTemplatizationConfig, spanKind ptrace.SpanKind) (string, *odigosattributes.UrlTemplatizationMethod) {
+func (p *urlTemplateProcessor) calculateTemplatedUrlFromAttrWithRules(attr pcommon.Map, config workloadUrlTemplatizationConfig, spanKind ptrace.SpanKind) (string, *odigosattributes.UrlTemplatizationResult) {
 	urlPath, urlPathFound := resolveUrlPath(attr)
 	if !urlPathFound {
 		p.logger.Debug("calculateTemplatedUrlFromAttrWithRules: no url/path in attributes, skip templatization")
@@ -322,20 +322,20 @@ func (p *urlTemplateProcessor) calculateTemplatedUrlFromAttrWithRules(attr pcomm
 	// normalize paths that are all slashes (e.g. "//", "///") to "/"
 	if strings.Trim(urlPath, "/") == "" {
 		p.logger.Debug("applyTemplatizationOnPath: all-slashes normalized to /", zap.String("path", urlPath))
-		return "/", odigosattributes.UrlTemplatizationMethodPathNormalization.Ptr()
+		return "/", odigosattributes.UrlTemplatizationResultPathNormalization.Ptr()
 	}
 
 	inputPathSegments, hadLeadingSlash := splitPathToSegments(urlPath)
 	if len(inputPathSegments) == 1 && inputPathSegments[0] == "" {
 		// if the path is empty, we can't generate a templated url
-		return "/", odigosattributes.UrlTemplatizationMethodPathNormalization.Ptr()
+		return "/", odigosattributes.UrlTemplatizationResultPathNormalization.Ptr()
 	}
 
 	// attempt the rules if we have any
 	if len(config.parsedRules) > 0 {
 		templatedUrl, matched := applyCustomRulesForTemplatization(inputPathSegments, config.parsedRules, hadLeadingSlash)
 		if matched {
-			return templatedUrl, odigosattributes.UrlTemplatizationMethodCustomRule.Ptr()
+			return templatedUrl, odigosattributes.UrlTemplatizationResultCustomRule.Ptr()
 		}
 	}
 
@@ -375,11 +375,11 @@ func (p *urlTemplateProcessor) calculateTemplatedUrlFromAttrWithRules(attr pcomm
 			// if the path has a leading slash, we need to add it back
 			templatedPath = "/" + templatedPath
 		}
-		return templatedPath, odigosattributes.UrlTemplatizationMethodDefaultHeuristic.Ptr()
+		return templatedPath, odigosattributes.UrlTemplatizationResultDefaultHeuristic.Ptr()
 	}
 
 	p.logger.Debug("applyTemplatizationOnPath: no match, path unchanged", zap.String("path", urlPath))
-	return urlPath, odigosattributes.UrlTemplatizationMethodUnchanged.Ptr()
+	return urlPath, odigosattributes.UrlTemplatizationResultStaticPath.Ptr()
 }
 
 func updateHttpSpanName(span ptrace.Span, httpMethod string, templatedUrl string) {
@@ -420,14 +420,14 @@ func (p *urlTemplateProcessor) enhanceSpanWithRules(span ptrace.Span, httpMethod
 		return
 	}
 
-	templatedUrl, templatizationMethod := p.calculateTemplatedUrlFromAttrWithRules(attr, config, span.Kind())
-	if templatizationMethod == nil {
+	templatedUrl, templatizationResult := p.calculateTemplatedUrlFromAttrWithRules(attr, config, span.Kind())
+	if templatizationResult == nil {
 		return
 	}
 
 	// set the templated url in the target attribute and update the span name if needed
 	attr.PutStr(targetAttribute, templatedUrl)
-	attr.PutStr(odigosattributes.UrlTemplatizationMethodAttribute, string(*templatizationMethod))
+	attr.PutStr(odigosattributes.UrlTemplatizationResultAttribute, string(*templatizationResult))
 	updateHttpSpanName(span, httpMethod, templatedUrl)
 }
 

--- a/collector/processors/odigosurltemplateprocessor/processor.go
+++ b/collector/processors/odigosurltemplateprocessor/processor.go
@@ -19,6 +19,7 @@ import (
 	commonapi "github.com/odigos-io/odigos/common/api"
 	commonactionsapi "github.com/odigos-io/odigos/common/api/actions"
 	"github.com/odigos-io/odigos/common/collector"
+	"github.com/odigos-io/odigos/common/odigosattributes"
 )
 
 // Ensure urlTemplateProcessor implements the callback interface used by the extension.
@@ -309,37 +310,38 @@ func splitPathToSegments(path string) ([]string, bool) {
 }
 
 // calculateTemplatedUrlFromAttrWithRules calculates a templated URL using the given rules.
-// returns the templated path, an boolean to indicate if templatization was applied.
-func (p *urlTemplateProcessor) calculateTemplatedUrlFromAttrWithRules(attr pcommon.Map, config workloadUrlTemplatizationConfig, spanKind ptrace.SpanKind) (string, bool) {
+// returns the templated path and a method indicating how it was produced.
+// a nil method means templatization was skipped and the route attribute should not be set.
+func (p *urlTemplateProcessor) calculateTemplatedUrlFromAttrWithRules(attr pcommon.Map, config workloadUrlTemplatizationConfig, spanKind ptrace.SpanKind) (string, *odigosattributes.UrlTemplatizationMethod) {
 	urlPath, urlPathFound := resolveUrlPath(attr)
 	if !urlPathFound {
 		p.logger.Debug("calculateTemplatedUrlFromAttrWithRules: no url/path in attributes, skip templatization")
-		return "", false
+		return "", nil
 	}
 
-	// M7: normalize paths that are all slashes (e.g. "//", "///") to "/"
+	// normalize paths that are all slashes (e.g. "//", "///") to "/"
 	if strings.Trim(urlPath, "/") == "" {
 		p.logger.Debug("applyTemplatizationOnPath: all-slashes normalized to /", zap.String("path", urlPath))
-		return "/", true
+		return "/", odigosattributes.UrlTemplatizationMethodPathNormalization.Ptr()
 	}
 
 	inputPathSegments, hadLeadingSlash := splitPathToSegments(urlPath)
 	if len(inputPathSegments) == 1 && inputPathSegments[0] == "" {
 		// if the path is empty, we can't generate a templated url
-		return "/", true // always set a leading slash even if missing
+		return "/", odigosattributes.UrlTemplatizationMethodPathNormalization.Ptr()
 	}
 
 	// attempt the rules if we have any
 	if len(config.parsedRules) > 0 {
 		templatedUrl, matched := applyCustomRulesForTemplatization(inputPathSegments, config.parsedRules, hadLeadingSlash)
 		if matched {
-			return templatedUrl, true
+			return templatedUrl, odigosattributes.UrlTemplatizationMethodCustomRule.Ptr()
 		}
 	}
 
 	// skip default templatization if the config is unset or disabled.
 	if config.defaultTemplatizationConfig == nil || config.defaultTemplatizationConfig.Disabled {
-		return "", false
+		return "", nil
 	}
 
 	// check for malicious bots routes so not to templatize them.
@@ -352,14 +354,14 @@ func (p *urlTemplateProcessor) calculateTemplatedUrlFromAttrWithRules(attr pcomm
 			if skipPolicyConfig.SkipForNonSuccessCodes {
 				if statusCode < 200 || statusCode >= 300 {
 					p.logger.Debug("applyTemplatizationOnPath: non-success http status code on span, skip default templatization", zap.Int("status_code", statusCode))
-					return "", false
+					return "", nil
 				}
 			}
 
 			if len(skipPolicyConfig.SkipHttpStatusCodes) > 0 {
 				if slices.Contains(skipPolicyConfig.SkipHttpStatusCodes, statusCode) {
 					p.logger.Debug("applyTemplatizationOnPath: http status code on span is in skip list, skip default templatization", zap.Int("status_code", statusCode))
-					return "", false
+					return "", nil
 				}
 			}
 		}
@@ -373,11 +375,11 @@ func (p *urlTemplateProcessor) calculateTemplatedUrlFromAttrWithRules(attr pcomm
 			// if the path has a leading slash, we need to add it back
 			templatedPath = "/" + templatedPath
 		}
-		return templatedPath, true
+		return templatedPath, odigosattributes.UrlTemplatizationMethodDefaultHeuristic.Ptr()
 	}
 
 	p.logger.Debug("applyTemplatizationOnPath: no match, path unchanged", zap.String("path", urlPath))
-	return urlPath, true
+	return urlPath, odigosattributes.UrlTemplatizationMethodUnchanged.Ptr()
 }
 
 func updateHttpSpanName(span ptrace.Span, httpMethod string, templatedUrl string) {
@@ -418,13 +420,14 @@ func (p *urlTemplateProcessor) enhanceSpanWithRules(span ptrace.Span, httpMethod
 		return
 	}
 
-	templatedUrl, templatizationApplied := p.calculateTemplatedUrlFromAttrWithRules(attr, config, span.Kind())
-	if !templatizationApplied {
+	templatedUrl, templatizationMethod := p.calculateTemplatedUrlFromAttrWithRules(attr, config, span.Kind())
+	if templatizationMethod == nil {
 		return
 	}
 
 	// set the templated url in the target attribute and update the span name if needed
 	attr.PutStr(targetAttribute, templatedUrl)
+	attr.PutStr(odigosattributes.UrlTemplatizationMethodAttribute, string(*templatizationMethod))
 	updateHttpSpanName(span, httpMethod, templatedUrl)
 }
 

--- a/common/odigosattributes/url_templatization.go
+++ b/common/odigosattributes/url_templatization.go
@@ -1,0 +1,26 @@
+package odigosattributes
+
+const (
+	// Span attribute indicating how URL templatization was applied. Type: string.
+	// Not set when templatization was skipped (no path, default disabled, skip policy).
+	UrlTemplatizationMethodAttribute = "odigos.url_templatization.method"
+)
+
+// UrlTemplatizationMethod describes which class of templatization was applied to a span.
+// nil means templatization was skipped.
+type UrlTemplatizationMethod string
+
+func (m UrlTemplatizationMethod) Ptr() *UrlTemplatizationMethod {
+	return &m
+}
+
+const (
+	// A custom templatization rule matched the path.
+	UrlTemplatizationMethodCustomRule UrlTemplatizationMethod = "custom_rule"
+	// Default heuristic templatization replaced one or more path segments.
+	UrlTemplatizationMethodDefaultHeuristic UrlTemplatizationMethod = "default_heuristic"
+	// The path was normalized without segment templatization (e.g. "//" or empty path → "/").
+	UrlTemplatizationMethodPathNormalization UrlTemplatizationMethod = "path_normalization"
+	// Templatization was evaluated but the path was left unchanged.
+	UrlTemplatizationMethodUnchanged UrlTemplatizationMethod = "unchanged"
+)

--- a/common/odigosattributes/url_templatization.go
+++ b/common/odigosattributes/url_templatization.go
@@ -3,24 +3,25 @@ package odigosattributes
 const (
 	// Span attribute indicating how URL templatization was applied. Type: string.
 	// Not set when templatization was skipped (no path, default disabled, skip policy).
-	UrlTemplatizationMethodAttribute = "odigos.url_templatization.method"
+	UrlTemplatizationResultAttribute = "odigos.url_templatization.result"
 )
 
-// UrlTemplatizationMethod describes which class of templatization was applied to a span.
+// UrlTemplatizationResult describes which class of templatization was applied to a span.
 // nil means templatization was skipped.
-type UrlTemplatizationMethod string
+type UrlTemplatizationResult string
 
-func (m UrlTemplatizationMethod) Ptr() *UrlTemplatizationMethod {
+func (m UrlTemplatizationResult) Ptr() *UrlTemplatizationResult {
 	return &m
 }
 
 const (
 	// A custom templatization rule matched the path.
-	UrlTemplatizationMethodCustomRule UrlTemplatizationMethod = "custom_rule"
+	UrlTemplatizationResultCustomRule UrlTemplatizationResult = "custom_rule"
 	// Default heuristic templatization replaced one or more path segments.
-	UrlTemplatizationMethodDefaultHeuristic UrlTemplatizationMethod = "default_heuristic"
+	UrlTemplatizationResultDefaultHeuristic UrlTemplatizationResult = "default_heuristic"
 	// The path was normalized without segment templatization (e.g. "//" or empty path → "/").
-	UrlTemplatizationMethodPathNormalization UrlTemplatizationMethod = "path_normalization"
-	// Templatization was evaluated but the path was left unchanged.
-	UrlTemplatizationMethodUnchanged UrlTemplatizationMethod = "unchanged"
+	UrlTemplatizationResultPathNormalization UrlTemplatizationResult = "path_normalization"
+	// Templatization ran but the path had no dynamic segments, so the templatized
+	// result is the static path as-is.
+	UrlTemplatizationResultStaticPath UrlTemplatizationResult = "static_path"
 )

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -1518,8 +1518,8 @@ metricsSources:
     #   span metrics collector settings.
     #   agents have different capabilities and support different configuration options.
     # @schema
-    spanMetrics:
-      enabled: true
+    # spanMetrics:
+    #   enabled: true
 
     # @schema
     # description: Configuration for runtime metrics collection.

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -1518,8 +1518,8 @@ metricsSources:
     #   span metrics collector settings.
     #   agents have different capabilities and support different configuration options.
     # @schema
-    # spanMetrics:
-    #   enabled: true
+    spanMetrics:
+      enabled: true
 
     # @schema
     # description: Configuration for runtime metrics collection.

--- a/instrumentor/controllers/agentenabled/pods_webhook.go
+++ b/instrumentor/controllers/agentenabled/pods_webhook.go
@@ -381,7 +381,7 @@ func (p *PodsWebhook) injectOdigosToContainer(containerConfig *odigosv1.Containe
 	}
 
 	// URL Templatization configuration
-	urlTemplatizationEnabled := containerConfig.Traces != nil && containerConfig.Traces.UrlTemplatization != nil && len(containerConfig.Traces.UrlTemplatization.Templates) > 0
+	urlTemplatizationEnabled := containerConfig.Traces != nil && containerConfig.Traces.UrlTemplatization != nil
 	supportsUrlTemplatization := distroMetadata.Traces != nil && distroMetadata.Traces.UrlTemplatization != nil && distroMetadata.Traces.UrlTemplatization.Supported
 	if urlTemplatizationEnabled && supportsUrlTemplatization && distroMetadata.ConfigAsEnvVars {
 		// parse URL templatization config to json using the existing AgentTracesConfig struct


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: CORE-1249

When troubleshooting issues, sometimes spans contains http route and it's not trivial to figure out if it's coming from the instrumentation itself (e.g. from an http framework), or from our templatization.

This PR adds a new attribute to spans which document this behavior.


#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
add span attribute when url-templatization is applied
```
