### PR TITLE
CORE-1307 | fix: cap the native symbolizer's transient symbol-table decode

### DIFF
--- a/collector/processors/odigossymbolizeprocessor/config.go
+++ b/collector/processors/odigossymbolizeprocessor/config.go
@@ -17,6 +17,9 @@ type Config struct {
 	// MaxSymbolBytes caps the total bytes of parsed symbols held across all cached
 	// binaries (LRU eviction by memory — the real guard at scale). 0 = default.
 	MaxSymbolBytes int64 `mapstructure:"max_symbol_bytes"`
+	// MaxSymtabBytes caps the transient decode: a symbol table larger than this on
+	// disk is skipped without decoding (the peak guard). 0 = default.
+	MaxSymtabBytes int64 `mapstructure:"max_symtab_bytes"`
 	// MaxMapsCache caps cached per-pid /proc maps (LRU). 0 = default.
 	MaxMapsCache int `mapstructure:"max_maps_cache"`
 	// MapsTTLSeconds is how long a cached /proc/<pid>/maps is reused. 0 = default.

--- a/collector/processors/odigossymbolizeprocessor/internal/symbolize/elf.go
+++ b/collector/processors/odigossymbolizeprocessor/internal/symbolize/elf.go
@@ -41,8 +41,9 @@ type elfSymbols struct {
 // memory or a parse worker. They are deliberately generous — real binaries
 // (including Oracle's ~50 MB libclntsh) pass; only absurd inputs are rejected.
 type parseLimits struct {
-	maxFileBytes int64 // skip ELF files larger than this
-	maxSymbols   int   // skip binaries with more than this many function symbols
+	maxFileBytes   int64 // skip ELF files larger than this
+	maxSymbols     int   // skip binaries with more than this many function symbols
+	maxSymtabBytes int64 // skip decoding a symbol table (+ its string table) larger than this
 }
 
 // limitExceededError is returned when a binary trips a parseLimit; the caller
@@ -75,7 +76,7 @@ func loadELFSymbols(path string, lim parseLimits) (*elfSymbols, error) {
 		}
 	}
 
-	functions, source := readFunctionSymbols(f)
+	functions, source := readFunctionSymbols(f, lim)
 	if lim.maxSymbols > 0 && len(functions) > lim.maxSymbols {
 		return nil, limitExceededError{fmt.Sprintf("symbolize: %s has %d symbols (> %d)", path, len(functions), lim.maxSymbols)}
 	}
@@ -101,14 +102,45 @@ func estimateHeapBytes(es *elfSymbols) int64 {
 
 // readFunctionSymbols returns the STT_FUNC symbols, preferring .symtab then
 // falling back to .dynsym, with a tag naming the source table.
-func readFunctionSymbols(f *elf.File) ([]functionSymbol, string) {
-	if syms := functionSymbolsFrom(f.Symbols); len(syms) > 0 {
-		return syms, "symtab"
+//
+// A symbol table larger than lim.maxSymtabBytes is skipped WITHOUT decoding:
+// Go's elf.File.Symbols() materialises the whole table (every symbol + the full
+// string table) transiently before we filter to STT_FUNC, so on a huge unstripped
+// binary that transient — not the retained cache — is what spikes RSS. Gating on
+// section size caps it before the allocation happens; the frames stay
+// module+offset, which the pipeline handles gracefully.
+func readFunctionSymbols(f *elf.File, lim parseLimits) ([]functionSymbol, string) {
+	if symtabWithinLimit(f, ".symtab", lim.maxSymtabBytes) {
+		if syms := functionSymbolsFrom(f.Symbols); len(syms) > 0 {
+			return syms, "symtab"
+		}
 	}
-	if syms := functionSymbolsFrom(f.DynamicSymbols); len(syms) > 0 {
-		return syms, "dynsym"
+	if symtabWithinLimit(f, ".dynsym", lim.maxSymtabBytes) {
+		if syms := functionSymbolsFrom(f.DynamicSymbols); len(syms) > 0 {
+			return syms, "dynsym"
+		}
 	}
 	return nil, ""
+}
+
+// symtabWithinLimit reports whether the named symbol table (plus its linked
+// string table) is small enough to decode. An absent table, or limit<=0,
+// returns true — there is either nothing to decode or no gate configured.
+func symtabWithinLimit(f *elf.File, name string, limit int64) bool {
+	if limit <= 0 {
+		return true
+	}
+	sec := f.Section(name)
+	if sec == nil {
+		return true
+	}
+	total := int64(sec.Size)
+	// elf.File.Symbols() also reads the linked string table (Link → .strtab/.dynstr);
+	// account for it so the gate reflects the real transient allocation.
+	if int(sec.Link) < len(f.Sections) {
+		total += int64(f.Sections[sec.Link].Size)
+	}
+	return total <= limit
 }
 
 // functionSymbolsFrom keeps only the named, addressed STT_FUNC entries from one

--- a/collector/processors/odigossymbolizeprocessor/internal/symbolize/elf.go
+++ b/collector/processors/odigossymbolizeprocessor/internal/symbolize/elf.go
@@ -35,6 +35,12 @@ type elfSymbols struct {
 	buildID   string // hex GNU build-id, "" if absent
 	source    string // "symtab" | "dynsym" | ""
 	heapBytes int64  // estimated memory this entry holds (for the byte-bounded cache)
+	// symtabSkippedForSize is true when a symbol table existed but exceeded
+	// maxSymtabBytes and was skipped without decoding — i.e. this binary's
+	// native frames will stay module+offset because of the size gate, not
+	// because it genuinely has no symbols (a fully stripped binary would also
+	// have source=="", but with this false).
+	symtabSkippedForSize bool
 }
 
 // parseLimits guards against pathological/corrupt binaries that could exhaust
@@ -76,7 +82,7 @@ func loadELFSymbols(path string, lim parseLimits) (*elfSymbols, error) {
 		}
 	}
 
-	functions, source := readFunctionSymbols(f, lim)
+	functions, source, skippedForSize := readFunctionSymbols(f, lim)
 	if lim.maxSymbols > 0 && len(functions) > lim.maxSymbols {
 		return nil, limitExceededError{fmt.Sprintf("symbolize: %s has %d symbols (> %d)", path, len(functions), lim.maxSymbols)}
 	}
@@ -84,6 +90,7 @@ func loadELFSymbols(path string, lim parseLimits) (*elfSymbols, error) {
 		es.functions, es.source = functions, source
 		sort.Slice(es.functions, func(i, j int) bool { return es.functions[i].addr < es.functions[j].addr })
 	}
+	es.symtabSkippedForSize = skippedForSize
 	es.heapBytes = estimateHeapBytes(es)
 	return es, nil
 }
@@ -104,19 +111,25 @@ func estimateHeapBytes(es *elfSymbols) int64 {
 // falling back to .dynsym. A table over lim.maxSymtabBytes is skipped without
 // decoding — elf.File.Symbols() transiently materialises the whole table, and
 // on a huge unstripped binary that transient, not the retained cache, is what
-// spikes RSS.
-func readFunctionSymbols(f *elf.File, lim parseLimits) ([]functionSymbol, string) {
+// spikes RSS. skippedForSize reports whether that happened to a table that
+// was actually present (as opposed to the binary simply having none), so the
+// caller can tell "no symbols to resolve" apart from "resolvable, but too big".
+func readFunctionSymbols(f *elf.File, lim parseLimits) (syms []functionSymbol, source string, skippedForSize bool) {
 	if symtabWithinLimit(f, ".symtab", lim.maxSymtabBytes) {
 		if syms := functionSymbolsFrom(f.Symbols); len(syms) > 0 {
-			return syms, "symtab"
+			return syms, "symtab", false
 		}
+	} else {
+		skippedForSize = true
 	}
 	if symtabWithinLimit(f, ".dynsym", lim.maxSymtabBytes) {
 		if syms := functionSymbolsFrom(f.DynamicSymbols); len(syms) > 0 {
-			return syms, "dynsym"
+			return syms, "dynsym", false
 		}
+	} else {
+		skippedForSize = true
 	}
-	return nil, ""
+	return nil, "", skippedForSize
 }
 
 // symtabWithinLimit reports whether name's symbol table, plus its linked string

--- a/collector/processors/odigossymbolizeprocessor/internal/symbolize/elf.go
+++ b/collector/processors/odigossymbolizeprocessor/internal/symbolize/elf.go
@@ -101,14 +101,10 @@ func estimateHeapBytes(es *elfSymbols) int64 {
 }
 
 // readFunctionSymbols returns the STT_FUNC symbols, preferring .symtab then
-// falling back to .dynsym, with a tag naming the source table.
-//
-// A symbol table larger than lim.maxSymtabBytes is skipped WITHOUT decoding:
-// Go's elf.File.Symbols() materialises the whole table (every symbol + the full
-// string table) transiently before we filter to STT_FUNC, so on a huge unstripped
-// binary that transient — not the retained cache — is what spikes RSS. Gating on
-// section size caps it before the allocation happens; the frames stay
-// module+offset, which the pipeline handles gracefully.
+// falling back to .dynsym. A table over lim.maxSymtabBytes is skipped without
+// decoding — elf.File.Symbols() transiently materialises the whole table, and
+// on a huge unstripped binary that transient, not the retained cache, is what
+// spikes RSS.
 func readFunctionSymbols(f *elf.File, lim parseLimits) ([]functionSymbol, string) {
 	if symtabWithinLimit(f, ".symtab", lim.maxSymtabBytes) {
 		if syms := functionSymbolsFrom(f.Symbols); len(syms) > 0 {
@@ -123,9 +119,8 @@ func readFunctionSymbols(f *elf.File, lim parseLimits) ([]functionSymbol, string
 	return nil, ""
 }
 
-// symtabWithinLimit reports whether the named symbol table (plus its linked
-// string table) is small enough to decode. An absent table, or limit<=0,
-// returns true — there is either nothing to decode or no gate configured.
+// symtabWithinLimit reports whether name's symbol table, plus its linked string
+// table, fits within limit. No table, or limit<=0, is always within limit.
 func symtabWithinLimit(f *elf.File, name string, limit int64) bool {
 	if limit <= 0 {
 		return true
@@ -135,10 +130,8 @@ func symtabWithinLimit(f *elf.File, name string, limit int64) bool {
 		return true
 	}
 	total := int64(sec.Size)
-	// elf.File.Symbols() also reads the linked string table (Link → .strtab/.dynstr);
-	// account for it so the gate reflects the real transient allocation.
 	if int(sec.Link) < len(f.Sections) {
-		total += int64(f.Sections[sec.Link].Size)
+		total += int64(f.Sections[sec.Link].Size) // linked .strtab/.dynstr, also decoded by Symbols()
 	}
 	return total <= limit
 }

--- a/collector/processors/odigossymbolizeprocessor/internal/symbolize/memory_bound_test.go
+++ b/collector/processors/odigossymbolizeprocessor/internal/symbolize/memory_bound_test.go
@@ -1,15 +1,8 @@
 //go:build linux
 
-// memory_bound_test.go proves the two memory guarantees behind CORE-1307:
-//
-//  1. the size-gate (maxSymtabBytes) skips a large symbol table WITHOUT
-//     materialising it, so the transient decode that ballooned the Vodafone
-//     collector's RSS (heap-inuse 66 MB while RSS hit 2.4 GB) never happens;
-//  2. the byte-bounded symbol cache never holds more than its budget, however
-//     many distinct binaries are symbolized.
-//
-// (1) is measured against a real unstripped native library (the Amdocs case),
-// compiled at test time with the same g++ pattern the rest of the suite uses.
+// memory_bound_test.go proves the size-gate skips a large symbol table without
+// materialising it (bounding the transient decode) and the symbol cache stays
+// within its byte budget, measured against a real g++-compiled native library.
 package symbolize
 
 import (
@@ -133,6 +126,37 @@ func TestSizeGateEliminatesTransientDecode(t *testing.T) {
 	}
 	if decodeAlloc < 4*gatedAlloc {
 		t.Fatalf("size-gate reduction too small: decode=%d gated=%d (want decode >= 4x gated)", decodeAlloc, gatedAlloc)
+	}
+}
+
+// TestConfigurableTransientCapIsHonored proves WithMaxSymtabBytes is wired: a
+// Symbolizer built with a small transient cap skips a binary whose symbol table
+// exceeds it (frames stay module+offset), while the default (512 MiB) decodes the
+// same binary. This is what lets an operator bound peak memory on a constrained
+// collector — the cap the config's max_symtab_bytes / budget knob drives.
+func TestConfigurableTransientCapIsHonored(t *testing.T) {
+	so := buildBigTestLib(t, 8000) // ~200 KiB+ symbol table
+	symBytes := symtabSectionBytes(t, so)
+	if symBytes < 128<<10 {
+		t.Skipf("fixture .symtab too small (%d bytes)", symBytes)
+	}
+
+	// Small cap (below the table): the binary is skipped without decoding.
+	capped := New(WithMaxSymtabBytes(32 << 10))
+	defer capped.Close()
+	if es, err := loadELFSymbols(so, capped.limits); err != nil {
+		t.Fatalf("capped parse: %v", err)
+	} else if len(es.functions) != 0 {
+		t.Fatalf("small transient cap must skip the table, got %d symbols", len(es.functions))
+	}
+
+	// Default cap (512 MiB): the same binary decodes normally.
+	def := New()
+	defer def.Close()
+	if es, err := loadELFSymbols(so, def.limits); err != nil {
+		t.Fatalf("default parse: %v", err)
+	} else if len(es.functions) == 0 {
+		t.Fatal("default cap must decode a normal binary")
 	}
 }
 

--- a/collector/processors/odigossymbolizeprocessor/internal/symbolize/memory_bound_test.go
+++ b/collector/processors/odigossymbolizeprocessor/internal/symbolize/memory_bound_test.go
@@ -62,16 +62,11 @@ func symtabSectionBytes(t *testing.T, path string) int64 {
 	return total
 }
 
-// TestSizeGateEliminatesTransientDecode is the direct proof of the transient cap.
-// We parse a real unstripped .so twice and compare bytes ALLOCATED (runtime
-// TotalAlloc delta, which counts the transient []elf.Symbol + string table even
-// though they're freed):
-//   - gate OFF (maxSymtabBytes=0): stdlib decodes the whole table -> large alloc
-//   - gate ON  (threshold below both tables): the tables are skipped -> tiny alloc
-//
-// The gated path must allocate dramatically less; we require >=4x to guard
-// against silent regressions. The ratio grows with symtab size, so on a real
-// 100+ MiB Oracle/Amdocs symtab the eliminated transient is hundreds of MB.
+// TestSizeGateEliminatesTransientDecode proves the gate cuts the transient
+// allocation: it parses the same binary with the gate off (decodes the whole
+// table) and on (skips it), comparing bytes allocated via runtime.MemStats
+// TotalAlloc, which counts memory freed after GC. Requires >=4x less to guard
+// against silent regressions.
 func TestSizeGateEliminatesTransientDecode(t *testing.T) {
 	self := os.Getenv("SYMBOLIZE_TEST_ELF")
 	if self == "" {
@@ -102,14 +97,12 @@ func TestSizeGateEliminatesTransientDecode(t *testing.T) {
 	off.maxSymtabBytes = 0 // no gate: decode everything
 	decodeAlloc := measure(off)
 
-	// Gate below BOTH .symtab and .dynsym so neither table is decoded (an exported
-	// .so carries the same functions in .dynsym; the fix code gates both tables).
+	// Below both .symtab and .dynsym, since an exported .so carries the same functions in .dynsym too.
 	on := base
-	on.maxSymtabBytes = 32 << 10 // 32 KiB, well under either table
+	on.maxSymtabBytes = 32 << 10
 	gatedAlloc := measure(on)
 
-	// Sanity: prove we compared the two real paths — ungated must produce symbols,
-	// gated must skip them.
+	// Sanity: ungated must produce symbols, gated must skip them.
 	esOff, _ := loadELFSymbols(self, off)
 	esOn, _ := loadELFSymbols(self, on)
 	if len(esOff.functions) == 0 {
@@ -130,10 +123,8 @@ func TestSizeGateEliminatesTransientDecode(t *testing.T) {
 }
 
 // TestConfigurableTransientCapIsHonored proves WithMaxSymtabBytes is wired: a
-// Symbolizer built with a small transient cap skips a binary whose symbol table
-// exceeds it (frames stay module+offset), while the default (512 MiB) decodes the
-// same binary. This is what lets an operator bound peak memory on a constrained
-// collector — the cap the config's max_symtab_bytes / budget knob drives.
+// small cap skips a binary whose symbol table exceeds it, while the default
+// (512 MiB) decodes the same binary normally.
 func TestConfigurableTransientCapIsHonored(t *testing.T) {
 	so := buildBigTestLib(t, 8000) // ~200 KiB+ symbol table
 	symBytes := symtabSectionBytes(t, so)
@@ -160,10 +151,9 @@ func TestConfigurableTransientCapIsHonored(t *testing.T) {
 	}
 }
 
-// TestSymbolCacheStaysWithinByteBudget proves the retained side stays bounded:
-// however many distinct binaries are symbolized, the parsed-symbol cache never
-// exceeds its configured byte budget. Fixture-free (synthetic entries) so it runs
-// everywhere, not just where a compiler is present.
+// TestSymbolCacheStaysWithinByteBudget proves the retained cache never exceeds
+// its configured byte budget, however many binaries are symbolized. Uses
+// synthetic entries so it runs without a compiler.
 func TestSymbolCacheStaysWithinByteBudget(t *testing.T) {
 	const entryBytes = 100_000
 	budget := int64(4 * entryBytes) // holds only a few entries -> eviction must run

--- a/collector/processors/odigossymbolizeprocessor/internal/symbolize/memory_bound_test.go
+++ b/collector/processors/odigossymbolizeprocessor/internal/symbolize/memory_bound_test.go
@@ -132,22 +132,27 @@ func TestConfigurableTransientCapIsHonored(t *testing.T) {
 		t.Skipf("fixture .symtab too small (%d bytes)", symBytes)
 	}
 
-	// Small cap (below the table): the binary is skipped without decoding.
+	// Small cap (below the table): the binary is skipped without decoding, and
+	// flagged as skipped-for-size (not just "no symbols") so the caller can warn.
 	capped := New(WithMaxSymtabBytes(32 << 10))
 	defer capped.Close()
 	if es, err := loadELFSymbols(so, capped.limits); err != nil {
 		t.Fatalf("capped parse: %v", err)
 	} else if len(es.functions) != 0 {
 		t.Fatalf("small transient cap must skip the table, got %d symbols", len(es.functions))
+	} else if !es.symtabSkippedForSize {
+		t.Fatal("expected symtabSkippedForSize=true when the table is skipped for exceeding the cap")
 	}
 
-	// Default cap (512 MiB): the same binary decodes normally.
+	// Default cap (512 MiB): the same binary decodes normally, not flagged.
 	def := New()
 	defer def.Close()
 	if es, err := loadELFSymbols(so, def.limits); err != nil {
 		t.Fatalf("default parse: %v", err)
 	} else if len(es.functions) == 0 {
 		t.Fatal("default cap must decode a normal binary")
+	} else if es.symtabSkippedForSize {
+		t.Fatal("expected symtabSkippedForSize=false when the table decodes normally")
 	}
 }
 

--- a/collector/processors/odigossymbolizeprocessor/internal/symbolize/memory_bound_test.go
+++ b/collector/processors/odigossymbolizeprocessor/internal/symbolize/memory_bound_test.go
@@ -1,0 +1,166 @@
+//go:build linux
+
+// memory_bound_test.go proves the two memory guarantees behind CORE-1307:
+//
+//  1. the size-gate (maxSymtabBytes) skips a large symbol table WITHOUT
+//     materialising it, so the transient decode that ballooned the Vodafone
+//     collector's RSS (heap-inuse 66 MB while RSS hit 2.4 GB) never happens;
+//  2. the byte-bounded symbol cache never holds more than its budget, however
+//     many distinct binaries are symbolized.
+//
+// (1) is measured against a real unstripped native library (the Amdocs case),
+// compiled at test time with the same g++ pattern the rest of the suite uses.
+package symbolize
+
+import (
+	"debug/elf"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// buildBigTestLib compiles a shared library with n trivial exported functions,
+// so its .symtab (and .dynsym) is large — mimicking a big unstripped native .so
+// (Oracle/Coherence/Amdocs) whose whole-table decode is the RSS spike we cap.
+func buildBigTestLib(t *testing.T, n int) string {
+	t.Helper()
+	if _, err := exec.LookPath("g++"); err != nil {
+		t.Skip("g++ not available")
+	}
+	dir := t.TempDir()
+	src := filepath.Join(dir, "big.cpp")
+	so := filepath.Join(dir, "libbig.so")
+
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&b, "extern \"C\" int fn_%d(int x){return x*%d+%d;}\n", i, i, i%7)
+	}
+	if err := os.WriteFile(src, []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("g++", "-shared", "-fPIC", "-O0", "-g0", "-Wl,--build-id", "-o", so, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("compile big lib: %v\n%s", err, out)
+	}
+	return so
+}
+
+// symtabSectionBytes returns the on-disk size of the binary's .symtab plus its
+// linked string table — the bytes elf.File.Symbols() materialises transiently.
+func symtabSectionBytes(t *testing.T, path string) int64 {
+	t.Helper()
+	f, err := elf.Open(path)
+	if err != nil {
+		t.Fatalf("open elf: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	sec := f.Section(".symtab")
+	if sec == nil {
+		return 0
+	}
+	total := int64(sec.Size)
+	if int(sec.Link) < len(f.Sections) {
+		total += int64(f.Sections[sec.Link].Size)
+	}
+	return total
+}
+
+// TestSizeGateEliminatesTransientDecode is the direct proof of the transient cap.
+// We parse a real unstripped .so twice and compare bytes ALLOCATED (runtime
+// TotalAlloc delta, which counts the transient []elf.Symbol + string table even
+// though they're freed):
+//   - gate OFF (maxSymtabBytes=0): stdlib decodes the whole table -> large alloc
+//   - gate ON  (threshold below both tables): the tables are skipped -> tiny alloc
+//
+// The gated path must allocate dramatically less; we require >=4x to guard
+// against silent regressions. The ratio grows with symtab size, so on a real
+// 100+ MiB Oracle/Amdocs symtab the eliminated transient is hundreds of MB.
+func TestSizeGateEliminatesTransientDecode(t *testing.T) {
+	self := os.Getenv("SYMBOLIZE_TEST_ELF")
+	if self == "" {
+		self = buildBigTestLib(t, 8000) // ~200 KiB+ .symtab, ~seconds to compile
+	}
+	symBytes := symtabSectionBytes(t, self)
+	if symBytes < 128<<10 {
+		t.Skipf("fixture .symtab too small (%d bytes) to measure meaningfully", symBytes)
+	}
+	t.Logf(".symtab+.strtab on disk = %d bytes (%.2f MiB)", symBytes, float64(symBytes)/(1<<20))
+
+	measure := func(lim parseLimits) uint64 {
+		var m0, m1 runtime.MemStats
+		runtime.GC()
+		runtime.ReadMemStats(&m0)
+		es, err := loadELFSymbols(self, lim)
+		if err != nil {
+			t.Fatalf("loadELFSymbols: %v", err)
+		}
+		runtime.ReadMemStats(&m1)
+		runtime.KeepAlive(es)
+		return m1.TotalAlloc - m0.TotalAlloc
+	}
+
+	base := parseLimits{maxFileBytes: defaultMaxFileBytes, maxSymbols: defaultMaxSymbols}
+
+	off := base
+	off.maxSymtabBytes = 0 // no gate: decode everything
+	decodeAlloc := measure(off)
+
+	// Gate below BOTH .symtab and .dynsym so neither table is decoded (an exported
+	// .so carries the same functions in .dynsym; the fix code gates both tables).
+	on := base
+	on.maxSymtabBytes = 32 << 10 // 32 KiB, well under either table
+	gatedAlloc := measure(on)
+
+	// Sanity: prove we compared the two real paths — ungated must produce symbols,
+	// gated must skip them.
+	esOff, _ := loadELFSymbols(self, off)
+	esOn, _ := loadELFSymbols(self, on)
+	if len(esOff.functions) == 0 {
+		t.Fatal("ungated parse produced no function symbols; fixture unusable")
+	}
+	if len(esOn.functions) != 0 {
+		t.Fatalf("gated parse still decoded %d symbols; gate did not skip", len(esOn.functions))
+	}
+
+	ratio := float64(decodeAlloc) / float64(gatedAlloc+1)
+	t.Logf("transient bytes allocated: decode=%d gated=%d (%.1fx less)", decodeAlloc, gatedAlloc, ratio)
+	if gatedAlloc >= decodeAlloc {
+		t.Fatalf("size-gate did not reduce allocation: decode=%d gated=%d", decodeAlloc, gatedAlloc)
+	}
+	if decodeAlloc < 4*gatedAlloc {
+		t.Fatalf("size-gate reduction too small: decode=%d gated=%d (want decode >= 4x gated)", decodeAlloc, gatedAlloc)
+	}
+}
+
+// TestSymbolCacheStaysWithinByteBudget proves the retained side stays bounded:
+// however many distinct binaries are symbolized, the parsed-symbol cache never
+// exceeds its configured byte budget. Fixture-free (synthetic entries) so it runs
+// everywhere, not just where a compiler is present.
+func TestSymbolCacheStaysWithinByteBudget(t *testing.T) {
+	const entryBytes = 100_000
+	budget := int64(4 * entryBytes) // holds only a few entries -> eviction must run
+	s := New(WithMaxSymbolBytes(budget))
+	defer s.Close()
+
+	for i := 0; i < 512; i++ {
+		e := &cachedSymbols{symbols: &elfSymbols{heapBytes: entryBytes}, heapBytes: entryBytes}
+		e.lastUsed.Store(s.nextClock())
+		s.mu.Lock()
+		s.symbolCache[itoa(i)] = e
+		s.cachedBytes += entryBytes
+		s.evictSymbolsOverBudget()
+		over := s.cachedBytes > s.maxSymbolBytes
+		bytes := s.cachedBytes
+		entries := len(s.symbolCache)
+		s.mu.Unlock()
+		if over {
+			t.Fatalf("cachedBytes %d exceeded budget %d after %d inserts (entries=%d)", bytes, budget, i+1, entries)
+		}
+	}
+	t.Logf("after 512 inserts of %d-byte entries under a %d-byte budget: cachedBytes=%d, entries=%d",
+		entryBytes, budget, s.cachedBytes, len(s.symbolCache))
+}

--- a/collector/processors/odigossymbolizeprocessor/internal/symbolize/symbolize.go
+++ b/collector/processors/odigossymbolizeprocessor/internal/symbolize/symbolize.go
@@ -31,6 +31,7 @@ const (
 	defaultSweepEvery     = 30 * time.Second // how often to drop caches for exited processes
 	defaultMaxFileBytes   = 8 << 30          // 8 GiB — corrupt/absurd ELF guard
 	defaultMaxSymbols     = 5_000_000        // pathological-binary guard
+	defaultMaxSymtabBytes = 512 << 20        // 512 MiB — cap the transient symbol-table decode
 )
 
 // Mapping describes one loaded module as an OTLP profile carries it.
@@ -171,7 +172,7 @@ func New(opts ...Option) *Symbolizer {
 		mapsTTL:         defaultMapsTTL,
 		backoffDuration: defaultBackoff,
 		sweepEvery:      defaultSweepEvery,
-		limits:          parseLimits{maxFileBytes: defaultMaxFileBytes, maxSymbols: defaultMaxSymbols},
+		limits:          parseLimits{maxFileBytes: defaultMaxFileBytes, maxSymbols: defaultMaxSymbols, maxSymtabBytes: defaultMaxSymtabBytes},
 		stop:            make(chan struct{}),
 	}
 	for _, o := range opts {

--- a/collector/processors/odigossymbolizeprocessor/internal/symbolize/symbolize.go
+++ b/collector/processors/odigossymbolizeprocessor/internal/symbolize/symbolize.go
@@ -131,6 +131,16 @@ func WithMaxSymbolBytes(n int64) Option {
 	}
 }
 
+// WithMaxSymtabBytes caps the transient decode: a symbol table larger than n bytes
+// on disk is skipped without decoding (the peak-memory guard). n<=0 keeps the default.
+func WithMaxSymtabBytes(n int64) Option {
+	return func(s *Symbolizer) {
+		if n > 0 {
+			s.limits.maxSymtabBytes = n
+		}
+	}
+}
+
 // WithMaxMapsCache caps cached per-pid maps (LRU). n<=0 keeps the default.
 func WithMaxMapsCache(n int) Option {
 	return func(s *Symbolizer) {

--- a/collector/processors/odigossymbolizeprocessor/internal/symbolize/symbolize.go
+++ b/collector/processors/odigossymbolizeprocessor/internal/symbolize/symbolize.go
@@ -392,6 +392,13 @@ func (s *Symbolizer) parseAndCache(path string) {
 		s.recordParseFailure(path, "parse", err)
 		return
 	}
+	if es.symtabSkippedForSize {
+		// Visible at Warn (not Debug): this binary's native frames will show as
+		// module+offset, not names, until max_symtab_bytes is raised — an operator
+		// should know why, not just wonder why an app isn't fully symbolized.
+		s.log.Warn("symbolize: symbol table exceeds max_symtab_bytes, skipping decode; native frames for this binary will stay unresolved",
+			zap.String("path", path), zap.Int64("max_symtab_bytes", s.limits.maxSymtabBytes))
+	}
 	e := &cachedSymbols{symbols: es, modTime: fi.ModTime().UnixNano(), size: fi.Size(), heapBytes: es.heapBytes}
 	e.lastUsed.Store(s.nextClock())
 	s.mu.Lock()

--- a/collector/processors/odigossymbolizeprocessor/processor_e2e_linux_test.go
+++ b/collector/processors/odigossymbolizeprocessor/processor_e2e_linux_test.go
@@ -134,16 +134,13 @@ func TestE2E_RealSymbolizerFillsNativeFrame(t *testing.T) {
 	const pid = 7777
 	fakeProc(t, pid, so)
 
-	// Build an OTLP profile with one native location at the function's VA.
-	// MemoryStart=0 => the symbolizer treats the location address as a virtual
-	// address directly (no segment math), so addr == the symbol VA.
+	// MemoryStart=0 => location address is used directly as the symbol VA.
 	pd := newProfilesWithNativeLoc(pid, "libe2e.so", va)
 
 	p := newProcessor(zap.NewNop(), &Config{})
 	defer func() { _ = p.Shutdown(context.Background()) }()
 
-	// Symbol parsing is asynchronous; processProfiles prewarms then resolves, so
-	// re-run until the warm cache fills the native Line (or time out).
+	// Parsing is async: prewarm then retry until the cache fills the Line.
 	deadline := time.Now().Add(5 * time.Second)
 	var gotName string
 	for time.Now().Before(deadline) {

--- a/collector/processors/odigossymbolizeprocessor/processor_e2e_linux_test.go
+++ b/collector/processors/odigossymbolizeprocessor/processor_e2e_linux_test.go
@@ -1,0 +1,164 @@
+//go:build linux
+
+// processor_e2e_linux_test.go runs the full path end to end: a real compiled ELF
+// and OTLP profile through processProfiles with the REAL symbolizer (not a fake),
+// proving OTLP -> /proc lookup -> ELF resolution -> filled native Line connects.
+package odigossymbolizeprocessor
+
+import (
+	"context"
+	"debug/elf"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pprofile"
+	"go.uber.org/zap"
+)
+
+// newProfilesWithNativeLoc builds a minimal OTLP profile with a single native
+// location (no Line yet) at addr, mapped to module for the given pid.
+func newProfilesWithNativeLoc(pid int, module string, addr uint64) pprofile.Profiles {
+	pd := pprofile.NewProfiles()
+	dict := pd.Dictionary()
+
+	st := dict.StringTable()
+	st.Append("")     // 0: sentinel
+	st.Append(module) // 1: mapping filename
+
+	mt := dict.MappingTable()
+	m := mt.AppendEmpty()
+	m.SetFilenameStrindex(1)
+	m.SetMemoryStart(0) // VA-direct: location address is treated as a virtual address
+	m.SetFileOffset(0)
+
+	lt := dict.LocationTable()
+	l0 := lt.AppendEmpty()
+	l0.SetMappingIndex(0)
+	l0.SetAddress(addr)
+
+	stk := dict.StackTable()
+	s := stk.AppendEmpty()
+	s.LocationIndices().Append(0)
+
+	rp := pd.ResourceProfiles().AppendEmpty()
+	rp.Resource().Attributes().PutInt("process.pid", int64(pid))
+	prof := rp.ScopeProfiles().AppendEmpty().Profiles().AppendEmpty()
+	sample := prof.Samples().AppendEmpty()
+	sample.SetStackIndex(0)
+	sample.Values().Append(1)
+	return pd
+}
+
+// firstNativeLineName returns the resolved function name on location 0, or "".
+func firstNativeLineName(pd pprofile.Profiles) string {
+	dict := pd.Dictionary()
+	lt := dict.LocationTable()
+	if lt.Len() == 0 {
+		return ""
+	}
+	loc := lt.At(0)
+	if loc.Lines().Len() == 0 {
+		return ""
+	}
+	fnIdx := loc.Lines().At(0).FunctionIndex()
+	nameIdx := dict.FunctionTable().At(int(fnIdx)).NameStrindex()
+	return dict.StringTable().At(int(nameIdx))
+}
+
+// buildE2ELib compiles a shared library exporting a C-named function so the
+// symbol name is exactly what we assert (no C++ mangling).
+func buildE2ELib(t *testing.T) (so, fn string) {
+	t.Helper()
+	if _, err := exec.LookPath("g++"); err != nil {
+		t.Skip("g++ not available")
+	}
+	dir := t.TempDir()
+	src := filepath.Join(dir, "e2e.cpp")
+	so = filepath.Join(dir, "libe2e.so")
+	fn = "e2e_entry"
+	const code = `extern "C" int e2e_entry(int x){ volatile int s=0; for(int i=0;i<x;i++) s+=i; return s; }`
+	if err := os.WriteFile(src, []byte(code), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command("g++", "-shared", "-fPIC", "-O0", "-Wl,--build-id", "-o", so, src).CombinedOutput(); err != nil {
+		t.Fatalf("compile: %v\n%s", err, out)
+	}
+	return so, fn
+}
+
+// symbolVA returns the virtual address of a named symbol in an ELF.
+func symbolVA(t *testing.T, path, want string) uint64 {
+	t.Helper()
+	f, err := elf.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	syms, err := f.Symbols()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range syms {
+		if s.Name == want {
+			return s.Value
+		}
+	}
+	t.Fatalf("symbol %q not found in %s", want, path)
+	return 0
+}
+
+// fakeProc writes a HOST_PROC tree so the symbolizer resolves the module
+// basename to our real .so path (matched by name, not address).
+func fakeProc(t *testing.T, pid int, so string) {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, strconv.Itoa(pid))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	maps := "00000000-00001000 r-xp 00000000 08:01 1 " + so + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "maps"), []byte(maps), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOST_PROC", root)
+}
+
+// TestE2E_RealSymbolizerFillsNativeFrame drives the real symbolizer end to end.
+func TestE2E_RealSymbolizerFillsNativeFrame(t *testing.T) {
+	so, fnName := buildE2ELib(t)
+	va := symbolVA(t, so, fnName)
+	const pid = 7777
+	fakeProc(t, pid, so)
+
+	// Build an OTLP profile with one native location at the function's VA.
+	// MemoryStart=0 => the symbolizer treats the location address as a virtual
+	// address directly (no segment math), so addr == the symbol VA.
+	pd := newProfilesWithNativeLoc(pid, "libe2e.so", va)
+
+	p := newProcessor(zap.NewNop(), &Config{})
+	defer func() { _ = p.Shutdown(context.Background()) }()
+
+	// Symbol parsing is asynchronous; processProfiles prewarms then resolves, so
+	// re-run until the warm cache fills the native Line (or time out).
+	deadline := time.Now().Add(5 * time.Second)
+	var gotName string
+	for time.Now().Before(deadline) {
+		out, err := p.processProfiles(context.Background(), pd)
+		if err != nil {
+			t.Fatalf("processProfiles: %v", err)
+		}
+		gotName = firstNativeLineName(out)
+		if gotName == fnName {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if gotName != fnName {
+		t.Fatalf("native frame not symbolized end to end: got %q, want %q", gotName, fnName)
+	}
+	t.Logf("E2E: OTLP native frame @%#x resolved through real symbolizer -> %q", va, gotName)
+}

--- a/collector/processors/odigossymbolizeprocessor/resolver_linux.go
+++ b/collector/processors/odigossymbolizeprocessor/resolver_linux.go
@@ -25,6 +25,7 @@ func newResolver(cfg *Config, logger *zap.Logger) resolver {
 		opts = append(opts,
 			symbolize.WithMaxSymbolCache(cfg.MaxSymbolCache),
 			symbolize.WithMaxSymbolBytes(cfg.MaxSymbolBytes),
+			symbolize.WithMaxSymtabBytes(cfg.MaxSymtabBytes),
 			symbolize.WithMaxMapsCache(cfg.MaxMapsCache),
 			symbolize.WithParseWorkers(cfg.ParseWorkers),
 		)


### PR DESCRIPTION
#### What this PR does / why we need it:

The native symbolize processor caps its **retained** symbol cache (256 MiB, LRU), but had no bound on the **transient** parse. Go's `elf.File.Symbols()` materialises the entire `.symtab` + string table before we filter to `STT_FUNC`, so on a large unstripped binary (Oracle/C++) that transient which is what spikes RSS. 

#### Where this fits (CORE-1307)

```
node-collector profiles pipeline — memory guards

  profiles in
     |
     v
  [ memory_limiter ]   (1) pipeline gate: reject under memory pressure    #5304
     |
     v
  filter > k8sattributes > odigosprofiles
     |
     v
  [ symbolize ]        (2) transient .symtab decode cap   max_symtab_bytes  #5302  <-- THIS PR
     |                 (3) retained symbol LRU cache       max_symbol_bytes  #5307
     v                      one knob -> maxMemoryMiB: symbol=B, symtab=B/5
  service-name > export
```

#### Changelog entry:

```release-note
odigossymbolizeprocessor: cap the transient ELF symbol-table decode.
```
---

