### PR TITLE
PLAT-1294: Update odigos-central Helm probes for central-backend /readyz

### DIFF
--- a/helm/odigos-central/templates/centralbackend/deployment.yaml
+++ b/helm/odigos-central/templates/centralbackend/deployment.yaml
@@ -55,11 +55,19 @@ spec:
           ports:
             - containerPort: 8081
               name: http
-          readinessProbe:
+          # /healthz is served as soon as the process binds the port (before Keycloak init).
+          # /readyz returns 200 only after Keycloak+Redis init completes.
+          startupProbe:
             httpGet:
               path: /healthz
               port: 8081
-            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 60
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
             periodSeconds: 5
             failureThreshold: 60
             timeoutSeconds: 3
@@ -67,7 +75,6 @@ spec:
             httpGet:
               path: /healthz
               port: 8081
-            initialDelaySeconds: 120
             periodSeconds: 10
             failureThreshold: 3
             timeoutSeconds: 3


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### What this PR does / why we need it:
Updates `central-backend` probes in the `odigos-central` Helm chart to match the enterprise image endpoints introduced in odigos-enterprise#3186:

- `startupProbe` on `/healthz` — covers Keycloak cold start (~10 minutes) without liveness restarts
- `readinessProbe` on `/readyz` — Ready only after Keycloak + Redis + full app init
- `livenessProbe` on `/healthz` — process alive once the port is bound; drops `initialDelaySeconds` (startupProbe owns the slow-start window)

Without this, installs keep treating `/healthz` as readiness, so pods can be marked Ready before GraphQL/auth init finishes. With the pre-fix image behavior, Keycloak cold start could also trigger liveness restarts and flake Central install / Central UI e2e at "Verify Odigos Central Installation".

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
odigos-central: central-backend readiness now uses /readyz (with startupProbe on /healthz) so pods become Ready only after Keycloak and Redis init complete.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7b8b02a-9fc8-4154-8efd-a82d5814d423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7b8b02a-9fc8-4154-8efd-a82d5814d423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

