### PR TITLE
ci: tag the new modules for release

### DIFF
--- a/.github/actions/tag-modules/action.yml
+++ b/.github/actions/tag-modules/action.yml
@@ -24,4 +24,5 @@ runs:
         git tag distros/${{ inputs.tag }}
         git tag destinations/${{ inputs.tag }}
         git tag instrumentor/${{ inputs.tag }}
+        git tag status/${{ inputs.tag }}
         git push origin --tags

--- a/.github/actions/tag-modules/action.yml
+++ b/.github/actions/tag-modules/action.yml
@@ -12,6 +12,7 @@ runs:
     - name: Tag Modules
       shell: bash
       run: |
+        git tag actions/${{ inputs.tag }}
         git tag api/${{ inputs.tag }}
         git tag common/${{ inputs.tag }}
         git tag instrumentation/${{ inputs.tag }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: CORE-1278

found during pre-release. odigos recently added 2 new modules, but they were not added in the release publish modules.
This PR adds them there

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
