### PR TITLE
Different approach shared other agent

### DIFF
--- a/common/otheragent/knownagents.go
+++ b/common/otheragent/knownagents.go
@@ -23,51 +23,81 @@ const (
 	otelDotNetProfilerGUID     = "918728DD-259F-4A6A-AC2B-B85E1B658318"
 )
 
+// Environment variable names inspected by the env-based entries in KnownAgents.
+const (
+	envCORECLRProfiler           = "CORECLR_PROFILER"
+	envJavaToolOptions           = "JAVA_TOOL_OPTIONS"
+	envNodeOptions               = "NODE_OPTIONS"
+	envRubyOpt                   = "RUBYOPT"
+	envLDPreload                 = "LD_PRELOAD"
+	envDDInjectionEnabled        = "DD_INJECTION_ENABLED"
+	envDDTraceAgentURL           = "DD_TRACE_AGENT_URL"
+	envNewRelicConfigFile        = "NEW_RELIC_CONFIG_FILE"
+	envDTDynamizerTargetExe      = "DT_DYNAMIZER_TARGET_EXE"
+	envAppDynamicsControllerHost = "APPDYNAMICS_CONTROLLER_HOST_NAME"
+)
+
+// AgentDetectionEnvKeys are the environment variables inspected by the env-based
+// entries in KnownAgents. Consumers collect these into the process env so that
+// detection can read them.
+var AgentDetectionEnvKeys = map[string]struct{}{
+	envCORECLRProfiler:           {},
+	envJavaToolOptions:           {},
+	envNodeOptions:               {},
+	envRubyOpt:                   {},
+	envLDPreload:                 {},
+	envDDInjectionEnabled:        {},
+	envDDTraceAgentURL:           {},
+	envNewRelicConfigFile:        {},
+	envDTDynamizerTargetExe:      {},
+	envAppDynamicsControllerHost: {},
+}
+
 // KnownAgents lists conclusive markers that an instrumentation agent is loaded
 // in a process. A single match means detected.
 var KnownAgents = []KnownAgent{
 	// Datadog
 	{Name: DatadogAgentName, Language: common.DotNetProgrammingLanguage, Signal: EnvValueContains,
-		Key: "CORECLR_PROFILER", Match: datadogDotNetProfilerGUID},
+		Key: envCORECLRProfiler, Match: datadogDotNetProfilerGUID},
 	{Name: DatadogAgentName, Language: common.JavaProgrammingLanguage, Signal: CmdlineContains, Match: "dd-java-agent"},
 	{Name: DatadogAgentName, Language: common.JavaProgrammingLanguage, Signal: EnvValueContains,
-		Key: "JAVA_TOOL_OPTIONS", Match: "dd-java-agent"},
-	{Name: DatadogAgentName, Language: common.JavascriptProgrammingLanguage, Signal: EnvValueContains, Key: "NODE_OPTIONS", Match: "dd-trace"},
-	{Name: DatadogAgentName, Language: common.RubyProgrammingLanguage, Signal: EnvValueContains, Key: "RUBYOPT", Match: "datadog"},
-	{Name: DatadogAgentName, Language: common.RubyProgrammingLanguage, Signal: EnvValueContains, Key: "RUBYOPT", Match: "ddtrace"},
+		Key: envJavaToolOptions, Match: "dd-java-agent"},
+	{Name: DatadogAgentName, Language: common.JavascriptProgrammingLanguage, Signal: EnvValueContains, Key: envNodeOptions, Match: "dd-trace"},
+	{Name: DatadogAgentName, Language: common.RubyProgrammingLanguage, Signal: EnvValueContains, Key: envRubyOpt, Match: "datadog"},
+	{Name: DatadogAgentName, Language: common.RubyProgrammingLanguage, Signal: EnvValueContains, Key: envRubyOpt, Match: "ddtrace"},
 	{Name: DatadogAgentName, Language: common.PythonProgrammingLanguage, Signal: CmdlineContains, Match: "ddtrace-run"},
 	{Name: DatadogAgentName, Language: common.PhpProgrammingLanguage, Signal: LibLoaded, Match: "ddtrace.so"},
-	{Name: DatadogAgentName, Signal: EnvValueContains, Key: "LD_PRELOAD", Match: "datadog-apm-inject"},
-	{Name: DatadogAgentName, Signal: EnvPresent, Key: "DD_INJECTION_ENABLED"},
-	{Name: DatadogAgentName, Signal: EnvPresent, Key: "DD_TRACE_AGENT_URL"},
+	{Name: DatadogAgentName, Signal: EnvValueContains, Key: envLDPreload, Match: "datadog-apm-inject"},
+	{Name: DatadogAgentName, Signal: EnvPresent, Key: envDDInjectionEnabled},
+	{Name: DatadogAgentName, Signal: EnvPresent, Key: envDDTraceAgentURL},
 
 	// New Relic
-	{Name: NewRelicAgentName, Signal: EnvPresent, Key: "NEW_RELIC_CONFIG_FILE"},
+	{Name: NewRelicAgentName, Signal: EnvPresent, Key: envNewRelicConfigFile},
 	{Name: NewRelicAgentName, Language: common.JavaProgrammingLanguage, Signal: CmdlineContains, Match: "newrelic.jar"},
-	{Name: NewRelicAgentName, Language: common.JavascriptProgrammingLanguage, Signal: EnvValueContains, Key: "NODE_OPTIONS", Match: "newrelic"},
+	{Name: NewRelicAgentName, Language: common.JavascriptProgrammingLanguage, Signal: EnvValueContains, Key: envNodeOptions, Match: "newrelic"},
 	{Name: NewRelicAgentName, Language: common.DotNetProgrammingLanguage, Signal: EnvValueContains,
-		Key: "CORECLR_PROFILER", Match: newRelicDotNetProfilerGUID},
+		Key: envCORECLRProfiler, Match: newRelicDotNetProfilerGUID},
 	{Name: NewRelicAgentName, Language: common.PhpProgrammingLanguage, Signal: LibLoaded, Match: "newrelic.so"},
 
 	// Dynatrace
-	{Name: DynatraceAgentName, Signal: EnvPresent, Key: "DT_DYNAMIZER_TARGET_EXE"},
-	{Name: DynatraceAgentName, Signal: EnvValueContains, Key: "LD_PRELOAD", Match: "/dynatrace/"},
+	{Name: DynatraceAgentName, Signal: EnvPresent, Key: envDTDynamizerTargetExe},
+	{Name: DynatraceAgentName, Signal: EnvValueContains, Key: envLDPreload, Match: "/dynatrace/"},
 	{Name: DynatraceAgentName, Signal: LibLoaded, Match: "liboneagent"},
 
 	// OpenTelemetry
 	{Name: OpenTelemetryAgentName, Language: common.JavaProgrammingLanguage, Signal: CmdlineContains, Match: "opentelemetry-javaagent"},
 	{Name: OpenTelemetryAgentName, Language: common.JavaProgrammingLanguage, Signal: EnvValueContains,
-		Key: "JAVA_TOOL_OPTIONS", Match: "opentelemetry-javaagent"},
+		Key: envJavaToolOptions, Match: "opentelemetry-javaagent"},
 	{Name: OpenTelemetryAgentName, Language: common.JavascriptProgrammingLanguage, Signal: EnvValueContains,
-		Key: "NODE_OPTIONS", Match: "@opentelemetry/auto-instrumentations-node"},
+		Key: envNodeOptions, Match: "@opentelemetry/auto-instrumentations-node"},
 	{Name: OpenTelemetryAgentName, Language: common.PythonProgrammingLanguage, Signal: CmdlineContains, Match: "opentelemetry-instrument"},
 	{Name: OpenTelemetryAgentName, Language: common.DotNetProgrammingLanguage, Signal: EnvValueContains,
-		Key: "CORECLR_PROFILER", Match: otelDotNetProfilerGUID},
+		Key: envCORECLRProfiler, Match: otelDotNetProfilerGUID},
 
 	// Grafana OpenTelemetry
 	{Name: GrafanaOtelAgentName, Language: common.JavaProgrammingLanguage, Signal: CmdlineContains, Match: "grafana-opentelemetry-java"},
 	{Name: GrafanaOtelAgentName, Language: common.JavaProgrammingLanguage, Signal: EnvValueContains,
-		Key: "JAVA_TOOL_OPTIONS", Match: "grafana-opentelemetry-java"},
+		Key: envJavaToolOptions, Match: "grafana-opentelemetry-java"},
 
 	// Splunk / SignalFx OpenTelemetry
 	{Name: SplunkOtelAgentName, Language: common.JavaProgrammingLanguage, Signal: CmdlineContains, Match: "splunk-otel-javaagent"},
@@ -79,7 +109,7 @@ var KnownAgents = []KnownAgent{
 	{Name: ElasticAPMAgentName, Language: common.JavaProgrammingLanguage, Signal: CmdlineContains, Match: "elastic-apm-agent"},
 
 	// AppDynamics
-	{Name: AppDynamicsAgentName, Signal: EnvPresent, Key: "APPDYNAMICS_CONTROLLER_HOST_NAME"},
+	{Name: AppDynamicsAgentName, Signal: EnvPresent, Key: envAppDynamicsControllerHost},
 	{Name: AppDynamicsAgentName, Language: common.JavaProgrammingLanguage, Signal: CmdlineContains, Match: "appdynamics"},
 
 	// Instana

--- a/common/otheragent/otheragent.go
+++ b/common/otheragent/otheragent.go
@@ -1,8 +1,6 @@
 // Package otheragent detects another instrumentation agent already running in a
 // process, so Odigos avoids double-instrumenting it. It is process-source
-// agnostic: callers pass a Process implementation, so the package has no /proc
-// or procdiscovery dependency and can be consumed anywhere (odiglet on k8s,
-// vm-agent on VMs).
+// agnostic: callers pass a Process implementation.
 package otheragent
 
 import (

--- a/common/otheragent/otheragent.go
+++ b/common/otheragent/otheragent.go
@@ -1,17 +1,33 @@
 // Package otheragent detects another instrumentation agent already running in a
-// process, so Odigos avoids double-instrumenting it. Shared by odiglet and vm-agent.
+// process, so Odigos avoids double-instrumenting it. It is process-source
+// agnostic: callers pass a Process implementation, so the package has no /proc
+// or procdiscovery dependency and can be consumed anywhere (odiglet on k8s,
+// vm-agent on VMs).
 package otheragent
 
 import (
+	"bufio"
+	"io"
 	"strings"
 
 	"github.com/odigos-io/odigos/common"
-	"github.com/odigos-io/odigos/procdiscovery/pkg/inspectors/utils"
-	"github.com/odigos-io/odigos/procdiscovery/pkg/process"
 )
 
 type OtherAgent struct {
 	Name string
+}
+
+// Process is the minimal view of a running process the detector needs.
+// procdiscovery's process.ProcessContext and vm-agent's process types both
+// satisfy it, keeping this package free of any /proc coupling.
+type Process interface {
+	// Cmdline returns the process command line.
+	Cmdline() string
+	// LookupEnv returns the value of an environment variable of the process.
+	LookupEnv(key string) (string, bool)
+	// MapsReader returns a reader over the process memory maps
+	// (/proc/<pid>/maps on Linux). Only used for library-load detection.
+	MapsReader() (io.Reader, error)
 }
 
 // SignalType is the kind of evidence that identifies an agent in a process.
@@ -51,7 +67,7 @@ func indexKnownAgentsByLanguage() map[common.ProgrammingLanguage][]*KnownAgent {
 // DetectAll returns every distinct agent detected in the process (deduplicated by
 // Name). Entries scoped to a language are only checked when it matches lang; the
 // language-agnostic entries always run.
-func DetectAll(pcx *process.ProcessContext, lang common.ProgrammingLanguage) []OtherAgent {
+func DetectAll(p Process, lang common.ProgrammingLanguage) []OtherAgent {
 	var detected []OtherAgent
 	seen := make(map[string]struct{})
 	scan := func(candidates []*KnownAgent) {
@@ -59,7 +75,7 @@ func DetectAll(pcx *process.ProcessContext, lang common.ProgrammingLanguage) []O
 			if _, done := seen[agent.Name]; done {
 				continue
 			}
-			if agentMatchesProcess(pcx, agent) {
+			if agentMatchesProcess(p, agent) {
 				seen[agent.Name] = struct{}{}
 				detected = append(detected, OtherAgent{Name: agent.Name})
 			}
@@ -74,8 +90,8 @@ func DetectAll(pcx *process.ProcessContext, lang common.ProgrammingLanguage) []O
 
 // Detect returns the first agent detected in the process, or nil. Kept for
 // callers that model a single agent (e.g. odiglet's RuntimeDetails CRD).
-func Detect(pcx *process.ProcessContext, lang common.ProgrammingLanguage) *OtherAgent {
-	if all := DetectAll(pcx, lang); len(all) > 0 {
+func Detect(p Process, lang common.ProgrammingLanguage) *OtherAgent {
+	if all := DetectAll(p, lang); len(all) > 0 {
 		return &all[0]
 	}
 	return nil
@@ -87,41 +103,30 @@ func Blocks(detected []OtherAgent, allowConcurrentAgents bool) bool {
 	return len(detected) > 0 && !allowConcurrentAgents
 }
 
-// EnvKeysOfInterest returns the env var names referenced by env-based entries, so
-// callers can add them to their env-collection whitelist (passed in explicitly,
-// not via a hidden global).
-func EnvKeysOfInterest() map[string]struct{} {
-	keys := make(map[string]struct{})
-	for i := range KnownAgents {
-		if a := &KnownAgents[i]; a.Signal == EnvPresent || a.Signal == EnvValueContains {
-			keys[a.Key] = struct{}{}
-		}
-	}
-	return keys
-}
-
-func agentMatchesProcess(pcx *process.ProcessContext, agent *KnownAgent) bool {
+func agentMatchesProcess(p Process, agent *KnownAgent) bool {
 	switch agent.Signal {
 	case EnvPresent:
-		_, ok := lookupEnv(pcx, agent.Key)
+		_, ok := p.LookupEnv(agent.Key)
 		return ok
 	case EnvValueContains:
-		v, ok := lookupEnv(pcx, agent.Key)
+		v, ok := p.LookupEnv(agent.Key)
 		return ok && strings.Contains(v, agent.Match)
 	case CmdlineContains:
-		return strings.Contains(pcx.CmdLine, agent.Match)
+		return strings.Contains(p.Cmdline(), agent.Match)
 	case LibLoaded:
-		f, err := pcx.GetMapsFile()
-		return err == nil && utils.IsMapsFileContainsBinary(f, []string{agent.Match})
+		r, err := p.MapsReader()
+		return err == nil && mapsContains(r, agent.Match)
 	}
 	return false
 }
 
-// lookupEnv reads an env var via the process getters, preferring the detailed set
-// then the overwrite set (where Odigos keeps values like LD_PRELOAD).
-func lookupEnv(pcx *process.ProcessContext, key string) (string, bool) {
-	if v, ok := pcx.GetDetailedEnvsValue(key); ok {
-		return v, true
+// mapsContains reports whether any line of a process maps reader contains name.
+func mapsContains(r io.Reader, name string) bool {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		if strings.Contains(scanner.Text(), name) {
+			return true
+		}
 	}
-	return pcx.GetOverwriteEnvsValue(key)
+	return false
 }

--- a/common/otheragent/otheragent_test.go
+++ b/common/otheragent/otheragent_test.go
@@ -1,34 +1,49 @@
 package otheragent
 
 import (
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/odigos-io/odigos/common"
-	"github.com/odigos-io/odigos/procdiscovery/pkg/process"
 )
 
-func ctx(cmdline string, detailed, overwrite map[string]string) *process.ProcessContext {
-	if detailed == nil {
-		detailed = map[string]string{}
+// fakeProcess is a test Process implementation with no /proc dependency.
+type fakeProcess struct {
+	cmdline string
+	envs    map[string]string
+	maps    string
+}
+
+func (f fakeProcess) Cmdline() string { return f.cmdline }
+
+func (f fakeProcess) LookupEnv(key string) (string, bool) {
+	v, ok := f.envs[key]
+	return v, ok
+}
+
+func (f fakeProcess) MapsReader() (io.Reader, error) {
+	return strings.NewReader(f.maps), nil
+}
+
+// ctx merges the detailed and overwrite env sets into one lookup (LookupEnv does
+// not distinguish them), matching how the real Process implementations behave.
+func ctx(cmdline string, detailed, overwrite map[string]string) fakeProcess {
+	envs := map[string]string{}
+	for k, v := range detailed {
+		envs[k] = v
 	}
-	if overwrite == nil {
-		overwrite = map[string]string{}
+	for k, v := range overwrite {
+		envs[k] = v
 	}
-	return process.NewProcessContext(process.Details{
-		ProcessID: -1, // no such pid; maps reads are expected to fail gracefully
-		CmdLine:   cmdline,
-		Environments: process.ProcessEnvs{
-			DetailedEnvs:  detailed,
-			OverwriteEnvs: overwrite,
-		},
-	})
+	return fakeProcess{cmdline: cmdline, envs: envs}
 }
 
 func TestDetect(t *testing.T) {
 	const unknown = common.UnknownProgrammingLanguage
 	tests := []struct {
 		name      string
-		pcx       *process.ProcessContext
+		pcx       Process
 		lang      common.ProgrammingLanguage
 		wantAgent string // "" means no detection
 	}{
@@ -129,14 +144,13 @@ func TestDetectAll_DedupSameAgent(t *testing.T) {
 	}
 }
 
-func TestEnvKeysOfInterest(t *testing.T) {
-	keys := EnvKeysOfInterest()
-	for _, want := range []string{
-		"NEW_RELIC_CONFIG_FILE", "DD_TRACE_AGENT_URL", "DT_DYNAMIZER_TARGET_EXE",
-		"NODE_OPTIONS", "JAVA_TOOL_OPTIONS", "CORECLR_PROFILER", "RUBYOPT", "LD_PRELOAD",
-	} {
-		if _, ok := keys[want]; !ok {
-			t.Errorf("EnvKeysOfInterest missing %q", want)
-		}
+func TestLibLoadedDetection(t *testing.T) {
+	// Dynatrace liboneagent present in the process maps.
+	p := fakeProcess{
+		maps: "7f0000000000-7f0000001000 r-xp 00000000 00:00 0 /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so\n",
+	}
+	got := Detect(p, common.UnknownProgrammingLanguage)
+	if got == nil || got.Name != DynatraceAgentName {
+		t.Fatalf("expected %q from maps, got %v", DynatraceAgentName, got)
 	}
 }

--- a/odiglet/pkg/kube/instrumentation_ebpf/instrumentationconfig.go
+++ b/odiglet/pkg/kube/instrumentation_ebpf/instrumentationconfig.go
@@ -235,7 +235,7 @@ func (i *InstrumentationConfigReconciler) sendInstrumentationRequest(ctx context
 			continue
 		}
 		for pid := range pidSet {
-			details := procdiscovery.GetPidDetails(pid, nil, nil)
+			details := procdiscovery.GetPidDetails(pid, nil)
 			ir.ProcessDetailsByPid[pid] = &ebpf.K8sProcessDetails{
 				ContainerName: podContainer.ContainerName,
 				Distro:        distribution,

--- a/odiglet/pkg/kube/runtime_details/inspection.go
+++ b/odiglet/pkg/kube/runtime_details/inspection.go
@@ -21,18 +21,12 @@ import (
 	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
 	"github.com/odigos-io/odigos/procdiscovery/pkg/inspectors"
-	"github.com/odigos-io/odigos/procdiscovery/pkg/otheragent"
+	"github.com/odigos-io/odigos/common/otheragent"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-// agentDetectionEnvs are the env var names the shared other-agent detector needs
-// collected into DetailedEnvs. Passed explicitly to GetPidDetails (no hidden
-// global): if otheragent stops being imported this fails to compile rather than
-// silently disabling detection.
-var agentDetectionEnvs = otheragent.EnvKeysOfInterest()
 
 type InspectionResults struct {
 	containerNameToNewRuntimeDetails map[string]odigosv1.RuntimeDetailsByContainer
@@ -168,7 +162,7 @@ func runtimeInspectionFromGroupedPIDs(ctx context.Context, pods []corev1.Pod, gr
 			pidSet := groupedPIDs[pc]
 			processes := make([]procdiscovery.Details, 0, len(pidSet))
 			for pid := range pidSet {
-				procDetails := procdiscovery.GetPidDetails(pid, runtimeDetectionEnvs, agentDetectionEnvs)
+				procDetails := procdiscovery.GetPidDetails(pid, runtimeDetectionEnvs)
 				processes = append(processes, procDetails)
 			}
 

--- a/procdiscovery/pkg/inspectors/inspect.go
+++ b/procdiscovery/pkg/inspectors/inspect.go
@@ -3,7 +3,7 @@ package inspectors
 import (
 	"github.com/odigos-io/odigos/common"
 	commonlogger "github.com/odigos-io/odigos/common/logger"
-	"github.com/odigos-io/odigos/procdiscovery/pkg/otheragent"
+	"github.com/odigos-io/odigos/common/otheragent"
 	"github.com/odigos-io/odigos/procdiscovery/pkg/process"
 )
 

--- a/procdiscovery/pkg/process/process.go
+++ b/procdiscovery/pkg/process/process.go
@@ -145,21 +145,14 @@ func (d *Details) GetOverwriteEnvsValue(key string) (string, bool) {
 	return value, exists
 }
 
-// The following methods make *ProcessContext satisfy otheragent.Process, so the
-// shared (process-source-agnostic) detector can run against it.
-
 // Cmdline returns the process command line.
 func (pcx *ProcessContext) Cmdline() string { return pcx.CmdLine }
 
-// LookupEnv returns an env var value from the collected sets, preferring the
-// detailed set then the overwrite set (where Odigos keeps values like LD_PRELOAD).
-// The other-agent detection keys are collected up front (see getRelevantEnvVars),
+// LookupEnv returns an env var value from the collected DetailedEnvs. The
+// other-agent detection keys are collected up front (see getRelevantEnvVars),
 // so env-based detection reads them from here without touching /proc again.
 func (pcx *ProcessContext) LookupEnv(key string) (string, bool) {
-	if v, ok := pcx.GetDetailedEnvsValue(key); ok {
-		return v, true
-	}
-	return pcx.GetOverwriteEnvsValue(key)
+	return pcx.GetDetailedEnvsValue(key)
 }
 
 // MapsReader returns a reader over the process memory maps for library-load detection.

--- a/procdiscovery/pkg/process/process.go
+++ b/procdiscovery/pkg/process/process.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"os"
 	"strings"
+
+	"github.com/odigos-io/odigos/common/otheragent"
 )
 
 const (
@@ -143,6 +145,28 @@ func (d *Details) GetOverwriteEnvsValue(key string) (string, bool) {
 	return value, exists
 }
 
+// The following methods make *ProcessContext satisfy otheragent.Process, so the
+// shared (process-source-agnostic) detector can run against it.
+
+// Cmdline returns the process command line.
+func (pcx *ProcessContext) Cmdline() string { return pcx.CmdLine }
+
+// LookupEnv returns an env var value from the collected sets, preferring the
+// detailed set then the overwrite set (where Odigos keeps values like LD_PRELOAD).
+// The other-agent detection keys are collected up front (see getRelevantEnvVars),
+// so env-based detection reads them from here without touching /proc again.
+func (pcx *ProcessContext) LookupEnv(key string) (string, bool) {
+	if v, ok := pcx.GetDetailedEnvsValue(key); ok {
+		return v, true
+	}
+	return pcx.GetOverwriteEnvsValue(key)
+}
+
+// MapsReader returns a reader over the process memory maps for library-load detection.
+func (pcx *ProcessContext) MapsReader() (io.Reader, error) {
+	return pcx.GetMapsFile()
+}
+
 // Find all processes in the system.
 // The function accepts a predicate function that can be used to filter the results.
 func FindAllProcesses(predicate func(int) bool) ([]int, error) {
@@ -219,10 +243,10 @@ func Group[K comparable](predicate func(int) (K, bool)) (map[K]map[int]struct{},
 	return result, nil
 }
 
-func GetPidDetails(pid int, runtimeDetectionEnvs, agentDetectionEnvs map[string]struct{}) Details {
+func GetPidDetails(pid int, runtimeDetectionEnvs map[string]struct{}) Details {
 	exePath := getExePath(pid)
 	cmdLine := getCommandLine(pid)
-	envVars := getRelevantEnvVars(pid, runtimeDetectionEnvs, agentDetectionEnvs)
+	envVars := getRelevantEnvVars(pid, runtimeDetectionEnvs)
 	secureExecutionMode, err := isSecureExecutionMode(pid)
 	secureExecutionModePtr := &secureExecutionMode
 	if err != nil {
@@ -266,7 +290,7 @@ func getCommandLine(pid int) string {
 	}
 }
 
-func getRelevantEnvVars(pid int, runtimeDetectionEnvs, agentDetectionEnvs map[string]struct{}) ProcessEnvs {
+func getRelevantEnvVars(pid int, runtimeDetectionEnvs map[string]struct{}) ProcessEnvs {
 	envFileName := ProcFilePath(pid, "environ")
 	fileContent, err := os.ReadFile(envFileName)
 	if err != nil {
@@ -309,9 +333,9 @@ func getRelevantEnvVars(pid int, runtimeDetectionEnvs, agentDetectionEnvs map[st
 			detailedEnvsResult[envName] = envDetectionValue
 		}
 
-		// Environment variables referenced by the shared other-agent detection,
-		// passed in explicitly by the caller (otheragent.EnvKeysOfInterest()).
-		if _, ok := agentDetectionEnvs[envName]; ok {
+		// Collect the keys the shared other-agent detector inspects, so detection
+		// can read them off the process env without any caller wiring.
+		if _, ok := otheragent.AgentDetectionEnvKeys[envName]; ok {
 			detailedEnvsResult[envName] = envDetectionValue
 		}
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Moved other-agent detection into common/otheragent behind a small Process interface (Cmdline, LookupEnv, MapsReader), so it's decoupled from procdiscovery and any consumer (odiglet, vm-agent) just implements those three methods and calls DetectAll. The detection env keys are now gathered during the initial process scan (getRelevantEnvVars) rather than via a separate read/whitelist step, so detection reads everything it needs from the already-collected process env.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
