### PR TITLE
RUN-872 | fix(odigosebpfreceiver): correct jvm.cpu.recent_utilization…

### DIFF
--- a/collector/receivers/odigosebpfreceiver/internal/metrics/jvm/handler.go
+++ b/collector/receivers/odigosebpfreceiver/internal/metrics/jvm/handler.go
@@ -420,7 +420,7 @@ func (h *JVMMetricsHandler) addCPUUtilizationMetric(scopeMetrics pmetric.ScopeMe
 
 	gaugeMetric := metric.SetEmptyGauge()
 	dataPoint := gaugeMetric.DataPoints().AppendEmpty()
-	utilization := float64(gauge.Value) / 1e7 // normalize values as they were scaled up to store float values as uint in ebpf maps
+	utilization := float64(gauge.Value) / 1e9 // normalize values as they were scaled up to store float values as uint in ebpf maps
 	dataPoint.SetDoubleValue(utilization)
 	now := pcommon.NewTimestampFromTime(time.Now())
 	dataPoint.SetTimestamp(now)


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->

cherry pick of https://github.com/odigos-io/odigos/pull/5201

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
fix(odigosebpfreceiver): correct jvm.cpu.recent_utilization scaling (100x inflation) 
```
