### PR TITLE
fix(helm): grant central proxy DeploymentConfig access

### DIFF
--- a/helm/odigos/templates/centralproxy/clusterrole.yaml
+++ b/helm/odigos/templates/centralproxy/clusterrole.yaml
@@ -15,6 +15,11 @@ rules:
   - apiGroups: ["batch"]
     resources: ["cronjobs"]
     verbs: ["list", "watch"]
+{{- if .Values.openshift.enabled }}
+  - apiGroups: ["apps.openshift.io"]
+    resources: ["deploymentconfigs"]
+    verbs: ["list", "watch"]
+{{- end }}
   - apiGroups: ["odigos.io"]
     resources: ["instrumentationconfigs", "sources"]
     verbs: ["list", "watch"]


### PR DESCRIPTION
Grant the central proxy permission to discover OpenShift DeploymentConfigs when OpenShift support is enabled.

#### What this PR does / why we need it:
The central proxy now includes DeploymentConfig workloads in cluster snapshots, but its ClusterRole did not allow listing or watching that OpenShift resource. Without this permission, DeploymentConfigs remain missing from Central source lists.

This conditionally grants `list` and `watch` access to `apps.openshift.io/deploymentconfigs` when `openshift.enabled=true`. This accompanies https://github.com/odigos-io/odigos-enterprise/pull/3239.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
Fixed DeploymentConfig workloads missing from Central source lists on OpenShift clusters.
```

cherry-pick v1.32