### PR TITLE
CORE-1331: fix webhook cert CI flake by waiting for the webhook to serve (no restart)

### DIFF
--- a/tests/common/assert/instrumentor-webhook-ready.yaml
+++ b/tests/common/assert/instrumentor-webhook-ready.yaml
@@ -1,0 +1,16 @@
+# The instrumentor's injection webhook only serves once its pods roll out to the
+# new version and become Ready — readiness gates on the serving cert being mounted
+# and the webhooks being registered. On a fresh install/upgrade the cert reaches
+# the pod through the mounted Secret, which the kubelet can take 30-100s to sync
+# (open-policy-agent/cert-controller#35). Asserting the rollout is complete here
+# lets the e2e wait out that window, avoiding the race where a workload is rolled
+# out and admitted without injection because the webhook isn't serving yet.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: odigos-instrumentor
+  namespace: odigos-test
+status:
+  # both replicas are on the new version AND Ready => webhook cert mounted + serving
+  updatedReplicas: 2
+  readyReplicas: 2

--- a/tests/e2e/cli-upgrade/chainsaw-test.yaml
+++ b/tests/e2e/cli-upgrade/chainsaw-test.yaml
@@ -141,9 +141,20 @@ spec:
             timeout: 1m10s
             file: ../../common/assert/pipeline-ready.yaml
 
+    # Wait for the upgraded instrumentor's injection webhook to actually serve
+    # (pods rolled out + Ready = serving cert mounted) before checking that the
+    # demo apps are instrumented. Without this, the workload rollout can race the
+    # kubelet secret-volume sync (cert-controller#35) and be admitted uninjected.
+    - name: Wait for instrumentor webhook to be serving after upgrade
+      try:
+        - assert:
+            timeout: 1m
+            file: ../../common/assert/instrumentor-webhook-ready.yaml
+
     - name: Simple-demo instrumented after upgrade
       try:
         - assert:
+            timeout: 3m
             file: ../../common/assert/simple-demo-instrumented.yaml
 
     - name: Generate Traffic

--- a/tests/e2e/helm-upgrade/chainsaw-test.yaml
+++ b/tests/e2e/helm-upgrade/chainsaw-test.yaml
@@ -160,9 +160,20 @@ spec:
             timeout: 1m10s
             file: ../../common/assert/pipeline-ready.yaml
 
+    # Wait for the upgraded instrumentor's injection webhook to actually serve
+    # (pods rolled out + Ready = serving cert mounted) before checking that the
+    # demo apps are instrumented. Without this, the workload rollout can race the
+    # kubelet secret-volume sync (cert-controller#35) and be admitted uninjected.
+    - name: Wait for instrumentor webhook to be serving after upgrade
+      try:
+        - assert:
+            timeout: 1m
+            file: ../../common/assert/instrumentor-webhook-ready.yaml
+
     - name: Simple-demo instrumented after upgrade
       try:
         - assert:
+            timeout: 3m
             file: ../../common/assert/simple-demo-instrumented.yaml
 
     - name: Generate Traffic


### PR DESCRIPTION
unblocking ci


```release-note
NONE
```