### PR TITLE
ci: tag missing odigosauth module on release

### DIFF
--- a/.github/actions/tag-modules/action.yml
+++ b/.github/actions/tag-modules/action.yml
@@ -20,9 +20,11 @@ runs:
         git tag distros/${{ inputs.tag }}
         git tag frontend/${{ inputs.tag }}
         git tag instrumentation/${{ inputs.tag }}
+        git tag instrumentationrules/${{ inputs.tag }}
         git tag instrumentor/${{ inputs.tag }}
         git tag k8sutils/${{ inputs.tag }}
         git tag odiglet/${{ inputs.tag }}
+        git tag odigosauth/${{ inputs.tag }}
         git tag opampserver/${{ inputs.tag }}
         git tag procdiscovery/${{ inputs.tag }}
         git tag profiles/${{ inputs.tag }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: CORE-1278

Same as #5233 but adding another module which is missing and fails the release

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
