### PR TITLE
fix: handle static pod for pods manifest injection status

### DIFF
--- a/instrumentor/controllers/podsmanifestinjectionstatus/sync.go
+++ b/instrumentor/controllers/podsmanifestinjectionstatus/sync.go
@@ -41,27 +41,33 @@ func syncWorkload(ctx context.Context, client ctrl.Client, pw k8sconsts.PodWorkl
 		return ctrl.IgnoreNotFound(err)
 	}
 
-	genericWorkload, err := workload.ObjectToWorkload(workloadObj)
-	if err != nil {
-		return err
-	}
+	var pods []corev1.Pod
+	if pw.Kind == k8sconsts.WorkloadKindStaticPod {
+		// Static pods are the workload themselves and have no label selector.
+		pods = []corev1.Pod{*workloadObj.(*corev1.Pod)}
+	} else {
+		genericWorkload, err := workload.ObjectToWorkload(workloadObj)
+		if err != nil {
+			return err
+		}
 
-	labelSelector := genericWorkload.LabelSelector()
-	if labelSelector == nil {
-		// TODO: handle this case
-		return nil
-	}
+		labelSelector := genericWorkload.LabelSelector()
+		if labelSelector == nil {
+			// TODO: handle this case
+			return nil
+		}
 
-	// get the pods that match the label selector
-	pods := &corev1.PodList{}
-	err = client.List(ctx, pods, ctrl.MatchingLabels(labelSelector.MatchLabels))
-	if err != nil {
-		return err
+		podList := &corev1.PodList{}
+		err = client.List(ctx, podList, ctrl.MatchingLabels(labelSelector.MatchLabels))
+		if err != nil {
+			return err
+		}
+		pods = podList.Items
 	}
 
 	podsManifestInjectionStatus := odigosv1.PodsManifestInjectionStatus{}
 
-	for _, pod := range pods.Items {
+	for _, pod := range pods {
 		if agentHashValue, ok := pod.Labels[k8sconsts.OdigosAgentsMetaHashLabel]; ok {
 			if agentHashValue == ic.Spec.AgentsMetaHash {
 				podsManifestInjectionStatus.HasInjectedUpToDatePods = true


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: CORE-1316

Static pods has no pods label selector, thus they were skipped for pods manifest injection status and showed up incorrectly in the ui

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```

cherry-pick: v1.32