### PR TITLE
CORE-1307 | feat: add memory_limiter to the profiles pipeline

### DIFF
--- a/autoscaler/controllers/actions/profiles_actions_test.go
+++ b/autoscaler/controllers/actions/profiles_actions_test.go
@@ -117,10 +117,11 @@ func TestE2E_ProfilesActions_ActionToRenderedConfig(t *testing.T) {
 	require.Empty(t, nodeResults.ProfilesProcessors)
 	nodeCfg, err := config.MergeConfigs(map[string]config.Config{
 		"processors": nodeResults.ProcessorsConfig,
-		"profiling":  collectorconfig.ProfilingPipelineConfig("odigos-system", &common.ProfilingConfiguration{Enabled: &on}, nodeResults.ProfilesProcessors),
+		"profiling":  collectorconfig.ProfilingPipelineConfig("odigos-system", &common.ProfilingConfiguration{Enabled: &on}, nodeResults.ProfilesProcessors, odigosv1.CollectorsGroupResourcesSettings{}),
 	})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
+		"memory_limiter",
 		commonconf.ProfilingNodeFilterProcessor,
 		commonconf.ProfilingNodeK8sAttributesProcessor,
 		commonconf.ProfilingNodeOdigosProfilesProcessor,

--- a/autoscaler/controllers/actions/profiles_actions_test.go
+++ b/autoscaler/controllers/actions/profiles_actions_test.go
@@ -115,9 +115,13 @@ func TestE2E_ProfilesActions_ActionToRenderedConfig(t *testing.T) {
 	on := true
 	nodeResults := config.CrdProcessorToConfig(commonconf.ToProcessorConfigurerArray(nodeProcs))
 	require.Empty(t, nodeResults.ProfilesProcessors)
+	// Merge alongside common_application_telemetry (as calculateCollectorConfigDomains does in
+	// production) so a processor name collision between domains — e.g. profiling redefining
+	// memory_limiter, which commonProcessors() already provides — fails this test.
 	nodeCfg, err := config.MergeConfigs(map[string]config.Config{
-		"processors": nodeResults.ProcessorsConfig,
-		"profiling":  collectorconfig.ProfilingPipelineConfig("odigos-system", &common.ProfilingConfiguration{Enabled: &on}, nodeResults.ProfilesProcessors, odigosv1.CollectorsGroupResourcesSettings{}),
+		"processors":                   nodeResults.ProcessorsConfig,
+		"common_application_telemetry": collectorconfig.CommonApplicationTelemetryConfig(&odigosv1.CollectorsGroup{}, false, "odigos-system", nil),
+		"profiling":                    collectorconfig.ProfilingPipelineConfig("odigos-system", &common.ProfilingConfiguration{Enabled: &on}, nodeResults.ProfilesProcessors),
 	})
 	require.NoError(t, err)
 	assert.Equal(t, []string{

--- a/autoscaler/controllers/nodecollector/collectorconfig/profiles.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/profiles.go
@@ -2,6 +2,7 @@ package collectorconfig
 
 import (
 	"github.com/odigos-io/odigos/api/k8sconsts"
+	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	commonconf "github.com/odigos-io/odigos/autoscaler/controllers/common"
 	"github.com/odigos-io/odigos/common"
 	"github.com/odigos-io/odigos/common/config"
@@ -9,7 +10,7 @@ import (
 )
 
 // ProfilingPipelineConfig builds the node collector profiles domain when profiling is enabled.
-func ProfilingPipelineConfig(odigosNamespace string, profiling *common.ProfilingConfiguration, manifestProcessorNames []string) config.Config {
+func ProfilingPipelineConfig(odigosNamespace string, profiling *common.ProfilingConfiguration, manifestProcessorNames []string, memorySettings odigosv1.CollectorsGroupResourcesSettings) config.Config {
 	if !common.ProfilingPipelineActive(profiling) {
 		return config.Config{}
 	}
@@ -22,12 +23,18 @@ func ProfilingPipelineConfig(odigosNamespace string, profiling *common.Profiling
 	}, profiling.Exporter)
 
 	processors := config.GenericMap{
+		// memory_limiter is the standard first processor on every pipeline (traces,
+		// metrics, logs) — the pipeline's memory backstop under the collector's
+		// GOMEMLIMIT/cgroup budget. Profiles get the same treatment so the symbolize
+		// processor is governed like every other component.
+		memoryLimiterProcessorName:                      commonconf.GetMemoryLimiterConfig(memorySettings),
 		commonconf.ProfilingNodeFilterProcessor:         commonconf.ProfilingFilterProcessorConfig(),
 		commonconf.ProfilingNodeK8sAttributesProcessor:  commonconf.K8sAttributesProfilesProcessorConfig(),
 		commonconf.ProfilingNodeOdigosProfilesProcessor: commonconf.OdigosProfilesProcessorConfig(),
 		commonconf.ProfilingNodeServiceNameProcessor:    commonconf.ProfilingServiceNameTransformConfig(),
 	}
 	pipelineProcessors := []string{
+		memoryLimiterProcessorName, // always first — reject before any parse/allocation under memory pressure
 		commonconf.ProfilingNodeFilterProcessor,
 		commonconf.ProfilingNodeK8sAttributesProcessor,
 		commonconf.ProfilingNodeOdigosProfilesProcessor,

--- a/autoscaler/controllers/nodecollector/collectorconfig/profiles.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/profiles.go
@@ -23,10 +23,7 @@ func ProfilingPipelineConfig(odigosNamespace string, profiling *common.Profiling
 	}, profiling.Exporter)
 
 	processors := config.GenericMap{
-		// memory_limiter is the standard first processor on every pipeline (traces,
-		// metrics, logs) — the pipeline's memory backstop under the collector's
-		// GOMEMLIMIT/cgroup budget. Profiles get the same treatment so the symbolize
-		// processor is governed like every other component.
+		// Same memory_limiter every other pipeline (traces, metrics, logs) starts with.
 		memoryLimiterProcessorName:                      commonconf.GetMemoryLimiterConfig(memorySettings),
 		commonconf.ProfilingNodeFilterProcessor:         commonconf.ProfilingFilterProcessorConfig(),
 		commonconf.ProfilingNodeK8sAttributesProcessor:  commonconf.K8sAttributesProfilesProcessorConfig(),
@@ -34,7 +31,7 @@ func ProfilingPipelineConfig(odigosNamespace string, profiling *common.Profiling
 		commonconf.ProfilingNodeServiceNameProcessor:    commonconf.ProfilingServiceNameTransformConfig(),
 	}
 	pipelineProcessors := []string{
-		memoryLimiterProcessorName, // always first — reject before any parse/allocation under memory pressure
+		memoryLimiterProcessorName,
 		commonconf.ProfilingNodeFilterProcessor,
 		commonconf.ProfilingNodeK8sAttributesProcessor,
 		commonconf.ProfilingNodeOdigosProfilesProcessor,

--- a/autoscaler/controllers/nodecollector/collectorconfig/profiles.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/profiles.go
@@ -2,7 +2,6 @@ package collectorconfig
 
 import (
 	"github.com/odigos-io/odigos/api/k8sconsts"
-	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	commonconf "github.com/odigos-io/odigos/autoscaler/controllers/common"
 	"github.com/odigos-io/odigos/common"
 	"github.com/odigos-io/odigos/common/config"
@@ -10,7 +9,7 @@ import (
 )
 
 // ProfilingPipelineConfig builds the node collector profiles domain when profiling is enabled.
-func ProfilingPipelineConfig(odigosNamespace string, profiling *common.ProfilingConfiguration, manifestProcessorNames []string, memorySettings odigosv1.CollectorsGroupResourcesSettings) config.Config {
+func ProfilingPipelineConfig(odigosNamespace string, profiling *common.ProfilingConfiguration, manifestProcessorNames []string) config.Config {
 	if !common.ProfilingPipelineActive(profiling) {
 		return config.Config{}
 	}
@@ -22,9 +21,9 @@ func ProfilingPipelineConfig(odigosNamespace string, profiling *common.Profiling
 		"compression": "none",
 	}, profiling.Exporter)
 
+	// memory_limiter itself is defined once, globally, by commonProcessors() (see
+	// common.go) — every pipeline just references its name, never redefines it.
 	processors := config.GenericMap{
-		// Same memory_limiter every other pipeline (traces, metrics, logs) starts with.
-		memoryLimiterProcessorName:                      commonconf.GetMemoryLimiterConfig(memorySettings),
 		commonconf.ProfilingNodeFilterProcessor:         commonconf.ProfilingFilterProcessorConfig(),
 		commonconf.ProfilingNodeK8sAttributesProcessor:  commonconf.K8sAttributesProfilesProcessorConfig(),
 		commonconf.ProfilingNodeOdigosProfilesProcessor: commonconf.OdigosProfilesProcessorConfig(),

--- a/autoscaler/controllers/nodecollector/collectorconfig/profiles_test.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/profiles_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/odigos-io/odigos/api/k8sconsts"
+	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	commonconf "github.com/odigos-io/odigos/autoscaler/controllers/common"
 	"github.com/odigos-io/odigos/common"
 	"github.com/odigos-io/odigos/common/config"
@@ -12,20 +13,20 @@ import (
 )
 
 func TestProfilingPipelineConfig_Disabled(t *testing.T) {
-	got := ProfilingPipelineConfig("odigos-system", nil, nil)
+	got := ProfilingPipelineConfig("odigos-system", nil, nil, odigosv1.CollectorsGroupResourcesSettings{})
 	assert.Empty(t, got.Receivers)
 	assert.Empty(t, got.Processors)
 	assert.Empty(t, got.Exporters)
 	assert.Empty(t, got.Service.Pipelines)
 
 	off := false
-	got = ProfilingPipelineConfig("odigos-system", &common.ProfilingConfiguration{Enabled: &off}, nil)
+	got = ProfilingPipelineConfig("odigos-system", &common.ProfilingConfiguration{Enabled: &off}, nil, odigosv1.CollectorsGroupResourcesSettings{})
 	assert.Empty(t, got.Service.Pipelines)
 }
 
 func TestProfilingPipelineConfig_Enabled(t *testing.T) {
 	on := true
-	got := ProfilingPipelineConfig("odigos-system", &common.ProfilingConfiguration{Enabled: &on}, nil)
+	got := ProfilingPipelineConfig("odigos-system", &common.ProfilingConfiguration{Enabled: &on}, nil, odigosv1.CollectorsGroupResourcesSettings{})
 	require.Contains(t, got.Receivers, commonconf.ProfilingReceiver)
 	require.Contains(t, got.Processors, commonconf.ProfilingNodeFilterProcessor)
 	require.Contains(t, got.Processors, commonconf.ProfilingNodeK8sAttributesProcessor)
@@ -39,6 +40,7 @@ func TestProfilingPipelineConfig_Enabled(t *testing.T) {
 	// Native symbolization is ON by default when profiling is enabled.
 	require.Contains(t, got.Processors, commonconf.ProfilingNodeSymbolizeProcessor)
 	assert.Equal(t, []string{
+		memoryLimiterProcessorName,
 		commonconf.ProfilingNodeFilterProcessor,
 		commonconf.ProfilingNodeK8sAttributesProcessor,
 		commonconf.ProfilingNodeOdigosProfilesProcessor,
@@ -61,13 +63,14 @@ func TestProfilingPipelineConfig_Enabled(t *testing.T) {
 func TestProfilingPipelineConfig_UserProcessorsAppended(t *testing.T) {
 	on := true
 	userProcessors := []string{"resource/addclusterinfo", "transform/rename"}
-	got := ProfilingPipelineConfig("odigos-system", &common.ProfilingConfiguration{Enabled: &on}, userProcessors)
+	got := ProfilingPipelineConfig("odigos-system", &common.ProfilingConfiguration{Enabled: &on}, userProcessors, odigosv1.CollectorsGroupResourcesSettings{})
 
 	pl, ok := got.Service.Pipelines["profiles"]
 	require.True(t, ok)
 	// User processors run after the built-in enrichment chain (native symbolization is on by
 	// default, so the symbolize processor is present) and before export.
 	assert.Equal(t, []string{
+		memoryLimiterProcessorName,
 		commonconf.ProfilingNodeFilterProcessor,
 		commonconf.ProfilingNodeK8sAttributesProcessor,
 		commonconf.ProfilingNodeOdigosProfilesProcessor,
@@ -86,11 +89,12 @@ func TestProfilingPipelineConfig_NativeSymbolizationDisabled(t *testing.T) {
 	got := ProfilingPipelineConfig("odigos-system", &common.ProfilingConfiguration{
 		Enabled:       &on,
 		Symbolization: &common.ProfilingSymbolizationConfiguration{Native: &off},
-	}, nil)
+	}, nil, odigosv1.CollectorsGroupResourcesSettings{})
 	require.NotContains(t, got.Processors, commonconf.ProfilingNodeSymbolizeProcessor)
 
 	pl := got.Service.Pipelines["profiles"]
 	assert.Equal(t, []string{
+		memoryLimiterProcessorName,
 		commonconf.ProfilingNodeFilterProcessor,
 		commonconf.ProfilingNodeK8sAttributesProcessor,
 		commonconf.ProfilingNodeOdigosProfilesProcessor,

--- a/autoscaler/controllers/nodecollector/collectorconfig/profiles_test.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/profiles_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/odigos-io/odigos/api/k8sconsts"
-	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	commonconf "github.com/odigos-io/odigos/autoscaler/controllers/common"
 	"github.com/odigos-io/odigos/common"
 	"github.com/odigos-io/odigos/common/config"
@@ -13,20 +12,20 @@ import (
 )
 
 func TestProfilingPipelineConfig_Disabled(t *testing.T) {
-	got := ProfilingPipelineConfig("odigos-system", nil, nil, odigosv1.CollectorsGroupResourcesSettings{})
+	got := ProfilingPipelineConfig("odigos-system", nil, nil)
 	assert.Empty(t, got.Receivers)
 	assert.Empty(t, got.Processors)
 	assert.Empty(t, got.Exporters)
 	assert.Empty(t, got.Service.Pipelines)
 
 	off := false
-	got = ProfilingPipelineConfig("odigos-system", &common.ProfilingConfiguration{Enabled: &off}, nil, odigosv1.CollectorsGroupResourcesSettings{})
+	got = ProfilingPipelineConfig("odigos-system", &common.ProfilingConfiguration{Enabled: &off}, nil)
 	assert.Empty(t, got.Service.Pipelines)
 }
 
 func TestProfilingPipelineConfig_Enabled(t *testing.T) {
 	on := true
-	got := ProfilingPipelineConfig("odigos-system", &common.ProfilingConfiguration{Enabled: &on}, nil, odigosv1.CollectorsGroupResourcesSettings{})
+	got := ProfilingPipelineConfig("odigos-system", &common.ProfilingConfiguration{Enabled: &on}, nil)
 	require.Contains(t, got.Receivers, commonconf.ProfilingReceiver)
 	require.Contains(t, got.Processors, commonconf.ProfilingNodeFilterProcessor)
 	require.Contains(t, got.Processors, commonconf.ProfilingNodeK8sAttributesProcessor)
@@ -63,7 +62,7 @@ func TestProfilingPipelineConfig_Enabled(t *testing.T) {
 func TestProfilingPipelineConfig_UserProcessorsAppended(t *testing.T) {
 	on := true
 	userProcessors := []string{"resource/addclusterinfo", "transform/rename"}
-	got := ProfilingPipelineConfig("odigos-system", &common.ProfilingConfiguration{Enabled: &on}, userProcessors, odigosv1.CollectorsGroupResourcesSettings{})
+	got := ProfilingPipelineConfig("odigos-system", &common.ProfilingConfiguration{Enabled: &on}, userProcessors)
 
 	pl, ok := got.Service.Pipelines["profiles"]
 	require.True(t, ok)
@@ -89,7 +88,7 @@ func TestProfilingPipelineConfig_NativeSymbolizationDisabled(t *testing.T) {
 	got := ProfilingPipelineConfig("odigos-system", &common.ProfilingConfiguration{
 		Enabled:       &on,
 		Symbolization: &common.ProfilingSymbolizationConfiguration{Native: &off},
-	}, nil, odigosv1.CollectorsGroupResourcesSettings{})
+	}, nil)
 	require.NotContains(t, got.Processors, commonconf.ProfilingNodeSymbolizeProcessor)
 
 	pl := got.Service.Pipelines["profiles"]

--- a/autoscaler/controllers/nodecollector/configmap.go
+++ b/autoscaler/controllers/nodecollector/configmap.go
@@ -294,7 +294,7 @@ func calculateCollectorConfigDomains(
 	}
 
 	if odigoscommon.ProfilingPipelineActive(profiling) {
-		configDomains["profiling"] = collectorconfig.ProfilingPipelineConfig(odigosNamespace, profiling, processorsResults.ProfilesProcessors)
+		configDomains["profiling"] = collectorconfig.ProfilingPipelineConfig(odigosNamespace, profiling, processorsResults.ProfilesProcessors, nodeCG.Spec.ResourcesSettings)
 	}
 
 	mergedConfig, err := config.MergeConfigs(configDomains)

--- a/autoscaler/controllers/nodecollector/configmap.go
+++ b/autoscaler/controllers/nodecollector/configmap.go
@@ -294,7 +294,7 @@ func calculateCollectorConfigDomains(
 	}
 
 	if odigoscommon.ProfilingPipelineActive(profiling) {
-		configDomains["profiling"] = collectorconfig.ProfilingPipelineConfig(odigosNamespace, profiling, processorsResults.ProfilesProcessors, nodeCG.Spec.ResourcesSettings)
+		configDomains["profiling"] = collectorconfig.ProfilingPipelineConfig(odigosNamespace, profiling, processorsResults.ProfilesProcessors)
 	}
 
 	mergedConfig, err := config.MergeConfigs(configDomains)


### PR DESCRIPTION
#### What this PR does / why we need it:

The node-collector **profiles** pipeline is the only pipeline without a
`memory_limiter` — traces, logs and metrics all start with one. That left the
continuous-profiling / native-symbolization path with no pipeline-level memory
backstop under the collector's `GOMEMLIMIT`/cgroup budget. This adds it, so
profiles memory is governed exactly like every other pipeline.

`memory_limiter` is a single processor instance already defined once, globally,
by `commonProcessors()` (shared with traces/logs/metrics). The profiles pipeline
now references it as its **first** processor, same as the other pipelines,
rejecting incoming profiles under memory pressure before any downstream
processing — no new config is defined, only the reference was missing.

Pairs with the symbolizer transient-decode guard (separate PR) and the collector
`GOMEMLIMIT` floor.

#### Changelog entry:

```release-note
Add a memory_limiter to the node-collector profiles pipeline so profiling memory is bounded like every other pipeline.
```



---

#### Where this fits (CORE-1307)

```
node-collector profiles pipeline — memory guards

  profiles in
     |
     v
  [ memory_limiter ]   (1) pipeline gate: reject under memory pressure    #5304  <-- THIS PR
     |
     v
  filter > k8sattributes > odigosprofiles
     |
     v
  [ symbolize ]        (2) transient .symtab decode cap   max_symtab_bytes  #5302
     |                 (3) retained symbol LRU cache       max_symbol_bytes  #5307
     v                      one knob -> maxMemoryMiB: symbol=B, symtab=B/5
  service-name > export
```
