### PR TITLE
fix(helm): grant central-backend RBAC for cloud connectors (PLAT-1286)

### DIFF
--- a/helm/odigos-central/templates/centralbackend/role.yaml
+++ b/helm/odigos-central/templates/centralbackend/role.yaml
@@ -9,10 +9,13 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "create", "update", "patch"]
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]
+  - apiGroups: ["odigos.io"]
+    resources: ["odigoscloudconnectors"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
 {{- end }}
 
 


### PR DESCRIPTION
Allow central-backend to create connector credential Secrets and manage `OdigosCloudConnector` CRs from the Central UI create-connector flow.

#### What this PR does / why we need it:
Central's cloud-connector create path writes an AWS credentials Secret and upserts an `OdigosCloudConnector` CR. The central-backend Role currently only allows `get`/`list` on Secrets and has no rules for `odigoscloudconnectors`, so those writes fail in-cluster.

This updates the Helm Role to:
- add `create`/`update`/`patch` on Secrets
- allow `get`/`list`/`watch`/`create`/`update`/`patch` on `odigos.io/odigoscloudconnectors`

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
NONE
```

Made with [Cursor](https://cursor.com)