### PR TITLE
feat: expose data throughput for node and cluster collector

### DIFF
--- a/frontend/graph/collectors.graphqls
+++ b/frontend/graph/collectors.graphqls
@@ -53,9 +53,9 @@ enum ManifestFormat {
 type GatewayDeploymentInfo {
   status: WorkloadRolloutStatus!
   hpa: HorizontalPodAutoscalerInfo
-  throughputTracesBytesPerSec: Float
-  throughputMetricsBytesPerSec: Float
-  throughputLogsBytesPerSec: Float
+  throughputTracesBytesPerSec: Int
+  throughputMetricsBytesPerSec: Int
+  throughputLogsBytesPerSec: Int
   resources: Resources
   imageVersion: String
   lastRolloutAt: String
@@ -67,9 +67,9 @@ type GatewayDeploymentInfo {
 type CollectorDaemonSetInfo {
   status: WorkloadRolloutStatus!
   nodes: NodesSummary!
-  throughputTracesBytesPerSec: Float
-  throughputMetricsBytesPerSec: Float
-  throughputLogsBytesPerSec: Float
+  throughputTracesBytesPerSec: Int
+  throughputMetricsBytesPerSec: Int
+  throughputLogsBytesPerSec: Int
   resources: Resources
   imageVersion: String
   lastRolloutAt: String

--- a/frontend/graph/collectors.graphqls
+++ b/frontend/graph/collectors.graphqls
@@ -53,6 +53,9 @@ enum ManifestFormat {
 type GatewayDeploymentInfo {
   status: WorkloadRolloutStatus!
   hpa: HorizontalPodAutoscalerInfo
+  throughputTracesBytesPerSec: Float
+  throughputMetricsBytesPerSec: Float
+  throughputLogsBytesPerSec: Float
   resources: Resources
   imageVersion: String
   lastRolloutAt: String
@@ -64,6 +67,9 @@ type GatewayDeploymentInfo {
 type CollectorDaemonSetInfo {
   status: WorkloadRolloutStatus!
   nodes: NodesSummary!
+  throughputTracesBytesPerSec: Float
+  throughputMetricsBytesPerSec: Float
+  throughputLogsBytesPerSec: Float
   resources: Resources
   imageVersion: String
   lastRolloutAt: String

--- a/frontend/graph/collectors.resolvers.go
+++ b/frontend/graph/collectors.resolvers.go
@@ -13,12 +13,12 @@ import (
 
 // GatewayDeploymentInfo is the resolver for the gatewayDeploymentInfo field.
 func (r *queryResolver) GatewayDeploymentInfo(ctx context.Context) (*model.GatewayDeploymentInfo, error) {
-	return collectors.GetGatewayDeploymentInfo(ctx)
+	return collectors.GetGatewayDeploymentInfo(ctx, r.PromAPI)
 }
 
 // OdigletDaemonSetInfo is the resolver for the odigletDaemonSetInfo field.
 func (r *queryResolver) OdigletDaemonSetInfo(ctx context.Context) (*model.CollectorDaemonSetInfo, error) {
-	return collectors.GetOdigletDaemonSetInfo(ctx)
+	return collectors.GetOdigletDaemonSetInfo(ctx, r.PromAPI)
 }
 
 // GatewayPods is the resolver for the gatewayPods field.

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -13971,9 +13971,9 @@ func (ec *executionContext) _CollectorDaemonSetInfo_throughputTracesBytesPerSec(
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*float64)
+	res := resTmp.(*int)
 	fc.Result = res
-	return ec.marshalOFloat2ᚖfloat64(ctx, field.Selections, res)
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CollectorDaemonSetInfo_throughputTracesBytesPerSec(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -13983,7 +13983,7 @@ func (ec *executionContext) fieldContext_CollectorDaemonSetInfo_throughputTraces
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Float does not have child fields")
+			return nil, errors.New("field of type Int does not have child fields")
 		},
 	}
 	return fc, nil
@@ -14012,9 +14012,9 @@ func (ec *executionContext) _CollectorDaemonSetInfo_throughputMetricsBytesPerSec
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*float64)
+	res := resTmp.(*int)
 	fc.Result = res
-	return ec.marshalOFloat2ᚖfloat64(ctx, field.Selections, res)
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CollectorDaemonSetInfo_throughputMetricsBytesPerSec(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -14024,7 +14024,7 @@ func (ec *executionContext) fieldContext_CollectorDaemonSetInfo_throughputMetric
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Float does not have child fields")
+			return nil, errors.New("field of type Int does not have child fields")
 		},
 	}
 	return fc, nil
@@ -14053,9 +14053,9 @@ func (ec *executionContext) _CollectorDaemonSetInfo_throughputLogsBytesPerSec(ct
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*float64)
+	res := resTmp.(*int)
 	fc.Result = res
-	return ec.marshalOFloat2ᚖfloat64(ctx, field.Selections, res)
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_CollectorDaemonSetInfo_throughputLogsBytesPerSec(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -14065,7 +14065,7 @@ func (ec *executionContext) fieldContext_CollectorDaemonSetInfo_throughputLogsBy
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Float does not have child fields")
+			return nil, errors.New("field of type Int does not have child fields")
 		},
 	}
 	return fc, nil
@@ -24335,9 +24335,9 @@ func (ec *executionContext) _GatewayDeploymentInfo_throughputTracesBytesPerSec(c
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*float64)
+	res := resTmp.(*int)
 	fc.Result = res
-	return ec.marshalOFloat2ᚖfloat64(ctx, field.Selections, res)
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_GatewayDeploymentInfo_throughputTracesBytesPerSec(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -24347,7 +24347,7 @@ func (ec *executionContext) fieldContext_GatewayDeploymentInfo_throughputTracesB
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Float does not have child fields")
+			return nil, errors.New("field of type Int does not have child fields")
 		},
 	}
 	return fc, nil
@@ -24376,9 +24376,9 @@ func (ec *executionContext) _GatewayDeploymentInfo_throughputMetricsBytesPerSec(
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*float64)
+	res := resTmp.(*int)
 	fc.Result = res
-	return ec.marshalOFloat2ᚖfloat64(ctx, field.Selections, res)
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_GatewayDeploymentInfo_throughputMetricsBytesPerSec(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -24388,7 +24388,7 @@ func (ec *executionContext) fieldContext_GatewayDeploymentInfo_throughputMetrics
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Float does not have child fields")
+			return nil, errors.New("field of type Int does not have child fields")
 		},
 	}
 	return fc, nil
@@ -24417,9 +24417,9 @@ func (ec *executionContext) _GatewayDeploymentInfo_throughputLogsBytesPerSec(ctx
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*float64)
+	res := resTmp.(*int)
 	fc.Result = res
-	return ec.marshalOFloat2ᚖfloat64(ctx, field.Selections, res)
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_GatewayDeploymentInfo_throughputLogsBytesPerSec(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -24429,7 +24429,7 @@ func (ec *executionContext) fieldContext_GatewayDeploymentInfo_throughputLogsByt
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Float does not have child fields")
+			return nil, errors.New("field of type Int does not have child fields")
 		},
 	}
 	return fc, nil

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -164,14 +164,17 @@ type ComplexityRoot struct {
 	}
 
 	CollectorDaemonSetInfo struct {
-		ConfigMapYaml     func(childComplexity int) int
-		ImageVersion      func(childComplexity int) int
-		LastRolloutAt     func(childComplexity int) int
-		ManifestYaml      func(childComplexity int) int
-		Nodes             func(childComplexity int) int
-		Resources         func(childComplexity int) int
-		RolloutInProgress func(childComplexity int) int
-		Status            func(childComplexity int) int
+		ConfigMapYaml                func(childComplexity int) int
+		ImageVersion                 func(childComplexity int) int
+		LastRolloutAt                func(childComplexity int) int
+		ManifestYaml                 func(childComplexity int) int
+		Nodes                        func(childComplexity int) int
+		Resources                    func(childComplexity int) int
+		RolloutInProgress            func(childComplexity int) int
+		Status                       func(childComplexity int) int
+		ThroughputLogsBytesPerSec    func(childComplexity int) int
+		ThroughputMetricsBytesPerSec func(childComplexity int) int
+		ThroughputTracesBytesPerSec  func(childComplexity int) int
 	}
 
 	CollectorGatewayConfig struct {
@@ -498,14 +501,17 @@ type ComplexityRoot struct {
 	}
 
 	GatewayDeploymentInfo struct {
-		ConfigMapYaml     func(childComplexity int) int
-		Hpa               func(childComplexity int) int
-		ImageVersion      func(childComplexity int) int
-		LastRolloutAt     func(childComplexity int) int
-		ManifestYaml      func(childComplexity int) int
-		Resources         func(childComplexity int) int
-		RolloutInProgress func(childComplexity int) int
-		Status            func(childComplexity int) int
+		ConfigMapYaml                func(childComplexity int) int
+		Hpa                          func(childComplexity int) int
+		ImageVersion                 func(childComplexity int) int
+		LastRolloutAt                func(childComplexity int) int
+		ManifestYaml                 func(childComplexity int) int
+		Resources                    func(childComplexity int) int
+		RolloutInProgress            func(childComplexity int) int
+		Status                       func(childComplexity int) int
+		ThroughputLogsBytesPerSec    func(childComplexity int) int
+		ThroughputMetricsBytesPerSec func(childComplexity int) int
+		ThroughputTracesBytesPerSec  func(childComplexity int) int
 	}
 
 	GetDestinationCategories struct {
@@ -2197,6 +2203,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.CollectorDaemonSetInfo.Status(childComplexity), true
 
+	case "CollectorDaemonSetInfo.throughputLogsBytesPerSec":
+		if e.complexity.CollectorDaemonSetInfo.ThroughputLogsBytesPerSec == nil {
+			break
+		}
+
+		return e.complexity.CollectorDaemonSetInfo.ThroughputLogsBytesPerSec(childComplexity), true
+
+	case "CollectorDaemonSetInfo.throughputMetricsBytesPerSec":
+		if e.complexity.CollectorDaemonSetInfo.ThroughputMetricsBytesPerSec == nil {
+			break
+		}
+
+		return e.complexity.CollectorDaemonSetInfo.ThroughputMetricsBytesPerSec(childComplexity), true
+
+	case "CollectorDaemonSetInfo.throughputTracesBytesPerSec":
+		if e.complexity.CollectorDaemonSetInfo.ThroughputTracesBytesPerSec == nil {
+			break
+		}
+
+		return e.complexity.CollectorDaemonSetInfo.ThroughputTracesBytesPerSec(childComplexity), true
+
 	case "CollectorGatewayConfig.clusterMetricsEnabled":
 		if e.complexity.CollectorGatewayConfig.ClusterMetricsEnabled == nil {
 			break
@@ -3788,6 +3815,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.GatewayDeploymentInfo.Status(childComplexity), true
+
+	case "GatewayDeploymentInfo.throughputLogsBytesPerSec":
+		if e.complexity.GatewayDeploymentInfo.ThroughputLogsBytesPerSec == nil {
+			break
+		}
+
+		return e.complexity.GatewayDeploymentInfo.ThroughputLogsBytesPerSec(childComplexity), true
+
+	case "GatewayDeploymentInfo.throughputMetricsBytesPerSec":
+		if e.complexity.GatewayDeploymentInfo.ThroughputMetricsBytesPerSec == nil {
+			break
+		}
+
+		return e.complexity.GatewayDeploymentInfo.ThroughputMetricsBytesPerSec(childComplexity), true
+
+	case "GatewayDeploymentInfo.throughputTracesBytesPerSec":
+		if e.complexity.GatewayDeploymentInfo.ThroughputTracesBytesPerSec == nil {
+			break
+		}
+
+		return e.complexity.GatewayDeploymentInfo.ThroughputTracesBytesPerSec(childComplexity), true
 
 	case "GetDestinationCategories.categories":
 		if e.complexity.GetDestinationCategories.Categories == nil {
@@ -13895,6 +13943,129 @@ func (ec *executionContext) fieldContext_CollectorDaemonSetInfo_nodes(_ context.
 				return ec.fieldContext_NodesSummary_ready(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type NodesSummary", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CollectorDaemonSetInfo_throughputTracesBytesPerSec(ctx context.Context, field graphql.CollectedField, obj *model.CollectorDaemonSetInfo) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CollectorDaemonSetInfo_throughputTracesBytesPerSec(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ThroughputTracesBytesPerSec, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*float64)
+	fc.Result = res
+	return ec.marshalOFloat2ᚖfloat64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CollectorDaemonSetInfo_throughputTracesBytesPerSec(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CollectorDaemonSetInfo",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CollectorDaemonSetInfo_throughputMetricsBytesPerSec(ctx context.Context, field graphql.CollectedField, obj *model.CollectorDaemonSetInfo) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CollectorDaemonSetInfo_throughputMetricsBytesPerSec(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ThroughputMetricsBytesPerSec, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*float64)
+	fc.Result = res
+	return ec.marshalOFloat2ᚖfloat64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CollectorDaemonSetInfo_throughputMetricsBytesPerSec(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CollectorDaemonSetInfo",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CollectorDaemonSetInfo_throughputLogsBytesPerSec(ctx context.Context, field graphql.CollectedField, obj *model.CollectorDaemonSetInfo) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CollectorDaemonSetInfo_throughputLogsBytesPerSec(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ThroughputLogsBytesPerSec, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*float64)
+	fc.Result = res
+	return ec.marshalOFloat2ᚖfloat64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CollectorDaemonSetInfo_throughputLogsBytesPerSec(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CollectorDaemonSetInfo",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
 		},
 	}
 	return fc, nil
@@ -24136,6 +24307,129 @@ func (ec *executionContext) fieldContext_GatewayDeploymentInfo_hpa(_ context.Con
 				return ec.fieldContext_HorizontalPodAutoscalerInfo_conditions(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type HorizontalPodAutoscalerInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GatewayDeploymentInfo_throughputTracesBytesPerSec(ctx context.Context, field graphql.CollectedField, obj *model.GatewayDeploymentInfo) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GatewayDeploymentInfo_throughputTracesBytesPerSec(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ThroughputTracesBytesPerSec, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*float64)
+	fc.Result = res
+	return ec.marshalOFloat2ᚖfloat64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GatewayDeploymentInfo_throughputTracesBytesPerSec(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GatewayDeploymentInfo",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GatewayDeploymentInfo_throughputMetricsBytesPerSec(ctx context.Context, field graphql.CollectedField, obj *model.GatewayDeploymentInfo) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GatewayDeploymentInfo_throughputMetricsBytesPerSec(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ThroughputMetricsBytesPerSec, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*float64)
+	fc.Result = res
+	return ec.marshalOFloat2ᚖfloat64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GatewayDeploymentInfo_throughputMetricsBytesPerSec(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GatewayDeploymentInfo",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GatewayDeploymentInfo_throughputLogsBytesPerSec(ctx context.Context, field graphql.CollectedField, obj *model.GatewayDeploymentInfo) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GatewayDeploymentInfo_throughputLogsBytesPerSec(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ThroughputLogsBytesPerSec, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*float64)
+	fc.Result = res
+	return ec.marshalOFloat2ᚖfloat64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GatewayDeploymentInfo_throughputLogsBytesPerSec(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GatewayDeploymentInfo",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
 		},
 	}
 	return fc, nil
@@ -45350,6 +45644,12 @@ func (ec *executionContext) fieldContext_Query_gatewayDeploymentInfo(_ context.C
 				return ec.fieldContext_GatewayDeploymentInfo_status(ctx, field)
 			case "hpa":
 				return ec.fieldContext_GatewayDeploymentInfo_hpa(ctx, field)
+			case "throughputTracesBytesPerSec":
+				return ec.fieldContext_GatewayDeploymentInfo_throughputTracesBytesPerSec(ctx, field)
+			case "throughputMetricsBytesPerSec":
+				return ec.fieldContext_GatewayDeploymentInfo_throughputMetricsBytesPerSec(ctx, field)
+			case "throughputLogsBytesPerSec":
+				return ec.fieldContext_GatewayDeploymentInfo_throughputLogsBytesPerSec(ctx, field)
 			case "resources":
 				return ec.fieldContext_GatewayDeploymentInfo_resources(ctx, field)
 			case "imageVersion":
@@ -45412,6 +45712,12 @@ func (ec *executionContext) fieldContext_Query_odigletDaemonSetInfo(_ context.Co
 				return ec.fieldContext_CollectorDaemonSetInfo_status(ctx, field)
 			case "nodes":
 				return ec.fieldContext_CollectorDaemonSetInfo_nodes(ctx, field)
+			case "throughputTracesBytesPerSec":
+				return ec.fieldContext_CollectorDaemonSetInfo_throughputTracesBytesPerSec(ctx, field)
+			case "throughputMetricsBytesPerSec":
+				return ec.fieldContext_CollectorDaemonSetInfo_throughputMetricsBytesPerSec(ctx, field)
+			case "throughputLogsBytesPerSec":
+				return ec.fieldContext_CollectorDaemonSetInfo_throughputLogsBytesPerSec(ctx, field)
 			case "resources":
 				return ec.fieldContext_CollectorDaemonSetInfo_resources(ctx, field)
 			case "imageVersion":
@@ -58554,6 +58860,12 @@ func (ec *executionContext) _CollectorDaemonSetInfo(ctx context.Context, sel ast
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "throughputTracesBytesPerSec":
+			out.Values[i] = ec._CollectorDaemonSetInfo_throughputTracesBytesPerSec(ctx, field, obj)
+		case "throughputMetricsBytesPerSec":
+			out.Values[i] = ec._CollectorDaemonSetInfo_throughputMetricsBytesPerSec(ctx, field, obj)
+		case "throughputLogsBytesPerSec":
+			out.Values[i] = ec._CollectorDaemonSetInfo_throughputLogsBytesPerSec(ctx, field, obj)
 		case "resources":
 			out.Values[i] = ec._CollectorDaemonSetInfo_resources(ctx, field, obj)
 		case "imageVersion":
@@ -60854,6 +61166,12 @@ func (ec *executionContext) _GatewayDeploymentInfo(ctx context.Context, sel ast.
 			}
 		case "hpa":
 			out.Values[i] = ec._GatewayDeploymentInfo_hpa(ctx, field, obj)
+		case "throughputTracesBytesPerSec":
+			out.Values[i] = ec._GatewayDeploymentInfo_throughputTracesBytesPerSec(ctx, field, obj)
+		case "throughputMetricsBytesPerSec":
+			out.Values[i] = ec._GatewayDeploymentInfo_throughputMetricsBytesPerSec(ctx, field, obj)
+		case "throughputLogsBytesPerSec":
+			out.Values[i] = ec._GatewayDeploymentInfo_throughputLogsBytesPerSec(ctx, field, obj)
 		case "resources":
 			out.Values[i] = ec._GatewayDeploymentInfo_resources(ctx, field, obj)
 		case "imageVersion":

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -158,9 +158,9 @@ type CodeAttributesInput struct {
 type CollectorDaemonSetInfo struct {
 	Status                       WorkloadRolloutStatus `json:"status"`
 	Nodes                        *NodesSummary         `json:"nodes"`
-	ThroughputTracesBytesPerSec  *float64              `json:"throughputTracesBytesPerSec,omitempty"`
-	ThroughputMetricsBytesPerSec *float64              `json:"throughputMetricsBytesPerSec,omitempty"`
-	ThroughputLogsBytesPerSec    *float64              `json:"throughputLogsBytesPerSec,omitempty"`
+	ThroughputTracesBytesPerSec  *int                  `json:"throughputTracesBytesPerSec,omitempty"`
+	ThroughputMetricsBytesPerSec *int                  `json:"throughputMetricsBytesPerSec,omitempty"`
+	ThroughputLogsBytesPerSec    *int                  `json:"throughputLogsBytesPerSec,omitempty"`
 	Resources                    *Resources            `json:"resources,omitempty"`
 	ImageVersion                 *string               `json:"imageVersion,omitempty"`
 	LastRolloutAt                *string               `json:"lastRolloutAt,omitempty"`
@@ -559,9 +559,9 @@ type FieldInput struct {
 type GatewayDeploymentInfo struct {
 	Status                       WorkloadRolloutStatus        `json:"status"`
 	Hpa                          *HorizontalPodAutoscalerInfo `json:"hpa,omitempty"`
-	ThroughputTracesBytesPerSec  *float64                     `json:"throughputTracesBytesPerSec,omitempty"`
-	ThroughputMetricsBytesPerSec *float64                     `json:"throughputMetricsBytesPerSec,omitempty"`
-	ThroughputLogsBytesPerSec    *float64                     `json:"throughputLogsBytesPerSec,omitempty"`
+	ThroughputTracesBytesPerSec  *int                         `json:"throughputTracesBytesPerSec,omitempty"`
+	ThroughputMetricsBytesPerSec *int                         `json:"throughputMetricsBytesPerSec,omitempty"`
+	ThroughputLogsBytesPerSec    *int                         `json:"throughputLogsBytesPerSec,omitempty"`
 	Resources                    *Resources                   `json:"resources,omitempty"`
 	ImageVersion                 *string                      `json:"imageVersion,omitempty"`
 	LastRolloutAt                *string                      `json:"lastRolloutAt,omitempty"`

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -156,14 +156,17 @@ type CodeAttributesInput struct {
 }
 
 type CollectorDaemonSetInfo struct {
-	Status            WorkloadRolloutStatus `json:"status"`
-	Nodes             *NodesSummary         `json:"nodes"`
-	Resources         *Resources            `json:"resources,omitempty"`
-	ImageVersion      *string               `json:"imageVersion,omitempty"`
-	LastRolloutAt     *string               `json:"lastRolloutAt,omitempty"`
-	RolloutInProgress bool                  `json:"rolloutInProgress"`
-	ManifestYaml      string                `json:"manifestYAML"`
-	ConfigMapYaml     string                `json:"configMapYAML"`
+	Status                       WorkloadRolloutStatus `json:"status"`
+	Nodes                        *NodesSummary         `json:"nodes"`
+	ThroughputTracesBytesPerSec  *float64              `json:"throughputTracesBytesPerSec,omitempty"`
+	ThroughputMetricsBytesPerSec *float64              `json:"throughputMetricsBytesPerSec,omitempty"`
+	ThroughputLogsBytesPerSec    *float64              `json:"throughputLogsBytesPerSec,omitempty"`
+	Resources                    *Resources            `json:"resources,omitempty"`
+	ImageVersion                 *string               `json:"imageVersion,omitempty"`
+	LastRolloutAt                *string               `json:"lastRolloutAt,omitempty"`
+	RolloutInProgress            bool                  `json:"rolloutInProgress"`
+	ManifestYaml                 string                `json:"manifestYAML"`
+	ConfigMapYaml                string                `json:"configMapYAML"`
 }
 
 type CollectorGatewayConfig struct {
@@ -554,14 +557,17 @@ type FieldInput struct {
 }
 
 type GatewayDeploymentInfo struct {
-	Status            WorkloadRolloutStatus        `json:"status"`
-	Hpa               *HorizontalPodAutoscalerInfo `json:"hpa,omitempty"`
-	Resources         *Resources                   `json:"resources,omitempty"`
-	ImageVersion      *string                      `json:"imageVersion,omitempty"`
-	LastRolloutAt     *string                      `json:"lastRolloutAt,omitempty"`
-	RolloutInProgress bool                         `json:"rolloutInProgress"`
-	ManifestYaml      string                       `json:"manifestYAML"`
-	ConfigMapYaml     string                       `json:"configMapYAML"`
+	Status                       WorkloadRolloutStatus        `json:"status"`
+	Hpa                          *HorizontalPodAutoscalerInfo `json:"hpa,omitempty"`
+	ThroughputTracesBytesPerSec  *float64                     `json:"throughputTracesBytesPerSec,omitempty"`
+	ThroughputMetricsBytesPerSec *float64                     `json:"throughputMetricsBytesPerSec,omitempty"`
+	ThroughputLogsBytesPerSec    *float64                     `json:"throughputLogsBytesPerSec,omitempty"`
+	Resources                    *Resources                   `json:"resources,omitempty"`
+	ImageVersion                 *string                      `json:"imageVersion,omitempty"`
+	LastRolloutAt                *string                      `json:"lastRolloutAt,omitempty"`
+	RolloutInProgress            bool                         `json:"rolloutInProgress"`
+	ManifestYaml                 string                       `json:"manifestYAML"`
+	ConfigMapYaml                string                       `json:"configMapYAML"`
 }
 
 type GetDestinationCategories struct {

--- a/frontend/services/collectors/gateway.go
+++ b/frontend/services/collectors/gateway.go
@@ -9,7 +9,9 @@ import (
 	"github.com/odigos-io/odigos/frontend/graph/model"
 	"github.com/odigos-io/odigos/frontend/kube"
 	"github.com/odigos-io/odigos/frontend/services"
+	"github.com/odigos-io/odigos/frontend/services/metrics"
 	"github.com/odigos-io/odigos/k8sutils/pkg/env"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
@@ -17,7 +19,7 @@ import (
 )
 
 // GetGatewayDeploymentInfo fetches Deployment/HPA and computes the header info for the gateway deployment.
-func GetGatewayDeploymentInfo(ctx context.Context) (*model.GatewayDeploymentInfo, error) {
+func GetGatewayDeploymentInfo(ctx context.Context, api v1.API) (*model.GatewayDeploymentInfo, error) {
 	ns := env.GetCurrentNamespace()
 
 	depList, err := kube.DefaultClient.AppsV1().Deployments(ns).List(ctx, metav1.ListOptions{LabelSelector: k8sconsts.OdigosCollectorRoleLabel + "=" + string(k8sconsts.CollectorsRoleClusterGateway)})
@@ -46,6 +48,24 @@ func GetGatewayDeploymentInfo(ctx context.Context) (*model.GatewayDeploymentInfo
 	result.RolloutInProgress = rolloutInProgress
 
 	result.Hpa = computeGatewayHPA(dep, hpa)
+
+	if api != nil {
+		if traceThroughput, err := metrics.GetThroughputBytesPerSec(ctx, api, metrics.MetricClusterGatewayTraceDataSize, metrics.DefaultMetricsWindow); err == nil {
+			result.ThroughputTracesBytesPerSec = &traceThroughput
+		} else {
+			log.Printf("failed to get gateway trace throughput: %v", err)
+		}
+		if metricsThroughput, err := metrics.GetThroughputBytesPerSec(ctx, api, metrics.MetricClusterGatewayMetricDataSize, metrics.DefaultMetricsWindow); err == nil {
+			result.ThroughputMetricsBytesPerSec = &metricsThroughput
+		} else {
+			log.Printf("failed to get gateway metrics throughput: %v", err)
+		}
+		if logThroughput, err := metrics.GetThroughputBytesPerSec(ctx, api, metrics.MetricClusterGatewayLogDataSize, metrics.DefaultMetricsWindow); err == nil {
+			result.ThroughputLogsBytesPerSec = &logThroughput
+		} else {
+			log.Printf("failed to get gateway logs throughput: %v", err)
+		}
+	}
 
 	if rr := extractResourcesForContainer(dep.Spec.Template.Spec.Containers, k8sconsts.OdigosClusterCollectorContainerName); rr != nil {
 		result.Resources = rr

--- a/frontend/services/collectors/odiglet.go
+++ b/frontend/services/collectors/odiglet.go
@@ -3,17 +3,20 @@ package collectors
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/odigos-io/odigos/api/k8sconsts"
 	"github.com/odigos-io/odigos/frontend/graph/model"
 	"github.com/odigos-io/odigos/frontend/kube"
 	"github.com/odigos-io/odigos/frontend/services"
+	"github.com/odigos-io/odigos/frontend/services/metrics"
 	"github.com/odigos-io/odigos/k8sutils/pkg/env"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func GetOdigletDaemonSetInfo(ctx context.Context) (*model.CollectorDaemonSetInfo, error) {
+func GetOdigletDaemonSetInfo(ctx context.Context, api v1.API) (*model.CollectorDaemonSetInfo, error) {
 	ns := env.GetCurrentNamespace()
 
 	dsList, err := kube.DefaultClient.AppsV1().DaemonSets(ns).List(ctx, metav1.ListOptions{LabelSelector: "app.kubernetes.io/name=odiglet"})
@@ -32,6 +35,24 @@ func GetOdigletDaemonSetInfo(ctx context.Context) (*model.CollectorDaemonSetInfo
 	nodes := &model.NodesSummary{Desired: int(ds.Status.DesiredNumberScheduled), Ready: int(ds.Status.NumberReady)}
 
 	result := &model.CollectorDaemonSetInfo{Status: status, Nodes: nodes, RolloutInProgress: inProgress, ImageVersion: services.StringPtr(extractImageVersionForContainer(ds.Spec.Template.Spec.Containers, k8sconsts.OdigosNodeCollectorContainerName)), LastRolloutAt: services.StringPtr(findDaemonSetLastRolloutTime(ctx, &ds))}
+
+	if api != nil {
+		if traceThroughput, err := metrics.GetThroughputBytesPerSec(ctx, api, metrics.MetricNodeCollectorTraceDataSize, metrics.DefaultMetricsWindow); err == nil {
+			result.ThroughputTracesBytesPerSec = &traceThroughput
+		} else {
+			log.Printf("failed to get node collector trace throughput: %v", err)
+		}
+		if metricsThroughput, err := metrics.GetThroughputBytesPerSec(ctx, api, metrics.MetricNodeCollectorMetricDataSize, metrics.DefaultMetricsWindow); err == nil {
+			result.ThroughputMetricsBytesPerSec = &metricsThroughput
+		} else {
+			log.Printf("failed to get node collector metrics throughput: %v", err)
+		}
+		if logThroughput, err := metrics.GetThroughputBytesPerSec(ctx, api, metrics.MetricNodeCollectorLogDataSize, metrics.DefaultMetricsWindow); err == nil {
+			result.ThroughputLogsBytesPerSec = &logThroughput
+		} else {
+			log.Printf("failed to get node collector logs throughput: %v", err)
+		}
+	}
 
 	if rr := extractResourcesForContainer(ds.Spec.Template.Spec.Containers, k8sconsts.OdigosNodeCollectorContainerName); rr != nil {
 		result.Resources = rr

--- a/frontend/services/metrics/collector_metrics.go
+++ b/frontend/services/metrics/collector_metrics.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"context"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/odigos-io/odigos/k8sutils/pkg/env"
@@ -180,7 +181,7 @@ func GetCollectorMetricsFromMetricsStore(ctx context.Context, api v1.API, namesp
 	return result, nil
 }
 
-func GetThroughputBytesPerSec(ctx context.Context, api v1.API, metricName, window string) (float64, error) {
+func GetThroughputBytesPerSec(ctx context.Context, api v1.API, metricName, window string) (int, error) {
 	if api == nil {
 		return 0, fmt.Errorf("own-metrics API is nil")
 	}
@@ -196,5 +197,5 @@ func GetThroughputBytesPerSec(ctx context.Context, api v1.API, metricName, windo
 	if !ok || len(vec) == 0 {
 		return 0, nil
 	}
-	return float64(vec[0].Value), nil
+	return int(math.Round(float64(vec[0].Value))), nil
 }

--- a/frontend/services/metrics/collector_metrics.go
+++ b/frontend/services/metrics/collector_metrics.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
 )
 
 const (
@@ -39,6 +40,16 @@ const (
 	// eBPF core metrics
 	metricEBPFCoreSentEvents   = "odigos_ebpf_events_sent"
 	metricEBPFCoreFailedEvents = "odigos_ebpf_events_send_failed"
+
+	// Throughput metrics from odigostrafficmetrics
+	// Node collector: OTLP push keeps the collector meter name
+	// Cluster gateway: Prometheus scrape adds unit+counter suffixes (_bytes_total)
+	MetricNodeCollectorTraceDataSize   = "otelcol_odigos_trace_data_size"
+	MetricNodeCollectorMetricDataSize  = "otelcol_odigos_metric_data_size"
+	MetricNodeCollectorLogDataSize     = "otelcol_odigos_log_data_size"
+	MetricClusterGatewayTraceDataSize  = "otelcol_odigos_trace_data_size_bytes_total"
+	MetricClusterGatewayMetricDataSize = "otelcol_odigos_metric_data_size_bytes_total"
+	MetricClusterGatewayLogDataSize    = "otelcol_odigos_log_data_size_bytes_total"
 )
 
 type PodRates struct {
@@ -167,4 +178,23 @@ func GetCollectorMetricsFromMetricsStore(ctx context.Context, api v1.API, namesp
 	}
 
 	return result, nil
+}
+
+func GetThroughputBytesPerSec(ctx context.Context, api v1.API, metricName, window string) (float64, error) {
+	if api == nil {
+		return 0, fmt.Errorf("own-metrics API is nil")
+	}
+	if window == "" {
+		window = DefaultMetricsWindow
+	}
+	query := fmt.Sprintf("sum(rate(%s[%s]))", metricName, window)
+	val, _, err := api.Query(ctx, query, time.Now())
+	if err != nil {
+		return 0, err
+	}
+	vec, ok := val.(model.Vector)
+	if !ok || len(vec) == 0 {
+		return 0, nil
+	}
+	return float64(vec[0].Value), nil
 }

--- a/frontend/webapp/graphql/queries/pipeline-collectors.ts
+++ b/frontend/webapp/graphql/queries/pipeline-collectors.ts
@@ -16,6 +16,9 @@ export const GET_GATEWAY_INFO = gql`
           message
         }
       }
+      throughputTracesBytesPerSec
+      throughputMetricsBytesPerSec
+      throughputLogsBytesPerSec
       resources {
         requests {
           cpu
@@ -65,6 +68,9 @@ export const GET_NODE_COLLECTOR_INFO = gql`
         desired
         ready
       }
+      throughputTracesBytesPerSec
+      throughputMetricsBytesPerSec
+      throughputLogsBytesPerSec
       resources {
         requests {
           cpu


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Expose data throughput for node and cluster collector by scraping otelcol_*_metric_data_size from VictoriaMetrics which were generated by odigostrafficmetrics.

Important note:
The `odigostrafficmetrics` processor is located differently in the pipelines for node and cluster collectors -
In the node collector, this is for the throughput that goes through the node collector, so head sampled data is taken into consideration, while tail sampled does not.
In the cluster collector, this is the throughput that is sent to the destinations.
**this means that if we send to multiple destinations per signal, we will multiply the throughput**

This is used to help customers select the right resource sizing for their cluster.


<img width="2434" height="712" alt="image" src="https://github.com/user-attachments/assets/c620ced2-9ddc-4656-9754-04b4c198163b" />

Related ui-kit PR:
https://github.com/odigos-io/ui-kit/pull/1111



#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Show data collectors (node, clusters) data throughput when activating MetricsStore (VictoriaMetrics) in the collectors pipeline page
```
