### PR TITLE
revert: cursor auto PR container override bug

### DIFF
--- a/instrumentor/controllers/agentenabled/distroresolver/distroresolver.go
+++ b/instrumentor/controllers/agentenabled/distroresolver/distroresolver.go
@@ -126,11 +126,6 @@ func ResolveDistroForContainer(
 		}
 	}
 
-	// if the user specifically overwritten the distro to use for this container, use it.
-	if containerOverride != nil && containerOverride.OtelDistroName != nil {
-		return resolveDistroByOverride(*containerOverride.OtelDistroName, distroGetter, runtimeDetails.Language)
-	}
-
 	// check unknown language before automatic distro resolution.
 	if runtimeDetails.Language == common.UnknownProgrammingLanguage {
 		return nil, &odigosv1.AgentDisabledInfo{


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: CORE-1273

https://github.com/odigos-io/odigos/pull/5149 was merged close to #5227 which caused a bad merge to revert the fix.
This PR fixes this issue.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
