### PR TITLE
CORE-1303: bump ws to 7.5.11 in frontend/webapp

### DIFF
--- a/frontend/webapp/yarn.lock
+++ b/frontend/webapp/yarn.lock
@@ -3623,9 +3623,9 @@ wrappy@1:
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
 ws@^7.3.1:
-  version "7.5.10"
-  resolved "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz"
-  integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
+  version "7.5.11"
+  resolved "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz"
+  integrity sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
Bumps `ws` from 7.5.10 to 7.5.11 in frontend/webapp/yarn.lock.

#### What this PR does / why we need it:
Fixes GHSA-96hv-2xvq-fx4p (CVE-2026-48779): memory exhaustion DoS from tiny fragments and data chunks sent by a peer. Stays on the 7.x line (no breaking changes) since the consumer's semver range is `^7.3.1`.

docs/yarn.lock was already fixed on main via an earlier PR (ws is on 8.21.1 there); this PR covers the remaining frontend/webapp instance of the same advisory.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
```release-note
Bump ws to 7.5.11 in frontend/webapp to fix a memory exhaustion DoS vulnerability (CVE-2026-48779).
```