### PR TITLE
Cherry-pick: fix(helm): grant central proxy DeploymentConfig access (backport to v1.32)

### DIFF
--- a/helm/odigos/templates/centralproxy/clusterrole.yaml
+++ b/helm/odigos/templates/centralproxy/clusterrole.yaml
@@ -15,6 +15,11 @@ rules:
   - apiGroups: ["batch"]
     resources: ["cronjobs"]
     verbs: ["list", "watch"]
+{{- if .Values.openshift.enabled }}
+  - apiGroups: ["apps.openshift.io"]
+    resources: ["deploymentconfigs"]
+    verbs: ["list", "watch"]
+{{- end }}
   - apiGroups: ["odigos.io"]
     resources: ["instrumentationconfigs", "sources"]
     verbs: ["list", "watch"]


### PR DESCRIPTION
Backports #5331 to the v1.32 release branch.

#### What this PR does / why we need it:
The central proxy needs `list` and `watch` access to OpenShift DeploymentConfigs so the enterprise snapshot fix can include those workloads in Central source lists.

This conditionally grants the required RBAC when `openshift.enabled=true`.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
Fixed DeploymentConfig workloads missing from Central source lists on OpenShift clusters.
```

cherry-pick: v1.32