### PR TITLE
RUN-872 | fix(odigosebpfreceiver): correct jvm.cpu.recent_utilization scaling (100x inflation)

### DIFF
--- a/collector/receivers/odigosebpfreceiver/internal/metrics/jvm/handler.go
+++ b/collector/receivers/odigosebpfreceiver/internal/metrics/jvm/handler.go
@@ -420,7 +420,7 @@ func (h *JVMMetricsHandler) addCPUUtilizationMetric(scopeMetrics pmetric.ScopeMe
 
 	gaugeMetric := metric.SetEmptyGauge()
 	dataPoint := gaugeMetric.DataPoints().AppendEmpty()
-	utilization := float64(gauge.Value) / 1e7 // normalize values as they were scaled up to store float values as uint in ebpf maps
+	utilization := float64(gauge.Value) / 1e9 // normalize values as they were scaled up to store float values as uint in ebpf maps
 	dataPoint.SetDoubleValue(utilization)
 	now := pcommon.NewTimestampFromTime(time.Now())
 	dataPoint.SetTimestamp(now)


### PR DESCRIPTION
## Summary
`jvm.cpu.recent_utilization` was being emitted ~100x too large — as a 0–100 value
instead of the OTel-spec 0–1 ratio. In backends (e.g. Coralogix) this surfaces as
`jvm_cpu_recent_utilization_1` reading ~45 when the real utilization is ~0.45.

Root cause is a scaling-constant mismatch between the agent (writer) and this
receiver (reader) across the shared eBPF map:

- Agent (`ebpf-java-instrumentation/jvmmetrics/cpu_collector.go`) encodes the
  clamped [0,1] ratio as fixed-point **×1e9** (`0.5 → 500000000`).
- This receiver decoded it with **÷1e7**, yielding `50.0` instead of `0.5`.

`1e9 / 1e7 = 100`, hence the constant 100x inflation. 

## Fix
Decode with `÷1e9` to match the agent's documented `×1e9` encoding.

## Scope / blast radius
- Only `jvm.cpu.recent_utilization` is affected. Verified sibling metrics use
  matching scales: `jvm.cpu.time` (raw ns → `÷1e9`), `jvm.cpu.count` (raw int),
  `jvm.gc.duration` sum (raw ns → `÷1e9`).
- This receiver is the only consumer of the scaled gauge. The agent's standalone
  path reports CPU directly to OTel (no map, no scaling) and is unaffected.


```release-note
Fixed: JVM CPU utilization metric no longer reported 100× too high.
```
