### PR TITLE
fix: combine remaining critical Cursor automation fixes

### DIFF
--- a/autoscaler/controllers/actions/action_controller.go
+++ b/autoscaler/controllers/actions/action_controller.go
@@ -68,6 +68,11 @@ func convertActionToProcessor(ctx context.Context, k8sclient client.Client, acti
 	}
 
 	if action.Spec.ExtractAttribute != nil {
+		for _, signal := range action.Spec.Signals {
+			if _, ok := supportedExtractAttributeSignals[signal]; !ok {
+				return nil, fmt.Errorf("unsupported signal in ExtractAttribute action: %s", signal)
+			}
+		}
 		config, err := extractAttributeConfig(action.Spec.ExtractAttribute)
 		if err != nil {
 			return nil, err

--- a/autoscaler/controllers/actions/action_controller_unit_test.go
+++ b/autoscaler/controllers/actions/action_controller_unit_test.go
@@ -1,0 +1,36 @@
+package actions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	odigosactions "github.com/odigos-io/odigos/api/odigos/v1alpha1/actions"
+	"github.com/odigos-io/odigos/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertActionToProcessorRejectsUnsupportedExtractAttributeSignal(t *testing.T) {
+	action := &v1alpha1.Action{
+		Spec: v1alpha1.ActionSpec{
+			Signals: []common.ObservabilitySignal{
+				common.TracesObservabilitySignal,
+				common.LogsObservabilitySignal,
+			},
+			ExtractAttribute: &odigosactions.ExtractAttributeConfig{
+				Extractions: []odigosactions.Extraction{
+					{
+						TargetAttributeName: "user.id",
+						LookupKey:           "user_id",
+						DataFormat:          odigosactions.FormatJSON,
+					},
+				},
+			},
+		},
+	}
+
+	processor, err := convertActionToProcessor(context.Background(), nil, action)
+
+	require.Nil(t, processor)
+	require.ErrorContains(t, err, "unsupported signal in ExtractAttribute action: LOGS")
+}

--- a/autoscaler/controllers/actions/extractattribute_config_test.go
+++ b/autoscaler/controllers/actions/extractattribute_config_test.go
@@ -1,0 +1,37 @@
+package actions
+
+import (
+	"testing"
+
+	odigosactions "github.com/odigos-io/odigos/api/odigos/v1alpha1/actions"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractAttributeConfigRejectsInvalidRegex(t *testing.T) {
+	_, err := extractAttributeConfig(&odigosactions.ExtractAttributeConfig{
+		Extractions: []odigosactions.Extraction{
+			{
+				TargetAttributeName: "request.id",
+				Regex:               "[invalid",
+			},
+		},
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid regex")
+}
+
+func TestExtractAttributeConfigAllowsValidRegex(t *testing.T) {
+	cfg, err := extractAttributeConfig(&odigosactions.ExtractAttributeConfig{
+		Extractions: []odigosactions.Extraction{
+			{
+				TargetAttributeName: "request.id",
+				Regex:               `request_id=([A-Za-z0-9-]+)`,
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, cfg.Extractions, 1)
+	require.Equal(t, `request_id=([A-Za-z0-9-]+)`, cfg.Extractions[0].Regex)
+}

--- a/autoscaler/controllers/actions/extractattribute_controller.go
+++ b/autoscaler/controllers/actions/extractattribute_controller.go
@@ -18,9 +18,15 @@ package actions
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/odigos-io/odigos/api/odigos/v1alpha1/actions"
+	"github.com/odigos-io/odigos/common"
 )
+
+var supportedExtractAttributeSignals = map[common.ObservabilitySignal]struct{}{
+	common.TracesObservabilitySignal: {},
+}
 
 type extractAttributeProcessorConfig struct {
 	Extractions []extractAttributeRule `json:"extractions"`
@@ -28,9 +34,9 @@ type extractAttributeProcessorConfig struct {
 
 type extractAttributeRule struct {
 	TargetAttributeName string `json:"target_attribute_name"`
-	LookupKey        string `json:"lookup_key,omitempty"`
-	DataFormat       string `json:"data_format,omitempty"`
-	Regex            string `json:"regex,omitempty"`
+	LookupKey           string `json:"lookup_key,omitempty"`
+	DataFormat          string `json:"data_format,omitempty"`
+	Regex               string `json:"regex,omitempty"`
 }
 
 // extractAttributeConfig translates the API-level ExtractAttributeConfig into the processor-level config and validates cross-field invariants
@@ -72,12 +78,17 @@ func extractAttributeConfig(cfg *actions.ExtractAttributeConfig) (extractAttribu
 		if hasRegex && extraction.LookupKey != "" {
 			return config, fmt.Errorf("extractions[%d]: lookupKey must be empty when regex is set", i)
 		}
+		if hasRegex {
+			if _, err := regexp.Compile(extraction.Regex); err != nil {
+				return config, fmt.Errorf("extractions[%d]: invalid regex: %w", i, err)
+			}
+		}
 
 		config.Extractions = append(config.Extractions, extractAttributeRule{
 			TargetAttributeName: extraction.TargetAttributeName,
-			LookupKey:        extraction.LookupKey,
-			DataFormat:       string(extraction.DataFormat),
-			Regex:            extraction.Regex,
+			LookupKey:           extraction.LookupKey,
+			DataFormat:          string(extraction.DataFormat),
+			Regex:               extraction.Regex,
 		})
 	}
 	return config, nil

--- a/autoscaler/controllers/actions/extractattribute_controller_test.go
+++ b/autoscaler/controllers/actions/extractattribute_controller_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -40,9 +41,9 @@ type extractAttributeRawConfig struct {
 
 type extractAttributeRawRule struct {
 	TargetAttributeName string `json:"target_attribute_name"`
-	LookupKey        string `json:"lookup_key,omitempty"`
-	DataFormat       string `json:"data_format,omitempty"`
-	Regex            string `json:"regex,omitempty"`
+	LookupKey           string `json:"lookup_key,omitempty"`
+	DataFormat          string `json:"data_format,omitempty"`
+	Regex               string `json:"regex,omitempty"`
 }
 
 var _ = Describe("ExtractAttribute Controller", func() {
@@ -72,8 +73,8 @@ var _ = Describe("ExtractAttribute Controller", func() {
 						Extractions: []odigosactions.Extraction{
 							{
 								TargetAttributeName: "study.id",
-								LookupKey:        "study_id",
-								DataFormat:       odigosactions.FormatJSON,
+								LookupKey:           "study_id",
+								DataFormat:          odigosactions.FormatJSON,
 							},
 						},
 					},
@@ -131,7 +132,7 @@ var _ = Describe("ExtractAttribute Controller", func() {
 						Extractions: []odigosactions.Extraction{
 							{
 								TargetAttributeName: "request.id",
-								Regex:            `request_id=([A-Za-z0-9-]+)`,
+								Regex:               `request_id=([A-Za-z0-9-]+)`,
 							},
 						},
 					},
@@ -174,17 +175,17 @@ var _ = Describe("ExtractAttribute Controller", func() {
 						Extractions: []odigosactions.Extraction{
 							{
 								TargetAttributeName: "extracted_study.id",
-								LookupKey:        "studies",
-								DataFormat:       odigosactions.FormatResourcePath,
+								LookupKey:           "studies",
+								DataFormat:          odigosactions.FormatResourcePath,
 							},
 							{
 								TargetAttributeName: "extracted_project.id",
-								LookupKey:        "projects",
-								DataFormat:       odigosactions.FormatResourcePath,
+								LookupKey:           "projects",
+								DataFormat:          odigosactions.FormatResourcePath,
 							},
 							{
 								TargetAttributeName: "trace.id",
-								Regex:            `traceId=([0-9a-f]+)`,
+								Regex:               `traceId=([0-9a-f]+)`,
 							},
 						},
 					},
@@ -220,26 +221,26 @@ var _ = Describe("ExtractAttribute Controller", func() {
 			Expect(rendered.Extractions[2].DataFormat).Should(BeEmpty())
 		})
 
-		It("Should propagate Disabled and multiple Signals to the Processor", func() {
-			By("Creating a disabled Action with multiple signals")
+		It("Should reject logs and metrics signals", func() {
+			By("Creating an Action with unsupported signals")
 			action := &odigosv1.Action{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      ActionName + "-disabled",
+					Name:      ActionName + "-unsupported-signals",
 					Namespace: ActionNamespace,
 				},
 				Spec: odigosv1.ActionSpec{
-					ActionName: "extract disabled",
-					Disabled:   true,
+					ActionName: "extract unsupported",
 					Signals: []common.ObservabilitySignal{
 						common.TracesObservabilitySignal,
 						common.LogsObservabilitySignal,
+						common.MetricsObservabilitySignal,
 					},
 					ExtractAttribute: &odigosactions.ExtractAttributeConfig{
 						Extractions: []odigosactions.Extraction{
 							{
 								TargetAttributeName: "user.id",
-								LookupKey:        "user_id",
-								DataFormat:       odigosactions.FormatJSON,
+								LookupKey:           "user_id",
+								DataFormat:          odigosactions.FormatJSON,
 							},
 						},
 					},
@@ -248,20 +249,32 @@ var _ = Describe("ExtractAttribute Controller", func() {
 
 			Expect(k8sClient.Create(testCtx, action)).Should(Succeed())
 
+			By("Checking that no Processor is created")
 			processor := &odigosv1.Processor{}
-			Eventually(func() bool {
+			Consistently(func() bool {
 				err := k8sClient.Get(testCtx, types.NamespacedName{
-					Name:      ActionName + "-disabled",
+					Name:      ActionName + "-unsupported-signals",
 					Namespace: ActionNamespace,
 				}, processor)
-				return err == nil
+				return err != nil
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(processor.Spec.Disabled).Should(BeTrue())
-			Expect(processor.Spec.Signals).Should(ContainElements(
-				common.TracesObservabilitySignal,
-				common.LogsObservabilitySignal,
-			))
+			By("Checking that the Action status reports the unsupported signal")
+			Eventually(func() string {
+				updatedAction := &odigosv1.Action{}
+				err := k8sClient.Get(testCtx, types.NamespacedName{
+					Name:      ActionName + "-unsupported-signals",
+					Namespace: ActionNamespace,
+				}, updatedAction)
+				if err != nil {
+					return ""
+				}
+				condition := meta.FindStatusCondition(updatedAction.Status.Conditions, odigosv1.ActionTransformedToProcessorType)
+				if condition == nil {
+					return ""
+				}
+				return condition.Message
+			}, timeout, interval).Should(ContainSubstring("unsupported signal in ExtractAttribute action: LOGS"))
 		})
 	})
 
@@ -280,9 +293,9 @@ var _ = Describe("ExtractAttribute Controller", func() {
 						Extractions: []odigosactions.Extraction{
 							{
 								TargetAttributeName: "x",
-								LookupKey:        "user_id",
-								DataFormat:       odigosactions.FormatJSON,
-								Regex:            `user_id=(\d+)`,
+								LookupKey:           "user_id",
+								DataFormat:          odigosactions.FormatJSON,
+								Regex:               `user_id=(\d+)`,
 							},
 						},
 					},
@@ -316,7 +329,7 @@ var _ = Describe("ExtractAttribute Controller", func() {
 						Extractions: []odigosactions.Extraction{
 							{
 								TargetAttributeName: "x",
-								LookupKey:        "user_id",
+								LookupKey:           "user_id",
 							},
 						},
 					},
@@ -330,6 +343,40 @@ var _ = Describe("ExtractAttribute Controller", func() {
 			Consistently(func() bool {
 				err := k8sClient.Get(testCtx, types.NamespacedName{
 					Name:      ActionName + "-invalid-format",
+					Namespace: ActionNamespace,
+				}, processor)
+				return err != nil
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("Should not create a Processor when regex is invalid", func() {
+			By("Creating an Action with an invalid regex")
+			action := &odigosv1.Action{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ActionName + "-invalid-regex",
+					Namespace: ActionNamespace,
+				},
+				Spec: odigosv1.ActionSpec{
+					ActionName: "invalid - malformed regex",
+					Signals:    []common.ObservabilitySignal{common.TracesObservabilitySignal},
+					ExtractAttribute: &odigosactions.ExtractAttributeConfig{
+						Extractions: []odigosactions.Extraction{
+							{
+								TargetAttributeName: "x",
+								Regex:               "[invalid",
+							},
+						},
+					},
+				},
+			}
+
+			Expect(k8sClient.Create(testCtx, action)).Should(Succeed())
+
+			By("Checking that no Processor is created")
+			processor := &odigosv1.Processor{}
+			Consistently(func() bool {
+				err := k8sClient.Get(testCtx, types.NamespacedName{
+					Name:      ActionName + "-invalid-regex",
 					Namespace: ActionNamespace,
 				}, processor)
 				return err != nil

--- a/autoscaler/controllers/clustercollector/deployment.go
+++ b/autoscaler/controllers/clustercollector/deployment.go
@@ -323,7 +323,7 @@ func getDesiredDeployment(ctx context.Context, c client.Client, enabledDests *od
 	}
 
 	var featureGates []string
-	if common.ProfilingPipelineActive(odigosConfiguration.Profiling) {
+	if common.ProfilingPipelineActive(odigosConfiguration.Profiling) || hasProfilesDestination(enabledDests) {
 		featureGates = append(featureGates, "service.profilesSupport")
 	}
 	if odigosConfiguration.ClickhouseJsonTypeEnabledProperty != nil && *odigosConfiguration.ClickhouseJsonTypeEnabledProperty {
@@ -359,6 +359,21 @@ func getSecretsFromDests(destList *odigosv1.DestinationList) []corev1.EnvFromSou
 	}
 
 	return result
+}
+
+func hasProfilesDestination(destList *odigosv1.DestinationList) bool {
+	if destList == nil {
+		return false
+	}
+
+	for _, dst := range destList.Items {
+		for _, signal := range dst.Spec.Signals {
+			if signal == common.ProfilesObservabilitySignal {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func boolPtr(b bool) *bool {

--- a/autoscaler/controllers/clustercollector/deployment_test.go
+++ b/autoscaler/controllers/clustercollector/deployment_test.go
@@ -1,0 +1,76 @@
+package clustercollector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/odigos-io/odigos/api/k8sconsts"
+	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	commonconfig "github.com/odigos-io/odigos/autoscaler/controllers/common"
+	controllerconfig "github.com/odigos-io/odigos/autoscaler/controllers/controller_config"
+	"github.com/odigos-io/odigos/common"
+	"github.com/odigos-io/odigos/common/consts"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGetDesiredDeploymentEnablesProfilesFeatureGateForProfilesDestination(t *testing.T) {
+	previousControllerConfig := commonconfig.ControllerConfig
+	commonconfig.ControllerConfig = &controllerconfig.ControllerConfig{CollectorImage: "otelcol"}
+	t.Cleanup(func() {
+		commonconfig.ControllerConfig = previousControllerConfig
+	})
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, odigosv1.AddToScheme(scheme))
+
+	effectiveConfig := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      consts.OdigosEffectiveConfigName,
+			Namespace: consts.DefaultOdigosNamespace,
+		},
+		Data: map[string]string{},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(effectiveConfig).Build()
+
+	dests := &odigosv1.DestinationList{Items: []odigosv1.Destination{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "profiles-destination",
+				Namespace: consts.DefaultOdigosNamespace,
+			},
+			Spec: odigosv1.DestinationSpec{
+				Type:    common.PyroscopeDestinationType,
+				Signals: []common.ObservabilitySignal{common.ProfilesObservabilitySignal},
+				Data: map[string]string{
+					"PYROSCOPE_URL": "pyroscope:4040",
+				},
+			},
+		},
+	}}
+	gateway := &odigosv1.CollectorsGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      k8sconsts.OdigosClusterCollectorConfigMapName,
+			Namespace: consts.DefaultOdigosNamespace,
+		},
+		Spec: odigosv1.CollectorsGroupSpec{
+			Role: odigosv1.CollectorsGroupRoleClusterGateway,
+			ResourcesSettings: odigosv1.CollectorsGroupResourcesSettings{
+				MemoryRequestMiB:     256,
+				MemoryLimitMiB:       512,
+				CpuRequestMillicores: 250,
+				CpuLimitMillicores:   500,
+			},
+		},
+	}
+
+	deployment, err := getDesiredDeployment(context.Background(), client, dests, "hash", gateway, scheme, "test-version", nil)
+	require.NoError(t, err)
+	require.Contains(t, deployment.Spec.Template.Spec.Containers[0].Args, "--feature-gates=service.profilesSupport")
+}

--- a/autoscaler/controllers/metricshandler/custom_metrics_handler.go
+++ b/autoscaler/controllers/metricshandler/custom_metrics_handler.go
@@ -27,8 +27,14 @@ import (
 )
 
 const (
-	gatewayRejectionMetricName = "odigos_collector_memory_limiter_batch_rejections_total"
+	gatewayRejectionMetricName       = "odigos_collector_memory_limiter_batch_rejections_total"
+	legacyGatewayRejectionMetricName = "odigos_gateway_memory_limiter_rejections_total"
 )
+
+var gatewayRejectionMetricNames = []string{
+	gatewayRejectionMetricName,
+	legacyGatewayRejectionMetricName,
+}
 
 type MetricValueList struct {
 	APIVersion string        `json:"apiVersion"`
@@ -275,27 +281,35 @@ func scrapeGatewayMetric(podIP string) (float64, error) {
 		return 0, fmt.Errorf("failed to read response body: %w", err)
 	}
 
+	return parseGatewayRejectionMetric(body)
+}
+
+func parseGatewayRejectionMetric(body []byte) (float64, error) {
 	parser := expfmt.NewTextParser(model.UTF8Validation)
 	metricFamilies, err := parser.TextToMetricFamilies(bytes.NewReader(body))
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse metrics: %w", err)
 	}
 
-	mf, ok := metricFamilies[gatewayRejectionMetricName]
-	if !ok {
-		// metric not found → treat as 0 rejections
-		// This can happen if the gateway is not running or the metric is not available yet.
-		return 0, nil
-	}
-
-	var total float64
-	for _, m := range mf.Metric {
-		if m.Counter != nil && m.Counter.Value != nil {
-			total += *m.Counter.Value
+	for _, metricName := range gatewayRejectionMetricNames {
+		mf, ok := metricFamilies[metricName]
+		if !ok {
+			continue
 		}
+
+		var total float64
+		for _, m := range mf.Metric {
+			if m.Counter != nil && m.Counter.Value != nil {
+				total += *m.Counter.Value
+			}
+		}
+
+		return total, nil
 	}
 
-	return total, nil
+	// Metric not found: treat as 0 rejections. This can happen while the gateway
+	// is starting up or if metrics are temporarily unavailable.
+	return 0, nil
 }
 
 // isPodOOMKilled checks if the pod is in CrashLoopBackOff due to OOM or currently OOMKilled

--- a/autoscaler/controllers/metricshandler/custom_metrics_handler_test.go
+++ b/autoscaler/controllers/metricshandler/custom_metrics_handler_test.go
@@ -1,0 +1,71 @@
+package metricshandler
+
+import "testing"
+
+func TestParseGatewayRejectionMetric(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		want    float64
+		wantErr bool
+	}{
+		{
+			name: "new metric sums all counter series",
+			body: `
+# TYPE odigos_collector_memory_limiter_batch_rejections_total counter
+odigos_collector_memory_limiter_batch_rejections_total{receiver="otlp"} 2
+odigos_collector_memory_limiter_batch_rejections_total{receiver="otlp/2"} 3
+`,
+			want: 5,
+		},
+		{
+			name: "legacy metric remains supported during rolling upgrade",
+			body: `
+# TYPE odigos_gateway_memory_limiter_rejections_total counter
+odigos_gateway_memory_limiter_rejections_total{receiver="otlp"} 4
+`,
+			want: 4,
+		},
+		{
+			name: "new metric wins if both names are present",
+			body: `
+# TYPE odigos_collector_memory_limiter_batch_rejections_total counter
+odigos_collector_memory_limiter_batch_rejections_total 7
+# TYPE odigos_gateway_memory_limiter_rejections_total counter
+odigos_gateway_memory_limiter_rejections_total 11
+`,
+			want: 7,
+		},
+		{
+			name: "missing metric is zero",
+			body: `
+# TYPE unrelated_total counter
+unrelated_total 9
+`,
+			want: 0,
+		},
+		{
+			name:    "invalid prometheus text returns error",
+			body:    "not valid{",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseGatewayRejectionMetric([]byte(tt.body))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("parseGatewayRejectionMetric() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/autoscaler/controllers/nodecollector/collectorconfig/logs.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/logs.go
@@ -16,12 +16,12 @@ const (
 
 func getReceivers(logger logr.Logger, sources *odigosv1.InstrumentationConfigList, odigosNamespace string) (config.GenericMap, []string) {
 
-	if isEbpfLogCaptureEnabled(sources) {
-		// eBPF receiver config lives in the common domain; no per-pipeline receiver config needed here
-		return config.GenericMap{}, []string{odigosEbpfReceiverName}
+	if sources == nil {
+		return config.GenericMap{}, nil
 	}
 
 	includes := make([]string, 0)
+	ebpfLogCaptureEnabled := false
 	for _, element := range sources.Items {
 		// Paths for log files: /var/log/pods/<namespace>_<pod name>_<pod ID>/<container name>/<auto-incremented file number>.log
 		// Pod specifiers
@@ -38,12 +38,15 @@ func getReceivers(logger logr.Logger, sources *odigosv1.InstrumentationConfigLis
 			continue
 		}
 		owner := element.OwnerReferences[0]
-		name := owner.Name
-		includes = append(includes, fmt.Sprintf("/var/log/pods/%s_%s-*_*/*/*.log", element.Namespace, name))
+		filelogIncludes, sourceUsesEbpf := filelogIncludesForSource(&element, owner.Name)
+		ebpfLogCaptureEnabled = ebpfLogCaptureEnabled || sourceUsesEbpf
+		includes = append(includes, filelogIncludes...)
 	}
 
-	return config.GenericMap{
-		filelogReceiverName: config.GenericMap{
+	receivers := config.GenericMap{}
+	pipelineReceivers := []string{}
+	if len(includes) > 0 {
+		receivers[filelogReceiverName] = config.GenericMap{
 			"include": includes,
 			"exclude": []string{"/var/log/pods/kube-system_*/**/*", "/var/log/pods/" + odigosNamespace + "_*/**/*"},
 			// 5s (vs upstream 200ms default) avoids a readdir storm from stanza's per-include glob loop on busy nodes.
@@ -68,35 +71,69 @@ func getReceivers(logger logr.Logger, sources *odigosv1.InstrumentationConfigLis
 				// downstream pressure.
 				"enabled": true,
 			},
-		},
-	}, []string{filelogReceiverName}
+		}
+		pipelineReceivers = append(pipelineReceivers, filelogReceiverName)
+	}
+	if ebpfLogCaptureEnabled {
+		// eBPF receiver config lives in the common domain; no per-pipeline receiver config needed here.
+		pipelineReceivers = append(pipelineReceivers, odigosEbpfReceiverName)
+	}
+
+	return receivers, pipelineReceivers
 }
 
-func isEbpfLogCaptureEnabled(sources *odigosv1.InstrumentationConfigList) bool {
-	if sources == nil {
-		return false
+func filelogIncludesForSource(ic *odigosv1.InstrumentationConfig, ownerName string) ([]string, bool) {
+	sourceUsesEbpf := sourceEbpfLogCaptureEnabled(ic)
+	if !sourceUsesEbpf {
+		return []string{workloadFilelogInclude(ic.Namespace, ownerName, "*")}, false
 	}
-	for _, ic := range sources.Items {
-		// check container config (new path)
-		for _, container := range ic.Spec.Containers {
-			if container.Logs != nil &&
-				container.Logs.EbpfLogCapture != nil &&
-				container.Logs.EbpfLogCapture.Enabled != nil &&
-				*container.Logs.EbpfLogCapture.Enabled {
-				return true
-			}
-		}
 
-		// TODO: remove once fully migrated to container config
-		for _, sdkConfig := range ic.Spec.SdkConfigs {
-			if sdkConfig.EbpfLogCapture != nil &&
-				sdkConfig.EbpfLogCapture.Enabled != nil &&
-				*sdkConfig.EbpfLogCapture.Enabled {
-				return true
-			}
+	if len(ic.Spec.Containers) == 0 || sdkEbpfLogCaptureEnabled(ic) {
+		return nil, true
+	}
+
+	includes := make([]string, 0)
+	for _, container := range ic.Spec.Containers {
+		if !containerEbpfLogCaptureEnabled(container) {
+			includes = append(includes, workloadFilelogInclude(ic.Namespace, ownerName, container.ContainerName))
+		}
+	}
+
+	return includes, true
+}
+
+func workloadFilelogInclude(namespace string, ownerName string, containerName string) string {
+	return fmt.Sprintf("/var/log/pods/%s_%s-*_*/%s/*.log", namespace, ownerName, containerName)
+}
+
+func sourceEbpfLogCaptureEnabled(ic *odigosv1.InstrumentationConfig) bool {
+	// check container config (new path)
+	for _, container := range ic.Spec.Containers {
+		if containerEbpfLogCaptureEnabled(container) {
+			return true
+		}
+	}
+
+	return sdkEbpfLogCaptureEnabled(ic)
+}
+
+func sdkEbpfLogCaptureEnabled(ic *odigosv1.InstrumentationConfig) bool {
+	// TODO: remove once fully migrated to container config
+	for _, sdkConfig := range ic.Spec.SdkConfigs {
+		if sdkConfig.EbpfLogCapture != nil &&
+			sdkConfig.EbpfLogCapture.Enabled != nil &&
+			*sdkConfig.EbpfLogCapture.Enabled {
+			return true
 		}
 	}
 	return false
+}
+
+func containerEbpfLogCaptureEnabled(container odigosv1.ContainerAgentConfig) bool {
+	return container.Logs != nil &&
+		container.Logs.EbpfLogCapture != nil &&
+		container.Logs.EbpfLogCapture.Enabled != nil &&
+		*container.Logs.EbpfLogCapture.Enabled
 }
 
 type LogsConfigOptions struct {

--- a/autoscaler/controllers/nodecollector/collectorconfig/logs_test.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/logs_test.go
@@ -1,0 +1,96 @@
+package collectorconfig
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	"github.com/odigos-io/odigos/common/api/agentsignalconfig"
+	"github.com/odigos-io/odigos/common/api/instrumentationrules"
+	"github.com/odigos-io/odigos/common/config"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetReceiversAllFilelogSources(t *testing.T) {
+	sources := &odigosv1.InstrumentationConfigList{
+		Items: []odigosv1.InstrumentationConfig{
+			newLogsInstrumentationConfig("default", "deployment-a"),
+			newLogsInstrumentationConfig("other", "deployment-b"),
+		},
+	}
+
+	receivers, pipelineReceivers := getReceivers(logr.Discard(), sources, "odigos-system")
+
+	assert.Equal(t, []string{filelogReceiverName}, pipelineReceivers)
+	filelogConfig := receivers[filelogReceiverName].(config.GenericMap)
+	assert.ElementsMatch(t, []string{
+		"/var/log/pods/default_deployment-a-*_*/*/*.log",
+		"/var/log/pods/other_deployment-b-*_*/*/*.log",
+	}, filelogConfig["include"])
+}
+
+func TestGetReceiversAllEbpfSources(t *testing.T) {
+	sources := &odigosv1.InstrumentationConfigList{
+		Items: []odigosv1.InstrumentationConfig{
+			withEbpfLogCapture(newLogsInstrumentationConfig("default", "deployment-a"), "app"),
+			withEbpfLogCapture(newLogsInstrumentationConfig("other", "deployment-b"), "app"),
+		},
+	}
+
+	receivers, pipelineReceivers := getReceivers(logr.Discard(), sources, "odigos-system")
+
+	assert.Equal(t, []string{odigosEbpfReceiverName}, pipelineReceivers)
+	assert.NotContains(t, receivers, filelogReceiverName)
+}
+
+func TestGetReceiversMixedEbpfAndFilelogSources(t *testing.T) {
+	sources := &odigosv1.InstrumentationConfigList{
+		Items: []odigosv1.InstrumentationConfig{
+			withEbpfLogCapture(newLogsInstrumentationConfig("default", "deployment-a"), "app"),
+			newLogsInstrumentationConfig("other", "deployment-b"),
+		},
+	}
+
+	receivers, pipelineReceivers := getReceivers(logr.Discard(), sources, "odigos-system")
+
+	assert.Equal(t, []string{filelogReceiverName, odigosEbpfReceiverName}, pipelineReceivers)
+	filelogConfig := receivers[filelogReceiverName].(config.GenericMap)
+	assert.Equal(t, []string{"/var/log/pods/other_deployment-b-*_*/*/*.log"}, filelogConfig["include"])
+}
+
+func TestGetReceiversMixedContainersInSource(t *testing.T) {
+	source := withEbpfLogCapture(newLogsInstrumentationConfig("default", "deployment-a"), "app")
+	source.Spec.Containers = append(source.Spec.Containers, odigosv1.ContainerAgentConfig{ContainerName: "sidecar"})
+	sources := &odigosv1.InstrumentationConfigList{
+		Items: []odigosv1.InstrumentationConfig{source},
+	}
+
+	receivers, pipelineReceivers := getReceivers(logr.Discard(), sources, "odigos-system")
+
+	assert.Equal(t, []string{filelogReceiverName, odigosEbpfReceiverName}, pipelineReceivers)
+	filelogConfig := receivers[filelogReceiverName].(config.GenericMap)
+	assert.Equal(t, []string{"/var/log/pods/default_deployment-a-*_*/sidecar/*.log"}, filelogConfig["include"])
+}
+
+func newLogsInstrumentationConfig(namespace string, ownerName string) odigosv1.InstrumentationConfig {
+	return odigosv1.InstrumentationConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{Name: ownerName},
+			},
+		},
+	}
+}
+
+func withEbpfLogCapture(ic odigosv1.InstrumentationConfig, containerName string) odigosv1.InstrumentationConfig {
+	enabled := true
+	ic.Spec.Containers = append(ic.Spec.Containers, odigosv1.ContainerAgentConfig{
+		ContainerName: containerName,
+		Logs: &agentsignalconfig.AgentLogsConfig{
+			EbpfLogCapture: &instrumentationrules.EbpfLogCapture{Enabled: &enabled},
+		},
+	})
+	return ic
+}

--- a/autoscaler/controllers/nodecollector/configmap.go
+++ b/autoscaler/controllers/nodecollector/configmap.go
@@ -391,7 +391,9 @@ func getSignalsFromOtelcolConfig(otelcolConfigContent string) ([]odigoscommon.Ob
 }
 
 func isTracingLoadBalancingNeeded(_ context.Context, _ client.Client, clusterCollectorGroup odigosv1.CollectorsGroup) (bool, error) {
-	// Tracing load balancing is required only when service graph is enabled.
+	// Tracing load balancing is required whenever gateway processors need complete traces.
 	serviceGraphEnabled := clusterCollectorGroup.Spec.ServiceGraphDisabled == nil || !*clusterCollectorGroup.Spec.ServiceGraphDisabled
-	return serviceGraphEnabled, nil
+	tailSamplingEnabled := clusterCollectorGroup.Spec.TailSampling != nil &&
+		(clusterCollectorGroup.Spec.TailSampling.Disabled == nil || !*clusterCollectorGroup.Spec.TailSampling.Disabled)
+	return serviceGraphEnabled || tailSamplingEnabled, nil
 }

--- a/autoscaler/controllers/nodecollector/configmap_test.go
+++ b/autoscaler/controllers/nodecollector/configmap_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	"github.com/odigos-io/odigos/common"
+	"github.com/odigos-io/odigos/common/api/sampling"
 	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -252,4 +253,54 @@ func TestCalculateConfigMapDataTracesOnlyNoLoadBalancing(t *testing.T) {
 
 	assert.Equal(t, err, nil)
 	assert.Equal(t, want, got)
+}
+
+func TestIsTracingLoadBalancingNeeded(t *testing.T) {
+	trueVal := true
+	falseVal := false
+
+	tests := []struct {
+		name                  string
+		serviceGraphDisabled  *bool
+		tailSampling          *sampling.TailSamplingConfiguration
+		wantLoadBalancingNeed bool
+	}{
+		{
+			name:                  "service graph enabled by default",
+			wantLoadBalancingNeed: true,
+		},
+		{
+			name:                 "service graph explicitly disabled without tail sampling",
+			serviceGraphDisabled: &trueVal,
+		},
+		{
+			name:                 "tail sampling requires load balancing when service graph disabled",
+			serviceGraphDisabled: &trueVal,
+			tailSampling: &sampling.TailSamplingConfiguration{
+				Disabled: &falseVal,
+			},
+			wantLoadBalancingNeed: true,
+		},
+		{
+			name:                 "disabled tail sampling does not require load balancing",
+			serviceGraphDisabled: &trueVal,
+			tailSampling: &sampling.TailSamplingConfiguration{
+				Disabled: &trueVal,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := isTracingLoadBalancingNeeded(context.Background(), nil, odigosv1.CollectorsGroup{
+				Spec: odigosv1.CollectorsGroupSpec{
+					ServiceGraphDisabled: tt.serviceGraphDisabled,
+					TailSampling:         tt.tailSampling,
+				},
+			})
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantLoadBalancingNeed, got)
+		})
+	}
 }

--- a/collector/Dockerfile
+++ b/collector/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.2-trixie AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-trixie AS builder
 COPY ./collector/ /go/src/collector
 # Need to copy the common folder to the collector for custom connector that uses it
 COPY ./common/ /go/src/common

--- a/collector/builder-config.yaml
+++ b/collector/builder-config.yaml
@@ -148,6 +148,7 @@ replaces:
   - github.com/odigos-io/odigos/collector/connectors/serviceioconnector => ../connectors/serviceioconnector
   - github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector => ../connectors/servicegraphconnector
   - github.com/odigos-io/odigos/collector/receivers/odigosebpfreceiver => ../receivers/odigosebpfreceiver
+  - github.com/odigos-io/go-rtml => ../internal/go-rtml
   - github.com/odigos-io/odigos/common => ../../common
   - go.opentelemetry.io/collector/config/configgrpc => ../config/configgrpc
   - github.com/odigos-io/odigos/collector/extension/odigosconfigk8sextension => ../extension/odigosconfigk8sextension

--- a/collector/config/configgrpc/go.mod
+++ b/collector/config/configgrpc/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/config/configgrpc
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/mostynb/go-grpc-compression v1.2.3
@@ -28,6 +28,8 @@ require (
 	go.uber.org/goleak v1.3.0
 	google.golang.org/grpc v1.81.1
 )
+
+replace github.com/odigos-io/go-rtml => ../../internal/go-rtml
 
 require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/collector/connectors/odigosrouterconnector/connector.go
+++ b/collector/connectors/odigosrouterconnector/connector.go
@@ -177,12 +177,14 @@ func (r *routerConnector) ConsumeTraces(ctx context.Context, td ptrace.Traces) e
 			continue
 		}
 
+		matchedPipeline := false
 		for _, pipeline := range pipelines {
 			pipelineID := collectorpipeline.NewIDWithName(collectorpipeline.SignalTraces, pipeline)
 			consumer, err := cfg.consumers.Consumer(pipelineID)
 			if err != nil {
 				continue
 			}
+			matchedPipeline = true
 
 			batch, ok := tracesByConsumer[consumer]
 			if !ok {
@@ -190,6 +192,9 @@ func (r *routerConnector) ConsumeTraces(ctx context.Context, td ptrace.Traces) e
 			}
 			rs.CopyTo(batch.ResourceSpans().AppendEmpty())
 			tracesByConsumer[consumer] = batch
+		}
+		if !matchedPipeline {
+			rs.CopyTo(defaultTraces.ResourceSpans().AppendEmpty())
 		}
 	}
 
@@ -231,12 +236,13 @@ func (r *routerConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metrics
 			continue
 		}
 
+		matchedPipeline := false
 		for _, pipeline := range pipelines {
 			consumer, err := cfg.consumers.Consumer(collectorpipeline.NewIDWithName(collectorpipeline.SignalMetrics, pipeline))
 			if err != nil {
-				errs = errors.Join(errs, fmt.Errorf("failed to get metrics consumer for pipeline %s: %w", pipeline, err))
 				continue
 			}
+			matchedPipeline = true
 
 			batch, ok := metricsByConsumer[consumer]
 			if !ok {
@@ -244,6 +250,10 @@ func (r *routerConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metrics
 			}
 			rm.CopyTo(batch.ResourceMetrics().AppendEmpty())
 			metricsByConsumer[consumer] = batch
+		}
+		if !matchedPipeline {
+			cfg.logger.Debug("no signal-specific pipelines matched for resource metrics", zap.Any("resource", rm.Resource().Attributes()))
+			rm.CopyTo(defaultMetrics.ResourceMetrics().AppendEmpty())
 		}
 	}
 
@@ -286,6 +296,7 @@ func (r *routerConnector) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 			continue
 		}
 
+		matchedPipeline := false
 		for _, pipeline := range pipelines {
 			consumer, err := cfg.consumers.Consumer(
 				collectorpipeline.NewIDWithName(collectorpipeline.SignalLogs, pipeline),
@@ -293,6 +304,7 @@ func (r *routerConnector) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 			if err != nil {
 				continue
 			}
+			matchedPipeline = true
 
 			batch, ok := logsByConsumer[consumer]
 			if !ok {
@@ -300,6 +312,9 @@ func (r *routerConnector) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 			}
 			rl.CopyTo(batch.ResourceLogs().AppendEmpty())
 			logsByConsumer[consumer] = batch
+		}
+		if !matchedPipeline {
+			rl.CopyTo(defaultLogs.ResourceLogs().AppendEmpty())
 		}
 	}
 

--- a/collector/connectors/odigosrouterconnector/connector_test.go
+++ b/collector/connectors/odigosrouterconnector/connector_test.go
@@ -1,0 +1,141 @@
+package odigosrouterconnector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/connector"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	collectorpipeline "go.opentelemetry.io/collector/pipeline"
+	"go.uber.org/zap"
+
+	commonapi "github.com/odigos-io/odigos/common/api"
+	odigoscollector "github.com/odigos-io/odigos/common/collector"
+	"github.com/odigos-io/odigos/common/consts"
+)
+
+type mockOdigosConfigExtension struct {
+	dataStreams []string
+}
+
+func (m *mockOdigosConfigExtension) GetFromResource(pcommon.Resource) (*commonapi.ContainerCollectorConfig, bool) {
+	return nil, false
+}
+
+func (m *mockOdigosConfigExtension) IsActiveSource(pcommon.Resource) bool {
+	return false
+}
+
+func (m *mockOdigosConfigExtension) GetWorkloadCacheKey(pcommon.Resource) (string, error) {
+	return "", nil
+}
+
+func (m *mockOdigosConfigExtension) GetWorkloadIdentityFromResource(pcommon.Resource) (string, pcommon.Map, error) {
+	return "", pcommon.NewMap(), nil
+}
+
+func (m *mockOdigosConfigExtension) RegisterWorkloadConfigCacheCallback(odigoscollector.WorkloadConfigCacheCallback) {
+}
+
+func (m *mockOdigosConfigExtension) UnregisterWorkloadConfigCacheCallback(odigoscollector.WorkloadConfigCacheCallback) {
+}
+
+func (m *mockOdigosConfigExtension) WaitForCacheSync(context.Context) bool {
+	return true
+}
+
+func (m *mockOdigosConfigExtension) GetDataStreamsForWorkload(pcommon.Resource) ([]string, bool) {
+	return m.dataStreams, true
+}
+
+func TestConsumeTracesFallsBackToDefaultWhenNoSignalPipelineMatches(t *testing.T) {
+	defaultSink := &consumertest.TracesSink{}
+	streamSink := &consumertest.TracesSink{}
+	defaultID := collectorpipeline.NewIDWithName(collectorpipeline.SignalTraces, consts.DefaultDataStream)
+	unrelatedID := collectorpipeline.NewIDWithName(collectorpipeline.SignalTraces, "unrelated-stream")
+	router := connector.NewTracesRouter(map[collectorpipeline.ID]consumer.Traces{
+		defaultID:   defaultSink,
+		unrelatedID: streamSink,
+	})
+	rc := &routerConnector{
+		tracesConfig:          tracesConfig{consumers: router, defaultCons: defaultSink, logger: zap.NewNop()},
+		odigosConfigExtension: &mockOdigosConfigExtension{dataStreams: []string{"logs-only-stream"}},
+	}
+
+	err := rc.ConsumeTraces(context.Background(), tracesWithOneSpan())
+
+	require.NoError(t, err)
+	require.Equal(t, 1, defaultSink.SpanCount())
+	require.Equal(t, 0, streamSink.SpanCount())
+}
+
+func TestConsumeMetricsFallsBackToDefaultWhenNoSignalPipelineMatches(t *testing.T) {
+	defaultSink := &consumertest.MetricsSink{}
+	streamSink := &consumertest.MetricsSink{}
+	defaultID := collectorpipeline.NewIDWithName(collectorpipeline.SignalMetrics, consts.DefaultDataStream)
+	unrelatedID := collectorpipeline.NewIDWithName(collectorpipeline.SignalMetrics, "unrelated-stream")
+	router := connector.NewMetricsRouter(map[collectorpipeline.ID]consumer.Metrics{
+		defaultID:   defaultSink,
+		unrelatedID: streamSink,
+	})
+	rc := &routerConnector{
+		metricsConfig:         metricsConfig{consumers: router, defaultCons: defaultSink, logger: zap.NewNop()},
+		odigosConfigExtension: &mockOdigosConfigExtension{dataStreams: []string{"traces-only-stream"}},
+	}
+
+	err := rc.ConsumeMetrics(context.Background(), metricsWithOneDataPoint())
+
+	require.NoError(t, err)
+	require.Equal(t, 1, defaultSink.DataPointCount())
+	require.Equal(t, 0, streamSink.DataPointCount())
+}
+
+func TestConsumeLogsFallsBackToDefaultWhenNoSignalPipelineMatches(t *testing.T) {
+	defaultSink := &consumertest.LogsSink{}
+	streamSink := &consumertest.LogsSink{}
+	defaultID := collectorpipeline.NewIDWithName(collectorpipeline.SignalLogs, consts.DefaultDataStream)
+	unrelatedID := collectorpipeline.NewIDWithName(collectorpipeline.SignalLogs, "unrelated-stream")
+	router := connector.NewLogsRouter(map[collectorpipeline.ID]consumer.Logs{
+		defaultID:   defaultSink,
+		unrelatedID: streamSink,
+	})
+	rc := &routerConnector{
+		logsConfig:            logsConfig{consumers: router, defaultCons: defaultSink, logger: zap.NewNop()},
+		odigosConfigExtension: &mockOdigosConfigExtension{dataStreams: []string{"traces-only-stream"}},
+	}
+
+	err := rc.ConsumeLogs(context.Background(), logsWithOneRecord())
+
+	require.NoError(t, err)
+	require.Equal(t, 1, defaultSink.LogRecordCount())
+	require.Equal(t, 0, streamSink.LogRecordCount())
+}
+
+func tracesWithOneSpan() ptrace.Traces {
+	td := ptrace.NewTraces()
+	span := td.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	span.SetName("test-span")
+	return td
+}
+
+func metricsWithOneDataPoint() pmetric.Metrics {
+	md := pmetric.NewMetrics()
+	sum := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty().SetEmptySum()
+	sum.DataPoints().AppendEmpty().SetIntValue(1)
+	return md
+}
+
+func logsWithOneRecord() plog.Logs {
+	ld := plog.NewLogs()
+	record := ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	record.Body().SetStr("test-log")
+	return ld
+}
+
+var _ odigoscollector.OdigosConfigExtension = (*mockOdigosConfigExtension)(nil)

--- a/collector/connectors/serviceioconnector/connections.go
+++ b/collector/connectors/serviceioconnector/connections.go
@@ -1,9 +1,12 @@
 package serviceioconnector
 
 import (
+	"time"
+
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
+	"go.uber.org/zap"
 
 	"github.com/odigos-io/odigos/collector/connectors/serviceioconnector/internal/metadata"
 	odigoscollector "github.com/odigos-io/odigos/common/collector"
@@ -64,8 +67,12 @@ func mergeAttributes(source, destination pcommon.Map) {
 }
 
 func (c *serviceioConnector) aggregateConnectionsFromTree(tree *TraceTree, odigosConfig odigoscollector.OdigosConfigExtension) bool {
+	now := time.Now()
+
 	c.seriesMutex.Lock()
 	defer c.seriesMutex.Unlock()
+
+	c.pruneStaleSeriesLocked(now)
 
 	added := false
 	for _, instance := range tree.ServiceInstances {
@@ -81,10 +88,22 @@ func (c *serviceioConnector) aggregateConnectionsFromTree(tree *TraceTree, odigo
 			key, attributes := buildConnectionAttributes(serviceInputBaseAttributes, outputAttrs)
 			series := c.keyToMetric[key]
 			if series.count == 0 {
+				if c.maxMetricSeries > 0 && len(c.keyToMetric) >= c.maxMetricSeries {
+					c.seriesLimitOnce.Do(func() {
+						if c.logger != nil {
+							c.logger.Warn(
+								"serviceio connector metric series limit reached; dropping new connection series",
+								zap.Int("max_metric_series", c.maxMetricSeries),
+							)
+						}
+					})
+					continue
+				}
 				series.dimensions = attributes
 				series.resource = buildMetricResourceAttributes(instance)
 			}
 			series.count++
+			series.updatedAt = now
 			c.keyToMetric[key] = series
 			added = true
 		}

--- a/collector/connectors/serviceioconnector/connections_test.go
+++ b/collector/connectors/serviceioconnector/connections_test.go
@@ -49,6 +49,33 @@ func TestAggregateConnectionsFromTree(t *testing.T) {
 	require.ElementsMatch(t, []string{"Users", "Orders"}, outputServices)
 }
 
+func TestAggregateConnectionsFromTreeDropsOnlyNewSeriesAtLimit(t *testing.T) {
+	td := buildServiceIOTestTrace(t)
+
+	tree, err := BuildTraceTree(td, nil)
+	require.NoError(t, err)
+
+	connector := &serviceioConnector{
+		keyToMetric:          make(map[uint64]metricSeries),
+		maxMetricSeries:      1,
+		inputSpanAttributes:  []string{"http.route"},
+		outputSpanAttributes: []string{"rpc.service"},
+		logger:               zap.NewNop(),
+	}
+	odigosConfig := &mockOdigosConfigExtension{
+		activeSources: map[string]struct{}{"svc-1": {}},
+	}
+
+	require.True(t, connector.aggregateConnectionsFromTree(tree, odigosConfig))
+	require.Len(t, connector.keyToMetric, 1)
+
+	require.True(t, connector.aggregateConnectionsFromTree(tree, odigosConfig))
+	require.Len(t, connector.keyToMetric, 1)
+	for _, series := range connector.keyToMetric {
+		require.EqualValues(t, 2, series.count)
+	}
+}
+
 func TestConnectorConsumeTraces_EmitsConnectionMetrics(t *testing.T) {
 	sink := &consumertest.MetricsSink{}
 	flushImmediately := time.Duration(0)

--- a/collector/connectors/serviceioconnector/connector.go
+++ b/collector/connectors/serviceioconnector/connector.go
@@ -30,8 +30,10 @@ type serviceioConnector struct {
 
 	startTime time.Time
 
-	seriesMutex sync.Mutex
-	keyToMetric map[uint64]metricSeries
+	seriesMutex     sync.Mutex
+	keyToMetric     map[uint64]metricSeries
+	maxMetricSeries int
+	seriesLimitOnce sync.Once
 
 	shutdownCh chan struct{}
 }
@@ -61,6 +63,7 @@ func newConnector(set component.TelemetrySettings, cfg component.Config, next co
 		collectorInstanceID:  collectorInstanceID,
 		startTime:            time.Now(),
 		keyToMetric:          make(map[uint64]metricSeries),
+		maxMetricSeries:      defaultMaxMetricSeries,
 		shutdownCh:           make(chan struct{}),
 	}, nil
 }

--- a/collector/connectors/serviceioconnector/metrics.go
+++ b/collector/connectors/serviceioconnector/metrics.go
@@ -11,12 +11,17 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
-const attributeHashSeparator = byte(0)
+const (
+	attributeHashSeparator = byte(0)
+	defaultMetricSeriesTTL = 15 * time.Minute
+	defaultMaxMetricSeries = 10000
+)
 
 type metricSeries struct {
 	dimensions pcommon.Map
 	resource   pcommon.Map
 	count      int64
+	updatedAt  time.Time
 }
 
 // hashAttributes returns a deterministic hash of sorted metric attribute names and values.
@@ -49,6 +54,11 @@ func (c *serviceioConnector) nowWithOffset() time.Time {
 
 func (c *serviceioConnector) buildMetrics() (pmetric.Metrics, error) {
 	m := pmetric.NewMetrics()
+
+	c.seriesMutex.Lock()
+	defer c.seriesMutex.Unlock()
+
+	c.pruneStaleSeriesLocked(time.Now())
 	if len(c.keyToMetric) == 0 {
 		return m, nil
 	}
@@ -57,9 +67,6 @@ func (c *serviceioConnector) buildMetrics() (pmetric.Metrics, error) {
 		resource   pcommon.Map
 		seriesList []metricSeries
 	}
-
-	c.seriesMutex.Lock()
-	defer c.seriesMutex.Unlock()
 
 	grouped := make(map[uint64]*resourceGroup)
 	for _, series := range c.keyToMetric {
@@ -95,6 +102,17 @@ func (c *serviceioConnector) buildMetrics() (pmetric.Metrics, error) {
 	}
 
 	return m, nil
+}
+
+func (c *serviceioConnector) pruneStaleSeriesLocked(now time.Time) {
+	for key, series := range c.keyToMetric {
+		if series.updatedAt.IsZero() {
+			continue
+		}
+		if series.updatedAt.Add(defaultMetricSeriesTTL).Before(now) {
+			delete(c.keyToMetric, key)
+		}
+	}
 }
 
 func (c *serviceioConnector) flushMetrics(ctx context.Context) error {

--- a/collector/connectors/serviceioconnector/metrics_test.go
+++ b/collector/connectors/serviceioconnector/metrics_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestBuildMetrics(t *testing.T) {
+	now := time.Now()
 	connector := &serviceioConnector{
 		config:              &Config{},
 		startTime:           time.Unix(1700000000, 0),
@@ -32,6 +33,7 @@ func TestBuildMetrics(t *testing.T) {
 		dimensions: attributes,
 		resource:   buildMetricResourceAttributes(instance),
 		count:      3,
+		updatedAt:  now,
 	}
 
 	md, err := connector.buildMetrics()
@@ -54,6 +56,43 @@ func TestBuildMetrics(t *testing.T) {
 	instanceID, ok := dp.Attributes().Get(collectorInstanceAttributeId)
 	require.True(t, ok)
 	require.Equal(t, "odigos-gateway-test-pod", instanceID.Str())
+}
+
+func TestBuildMetricsPrunesStaleSeries(t *testing.T) {
+	now := time.Now()
+	connector := &serviceioConnector{
+		config:              &Config{},
+		startTime:           time.Unix(1700000000, 0),
+		keyToMetric:         make(map[uint64]metricSeries),
+		collectorInstanceID: "odigos-gateway-test-pod",
+	}
+
+	activeAttrs := pcommon.NewMap()
+	activeAttrs.PutStr(serviceNameAttribute, "active")
+	staleAttrs := pcommon.NewMap()
+	staleAttrs.PutStr(serviceNameAttribute, "stale")
+	resource := pcommon.NewMap()
+
+	activeKey := hashAttributes(activeAttrs)
+	staleKey := hashAttributes(staleAttrs)
+	connector.keyToMetric[activeKey] = metricSeries{
+		dimensions: activeAttrs,
+		resource:   resource,
+		count:      2,
+		updatedAt:  now,
+	}
+	connector.keyToMetric[staleKey] = metricSeries{
+		dimensions: staleAttrs,
+		resource:   resource,
+		count:      5,
+		updatedAt:  now.Add(-defaultMetricSeriesTTL - time.Second),
+	}
+
+	md, err := connector.buildMetrics()
+	require.NoError(t, err)
+	require.Equal(t, 1, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().Len())
+	require.Contains(t, connector.keyToMetric, activeKey)
+	require.NotContains(t, connector.keyToMetric, staleKey)
 }
 
 func TestConnectionAttributes_IsDeterministic(t *testing.T) {

--- a/collector/connectors/serviceioconnector/resource_test.go
+++ b/collector/connectors/serviceioconnector/resource_test.go
@@ -2,6 +2,7 @@ package serviceioconnector
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -60,10 +61,12 @@ func TestBuildMetricsSetsResourceAttributes(t *testing.T) {
 
 	inputAttributes := buildServiceInstanceBaseAttributes(instance, inputAttrs)
 	key, attributes := buildConnectionAttributes(inputAttributes, outputAttrs)
+	now := time.Now()
 	connector.keyToMetric[key] = metricSeries{
 		dimensions: attributes,
 		resource:   buildMetricResourceAttributes(instance),
 		count:      2,
+		updatedAt:  now,
 	}
 
 	md, err := connector.buildMetrics()

--- a/collector/internal/go-rtml/go.mod
+++ b/collector/internal/go-rtml/go.mod
@@ -1,0 +1,3 @@
+module github.com/odigos-io/go-rtml
+
+go 1.26.4

--- a/collector/internal/go-rtml/rtml.go
+++ b/collector/internal/go-rtml/rtml.go
@@ -1,0 +1,94 @@
+package rtml
+
+import (
+	"math"
+	"runtime/metrics"
+)
+
+const (
+	metricGOMEMLimit = "/gc/gomemlimit:bytes"
+	metricHeapGoal   = "/gc/heap/goal:bytes"
+	metricHeapLive   = "/gc/heap/live:bytes"
+	metricHeapFree   = "/memory/classes/heap/free:bytes"
+	metricHeapRel    = "/memory/classes/heap/released:bytes"
+	metricMemTotal   = "/memory/classes/total:bytes"
+	metricTotalAlloc = "/gc/heap/allocs:bytes"
+	metricTotalFree  = "/gc/heap/frees:bytes"
+)
+
+// IsMemLimitReached reports whether the Go runtime is at risk of exceeding its
+// configured memory limit. It intentionally uses stable runtime metrics instead
+// of linkname access to runtime internals, so collector builds are not coupled
+// to private Go symbols.
+func IsMemLimitReached() bool {
+	stats := GetMemLimitRelatedStats()
+	if stats.MemoryLimit == 0 || stats.MemoryLimit == math.MaxInt64 {
+		return false
+	}
+
+	if stats.MemoryLimit > stats.MappedReady {
+		return false
+	}
+
+	if stats.HeapFree >= stats.MappedReady {
+		return false
+	}
+	if stats.MemoryLimit > stats.MappedReady-stats.HeapFree {
+		return false
+	}
+
+	return stats.HeapLive >= stats.HeapGoal
+}
+
+// MemLimitRelatedStats contains the runtime values used by IsMemLimitReached.
+type MemLimitRelatedStats struct {
+	MemoryLimit uint64
+	HeapGoal    uint64
+	HeapLive    uint64
+	MappedReady uint64
+	HeapFree    uint64
+	TotalAlloc  uint64
+	TotalFree   uint64
+}
+
+// GetMemLimitRelatedStats returns a point-in-time view of Go memory-limit
+// metrics. Runtime metrics are sampled together to keep the snapshot as
+// consistent as the public API allows.
+func GetMemLimitRelatedStats() MemLimitRelatedStats {
+	samples := []metrics.Sample{
+		{Name: metricGOMEMLimit},
+		{Name: metricHeapGoal},
+		{Name: metricHeapLive},
+		{Name: metricHeapFree},
+		{Name: metricHeapRel},
+		{Name: metricMemTotal},
+		{Name: metricTotalAlloc},
+		{Name: metricTotalFree},
+	}
+
+	metrics.Read(samples)
+
+	memTotal := uintMetric(samples[5])
+	heapReleased := uintMetric(samples[4])
+	mappedReady := uint64(0)
+	if memTotal > heapReleased {
+		mappedReady = memTotal - heapReleased
+	}
+
+	return MemLimitRelatedStats{
+		MemoryLimit: uintMetric(samples[0]),
+		HeapGoal:    uintMetric(samples[1]),
+		HeapLive:    uintMetric(samples[2]),
+		MappedReady: mappedReady,
+		HeapFree:    uintMetric(samples[3]),
+		TotalAlloc:  uintMetric(samples[6]),
+		TotalFree:   uintMetric(samples[7]),
+	}
+}
+
+func uintMetric(sample metrics.Sample) uint64 {
+	if sample.Value.Kind() != metrics.KindUint64 {
+		return 0
+	}
+	return sample.Value.Uint64()
+}

--- a/collector/internal/go-rtml/rtml_test.go
+++ b/collector/internal/go-rtml/rtml_test.go
@@ -1,0 +1,15 @@
+package rtml
+
+import "testing"
+
+func TestMemoryLimitMetricsAreReadable(t *testing.T) {
+	stats := GetMemLimitRelatedStats()
+	if stats.MemoryLimit == 0 {
+		t.Fatal("expected Go memory limit metric to be available")
+	}
+	if stats.HeapGoal == 0 {
+		t.Fatal("expected Go heap goal metric to be available")
+	}
+
+	_ = IsMemLimitReached()
+}

--- a/collector/odigosotelcol/go.mod
+++ b/collector/odigosotelcol/go.mod
@@ -2,7 +2,7 @@
 
 module odigos.io/opentelemetry-collector/cmd/odigosotelcol
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/odigos-io/odigos/collector/connectors/odigosrouterconnector v0.151.0
@@ -804,6 +804,8 @@ replace github.com/odigos-io/odigos/collector/connectors/serviceioconnector => .
 replace github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector => ../connectors/servicegraphconnector
 
 replace github.com/odigos-io/odigos/collector/receivers/odigosebpfreceiver => ../receivers/odigosebpfreceiver
+
+replace github.com/odigos-io/go-rtml => ../internal/go-rtml
 
 replace github.com/odigos-io/odigos/common => ../../common
 

--- a/collector/processors/odigossymbolizeprocessor/processor.go
+++ b/collector/processors/odigossymbolizeprocessor/processor.go
@@ -4,8 +4,9 @@
 // already named (interpreted runtimes, Go) pass through untouched. See README.md.
 //
 // processor.go is the pipeline entry point: for each ResourceProfiles it reads
-// the process.pid, pre-warms the symbol cache for newly-seen processes, and fills
-// each native Location's Lines with the resolved function name.
+// process.pid from the resource or profile samples, pre-warms the symbol cache
+// for newly-seen processes, and fills each native Location's Lines with the
+// resolved function name.
 package odigossymbolizeprocessor
 
 import (
@@ -112,7 +113,7 @@ func (p *symbolizeProcessor) processProfiles(_ context.Context, pd pprofile.Prof
 	rps := pd.ResourceProfiles()
 	for ri := 0; ri < rps.Len(); ri++ {
 		rp := rps.At(ri)
-		pid := pidFromResource(rp.Resource().Attributes(), p.cfg.pidAttribute())
+		pid := pidFromResourceProfiles(dict, rp, p.cfg.pidAttribute())
 		if pid <= 0 {
 			continue
 		}
@@ -143,6 +144,42 @@ func (p *symbolizeProcessor) processProfiles(_ context.Context, pd pprofile.Prof
 	}
 
 	return pd, nil
+}
+
+func pidFromResourceProfiles(dict pprofile.ProfilesDictionary, rp pprofile.ResourceProfiles, key string) int64 {
+	if pid := pidFromResource(rp.Resource().Attributes(), key); pid > 0 {
+		return pid
+	}
+
+	keyIdx := stringTableIndex(dict.StringTable(), key)
+	if keyIdx < 0 {
+		return 0
+	}
+	attrTable := dict.AttributeTable()
+
+	sps := rp.ScopeProfiles()
+	for si := 0; si < sps.Len(); si++ {
+		profs := sps.At(si).Profiles()
+		for pi := 0; pi < profs.Len(); pi++ {
+			samples := profs.At(pi).Samples()
+			for sampleIdx := 0; sampleIdx < samples.Len(); sampleIdx++ {
+				attrs := samples.At(sampleIdx).AttributeIndices()
+				for ai := 0; ai < attrs.Len(); ai++ {
+					attrIdx := int(attrs.At(ai))
+					if attrIdx < 0 || attrIdx >= attrTable.Len() {
+						continue
+					}
+					kv := attrTable.At(attrIdx)
+					if kv.KeyStrindex() == keyIdx {
+						if pid := pidFromValue(kv.Value()); pid > 0 {
+							return pid
+						}
+					}
+				}
+			}
+		}
+	}
+	return 0
 }
 
 // prewarmOnce asynchronously parses a newly-seen process's mapped binaries so
@@ -224,6 +261,10 @@ func pidFromResource(attrs pcommon.Map, key string) int64 {
 	if !ok {
 		return 0
 	}
+	return pidFromValue(v)
+}
+
+func pidFromValue(v pcommon.Value) int64 {
 	switch v.Type() {
 	case pcommon.ValueTypeInt:
 		return v.Int()
@@ -239,4 +280,13 @@ func pidFromResource(attrs pcommon.Map, key string) int64 {
 	default:
 		return 0
 	}
+}
+
+func stringTableIndex(st pcommon.StringSlice, want string) int32 {
+	for i := 0; i < st.Len(); i++ {
+		if st.At(i) == want {
+			return int32(i)
+		}
+	}
+	return -1
 }

--- a/collector/processors/odigossymbolizeprocessor/processor_test.go
+++ b/collector/processors/odigossymbolizeprocessor/processor_test.go
@@ -86,6 +86,19 @@ func buildProfiles() (pprofile.Profiles, int /*nativeLoc*/, int /*namedLoc*/) {
 	return pd, 0, 2
 }
 
+func putSamplePID(pd pprofile.Profiles, pid int64) {
+	dict := pd.Dictionary()
+	keyIdx := int32(dict.StringTable().Len())
+	dict.StringTable().Append("process.pid")
+	attr := dict.AttributeTable().AppendEmpty()
+	attr.SetKeyStrindex(keyIdx)
+	attr.Value().SetInt(pid)
+	attrIdx := int32(dict.AttributeTable().Len() - 1)
+
+	sample := pd.ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().At(0).Samples().At(0)
+	sample.AttributeIndices().Append(attrIdx)
+}
+
 func TestProcessProfilesFillsNativeLines(t *testing.T) {
 	pd, nativeLoc, namedLoc := buildProfiles()
 
@@ -123,6 +136,22 @@ func TestProcessProfilesFillsNativeLines(t *testing.T) {
 	// Correct pid was used.
 	require.Equal(t, int64(4242), fr.gotPID)
 	require.Equal(t, "libfix.so", fr.gotName)
+}
+
+func TestProcessProfilesUsesSamplePID(t *testing.T) {
+	pd, nativeLoc, _ := buildProfiles()
+	pd.ResourceProfiles().At(0).Resource().Attributes().Clear()
+	putSamplePID(pd, 4242)
+
+	fr := &fakeResolver{names: map[uint64]string{0x1000: "sample_pid_symbol"}}
+	p := newTestProcessor(fr)
+
+	out, err := p.processProfiles(context.Background(), pd)
+	require.NoError(t, err)
+
+	resolved := out.Dictionary().LocationTable().At(nativeLoc)
+	require.Equal(t, 1, resolved.Lines().Len(), "sample process.pid should drive symbolization")
+	require.Equal(t, int64(4242), fr.gotPID)
 }
 
 func TestProcessProfilesNoPIDSkips(t *testing.T) {

--- a/collector/processors/odigostracefilterprocessor/processor.go
+++ b/collector/processors/odigostracefilterprocessor/processor.go
@@ -17,26 +17,22 @@ func (p *traceFilterProcessor) processTraces(_ context.Context, td ptrace.Traces
 		return td, nil
 	}
 
-	for i := td.ResourceSpans().Len() - 1; i >= 0; i-- {
+	for i := 0; i < td.ResourceSpans().Len(); i++ {
 		rs := td.ResourceSpans().At(i)
 
-		for j := rs.ScopeSpans().Len() - 1; j >= 0; j-- {
+		for j := 0; j < rs.ScopeSpans().Len(); j++ {
 			ss := rs.ScopeSpans().At(j)
 			p.filterSpans(ss.Spans())
-
-			if ss.Spans().Len() == 0 {
-				rs.ScopeSpans().RemoveIf(func(s ptrace.ScopeSpans) bool {
-					return s.Spans().Len() == 0
-				})
-			}
 		}
 
-		if rs.ScopeSpans().Len() == 0 {
-			td.ResourceSpans().RemoveIf(func(r ptrace.ResourceSpans) bool {
-				return r.ScopeSpans().Len() == 0
-			})
-		}
+		rs.ScopeSpans().RemoveIf(func(s ptrace.ScopeSpans) bool {
+			return s.Spans().Len() == 0
+		})
 	}
+
+	td.ResourceSpans().RemoveIf(func(r ptrace.ResourceSpans) bool {
+		return r.ScopeSpans().Len() == 0
+	})
 
 	return td, nil
 }

--- a/collector/processors/odigostracefilterprocessor/processor_test.go
+++ b/collector/processors/odigostracefilterprocessor/processor_test.go
@@ -155,6 +155,45 @@ func TestEmptyResourceSpansRemoved(t *testing.T) {
 	assert.Equal(t, "svc2", svcName.Str())
 }
 
+func TestMultipleEmptyScopesAndResourcesDoNotPanic(t *testing.T) {
+	proc := &traceFilterProcessor{
+		logger:     zap.NewNop(),
+		evaluators: []SpanFilterEvaluator{&unsampledBitEvaluator{}},
+	}
+
+	td := ptrace.NewTraces()
+
+	emptyResource := td.ResourceSpans().AppendEmpty()
+	emptyResource.Resource().Attributes().PutStr("service.name", "empty-resource")
+
+	keptResource := td.ResourceSpans().AppendEmpty()
+	keptResource.Resource().Attributes().PutStr("service.name", "kept-resource")
+	keptResource.ScopeSpans().AppendEmpty().Spans().AppendEmpty().SetFlags(1)
+
+	mixedResource := td.ResourceSpans().AppendEmpty()
+	mixedResource.Resource().Attributes().PutStr("service.name", "mixed-resource")
+
+	keptScope := mixedResource.ScopeSpans().AppendEmpty()
+	sampledSpan := keptScope.Spans().AppendEmpty()
+	sampledSpan.SetName("sampled")
+	sampledSpan.SetFlags(1)
+
+	mixedResource.ScopeSpans().AppendEmpty()
+
+	drainedScope := mixedResource.ScopeSpans().AppendEmpty()
+	unsampledSpan := drainedScope.Spans().AppendEmpty()
+	unsampledSpan.SetName("unsampled")
+	unsampledSpan.SetFlags(0)
+
+	result, err := proc.processTraces(context.Background(), td)
+	require.NoError(t, err)
+	require.Equal(t, 2, result.ResourceSpans().Len())
+	require.Equal(t, 1, result.ResourceSpans().At(1).ScopeSpans().Len())
+	spans := result.ResourceSpans().At(1).ScopeSpans().At(0).Spans()
+	require.Equal(t, 1, spans.Len())
+	assert.Equal(t, "sampled", spans.At(0).Name())
+}
+
 func createTestTraces(flags uint32) ptrace.Traces {
 	td := ptrace.NewTraces()
 	rs := td.ResourceSpans().AppendEmpty()

--- a/collector/receivers/odigosebpfreceiver/go.mod
+++ b/collector/receivers/odigosebpfreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/odigos-io/odigos/collector/receivers/odigosebpfreceiver
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/cilium/ebpf v0.20.0
@@ -66,5 +66,7 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/odigos-io/go-rtml => ../../internal/go-rtml
 
 replace github.com/odigos-io/odigos/common => ../../../common

--- a/common/api/instrumentationrules/custom_instrumentation.go
+++ b/common/api/instrumentationrules/custom_instrumentation.go
@@ -31,6 +31,12 @@ func (ci *CustomInstrumentations) Verify() error {
 			return fmt.Errorf("invalid configuration for java custom instrumentation: %w", err)
 		}
 	}
+	// Validate C++ probes
+	for _, p := range ci.Cpp {
+		if err := p.Verify(); err != nil {
+			return fmt.Errorf("invalid configuration for cpp custom instrumentation: %w", err)
+		}
+	}
 	return nil
 }
 

--- a/common/api/instrumentationrules/custom_instrumentation_test.go
+++ b/common/api/instrumentationrules/custom_instrumentation_test.go
@@ -1,0 +1,16 @@
+package instrumentationrules
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCustomInstrumentationsVerifyValidatesCpp(t *testing.T) {
+	err := (&CustomInstrumentations{
+		Cpp: []CppCustomProbe{{}},
+	}).Verify()
+
+	require.ErrorContains(t, err, "invalid configuration for cpp custom instrumentation")
+	require.ErrorContains(t, err, "signature is required")
+}

--- a/common/fs/agents.go
+++ b/common/fs/agents.go
@@ -48,6 +48,7 @@ func CopyAgentsDirectoryToHost(srcDir, dstDir string, optionalRsyncPath *string)
 
 		if err != nil {
 			logger.Error("Error getting changed files", "err", err)
+			return err
 		}
 
 		if err := writeKeeplist(dstDir, keeplistPath, updatedFilesToKeepMap); err != nil {

--- a/common/fs/copy_test.go
+++ b/common/fs/copy_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -160,6 +161,45 @@ func TestRemoveChangedFilesFromKeepMap_RenamesChangedFile(t *testing.T) {
 		if _, err := os.Stat(dstPath); err != nil {
 			t.Fatalf("renamed file %s does not exist: %v", dstPath, err)
 		}
+	}
+}
+
+func TestCopyAgentsDirectoryToHost_AbortsWhenCriticalFileInspectionFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake rsync script uses POSIX shell")
+	}
+
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+	fakeBinDir := t.TempDir()
+
+	criticalRelPath := filepath.Join("loader", "loader.so")
+	if err := os.MkdirAll(filepath.Join(srcDir, "loader"), 0755); err != nil {
+		t.Fatalf("mkdir source loader dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, criticalRelPath), []byte("new-loader"), 0644); err != nil {
+		t.Fatalf("write source critical file: %v", err)
+	}
+
+	// A directory at a critical-file path makes hashing fail. The copy must
+	// abort before rsync, otherwise rsync would run without a safe keep list.
+	if err := os.MkdirAll(filepath.Join(dstDir, criticalRelPath), 0755); err != nil {
+		t.Fatalf("mkdir invalid destination critical path: %v", err)
+	}
+
+	rsyncMarker := filepath.Join(dstDir, "rsync-was-called")
+	fakeRsync := filepath.Join(fakeBinDir, "rsync")
+	fakeRsyncScript := fmt.Sprintf("#!/bin/sh\nprintf called > %q\nexit 0\n", rsyncMarker)
+	if err := os.WriteFile(fakeRsync, []byte(fakeRsyncScript), 0755); err != nil {
+		t.Fatalf("write fake rsync: %v", err)
+	}
+
+	err := CopyAgentsDirectoryToHost(srcDir, dstDir, &fakeRsync)
+	if err == nil {
+		t.Fatalf("expected critical-file inspection failure")
+	}
+	if _, statErr := os.Stat(rsyncMarker); !os.IsNotExist(statErr) {
+		t.Fatalf("rsync should not have been called; marker stat err: %v", statErr)
 	}
 }
 

--- a/common/odigos_config.go
+++ b/common/odigos_config.go
@@ -26,6 +26,10 @@ func (l OdigosLogLevel) EnvVarValue() string {
 
 // Compare returns a negative integer, zero, or a positive integer as l is less than, equal to, or greater than other.
 func (l OdigosLogLevel) Compare(other OdigosLogLevel) int {
+	return odigosLogLevelRank(l) - odigosLogLevelRank(other)
+}
+
+func odigosLogLevelRank(l OdigosLogLevel) int {
 	switch l {
 	case LogLevelError:
 		return 10

--- a/common/odigos_config_test.go
+++ b/common/odigos_config_test.go
@@ -1,0 +1,19 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOdigosLogLevelCompareOrdersByVerbosity(t *testing.T) {
+	require.Positive(t, LogLevelDebug.Compare(LogLevelInfo))
+	require.Positive(t, LogLevelInfo.Compare(LogLevelWarn))
+	require.Positive(t, LogLevelWarn.Compare(LogLevelError))
+
+	require.Negative(t, LogLevelError.Compare(LogLevelWarn))
+	require.Negative(t, LogLevelWarn.Compare(LogLevelInfo))
+	require.Negative(t, LogLevelInfo.Compare(LogLevelDebug))
+
+	require.Zero(t, LogLevelDebug.Compare(LogLevelDebug))
+}

--- a/frontend/graph/conversions.go
+++ b/frontend/graph/conversions.go
@@ -870,6 +870,19 @@ func headSamplingOperationMatcherToModel(matcher *sampling.HeadSamplingOperation
 			Method:              services.StringPtrIfNotEmpty(matcher.HttpClient.Method),
 		}
 	}
+	if matcher.GrpcServer != nil {
+		result.GrpcServer = &model.HeadSamplingGrpcServerMatcher{
+			Method:  services.StringPtrIfNotEmpty(matcher.GrpcServer.Method),
+			Service: services.StringPtrIfNotEmpty(matcher.GrpcServer.Service),
+		}
+	}
+	if matcher.GrpcClient != nil {
+		result.GrpcClient = &model.HeadSamplingGrpcClientMatcher{
+			Method:        services.StringPtrIfNotEmpty(matcher.GrpcClient.Method),
+			Service:       services.StringPtrIfNotEmpty(matcher.GrpcClient.Service),
+			ServerAddress: services.StringPtrIfNotEmpty(matcher.GrpcClient.ServerAddress),
+		}
+	}
 	return result
 }
 

--- a/frontend/graph/conversions_test.go
+++ b/frontend/graph/conversions_test.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"testing"
 
+	"github.com/odigos-io/odigos/common"
 	commonapisampling "github.com/odigos-io/odigos/common/api/sampling"
 	"github.com/stretchr/testify/require"
 )
@@ -32,4 +33,27 @@ func TestHeadSamplingOperationMatcherToModelPreservesQueryParams(t *testing.T) {
 	require.Equal(t, "query", got.HTTPServer.QueryParams[0].Name)
 	require.NotNil(t, got.HTTPServer.QueryParams[0].ValueExact)
 	require.Equal(t, valueExact, *got.HTTPServer.QueryParams[0].ValueExact)
+}
+
+func TestConvertCollectorGatewayToModelHandlesMissingServiceGraph(t *testing.T) {
+	got, err := convertCollectorGatewayToModel(&common.CollectorGatewayConfiguration{}, newProvenanceCollector(nil))
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Nil(t, got.ServiceGraphDisabled)
+}
+
+func TestConvertCollectorGatewayToModelPreservesServiceGraphDisabled(t *testing.T) {
+	disabled := true
+
+	got, err := convertCollectorGatewayToModel(&common.CollectorGatewayConfiguration{
+		ServiceGraph: &common.ServiceGraphOptions{
+			Disabled: &disabled,
+		},
+	}, newProvenanceCollector(nil))
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotNil(t, got.ServiceGraphDisabled)
+	require.True(t, *got.ServiceGraphDisabled)
 }

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -510,6 +510,17 @@ type ComplexityRoot struct {
 		ReceiverName       func(childComplexity int) int
 	}
 
+	HeadSamplingGrpcClientMatcher struct {
+		Method        func(childComplexity int) int
+		ServerAddress func(childComplexity int) int
+		Service       func(childComplexity int) int
+	}
+
+	HeadSamplingGrpcServerMatcher struct {
+		Method  func(childComplexity int) int
+		Service func(childComplexity int) int
+	}
+
 	HeadSamplingHttpClientMatcher struct {
 		Method              func(childComplexity int) int
 		ServerAddress       func(childComplexity int) int
@@ -525,6 +536,8 @@ type ComplexityRoot struct {
 	}
 
 	HeadSamplingOperationMatcher struct {
+		GrpcClient func(childComplexity int) int
+		GrpcServer func(childComplexity int) int
 		HTTPClient func(childComplexity int) int
 		HTTPServer func(childComplexity int) int
 	}
@@ -3762,6 +3775,41 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.GolangCustomProbe.ReceiverName(childComplexity), true
 
+	case "HeadSamplingGrpcClientMatcher.method":
+		if e.complexity.HeadSamplingGrpcClientMatcher.Method == nil {
+			break
+		}
+
+		return e.complexity.HeadSamplingGrpcClientMatcher.Method(childComplexity), true
+
+	case "HeadSamplingGrpcClientMatcher.serverAddress":
+		if e.complexity.HeadSamplingGrpcClientMatcher.ServerAddress == nil {
+			break
+		}
+
+		return e.complexity.HeadSamplingGrpcClientMatcher.ServerAddress(childComplexity), true
+
+	case "HeadSamplingGrpcClientMatcher.service":
+		if e.complexity.HeadSamplingGrpcClientMatcher.Service == nil {
+			break
+		}
+
+		return e.complexity.HeadSamplingGrpcClientMatcher.Service(childComplexity), true
+
+	case "HeadSamplingGrpcServerMatcher.method":
+		if e.complexity.HeadSamplingGrpcServerMatcher.Method == nil {
+			break
+		}
+
+		return e.complexity.HeadSamplingGrpcServerMatcher.Method(childComplexity), true
+
+	case "HeadSamplingGrpcServerMatcher.service":
+		if e.complexity.HeadSamplingGrpcServerMatcher.Service == nil {
+			break
+		}
+
+		return e.complexity.HeadSamplingGrpcServerMatcher.Service(childComplexity), true
+
 	case "HeadSamplingHttpClientMatcher.method":
 		if e.complexity.HeadSamplingHttpClientMatcher.Method == nil {
 			break
@@ -3817,6 +3865,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.HeadSamplingHttpServerMatcher.RoutePrefix(childComplexity), true
+
+	case "HeadSamplingOperationMatcher.grpcClient":
+		if e.complexity.HeadSamplingOperationMatcher.GrpcClient == nil {
+			break
+		}
+
+		return e.complexity.HeadSamplingOperationMatcher.GrpcClient(childComplexity), true
+
+	case "HeadSamplingOperationMatcher.grpcServer":
+		if e.complexity.HeadSamplingOperationMatcher.GrpcServer == nil {
+			break
+		}
+
+		return e.complexity.HeadSamplingOperationMatcher.GrpcServer(childComplexity), true
 
 	case "HeadSamplingOperationMatcher.httpClient":
 		if e.complexity.HeadSamplingOperationMatcher.HTTPClient == nil {
@@ -8035,6 +8097,8 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputExtractionInput,
 		ec.unmarshalInputFieldInput,
 		ec.unmarshalInputGolangCustomProbeInput,
+		ec.unmarshalInputHeadSamplingGrpcClientMatcherInput,
+		ec.unmarshalInputHeadSamplingGrpcServerMatcherInput,
 		ec.unmarshalInputHeadSamplingHttpClientMatcherInput,
 		ec.unmarshalInputHeadSamplingHttpServerMatcherInput,
 		ec.unmarshalInputHeadSamplingOperationMatcherInput,
@@ -24241,6 +24305,211 @@ func (ec *executionContext) fieldContext_GolangCustomProbe_receiverMethodName(_ 
 	return fc, nil
 }
 
+func (ec *executionContext) _HeadSamplingGrpcClientMatcher_method(ctx context.Context, field graphql.CollectedField, obj *model.HeadSamplingGrpcClientMatcher) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HeadSamplingGrpcClientMatcher_method(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Method, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HeadSamplingGrpcClientMatcher_method(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HeadSamplingGrpcClientMatcher",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _HeadSamplingGrpcClientMatcher_service(ctx context.Context, field graphql.CollectedField, obj *model.HeadSamplingGrpcClientMatcher) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HeadSamplingGrpcClientMatcher_service(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Service, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HeadSamplingGrpcClientMatcher_service(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HeadSamplingGrpcClientMatcher",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _HeadSamplingGrpcClientMatcher_serverAddress(ctx context.Context, field graphql.CollectedField, obj *model.HeadSamplingGrpcClientMatcher) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HeadSamplingGrpcClientMatcher_serverAddress(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ServerAddress, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HeadSamplingGrpcClientMatcher_serverAddress(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HeadSamplingGrpcClientMatcher",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _HeadSamplingGrpcServerMatcher_method(ctx context.Context, field graphql.CollectedField, obj *model.HeadSamplingGrpcServerMatcher) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HeadSamplingGrpcServerMatcher_method(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Method, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HeadSamplingGrpcServerMatcher_method(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HeadSamplingGrpcServerMatcher",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _HeadSamplingGrpcServerMatcher_service(ctx context.Context, field graphql.CollectedField, obj *model.HeadSamplingGrpcServerMatcher) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HeadSamplingGrpcServerMatcher_service(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Service, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HeadSamplingGrpcServerMatcher_service(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HeadSamplingGrpcServerMatcher",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _HeadSamplingHttpClientMatcher_serverAddress(ctx context.Context, field graphql.CollectedField, obj *model.HeadSamplingHTTPClientMatcher) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_HeadSamplingHttpClientMatcher_serverAddress(ctx, field)
 	if err != nil {
@@ -24672,6 +24941,102 @@ func (ec *executionContext) fieldContext_HeadSamplingOperationMatcher_httpClient
 				return ec.fieldContext_HeadSamplingHttpClientMatcher_method(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type HeadSamplingHttpClientMatcher", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _HeadSamplingOperationMatcher_grpcServer(ctx context.Context, field graphql.CollectedField, obj *model.HeadSamplingOperationMatcher) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HeadSamplingOperationMatcher_grpcServer(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.GrpcServer, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.HeadSamplingGrpcServerMatcher)
+	fc.Result = res
+	return ec.marshalOHeadSamplingGrpcServerMatcher2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐHeadSamplingGrpcServerMatcher(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HeadSamplingOperationMatcher_grpcServer(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HeadSamplingOperationMatcher",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "method":
+				return ec.fieldContext_HeadSamplingGrpcServerMatcher_method(ctx, field)
+			case "service":
+				return ec.fieldContext_HeadSamplingGrpcServerMatcher_service(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type HeadSamplingGrpcServerMatcher", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _HeadSamplingOperationMatcher_grpcClient(ctx context.Context, field graphql.CollectedField, obj *model.HeadSamplingOperationMatcher) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HeadSamplingOperationMatcher_grpcClient(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.GrpcClient, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.HeadSamplingGrpcClientMatcher)
+	fc.Result = res
+	return ec.marshalOHeadSamplingGrpcClientMatcher2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐHeadSamplingGrpcClientMatcher(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HeadSamplingOperationMatcher_grpcClient(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HeadSamplingOperationMatcher",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "method":
+				return ec.fieldContext_HeadSamplingGrpcClientMatcher_method(ctx, field)
+			case "service":
+				return ec.fieldContext_HeadSamplingGrpcClientMatcher_service(ctx, field)
+			case "serverAddress":
+				return ec.fieldContext_HeadSamplingGrpcClientMatcher_serverAddress(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type HeadSamplingGrpcClientMatcher", field.Name)
 		},
 	}
 	return fc, nil
@@ -32191,6 +32556,10 @@ func (ec *executionContext) fieldContext_K8sWorkloadContainerAgentConfigTracesHe
 				return ec.fieldContext_HeadSamplingOperationMatcher_httpServer(ctx, field)
 			case "httpClient":
 				return ec.fieldContext_HeadSamplingOperationMatcher_httpClient(ctx, field)
+			case "grpcServer":
+				return ec.fieldContext_HeadSamplingOperationMatcher_grpcServer(ctx, field)
+			case "grpcClient":
+				return ec.fieldContext_HeadSamplingOperationMatcher_grpcClient(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type HeadSamplingOperationMatcher", field.Name)
 		},
@@ -33146,6 +33515,10 @@ func (ec *executionContext) fieldContext_K8sWorkloadContainerCollectorConfigTail
 				return ec.fieldContext_HeadSamplingOperationMatcher_httpServer(ctx, field)
 			case "httpClient":
 				return ec.fieldContext_HeadSamplingOperationMatcher_httpClient(ctx, field)
+			case "grpcServer":
+				return ec.fieldContext_HeadSamplingOperationMatcher_grpcServer(ctx, field)
+			case "grpcClient":
+				return ec.fieldContext_HeadSamplingOperationMatcher_grpcClient(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type HeadSamplingOperationMatcher", field.Name)
 		},
@@ -40663,6 +41036,10 @@ func (ec *executionContext) fieldContext_NoisyOperationRule_operation(_ context.
 				return ec.fieldContext_HeadSamplingOperationMatcher_httpServer(ctx, field)
 			case "httpClient":
 				return ec.fieldContext_HeadSamplingOperationMatcher_httpClient(ctx, field)
+			case "grpcServer":
+				return ec.fieldContext_HeadSamplingOperationMatcher_grpcServer(ctx, field)
+			case "grpcClient":
+				return ec.fieldContext_HeadSamplingOperationMatcher_grpcClient(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type HeadSamplingOperationMatcher", field.Name)
 		},
@@ -54669,6 +55046,81 @@ func (ec *executionContext) unmarshalInputGolangCustomProbeInput(ctx context.Con
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputHeadSamplingGrpcClientMatcherInput(ctx context.Context, obj any) (model.HeadSamplingGrpcClientMatcherInput, error) {
+	var it model.HeadSamplingGrpcClientMatcherInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"method", "service", "serverAddress"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "method":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("method"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Method = data
+		case "service":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("service"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Service = data
+		case "serverAddress":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("serverAddress"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ServerAddress = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputHeadSamplingGrpcServerMatcherInput(ctx context.Context, obj any) (model.HeadSamplingGrpcServerMatcherInput, error) {
+	var it model.HeadSamplingGrpcServerMatcherInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"method", "service"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "method":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("method"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Method = data
+		case "service":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("service"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Service = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputHeadSamplingHttpClientMatcherInput(ctx context.Context, obj any) (model.HeadSamplingHTTPClientMatcherInput, error) {
 	var it model.HeadSamplingHTTPClientMatcherInput
 	asMap := map[string]any{}
@@ -54772,7 +55224,7 @@ func (ec *executionContext) unmarshalInputHeadSamplingOperationMatcherInput(ctx 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"httpServer", "httpClient"}
+	fieldsInOrder := [...]string{"httpServer", "httpClient", "grpcServer", "grpcClient"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -54793,6 +55245,20 @@ func (ec *executionContext) unmarshalInputHeadSamplingOperationMatcherInput(ctx 
 				return it, err
 			}
 			it.HTTPClient = data
+		case "grpcServer":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("grpcServer"))
+			data, err := ec.unmarshalOHeadSamplingGrpcServerMatcherInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐHeadSamplingGrpcServerMatcherInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.GrpcServer = data
+		case "grpcClient":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("grpcClient"))
+			data, err := ec.unmarshalOHeadSamplingGrpcClientMatcherInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐHeadSamplingGrpcClientMatcherInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.GrpcClient = data
 		}
 	}
 
@@ -59910,6 +60376,84 @@ func (ec *executionContext) _GolangCustomProbe(ctx context.Context, sel ast.Sele
 	return out
 }
 
+var headSamplingGrpcClientMatcherImplementors = []string{"HeadSamplingGrpcClientMatcher"}
+
+func (ec *executionContext) _HeadSamplingGrpcClientMatcher(ctx context.Context, sel ast.SelectionSet, obj *model.HeadSamplingGrpcClientMatcher) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, headSamplingGrpcClientMatcherImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("HeadSamplingGrpcClientMatcher")
+		case "method":
+			out.Values[i] = ec._HeadSamplingGrpcClientMatcher_method(ctx, field, obj)
+		case "service":
+			out.Values[i] = ec._HeadSamplingGrpcClientMatcher_service(ctx, field, obj)
+		case "serverAddress":
+			out.Values[i] = ec._HeadSamplingGrpcClientMatcher_serverAddress(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var headSamplingGrpcServerMatcherImplementors = []string{"HeadSamplingGrpcServerMatcher"}
+
+func (ec *executionContext) _HeadSamplingGrpcServerMatcher(ctx context.Context, sel ast.SelectionSet, obj *model.HeadSamplingGrpcServerMatcher) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, headSamplingGrpcServerMatcherImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("HeadSamplingGrpcServerMatcher")
+		case "method":
+			out.Values[i] = ec._HeadSamplingGrpcServerMatcher_method(ctx, field, obj)
+		case "service":
+			out.Values[i] = ec._HeadSamplingGrpcServerMatcher_service(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var headSamplingHttpClientMatcherImplementors = []string{"HeadSamplingHttpClientMatcher"}
 
 func (ec *executionContext) _HeadSamplingHttpClientMatcher(ctx context.Context, sel ast.SelectionSet, obj *model.HeadSamplingHTTPClientMatcher) graphql.Marshaler {
@@ -60009,6 +60553,10 @@ func (ec *executionContext) _HeadSamplingOperationMatcher(ctx context.Context, s
 			out.Values[i] = ec._HeadSamplingOperationMatcher_httpServer(ctx, field, obj)
 		case "httpClient":
 			out.Values[i] = ec._HeadSamplingOperationMatcher_httpClient(ctx, field, obj)
+		case "grpcServer":
+			out.Values[i] = ec._HeadSamplingOperationMatcher_grpcServer(ctx, field, obj)
+		case "grpcClient":
+			out.Values[i] = ec._HeadSamplingOperationMatcher_grpcClient(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -73045,6 +73593,36 @@ func (ec *executionContext) unmarshalOGolangCustomProbeInput2ᚖgithubᚗcomᚋo
 		return nil, nil
 	}
 	res, err := ec.unmarshalInputGolangCustomProbeInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOHeadSamplingGrpcClientMatcher2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐHeadSamplingGrpcClientMatcher(ctx context.Context, sel ast.SelectionSet, v *model.HeadSamplingGrpcClientMatcher) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._HeadSamplingGrpcClientMatcher(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOHeadSamplingGrpcClientMatcherInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐHeadSamplingGrpcClientMatcherInput(ctx context.Context, v any) (*model.HeadSamplingGrpcClientMatcherInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputHeadSamplingGrpcClientMatcherInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOHeadSamplingGrpcServerMatcher2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐHeadSamplingGrpcServerMatcher(ctx context.Context, sel ast.SelectionSet, v *model.HeadSamplingGrpcServerMatcher) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._HeadSamplingGrpcServerMatcher(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOHeadSamplingGrpcServerMatcherInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐHeadSamplingGrpcServerMatcherInput(ctx context.Context, v any) (*model.HeadSamplingGrpcServerMatcherInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputHeadSamplingGrpcServerMatcherInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -572,6 +572,28 @@ type GolangCustomProbeInput struct {
 	ReceiverMethodName *string `json:"receiverMethodName,omitempty"`
 }
 
+type HeadSamplingGrpcClientMatcher struct {
+	Method        *string `json:"method,omitempty"`
+	Service       *string `json:"service,omitempty"`
+	ServerAddress *string `json:"serverAddress,omitempty"`
+}
+
+type HeadSamplingGrpcClientMatcherInput struct {
+	Method        *string `json:"method,omitempty"`
+	Service       *string `json:"service,omitempty"`
+	ServerAddress *string `json:"serverAddress,omitempty"`
+}
+
+type HeadSamplingGrpcServerMatcher struct {
+	Method  *string `json:"method,omitempty"`
+	Service *string `json:"service,omitempty"`
+}
+
+type HeadSamplingGrpcServerMatcherInput struct {
+	Method  *string `json:"method,omitempty"`
+	Service *string `json:"service,omitempty"`
+}
+
 type HeadSamplingHTTPClientMatcher struct {
 	ServerAddress       *string `json:"serverAddress,omitempty"`
 	TemplatedPath       *string `json:"templatedPath,omitempty"`
@@ -603,11 +625,15 @@ type HeadSamplingHTTPServerMatcherInput struct {
 type HeadSamplingOperationMatcher struct {
 	HTTPServer *HeadSamplingHTTPServerMatcher `json:"httpServer,omitempty"`
 	HTTPClient *HeadSamplingHTTPClientMatcher `json:"httpClient,omitempty"`
+	GrpcServer *HeadSamplingGrpcServerMatcher `json:"grpcServer,omitempty"`
+	GrpcClient *HeadSamplingGrpcClientMatcher `json:"grpcClient,omitempty"`
 }
 
 type HeadSamplingOperationMatcherInput struct {
 	HTTPServer *HeadSamplingHTTPServerMatcherInput `json:"httpServer,omitempty"`
 	HTTPClient *HeadSamplingHTTPClientMatcherInput `json:"httpClient,omitempty"`
+	GrpcServer *HeadSamplingGrpcServerMatcherInput `json:"grpcServer,omitempty"`
+	GrpcClient *HeadSamplingGrpcClientMatcherInput `json:"grpcClient,omitempty"`
 }
 
 type HeadSamplingQueryParamMatcher struct {

--- a/frontend/graph/sampling.graphqls
+++ b/frontend/graph/sampling.graphqls
@@ -131,9 +131,22 @@ type HeadSamplingHttpClientMatcher {
   method: String
 }
 
+type HeadSamplingGrpcServerMatcher {
+  method: String
+  service: String
+}
+
+type HeadSamplingGrpcClientMatcher {
+  method: String
+  service: String
+  serverAddress: String
+}
+
 type HeadSamplingOperationMatcher {
   httpServer: HeadSamplingHttpServerMatcher
   httpClient: HeadSamplingHttpClientMatcher
+  grpcServer: HeadSamplingGrpcServerMatcher
+  grpcClient: HeadSamplingGrpcClientMatcher
 }
 
 input HeadSamplingHttpServerMatcherInput {
@@ -150,9 +163,22 @@ input HeadSamplingHttpClientMatcherInput {
   method: String
 }
 
+input HeadSamplingGrpcServerMatcherInput {
+  method: String
+  service: String
+}
+
+input HeadSamplingGrpcClientMatcherInput {
+  method: String
+  service: String
+  serverAddress: String
+}
+
 input HeadSamplingOperationMatcherInput {
   httpServer: HeadSamplingHttpServerMatcherInput
   httpClient: HeadSamplingHttpClientMatcherInput
+  grpcServer: HeadSamplingGrpcServerMatcherInput
+  grpcClient: HeadSamplingGrpcClientMatcherInput
 }
 
 # ---- Tail sampling operation matchers (used by highly relevant + cost reduction) ----

--- a/frontend/services/action_test.go
+++ b/frontend/services/action_test.go
@@ -1,0 +1,45 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/odigos-io/odigos/api/k8sconsts"
+	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	urlactions "github.com/odigos-io/odigos/api/odigos/v1alpha1/actions"
+	commonactions "github.com/odigos-io/odigos/common/api/actions"
+	"github.com/odigos-io/odigos/frontend/graph/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertUrlTemplatizationFromInputPreservesExistingDefaultConfig(t *testing.T) {
+	existingDefault := []urlactions.URLTemplatizationDefaultTemplatizationGroup{{
+		Scopes: &k8sconsts.SourcesScopes{
+			Namespaces: []string{"public"},
+		},
+		DefaultTemplatizationConfig: commonactions.DefaultTemplatizationConfig{
+			SkipPolicy: &commonactions.DefaultTemplatizationSkipPolicyConfig{
+				SkipForNonSuccessCodes: true,
+			},
+		},
+	}}
+	existingAction := &v1alpha1.Action{
+		Spec: v1alpha1.ActionSpec{
+			URLTemplatization: &urlactions.URLTemplatizationConfig{
+				Default: existingDefault,
+			},
+		},
+	}
+
+	cfg := convertUrlTemplatizationFromInput(&model.ActionFieldsInput{
+		URLTemplatizationRulesGroups: []*model.URLTemplatizationRulesGroupInput{{
+			TemplatizationRules: []*model.URLTemplatizationRuleInput{{
+				Template: "/users/{id}",
+			}},
+		}},
+	}, existingAction)
+
+	require.NotNil(t, cfg)
+	require.Equal(t, existingDefault, cfg.Default)
+	require.Len(t, cfg.Rules, 1)
+	require.Equal(t, []string{"/users/{id}"}, cfg.Rules[0].Templates)
+}

--- a/frontend/services/instrumentationrule.go
+++ b/frontend/services/instrumentationrule.go
@@ -448,8 +448,6 @@ func UpdateInstrumentationRule(ctx context.Context, id string, input model.Instr
 
 	if input.SourcesScopes != nil {
 		existingRule.Spec.Scopes = convertSourcesScopeInput(input.SourcesScopes)
-	} else {
-		existingRule.Spec.Scopes = nil
 	}
 
 	if input.InstrumentationLibraries != nil {
@@ -462,8 +460,6 @@ func UpdateInstrumentationRule(ctx context.Context, id string, input model.Instr
 			}
 		}
 		existingRule.Spec.InstrumentationLibraries = &convertedLibraries
-	} else {
-		existingRule.Spec.InstrumentationLibraries = nil
 	}
 
 	if input.PayloadCollection != nil {

--- a/frontend/services/instrumentationrule_test.go
+++ b/frontend/services/instrumentationrule_test.go
@@ -1,12 +1,37 @@
 package services
 
 import (
+	"context"
 	"testing"
 
+	odigosfake "github.com/odigos-io/odigos/api/generated/odigos/clientset/versioned/fake"
+	"github.com/odigos-io/odigos/api/k8sconsts"
+	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	"github.com/odigos-io/odigos/common"
 	apirules "github.com/odigos-io/odigos/common/api/instrumentationrules"
+	"github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/frontend/graph/model"
+	"github.com/odigos-io/odigos/frontend/kube"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
+
+func setFakeOdigosInstrumentationRuleClient(t *testing.T, objects ...*v1alpha1.InstrumentationRule) {
+	t.Helper()
+
+	runtimeObjects := make([]runtime.Object, 0, len(objects))
+	for _, obj := range objects {
+		runtimeObjects = append(runtimeObjects, obj)
+	}
+
+	clientset := odigosfake.NewSimpleClientset(runtimeObjects...)
+	previousClient := kube.DefaultClient
+	kube.SetDefaultClient(&kube.Client{OdigosClient: clientset.OdigosV1alpha1()})
+	t.Cleanup(func() {
+		kube.SetDefaultClient(previousClient)
+	})
+}
 
 func TestMergePayloadCollectionUpdatePreservesOmittedAdvancedOptions(t *testing.T) {
 	maxHTTP := int64(2048)
@@ -87,4 +112,99 @@ func TestMergePayloadCollectionUpdateReplacesExplicitAdvancedOptions(t *testing.
 	require.Equal(t, int64(4096), *out.HttpRequest.MaxPayloadLength)
 	require.False(t, *out.HttpRequest.DropPartialPayloads)
 	require.Nil(t, out.HttpResponse, "omitted payload sections should still be disabled")
+}
+
+func TestUpdateInstrumentationRulePreservesOmittedScopesAndLibraries(t *testing.T) {
+	ctx := context.Background()
+	ruleID := "scoped-rule"
+	ruleName := "renamed rule"
+	notes := "updated notes"
+	disabled := false
+
+	scopes := &k8sconsts.SourcesScopes{
+		Sources: []k8sconsts.PodWorkload{{
+			Name:      "checkout",
+			Namespace: "prod",
+			Kind:      k8sconsts.WorkloadKindDeployment,
+		}},
+		Languages: []common.ProgrammingLanguage{common.JavaProgrammingLanguage},
+	}
+	libraries := []v1alpha1.InstrumentationLibraryGlobalId{{
+		Name:     "spring-webmvc",
+		SpanKind: common.ServerSpanKind,
+		Language: common.JavaProgrammingLanguage,
+	}}
+
+	setFakeOdigosInstrumentationRuleClient(t, &v1alpha1.InstrumentationRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ruleID,
+			Namespace: consts.DefaultOdigosNamespace,
+		},
+		Spec: v1alpha1.InstrumentationRuleSpec{
+			RuleName:                 "original rule",
+			Notes:                    "original notes",
+			Scopes:                   scopes,
+			InstrumentationLibraries: &libraries,
+			PayloadCollection:        &apirules.PayloadCollection{HttpRequest: &apirules.HttpPayloadCollection{}},
+		},
+	})
+
+	_, err := UpdateInstrumentationRule(ctx, ruleID, model.InstrumentationRuleInput{
+		RuleName: &ruleName,
+		Notes:    &notes,
+		Disabled: &disabled,
+		// Older UI clients omit SourcesScopes and InstrumentationLibraries on edit.
+		PayloadCollection: &model.PayloadCollectionInput{HTTPRequest: &model.HTTPPayloadCollectionInput{}},
+	})
+	require.NoError(t, err)
+
+	updatedRule, err := kube.DefaultClient.OdigosClient.InstrumentationRules(consts.DefaultOdigosNamespace).Get(ctx, ruleID, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, scopes, updatedRule.Spec.Scopes)
+	require.Equal(t, &libraries, updatedRule.Spec.InstrumentationLibraries)
+	require.Equal(t, ruleName, updatedRule.Spec.RuleName)
+	require.Equal(t, notes, updatedRule.Spec.Notes)
+}
+
+func TestUpdateInstrumentationRuleAllowsExplicitClearingScopesAndLibraries(t *testing.T) {
+	ctx := context.Background()
+	ruleID := "scoped-rule"
+	ruleName := "cluster wide rule"
+	notes := "clear selectors"
+	disabled := false
+
+	libraries := []v1alpha1.InstrumentationLibraryGlobalId{{
+		Name:     "spring-webmvc",
+		SpanKind: common.ServerSpanKind,
+		Language: common.JavaProgrammingLanguage,
+	}}
+
+	setFakeOdigosInstrumentationRuleClient(t, &v1alpha1.InstrumentationRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ruleID,
+			Namespace: consts.DefaultOdigosNamespace,
+		},
+		Spec: v1alpha1.InstrumentationRuleSpec{
+			RuleName: "original rule",
+			Scopes: &k8sconsts.SourcesScopes{
+				Namespaces: []string{"prod"},
+			},
+			InstrumentationLibraries: &libraries,
+		},
+	})
+
+	_, err := UpdateInstrumentationRule(ctx, ruleID, model.InstrumentationRuleInput{
+		RuleName:                 &ruleName,
+		Notes:                    &notes,
+		Disabled:                 &disabled,
+		SourcesScopes:            []*model.InstrumentationRuleSourcesScopeInput{},
+		InstrumentationLibraries: []*model.InstrumentationLibraryGlobalIDInput{},
+	})
+	require.NoError(t, err)
+
+	updatedRule, err := kube.DefaultClient.OdigosClient.InstrumentationRules(consts.DefaultOdigosNamespace).Get(ctx, ruleID, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Nil(t, updatedRule.Spec.Scopes)
+	require.NotNil(t, updatedRule.Spec.InstrumentationLibraries)
+	require.Empty(t, *updatedRule.Spec.InstrumentationLibraries)
 }

--- a/frontend/services/sampling/conversions.go
+++ b/frontend/services/sampling/conversions.go
@@ -166,6 +166,19 @@ func headSamplingOperationMatcherInputToCRD(input *model.HeadSamplingOperationMa
 			Method:              services.DerefString(input.HTTPClient.Method),
 		}
 	}
+	if input.GrpcServer != nil {
+		matcher.GrpcServer = &commonapisampling.HeadSamplingGrpcServerOperationMatcher{
+			Method:  services.DerefString(input.GrpcServer.Method),
+			Service: services.DerefString(input.GrpcServer.Service),
+		}
+	}
+	if input.GrpcClient != nil {
+		matcher.GrpcClient = &commonapisampling.HeadSamplingGrpcClientOperationMatcher{
+			Method:        services.DerefString(input.GrpcClient.Method),
+			Service:       services.DerefString(input.GrpcClient.Service),
+			ServerAddress: services.DerefString(input.GrpcClient.ServerAddress),
+		}
+	}
 	return matcher
 }
 
@@ -188,6 +201,19 @@ func headSamplingOperationMatcherCRDToModel(matcher *commonapisampling.HeadSampl
 			TemplatedPath:       services.StringPtrIfNotEmpty(matcher.HttpClient.TemplatedPath),
 			TemplatedPathPrefix: services.StringPtrIfNotEmpty(matcher.HttpClient.TemplatedPathPrefix),
 			Method:              services.StringPtrIfNotEmpty(matcher.HttpClient.Method),
+		}
+	}
+	if matcher.GrpcServer != nil {
+		result.GrpcServer = &model.HeadSamplingGrpcServerMatcher{
+			Method:  services.StringPtrIfNotEmpty(matcher.GrpcServer.Method),
+			Service: services.StringPtrIfNotEmpty(matcher.GrpcServer.Service),
+		}
+	}
+	if matcher.GrpcClient != nil {
+		result.GrpcClient = &model.HeadSamplingGrpcClientMatcher{
+			Method:        services.StringPtrIfNotEmpty(matcher.GrpcClient.Method),
+			Service:       services.StringPtrIfNotEmpty(matcher.GrpcClient.Service),
+			ServerAddress: services.StringPtrIfNotEmpty(matcher.GrpcClient.ServerAddress),
 		}
 	}
 	return result

--- a/frontend/services/sampling/conversions_test.go
+++ b/frontend/services/sampling/conversions_test.go
@@ -72,6 +72,56 @@ func TestHeadSamplingOperationMatcherCRDToModelPreservesQueryParams(t *testing.T
 	require.Nil(t, got.HTTPServer.QueryParams[1].ValueExact)
 }
 
+func TestHeadSamplingOperationMatcherCRDToModelPreservesGrpc(t *testing.T) {
+	matcher := &commonapisampling.HeadSamplingOperationMatcher{
+		GrpcServer: &commonapisampling.HeadSamplingGrpcServerOperationMatcher{
+			Method:  "Check",
+			Service: "grpc.health.v1.Health",
+		},
+		GrpcClient: &commonapisampling.HeadSamplingGrpcClientOperationMatcher{
+			Method:        "Export",
+			Service:       "opentelemetry.proto.collector.trace.v1.TraceService",
+			ServerAddress: "collector.odigos-system.svc",
+		},
+	}
+
+	got := headSamplingOperationMatcherCRDToModel(matcher)
+
+	require.NotNil(t, got)
+	require.NotNil(t, got.GrpcServer)
+	require.Equal(t, "Check", *got.GrpcServer.Method)
+	require.Equal(t, "grpc.health.v1.Health", *got.GrpcServer.Service)
+	require.NotNil(t, got.GrpcClient)
+	require.Equal(t, "Export", *got.GrpcClient.Method)
+	require.Equal(t, "opentelemetry.proto.collector.trace.v1.TraceService", *got.GrpcClient.Service)
+	require.Equal(t, "collector.odigos-system.svc", *got.GrpcClient.ServerAddress)
+}
+
+func TestHeadSamplingOperationMatcherInputToCRDPreservesGrpc(t *testing.T) {
+	input := &model.HeadSamplingOperationMatcherInput{
+		GrpcServer: &model.HeadSamplingGrpcServerMatcherInput{
+			Method:  stringPtr("Check"),
+			Service: stringPtr("grpc.health.v1.Health"),
+		},
+		GrpcClient: &model.HeadSamplingGrpcClientMatcherInput{
+			Method:        stringPtr("Export"),
+			Service:       stringPtr("opentelemetry.proto.collector.trace.v1.TraceService"),
+			ServerAddress: stringPtr("collector.odigos-system.svc"),
+		},
+	}
+
+	got := headSamplingOperationMatcherInputToCRD(input)
+
+	require.NotNil(t, got)
+	require.NotNil(t, got.GrpcServer)
+	require.Equal(t, "Check", got.GrpcServer.Method)
+	require.Equal(t, "grpc.health.v1.Health", got.GrpcServer.Service)
+	require.NotNil(t, got.GrpcClient)
+	require.Equal(t, "Export", got.GrpcClient.Method)
+	require.Equal(t, "opentelemetry.proto.collector.trace.v1.TraceService", got.GrpcClient.Service)
+	require.Equal(t, "collector.odigos-system.svc", got.GrpcClient.ServerAddress)
+}
+
 func stringPtr(value string) *string {
 	return &value
 }

--- a/frontend/services/url_validation.go
+++ b/frontend/services/url_validation.go
@@ -16,36 +16,46 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-func validateURLForTestConnection(ctx context.Context, testURL string) error {
-	cfg, err := getOdigosConfiguration(ctx)
-	if err != nil {
+var testConnectionEndpointFields = map[string]struct{}{
+	"OTLP_HTTP_ENDPOINT":          {},
+	"OTLP_HTTP_TRACES_ENDPOINT":   {},
+	"OTLP_HTTP_METRICS_ENDPOINT":  {},
+	"OTLP_HTTP_LOGS_ENDPOINT":     {},
+	"OTLP_HTTP_PROFILES_ENDPOINT": {},
+	"OTLP_GRPC_ENDPOINT":          {},
+}
+
+type testConnectionDomain struct {
+	scheme string
+	host   string
+}
+
+func validateURLAgainstAllowedHosts(testURL string, allowedHosts []string) error {
+	if len(allowedHosts) == 0 {
 		return nil
 	}
 
-	if len(cfg.AllowedTestConnectionHosts) == 0 {
+	if slices.Contains(allowedHosts, "*") {
 		return nil
 	}
 
-	if slices.Contains(cfg.AllowedTestConnectionHosts, "*") {
-		return nil
-	}
-
-	parsedURL, err := url.Parse(testURL)
+	urlDomain, err := parseTestConnectionDomain(testURL)
 	if err != nil {
 		return fmt.Errorf("invalid URL format: %w", err)
 	}
 
-	urlDomain := fmt.Sprintf("%s://%s", parsedURL.Scheme, parsedURL.Host)
-
-	for _, allowedDomain := range cfg.AllowedTestConnectionHosts {
-		normalizedAllowedDomain := normalizeDomain(allowedDomain)
+	for _, allowedDomain := range allowedHosts {
+		normalizedAllowedDomain, err := parseTestConnectionDomain(allowedDomain)
+		if err != nil {
+			continue
+		}
 
 		if urlDomain == normalizedAllowedDomain {
 			return nil
 		}
 
-		if domainWithoutWildcard, ok := strings.CutPrefix(normalizedAllowedDomain, "*."); ok {
-			if strings.HasSuffix(parsedURL.Host, "."+domainWithoutWildcard) {
+		if domainWithoutWildcard, ok := strings.CutPrefix(normalizedAllowedDomain.host, "*."); ok {
+			if urlDomain.scheme == normalizedAllowedDomain.scheme && strings.HasSuffix(urlDomain.host, "."+domainWithoutWildcard) {
 				return nil
 			}
 		}
@@ -71,30 +81,42 @@ func getOdigosConfiguration(ctx context.Context) (*common.OdigosConfiguration, e
 	return &cfg, nil
 }
 
-func normalizeDomain(domain string) string {
-	domain = strings.TrimSpace(domain)
+func parseTestConnectionDomain(domain string) (testConnectionDomain, error) {
+	normalizedDomain := strings.TrimSpace(domain)
 
-	if !strings.Contains(domain, "://") {
-		domain = "https://" + domain
+	if !strings.Contains(normalizedDomain, "://") {
+		normalizedDomain = "https://" + normalizedDomain
 	}
 
-	return domain
+	parsedURL, err := url.Parse(normalizedDomain)
+	if err != nil {
+		return testConnectionDomain{}, err
+	}
+	if parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return testConnectionDomain{}, fmt.Errorf("missing scheme or host")
+	}
+
+	return testConnectionDomain{
+		scheme: parsedURL.Scheme,
+		host:   parsedURL.Host,
+	}, nil
 }
 
 func ValidateDestinationURLs(ctx context.Context, destination model.DestinationInput) error {
-
-	endpointFields := []string{
-		"OTLP_HTTP_ENDPOINT",
+	cfg, err := getOdigosConfiguration(ctx)
+	if err != nil {
+		return nil
 	}
 
+	return validateDestinationURLsAgainstAllowedHosts(destination, cfg.AllowedTestConnectionHosts)
+}
+
+func validateDestinationURLsAgainstAllowedHosts(destination model.DestinationInput, allowedHosts []string) error {
 	for _, field := range destination.Fields {
-		for _, endpointField := range endpointFields {
-			if field.Key == endpointField && field.Value != "" {
-				err := validateURLForTestConnection(ctx, field.Value)
-				if err != nil {
-					return err
-				}
-				break
+		if _, ok := testConnectionEndpointFields[field.Key]; ok && field.Value != "" {
+			err := validateURLAgainstAllowedHosts(field.Value, allowedHosts)
+			if err != nil {
+				return err
 			}
 		}
 	}

--- a/frontend/services/url_validation_test.go
+++ b/frontend/services/url_validation_test.go
@@ -1,0 +1,58 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/odigos-io/odigos/frontend/graph/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateDestinationURLsAgainstAllowedHostsRejectsGrpcEndpoint(t *testing.T) {
+	destination := model.DestinationInput{
+		Fields: []*model.FieldInput{
+			{Key: "OTLP_GRPC_ENDPOINT", Value: "internal-service.odigos-system.svc:4317"},
+		},
+	}
+
+	err := validateDestinationURLsAgainstAllowedHosts(destination, []string{"allowed.example.com:4317"})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "internal-service.odigos-system.svc:4317")
+}
+
+func TestValidateDestinationURLsAgainstAllowedHostsRejectsPerSignalHTTPEndpoint(t *testing.T) {
+	destination := model.DestinationInput{
+		Fields: []*model.FieldInput{
+			{Key: "OTLP_HTTP_TRACES_ENDPOINT", Value: "http://internal-service.odigos-system.svc:4318/v1/traces"},
+		},
+	}
+
+	err := validateDestinationURLsAgainstAllowedHosts(destination, []string{"https://allowed.example.com:4318"})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "internal-service.odigos-system.svc")
+}
+
+func TestValidateDestinationURLsAgainstAllowedHostsAllowsConfiguredGrpcEndpoint(t *testing.T) {
+	destination := model.DestinationInput{
+		Fields: []*model.FieldInput{
+			{Key: "OTLP_GRPC_ENDPOINT", Value: "collector.example.com:4317"},
+		},
+	}
+
+	err := validateDestinationURLsAgainstAllowedHosts(destination, []string{"collector.example.com:4317"})
+
+	require.NoError(t, err)
+}
+
+func TestValidateDestinationURLsAgainstAllowedHostsAllowsWildcardConfig(t *testing.T) {
+	destination := model.DestinationInput{
+		Fields: []*model.FieldInput{
+			{Key: "OTLP_GRPC_ENDPOINT", Value: "internal-service.odigos-system.svc:4317"},
+		},
+	}
+
+	err := validateDestinationURLsAgainstAllowedHosts(destination, []string{"*"})
+
+	require.NoError(t, err)
+}

--- a/frontend/webapp/graphql/mutations/sampling.ts
+++ b/frontend/webapp/graphql/mutations/sampling.ts
@@ -12,6 +12,8 @@ export const CREATE_NOISY_OPERATION_RULE = gql`
       operation {
         httpServer { route routePrefix method queryParams { name valueExact } }
         httpClient { serverAddress templatedPath templatedPathPrefix method }
+        grpcServer { method service }
+        grpcClient { method service serverAddress }
       }
       percentageAtMost
       notes
@@ -29,6 +31,8 @@ export const UPDATE_NOISY_OPERATION_RULE = gql`
       operation {
         httpServer { route routePrefix method queryParams { name valueExact } }
         httpClient { serverAddress templatedPath templatedPathPrefix method }
+        grpcServer { method service }
+        grpcClient { method service serverAddress }
       }
       percentageAtMost
       notes

--- a/frontend/webapp/graphql/queries/sampling.ts
+++ b/frontend/webapp/graphql/queries/sampling.ts
@@ -14,6 +14,8 @@ const NOISY_OPERATION_FIELDS = `
   operation {
     httpServer { route routePrefix method queryParams { name valueExact } }
     httpClient { serverAddress templatedPath templatedPathPrefix method }
+    grpcServer { method service }
+    grpcClient { method service serverAddress }
   }
   percentageAtMost
   notes

--- a/frontend/webapp/types/sampling.ts
+++ b/frontend/webapp/types/sampling.ts
@@ -37,9 +37,22 @@ export interface HeadSamplingHttpClientMatcher {
   method?: string | null;
 }
 
+export interface HeadSamplingGrpcServerMatcher {
+  method?: string | null;
+  service?: string | null;
+}
+
+export interface HeadSamplingGrpcClientMatcher {
+  method?: string | null;
+  service?: string | null;
+  serverAddress?: string | null;
+}
+
 export interface HeadSamplingOperationMatcher {
   httpServer?: HeadSamplingHttpServerMatcher | null;
   httpClient?: HeadSamplingHttpClientMatcher | null;
+  grpcServer?: HeadSamplingGrpcServerMatcher | null;
+  grpcClient?: HeadSamplingGrpcClientMatcher | null;
 }
 
 export interface TailSamplingHttpServerMatcher {

--- a/helm/odigos-central/templates/keycloak/deployment.yaml
+++ b/helm/odigos-central/templates/keycloak/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: keycloak
     spec:
+      {{ include "odigos.renderPullSecrets" . | nindent 6 }}
       {{- if .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- range .Values.topologySpreadConstraints }}

--- a/helm/odigos/templates/odiglet/daemonset.yaml
+++ b/helm/odigos/templates/odiglet/daemonset.yaml
@@ -20,6 +20,9 @@
 {{- if and $privilegedRequired .Values.odiglet.unPrivileged }}
 {{ fail "privileged mode is required when collecting logs or metrics, this is currently not supported in unprivileged mode" }}
 {{- end }}
+{{- if and .Values.gke.autopilot (or (eq .Values.instrumentor.mountMethod "k8s-host-path") (eq .Values.instrumentor.mountMethod "k8s-csi-driver")) }}
+{{ fail "GKE Autopilot requires instrumentor.mountMethod to be k8s-virtual-device or k8s-init-container" }}
+{{- end }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/helm/odigos/templates/odiglet/resourcequota.yaml
+++ b/helm/odigos/templates/odiglet/resourcequota.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.gke.enabled }}
+{{ if or .Values.gke.enabled .Values.gke.autopilot }}
 apiVersion: v1
 kind: ResourceQuota
 metadata:

--- a/helm/odigos/values.schema.json
+++ b/helm/odigos/values.schema.json
@@ -2141,7 +2141,7 @@
               "title": "metricsFlushInterval"
             },
             "outputSpanAttributes": {
-              "description": "span attribute names read from outbound spans on the sending side (e.g. client/producer spans).\neach name should refer to a low-cardinality attribute.",
+              "description": "span attribute names read from outbound spans on the sending side (e.g. client/producer spans).\neach name should refer to a low-cardinality attribute. avoid raw SQL, user, or request-specific values.",
               "items": {
                 "type": "string"
               },

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -1577,7 +1577,7 @@ traceCorrelations:
       - rpc.method
       - http.route
       - http.status_code
-      - http.response.status_code	
+      - http.response.status_code
       - http.method
       - http.request.method
       - server.address
@@ -1588,7 +1588,7 @@ traceCorrelations:
     #   type: string
     # description: |-
     #   span attribute names read from outbound spans on the sending side (e.g. client/producer spans).
-    #   each name should refer to a low-cardinality attribute.
+    #   each name should refer to a low-cardinality attribute. avoid raw SQL, user, or request-specific values.
     # @schema
     outputSpanAttributes:
       - rpc.system
@@ -1596,12 +1596,9 @@ traceCorrelations:
       - rpc.method
       - db.system.name
       - db.system
-      - db.statement
-      - db.query.text
       - db.operation
       - db.operation.name
       - db.name
-      - db.user
       - url.template
       - http.status_code
       - http.response.status_code

--- a/instrumentor/controllers/agentenabled/distroresolver/distroresolver.go
+++ b/instrumentor/controllers/agentenabled/distroresolver/distroresolver.go
@@ -126,17 +126,17 @@ func ResolveDistroForContainer(
 		}
 	}
 
-	// check unknown language first. if language is not supported, we can skip the rest of the checks.
+	// if the user specifically overwritten the distro to use for this container, use it.
+	if containerOverride != nil && containerOverride.OtelDistroName != nil {
+		return resolveDistroByOverride(*containerOverride.OtelDistroName, distroGetter, runtimeDetails.Language)
+	}
+
+	// check unknown language before automatic distro resolution.
 	if runtimeDetails.Language == common.UnknownProgrammingLanguage {
 		return nil, &odigosv1.AgentDisabledInfo{
 			AgentEnabledReason:  odigosv1.AgentEnabledReasonUnsupportedProgrammingLanguage,
 			AgentEnabledMessage: "unknown programming language",
 		}
-	}
-
-	// if the user specifically overwritten the distro to use for this container, use it.
-	if containerOverride != nil && containerOverride.OtelDistroName != nil {
-		return resolveDistroByOverride(*containerOverride.OtelDistroName, distroGetter, runtimeDetails.Language)
 	}
 
 	// use the default distro and detected language to resolve the distro to use.

--- a/instrumentor/controllers/agentenabled/distroresolver/distroresolver_test.go
+++ b/instrumentor/controllers/agentenabled/distroresolver/distroresolver_test.go
@@ -73,6 +73,22 @@ func TestResolveDistroForContainer_wildcardOverrideAcceptsMismatchedContainerLan
 	require.True(t, common.IsProgrammingLanguageWildcard(d.Language), "OBI should report wildcard language in spec")
 }
 
+func TestResolveDistroForContainer_wildcardOverrideAcceptsUnknownContainerLanguage(t *testing.T) {
+	g := mustNewCommunityGetter(t)
+	overrideName := obiDistroName
+	config := &common.OdigosConfiguration{}
+	rt := &odigosv1.RuntimeDetailsByContainer{
+		Language: common.UnknownProgrammingLanguage,
+	}
+	co := &odigosv1.ContainerOverride{OtelDistroName: &overrideName}
+
+	d, info := ResolveDistroForContainer(config, rt, nil, g, co, "c1")
+	require.Nil(t, info)
+	require.NotNil(t, d)
+	require.Equal(t, obiDistroName, d.Name)
+	require.True(t, common.IsProgrammingLanguageWildcard(d.Language), "manual OBI override should work when auto-detection reports unknown")
+}
+
 func TestResolveDistroForContainer_wildcardDistroSkipsRuntimeSemver(t *testing.T) {
 	g := mustNewCommunityGetter(t)
 	config := &common.OdigosConfiguration{}

--- a/instrumentor/controllers/agentenabled/dynamicconfig/traces/custominstrumentations.go
+++ b/instrumentor/controllers/agentenabled/dynamicconfig/traces/custominstrumentations.go
@@ -39,6 +39,8 @@ func mergeCustomInstrumentations(existing *instrumentationrules.CustomInstrument
 		existing.Golang = append(existing.Golang, incoming.Golang...)
 	case common.JavaProgrammingLanguage:
 		existing.Java = append(existing.Java, incoming.Java...)
+	case common.CPlusPlusProgrammingLanguage:
+		existing.Cpp = append(existing.Cpp, incoming.Cpp...)
 	}
 
 	return existing

--- a/instrumentor/controllers/agentenabled/dynamicconfig/traces/custominstrumentations_test.go
+++ b/instrumentor/controllers/agentenabled/dynamicconfig/traces/custominstrumentations_test.go
@@ -1,0 +1,56 @@
+package traces
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	"github.com/odigos-io/odigos/common"
+	"github.com/odigos-io/odigos/common/api/instrumentationrules"
+	"github.com/odigos-io/odigos/distros/distro"
+)
+
+func TestCalculateCustomInstrumentationsConfigIncludesCppForCppDistro(t *testing.T) {
+	rules := []odigosv1.InstrumentationRule{
+		{
+			Spec: odigosv1.InstrumentationRuleSpec{
+				CustomInstrumentations: &instrumentationrules.CustomInstrumentations{
+					Cpp: []instrumentationrules.CppCustomProbe{
+						{Signature: "std::vector::push_back"},
+					},
+					Java: []instrumentationrules.JavaCustomProbe{
+						{ClassName: "com.example.Service", MethodName: "handle"},
+					},
+				},
+			},
+		},
+		{
+			Spec: odigosv1.InstrumentationRuleSpec{
+				CustomInstrumentations: &instrumentationrules.CustomInstrumentations{
+					Cpp: []instrumentationrules.CppCustomProbe{
+						{Signature: "SSL_write"},
+					},
+				},
+			},
+		},
+	}
+	d := &distro.OtelDistro{
+		Language: common.CPlusPlusProgrammingLanguage,
+		Traces: &distro.Traces{
+			CustomInstrumentations: &distro.CustomInstrumentations{
+				Supported: true,
+			},
+		},
+	}
+
+	result := CalculateCustomInstrumentationsConfig(d, &rules)
+
+	require.NotNil(t, result)
+	require.Equal(t, []instrumentationrules.CppCustomProbe{
+		{Signature: "std::vector::push_back"},
+		{Signature: "SSL_write"},
+	}, result.Cpp)
+	require.Empty(t, result.Java)
+	require.Empty(t, result.Golang)
+}

--- a/instrumentor/controllers/sourceinstrumentation/common.go
+++ b/instrumentor/controllers/sourceinstrumentation/common.go
@@ -26,7 +26,9 @@ import (
 
 	"github.com/odigos-io/odigos/api/k8sconsts"
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	"github.com/odigos-io/odigos/common"
 	commonlogger "github.com/odigos-io/odigos/common/logger"
+	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	sourceutils "github.com/odigos-io/odigos/k8sutils/pkg/source"
 	k8sutils "github.com/odigos-io/odigos/k8sutils/pkg/utils"
 	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
@@ -276,6 +278,10 @@ func syncWorkload(ctx context.Context, k8sClient client.Client, scheme *runtime.
 		// instrumentation config has the workload as owner, so it will be deleted automatically by k8s,
 		// thus NotFound is expected and we can return without error.
 		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if pw.Kind == k8sconsts.WorkloadKindStaticPod && env.GetOdigosTierFromEnv() != common.OnPremOdigosTier {
+		return ctrl.Result{}, deleteWorkloadInstrumentationConfig(ctx, k8sClient, pw)
 	}
 
 	sources, err := odigosv1.GetSources(ctx, k8sClient, pw)

--- a/instrumentor/controllers/sourceinstrumentation/namespace_controller_test.go
+++ b/instrumentor/controllers/sourceinstrumentation/namespace_controller_test.go
@@ -2,9 +2,12 @@ package sourceinstrumentation_test
 
 import (
 	"context"
+	"os"
 
 	k8sconsts "github.com/odigos-io/odigos/api/k8sconsts"
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	"github.com/odigos-io/odigos/common"
+	"github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/instrumentor/internal/testutil"
 
 	. "github.com/onsi/ginkgo"
@@ -22,12 +25,14 @@ var _ = Describe("Namespace controller", func() {
 	var deployment *appsv1.Deployment
 	var daemonSet *appsv1.DaemonSet
 	var statefulSet *appsv1.StatefulSet
+	var staticPod *corev1.Pod
 
 	var sourceNamespace, sourceDeployment, sourceDaemonSet, sourceStatefulSet *odigosv1.Source
 
 	var instrumentationConfigDeployment *odigosv1.InstrumentationConfig
 	var instrumentationConfigDaemonSet *odigosv1.InstrumentationConfig
 	var instrumentationConfigStatefulSet *odigosv1.InstrumentationConfig
+	var instrumentationConfigStaticPod *odigosv1.InstrumentationConfig
 
 	When("namespace instrumentation is disabled", func() {
 
@@ -99,6 +104,48 @@ var _ = Describe("Namespace controller", func() {
 				testutil.AssertInstrumentationConfigRetained(ctx, k8sClient, instrumentationConfigDaemonSet)
 				testutil.AssertInstrumentationConfigRetained(ctx, k8sClient, instrumentationConfigStatefulSet)
 			})
+		})
+	})
+
+	When("static pod instrumentation is tier gated", func() {
+		var originalTier string
+		var hadOriginalTier bool
+
+		BeforeEach(func() {
+			originalTier, hadOriginalTier = os.LookupEnv(consts.OdigosTierEnvVarName)
+			Expect(os.Setenv(consts.OdigosTierEnvVarName, string(common.CommunityOdigosTier))).Should(Succeed())
+
+			namespace = testutil.NewMockNamespace()
+			Expect(k8sClient.Create(ctx, namespace)).Should(Succeed())
+
+			staticPod = testutil.NewMockTestStaticPod(namespace, "test-static-pod")
+			Expect(k8sClient.Create(ctx, staticPod)).Should(Succeed())
+			instrumentationConfigStaticPod = testutil.NewMockInstrumentationConfig(staticPod)
+		})
+
+		AfterEach(func() {
+			if hadOriginalTier {
+				Expect(os.Setenv(consts.OdigosTierEnvVarName, originalTier)).Should(Succeed())
+			} else {
+				Expect(os.Unsetenv(consts.OdigosTierEnvVarName)).Should(Succeed())
+			}
+		})
+
+		It("should not create InstrumentationConfig for static pods on community tier", func() {
+			sourceNamespace = testutil.NewMockSource(namespace, false)
+			sourceNamespace.Finalizers = []string{k8sconsts.SourceInstrumentationFinalizer}
+			Expect(k8sClient.Create(ctx, sourceNamespace)).Should(Succeed())
+
+			testutil.AssertInstrumentationConfigNotCreated(ctx, k8sClient, instrumentationConfigStaticPod)
+		})
+
+		It("should delete existing InstrumentationConfig for static pods on community tier", func() {
+			Expect(k8sClient.Create(ctx, instrumentationConfigStaticPod)).Should(Succeed())
+			sourceNamespace = testutil.NewMockSource(namespace, false)
+			sourceNamespace.Finalizers = []string{k8sconsts.SourceInstrumentationFinalizer}
+			Expect(k8sClient.Create(ctx, sourceNamespace)).Should(Succeed())
+
+			testutil.AssertInstrumentationConfigDeleted(ctx, k8sClient, instrumentationConfigStaticPod)
 		})
 	})
 })

--- a/instrumentor/internal/pod/pod.go
+++ b/instrumentor/internal/pod/pod.go
@@ -8,6 +8,12 @@ import (
 
 func AddOdigletInstalledAffinity(pod *corev1.Pod) {
 	odigletInstalledLabel := k8snode.DetermineNodeOdigletInstalledLabelByTier()
+	odigletInstalledRequirement := corev1.NodeSelectorRequirement{
+		Key:      odigletInstalledLabel,
+		Operator: corev1.NodeSelectorOpIn,
+		Values:   []string{k8sconsts.OdigletInstalledLabelValue},
+	}
+
 	// Ensure Affinity exists
 	if pod.Spec.Affinity == nil {
 		pod.Spec.Affinity = &corev1.Affinity{}
@@ -25,32 +31,33 @@ func AddOdigletInstalledAffinity(pod *corev1.Pod) {
 		}
 	}
 
-	// Check if the term already exists to avoid duplicates
-	for _, term := range pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
-		for _, expr := range term.MatchExpressions {
-			if expr.Key == odigletInstalledLabel && expr.Operator == corev1.NodeSelectorOpIn {
-				for _, val := range expr.Values {
-					if val == k8sconsts.OdigletInstalledLabelValue {
-						// return without adding a duplicate
-						return
-					}
-				}
+	nodeSelectorTerms := &pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	if len(*nodeSelectorTerms) == 0 {
+		*nodeSelectorTerms = append(*nodeSelectorTerms, corev1.NodeSelectorTerm{
+			MatchExpressions: []corev1.NodeSelectorRequirement{odigletInstalledRequirement},
+		})
+		return
+	}
+
+	for i := range *nodeSelectorTerms {
+		if termHasOdigletInstalledRequirement((*nodeSelectorTerms)[i], odigletInstalledRequirement) {
+			continue
+		}
+		(*nodeSelectorTerms)[i].MatchExpressions = append((*nodeSelectorTerms)[i].MatchExpressions, odigletInstalledRequirement)
+	}
+}
+
+func termHasOdigletInstalledRequirement(term corev1.NodeSelectorTerm, requirement corev1.NodeSelectorRequirement) bool {
+	for _, expr := range term.MatchExpressions {
+		if expr.Key != requirement.Key || expr.Operator != requirement.Operator {
+			continue
+		}
+		for _, val := range expr.Values {
+			if val == k8sconsts.OdigletInstalledLabelValue {
+				return true
 			}
 		}
 	}
 
-	// Append the new NodeSelectorTerm if it doesn't exist
-	newTerm := corev1.NodeSelectorTerm{
-		MatchExpressions: []corev1.NodeSelectorRequirement{
-			{
-				Key:      odigletInstalledLabel,
-				Operator: corev1.NodeSelectorOpIn,
-				Values:   []string{k8sconsts.OdigletInstalledLabelValue},
-			},
-		},
-	}
-	pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(
-		pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
-		newTerm,
-	)
+	return false
 }

--- a/instrumentor/internal/pod/pod_test.go
+++ b/instrumentor/internal/pod/pod_test.go
@@ -1,0 +1,127 @@
+package pod
+
+import (
+	"testing"
+
+	"github.com/odigos-io/odigos/api/k8sconsts"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestAddOdigletInstalledAffinityCreatesRequiredAffinity(t *testing.T) {
+	t.Setenv("ODIGOS_TIER", "community")
+	p := &corev1.Pod{}
+
+	AddOdigletInstalledAffinity(p)
+
+	terms := p.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	require.Len(t, terms, 1)
+	requireOdigletInstalledRequirement(t, terms[0])
+}
+
+func TestAddOdigletInstalledAffinityAndsWithExistingRequiredTerms(t *testing.T) {
+	t.Setenv("ODIGOS_TIER", "community")
+	p := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Affinity: &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{{
+									Key:      "topology.kubernetes.io/zone",
+									Operator: corev1.NodeSelectorOpIn,
+									Values:   []string{"us-east-1a"},
+								}},
+							},
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{{
+									Key:      "node.kubernetes.io/instance-type",
+									Operator: corev1.NodeSelectorOpIn,
+									Values:   []string{"c6i.large"},
+								}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	AddOdigletInstalledAffinity(p)
+
+	terms := p.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	require.Len(t, terms, 2, "adding odiglet affinity must not create an extra OR term")
+	for _, term := range terms {
+		require.Len(t, term.MatchExpressions, 2)
+		requireOdigletInstalledRequirement(t, term)
+	}
+}
+
+func TestAddOdigletInstalledAffinityIsIdempotentPerRequiredTerm(t *testing.T) {
+	t.Setenv("ODIGOS_TIER", "community")
+	p := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Affinity: &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									odigletInstalledRequirementForTest(),
+									{
+										Key:      "topology.kubernetes.io/zone",
+										Operator: corev1.NodeSelectorOpIn,
+										Values:   []string{"us-east-1a"},
+									},
+								},
+							},
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{{
+									Key:      "node.kubernetes.io/instance-type",
+									Operator: corev1.NodeSelectorOpIn,
+									Values:   []string{"c6i.large"},
+								}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	AddOdigletInstalledAffinity(p)
+	AddOdigletInstalledAffinity(p)
+
+	terms := p.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	require.Len(t, terms, 2)
+	for _, term := range terms {
+		require.Equal(t, 1, countOdigletInstalledRequirements(term))
+	}
+}
+
+func requireOdigletInstalledRequirement(t *testing.T, term corev1.NodeSelectorTerm) {
+	t.Helper()
+	require.Equal(t, 1, countOdigletInstalledRequirements(term))
+}
+
+func countOdigletInstalledRequirements(term corev1.NodeSelectorTerm) int {
+	count := 0
+	for _, expr := range term.MatchExpressions {
+		if expr.Key == k8sconsts.OdigletOSSInstalledLabel &&
+			expr.Operator == corev1.NodeSelectorOpIn &&
+			len(expr.Values) == 1 &&
+			expr.Values[0] == k8sconsts.OdigletInstalledLabelValue {
+			count++
+		}
+	}
+	return count
+}
+
+func odigletInstalledRequirementForTest() corev1.NodeSelectorRequirement {
+	return corev1.NodeSelectorRequirement{
+		Key:      k8sconsts.OdigletOSSInstalledLabel,
+		Operator: corev1.NodeSelectorOpIn,
+		Values:   []string{k8sconsts.OdigletInstalledLabelValue},
+	}
+}

--- a/odiglet/pkg/process/process_linux.go
+++ b/odiglet/pkg/process/process_linux.go
@@ -37,6 +37,8 @@ func groupByCgroup(pcs []PodContainer) (map[PodContainerKey]map[int]struct{}, er
 	return result, nil
 }
 
+var groupByCgroupFunc = groupByCgroup
+
 // groupByProcMountInfo is the legacy fallback: a single /proc scan
 // that checks each PID's mountinfo for the k8s service-account mount
 // path identifying its pod+container. Slower per-PID but only walks
@@ -52,6 +54,8 @@ func groupByProcMountInfo(pcs []PodContainer) (map[PodContainerKey]map[int]struc
 	}
 	return groups, nil
 }
+
+var groupByProcMountInfoFunc = groupByProcMountInfo
 
 func isInPodContainersBatchPredicate(keys []PodContainerKey) func(int) (PodContainerKey, bool) {
 	expectedMountByPodContainer := make(map[PodContainerKey][]byte, len(keys))
@@ -99,12 +103,21 @@ func GroupByPodContainer(pcs []PodContainer) (map[PodContainerKey]map[int]struct
 	// if we have the cgroup layout available,
 	// use it for grouping as it's more efficient.
 	if hostCgroupLayout.Valid {
-		groups, err := groupByCgroup(pcs)
-		// if we had and error or no groups, fallback to the legacy proc mountinfo parsing
+		groups, err := groupByCgroupFunc(pcs)
+		// if we had an error or no groups, fallback to the legacy proc mountinfo parsing.
 		// currently we fallback even when err is nil and no matches were found,
 		// to avoid possible regressions due to the cgroup path resolution logic.
 		switch {
 		case err == nil && len(groups) > 0:
+			missingPCs := podContainersMissingGroups(pcs, groups)
+			if len(missingPCs) > 0 {
+				fallbackGroups, fallbackErr := groupByProcMountInfoFunc(missingPCs)
+				if fallbackErr != nil {
+					commonlogger.LoggerCompat().Warn("failed to resolve missing process groups from proc scan, using partial cgroup result", "error", fallbackErr, "missing-pod-containers", missingPCs)
+				} else {
+					mergeProcessGroups(groups, fallbackGroups)
+				}
+			}
 			commonlogger.LoggerCompat().Debug("found process groups based on cgroups", "groups", len(groups), "pod-containers", pcs)
 			return groups, nil
 		case err != nil:
@@ -112,5 +125,37 @@ func GroupByPodContainer(pcs []PodContainer) (map[PodContainerKey]map[int]struct
 		}
 	}
 	// fallback to /proc/<pid>/mountinfo parsing
-	return groupByProcMountInfo(pcs)
+	return groupByProcMountInfoFunc(pcs)
+}
+
+func podContainersMissingGroups(pcs []PodContainer, groups map[PodContainerKey]map[int]struct{}) []PodContainer {
+	missing := make([]PodContainer, 0)
+	seenMissing := make(map[PodContainerKey]struct{}, len(pcs))
+	for _, pc := range pcs {
+		if _, ok := groups[pc.PodContainerKey]; ok {
+			continue
+		}
+		if _, seen := seenMissing[pc.PodContainerKey]; seen {
+			continue
+		}
+		seenMissing[pc.PodContainerKey] = struct{}{}
+		missing = append(missing, pc)
+	}
+	return missing
+}
+
+func mergeProcessGroups(dst, src map[PodContainerKey]map[int]struct{}) {
+	for key, pids := range src {
+		if len(pids) == 0 {
+			continue
+		}
+		dstPIDs, ok := dst[key]
+		if !ok {
+			dstPIDs = make(map[int]struct{}, len(pids))
+			dst[key] = dstPIDs
+		}
+		for pid := range pids {
+			dstPIDs[pid] = struct{}{}
+		}
+	}
 }

--- a/odiglet/pkg/process/process_linux_test.go
+++ b/odiglet/pkg/process/process_linux_test.go
@@ -1,0 +1,62 @@
+package process
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestGroupByPodContainerFallsBackForMissingCgroupResults(t *testing.T) {
+	prevLayout := hostCgroupLayout
+	prevCgroup := groupByCgroupFunc
+	prevFallback := groupByProcMountInfoFunc
+	t.Cleanup(func() {
+		hostCgroupLayout = prevLayout
+		groupByCgroupFunc = prevCgroup
+		groupByProcMountInfoFunc = prevFallback
+	})
+
+	hostCgroupLayout = cgroupLayout{
+		Valid: true,
+	}
+
+	resolvedPC := PodContainer{
+		PodContainerKey: PodContainerKey{PodUID: "resolved", ContainerName: "app"},
+		QOSClass:        corev1.PodQOSGuaranteed,
+		ContainerID:     "containerd://resolved-container",
+	}
+	missingPC := PodContainer{
+		PodContainerKey: PodContainerKey{PodUID: "missing", ContainerName: "app"},
+		QOSClass:        corev1.PodQOSGuaranteed,
+		ContainerID:     "containerd://missing-container",
+	}
+
+	groupByCgroupFunc = func(pcs []PodContainer) (map[PodContainerKey]map[int]struct{}, error) {
+		if len(pcs) != 2 {
+			t.Fatalf("cgroup resolver called with %#v, want both pod-containers", pcs)
+		}
+		return map[PodContainerKey]map[int]struct{}{
+			resolvedPC.PodContainerKey: {101: {}},
+		}, nil
+	}
+
+	groupByProcMountInfoFunc = func(pcs []PodContainer) (map[PodContainerKey]map[int]struct{}, error) {
+		if len(pcs) != 1 || pcs[0].PodContainerKey != missingPC.PodContainerKey {
+			t.Fatalf("fallback called with %#v, want only missing pod-container", pcs)
+		}
+		return map[PodContainerKey]map[int]struct{}{
+			missingPC.PodContainerKey: {202: {}},
+		}, nil
+	}
+
+	groups, err := GroupByPodContainer([]PodContainer{resolvedPC, missingPC})
+	if err != nil {
+		t.Fatalf("GroupByPodContainer: %v", err)
+	}
+	if _, ok := groups[resolvedPC.PodContainerKey][101]; !ok {
+		t.Fatalf("expected cgroup PID for resolved pod-container, got %#v", groups)
+	}
+	if _, ok := groups[missingPC.PodContainerKey][202]; !ok {
+		t.Fatalf("expected proc fallback PID for missing pod-container, got %#v", groups)
+	}
+}

--- a/scheduler/controllers/clustercollectorsgroup/common.go
+++ b/scheduler/controllers/clustercollectorsgroup/common.go
@@ -112,6 +112,18 @@ func newClusterCollectorGroup(namespace string, resourcesSettings *odigosv1.Coll
 	}
 }
 
+func resolveServiceGraphOptions(gatewayConfig *common.CollectorGatewayConfiguration) common.ServiceGraphOptions {
+	serviceGraph := common.ServiceGraphOptions{}
+	if gatewayConfig != nil && gatewayConfig.ServiceGraph != nil {
+		serviceGraph = *gatewayConfig.ServiceGraph
+	}
+	if serviceGraph.Disabled == nil {
+		disabled := false
+		serviceGraph.Disabled = &disabled
+	}
+	return serviceGraph
+}
+
 func sync(ctx context.Context, c client.Client, scheme *runtime.Scheme) error {
 
 	namespace := env.GetCurrentNamespace()
@@ -122,22 +134,21 @@ func sync(ctx context.Context, c client.Client, scheme *runtime.Scheme) error {
 	}
 	resourceSettings := getGatewayResourceSettings(&odigosConfiguration)
 
-	serviceGraph := odigosConfiguration.CollectorGateway.ServiceGraph
-	// Default Disabled to false (feature is enabled by default).
-	if serviceGraph.Disabled == nil {
-		disabled := false
-		serviceGraph.Disabled = &disabled
+	gatewayConfig := odigosConfiguration.CollectorGateway
+	if gatewayConfig == nil {
+		gatewayConfig = &common.CollectorGatewayConfiguration{}
 	}
+	serviceGraph := resolveServiceGraphOptions(gatewayConfig)
 
 	// default cluster metrics is disabled (clusterMetricsEnabled to false)
-	clusterMetricsEnabled := odigosConfiguration.CollectorGateway.ClusterMetricsEnabled
+	clusterMetricsEnabled := gatewayConfig.ClusterMetricsEnabled
 	if clusterMetricsEnabled == nil {
 		result := false
 		clusterMetricsEnabled = &result
 	}
 
-	nodeSelector := odigosConfiguration.CollectorGateway.NodeSelector
-	deploymentName := odigosConfiguration.CollectorGateway.DeploymentName
+	nodeSelector := gatewayConfig.NodeSelector
+	deploymentName := gatewayConfig.DeploymentName
 	allDestinations := &odigosv1.DestinationList{}
 	if err := c.List(ctx, allDestinations); err != nil {
 		return err
@@ -163,7 +174,7 @@ func sync(ctx context.Context, c client.Client, scheme *runtime.Scheme) error {
 	// in the future we might want to support a deployment of instrumentations only and allow user
 	// to setup their own collectors, then we would avoid adding the cluster collector by default.
 	clusterCollectorGroup := newClusterCollectorGroup(namespace, resourceSettings,
-		*serviceGraph, clusterMetricsEnabled, odigosConfiguration.CollectorGateway.HttpsProxyAddress,
+		serviceGraph, clusterMetricsEnabled, gatewayConfig.HttpsProxyAddress,
 		nodeSelector, deploymentName, ownMetricsConfig, tailSampling, dryRun, spanSamplingAttributes,
 		getTraceCorrelationsSettings(&odigosConfiguration))
 	err = utils.SetOwnerControllerToSchedulerDeployment(ctx, c, clusterCollectorGroup, scheme)

--- a/scheduler/controllers/clustercollectorsgroup/common_test.go
+++ b/scheduler/controllers/clustercollectorsgroup/common_test.go
@@ -1,0 +1,50 @@
+package clustercollectorsgroup
+
+import (
+	"testing"
+
+	"github.com/odigos-io/odigos/common"
+)
+
+func TestResolveServiceGraphOptionsDefaultsWhenGatewayConfigMissing(t *testing.T) {
+	options := resolveServiceGraphOptions(nil)
+
+	if options.Disabled == nil {
+		t.Fatalf("expected Disabled to be defaulted")
+	}
+	if *options.Disabled {
+		t.Fatalf("expected Disabled default to be false")
+	}
+}
+
+func TestResolveServiceGraphOptionsDefaultsWhenServiceGraphMissing(t *testing.T) {
+	options := resolveServiceGraphOptions(&common.CollectorGatewayConfiguration{})
+
+	if options.Disabled == nil {
+		t.Fatalf("expected Disabled to be defaulted")
+	}
+	if *options.Disabled {
+		t.Fatalf("expected Disabled default to be false")
+	}
+}
+
+func TestResolveServiceGraphOptionsPreservesConfiguredValues(t *testing.T) {
+	disabled := true
+	options := resolveServiceGraphOptions(&common.CollectorGatewayConfiguration{
+		ServiceGraph: &common.ServiceGraphOptions{
+			Disabled:                  &disabled,
+			ExtraDimensions:           []string{"k8s.namespace.name"},
+			VirtualNodePeerAttributes: []string{"peer.service"},
+		},
+	})
+
+	if options.Disabled == nil || !*options.Disabled {
+		t.Fatalf("expected Disabled to remain true")
+	}
+	if len(options.ExtraDimensions) != 1 || options.ExtraDimensions[0] != "k8s.namespace.name" {
+		t.Fatalf("expected ExtraDimensions to be preserved, got %v", options.ExtraDimensions)
+	}
+	if len(options.VirtualNodePeerAttributes) != 1 || options.VirtualNodePeerAttributes[0] != "peer.service" {
+		t.Fatalf("expected VirtualNodePeerAttributes to be preserved, got %v", options.VirtualNodePeerAttributes)
+	}
+}

--- a/scheduler/controllers/odigosconfiguration/odigosconfiguration_controller.go
+++ b/scheduler/controllers/odigosconfiguration/odigosconfiguration_controller.go
@@ -63,20 +63,20 @@ func (r *odigosConfigurationController) Reconcile(ctx context.Context, _ ctrl.Re
 
 	// Read and merge remote config (from central-backend) if it exists
 	// Remote config takes precedence over helm-managed config
-	remoteConfig, err := r.getAdditionalConfig(ctx, consts.OdigosRemoteConfigName)
+	remoteConfig, remoteTelemetryExplicit, err := r.getAdditionalConfig(ctx, consts.OdigosRemoteConfigName)
 	if err != nil {
 		logger.Error(err, "Failed to get remote config, using only helm-managed config")
 	} else if remoteConfig != nil {
-		mergeConfigs(&odigosConfiguration, remoteConfig)
+		mergeConfigs(&odigosConfiguration, remoteConfig, remoteTelemetryExplicit)
 		logger.Debug("Merged remote config into effective config")
 	}
 
 	// Read and merge local UI config (log level, sampling) if it exists.
-	localUiConfig, err := r.getAdditionalConfig(ctx, consts.OdigosLocalUiConfigName)
+	localUiConfig, localTelemetryExplicit, err := r.getAdditionalConfig(ctx, consts.OdigosLocalUiConfigName)
 	if err != nil {
 		logger.Error(err, "Failed to get local UI config, using only helm-managed config")
 	} else if localUiConfig != nil {
-		mergeConfigs(&odigosConfiguration, localUiConfig)
+		mergeConfigs(&odigosConfiguration, localUiConfig, localTelemetryExplicit)
 		logger.Debug("Merged local UI config into effective config")
 	}
 
@@ -164,7 +164,7 @@ func (r *odigosConfigurationController) getOdigosConfigMap(ctx context.Context) 
 // getAdditionalConfig reads the odigos-remote-config ConfigMap which contains
 // configuration managed by the central-backend. This config takes precedence
 // over helm-managed configuration for supported fields.
-func (r *odigosConfigurationController) getAdditionalConfig(ctx context.Context, configMapName string) (*common.OdigosConfiguration, error) {
+func (r *odigosConfigurationController) getAdditionalConfig(ctx context.Context, configMapName string) (*common.OdigosConfiguration, bool, error) {
 	var configMap corev1.ConfigMap
 	odigosNs := env.GetCurrentNamespace()
 
@@ -172,35 +172,36 @@ func (r *odigosConfigurationController) getAdditionalConfig(ctx context.Context,
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// Remote config doesn't exist - this is expected for most deployments
-			return nil, nil
+			return nil, false, nil
 		}
-		return nil, fmt.Errorf("failed to get remote config ConfigMap: %w", err)
+		return nil, false, fmt.Errorf("failed to get remote config ConfigMap: %w", err)
 	}
 
 	if configMap.Data == nil || configMap.Data[consts.OdigosConfigurationFileName] == "" {
 		// ConfigMap exists but is empty - treat as no remote config
-		return nil, nil
+		return nil, false, nil
 	}
 
+	configBytes := []byte(configMap.Data[consts.OdigosConfigurationFileName])
 	additionalConfig := &common.OdigosConfiguration{}
-	err = yaml.Unmarshal([]byte(configMap.Data[consts.OdigosConfigurationFileName]), additionalConfig)
+	err = yaml.Unmarshal(configBytes, additionalConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse additional config: %w", err)
+		return nil, false, fmt.Errorf("failed to parse additional config: %w", err)
 	}
 
-	return additionalConfig, nil
+	return additionalConfig, hasTopLevelField(configBytes, "telemetryEnabled"), nil
 }
 
 // mergeConfigs merges an "additional" configuration into the base configuration.
 // for supported fields, the additional config values, if set, take precedence over the base configuration values.
 // can be called multiple times with different additional configs to merge them into the base configuration,
 // in which case, most important config should be merged last.
-func mergeConfigs(baseConfig *common.OdigosConfiguration, addtionalConfig *common.OdigosConfiguration) {
+func mergeConfigs(baseConfig *common.OdigosConfiguration, addtionalConfig *common.OdigosConfiguration, telemetryEnabledExplicit bool) {
 	if addtionalConfig == nil {
 		return
 	}
 
-	if addtionalConfig.TelemetryEnabled {
+	if telemetryEnabledExplicit || addtionalConfig.TelemetryEnabled {
 		baseConfig.TelemetryEnabled = addtionalConfig.TelemetryEnabled
 	}
 
@@ -393,6 +394,15 @@ func mergeConfigs(baseConfig *common.OdigosConfiguration, addtionalConfig *commo
 	// - ignoredNamespaces, ignoredContainers
 	// - profiles
 	// - ...
+}
+
+func hasTopLevelField(configBytes []byte, fieldName string) bool {
+	var rawConfig map[string]any
+	if err := yaml.Unmarshal(configBytes, &rawConfig); err != nil {
+		return false
+	}
+	_, ok := rawConfig[fieldName]
+	return ok
 }
 
 func (r *odigosConfigurationController) persistEffectiveConfig(ctx context.Context, effectiveConfig *common.OdigosConfiguration, owner *corev1.ConfigMap) error {

--- a/scheduler/controllers/odigosconfiguration/odigosconfiguration_controller_test.go
+++ b/scheduler/controllers/odigosconfiguration/odigosconfiguration_controller_test.go
@@ -1,0 +1,65 @@
+package odigosconfiguration
+
+import (
+	"testing"
+
+	"github.com/odigos-io/odigos/common"
+)
+
+func TestHasTopLevelField(t *testing.T) {
+	t.Run("detects explicit top-level field", func(t *testing.T) {
+		yamlBytes := []byte("telemetryEnabled: false\nclusterName: test\n")
+		if !hasTopLevelField(yamlBytes, "telemetryEnabled") {
+			t.Fatalf("expected telemetryEnabled to be detected as top-level field")
+		}
+	})
+
+	t.Run("returns false when field is absent", func(t *testing.T) {
+		yamlBytes := []byte("clusterName: test\n")
+		if hasTopLevelField(yamlBytes, "telemetryEnabled") {
+			t.Fatalf("expected telemetryEnabled to be absent")
+		}
+	})
+
+	t.Run("ignores nested field with same name", func(t *testing.T) {
+		yamlBytes := []byte("instrumentor:\n  telemetryEnabled: true\n")
+		if hasTopLevelField(yamlBytes, "telemetryEnabled") {
+			t.Fatalf("expected only top-level telemetryEnabled to match")
+		}
+	})
+}
+
+func TestMergeConfigsTelemetryEnabled(t *testing.T) {
+	t.Run("applies explicit false override", func(t *testing.T) {
+		base := &common.OdigosConfiguration{TelemetryEnabled: true}
+		overlay := &common.OdigosConfiguration{TelemetryEnabled: false}
+
+		mergeConfigs(base, overlay, true)
+
+		if base.TelemetryEnabled {
+			t.Fatalf("expected telemetryEnabled=false after explicit override")
+		}
+	})
+
+	t.Run("does not override when field not explicitly set", func(t *testing.T) {
+		base := &common.OdigosConfiguration{TelemetryEnabled: true}
+		overlay := &common.OdigosConfiguration{TelemetryEnabled: false}
+
+		mergeConfigs(base, overlay, false)
+
+		if !base.TelemetryEnabled {
+			t.Fatalf("expected telemetryEnabled to remain true when overlay field is absent")
+		}
+	})
+
+	t.Run("applies true override without explicit field metadata", func(t *testing.T) {
+		base := &common.OdigosConfiguration{TelemetryEnabled: false}
+		overlay := &common.OdigosConfiguration{TelemetryEnabled: true}
+
+		mergeConfigs(base, overlay, false)
+
+		if !base.TelemetryEnabled {
+			t.Fatalf("expected telemetryEnabled=true override to remain supported")
+		}
+	})
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Combines the still-relevant open Cursor automation PRs into **one PR** so CI runs once instead of ~23 times.

Previously reviewed 61 open `cursor[bot]` PRs: closed 38 as obsolete/duplicates, kept 23 relevant fixes, and ported them onto current `main` here.

### Included fixes

| Area | Fix |
|------|-----|
| Node collector logs | Mixed eBPF + filelog receivers (no filelog blackhole) |
| Router | Fallback when signal-specific datastream has no consumer |
| Agent sync | Abort when keeplist/critical-file calc fails |
| Service I/O | Series limit/TTL + remove high-cardinality default labels |
| Scheduler | `serviceGraph` nil-safe defaults; honor `telemetryEnabled: false` overlays |
| Actions | ExtractAttribute traces-only signals + invalid regex rejection |
| Trace pipeline | LB when tail sampling enabled; trace-filter empty-span compact |
| Frontend | Rule scope preservation; test-connection allowlist; gRPC sampling UI |
| Instrumentor | Affinity AND-into-terms; C++ custom probes; static-pod tier gate |
| Profiling/central | `profilesSupport` for profile destinations; Keycloak pull secrets; symbolize sample PID |
| Build/ops | Go 1.26.4 + local go-rtml; legacy gateway rejection metric; GKE Autopilot chart guards |
| Config | `OdigosLogLevel.Compare` ordering |

### Supersedes

Closes / supersedes: #4448 #4574 #4738 #4768 #4815 #4895 #4900 #4919 #4943 #4950 #4986 #4995 #5000 #5008 #5010 #5020 #5046 #5072 #5088 #5094 #5119 #5131 #5149

### Test plan

- [ ] CI green on this combined PR
- [ ] Spot-check: mixed eBPF+filelog config, keeplist failure aborts sync, serviceGraph-nil scheduler path, ExtractAttribute rejects logs/metrics + bad regex
- [ ] After merge, confirm the listed individual Cursor PRs are closed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23f2744e-c9e3-45c3-a2cf-eff755e0cdac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23f2744e-c9e3-45c3-a2cf-eff755e0cdac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

