### PR TITLE
CORE-1335 | fix: restore EKS-safe chainsaw timeouts

### DIFF
--- a/tests/e2e/helm-chart/chainsaw-test.yaml
+++ b/tests/e2e/helm-chart/chainsaw-test.yaml
@@ -54,7 +54,7 @@ spec:
     - name: Verify Odigos Installation
       try:
         - script:
-            timeout: 2m
+            timeout: 6m
             content: |
               echo "Starting Odigos version check..."
               export ACTUAL_VERSION=$(../../../cli/odigos version --cluster)

--- a/tests/e2e/source/chainsaw-test.yaml
+++ b/tests/e2e/source/chainsaw-test.yaml
@@ -19,7 +19,7 @@ spec:
     - name: '[1 - Setup] Install Odigos'
       try:
         - script:
-            timeout: 2m
+            timeout: 4m
             content: |
               if [ "$MODE" = "cross-cloud-tests" ]; then
                 ../../../cli/odigos install --ns odigos-test --set image.tag="$COMMIT_HASH" --set imagePrefix=public.ecr.aws/y2v0v6s7


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: CORE-1335

Nightly cross-cloud EKS jobs (`source` and `helm-chart`, both arm/amd) have failed every run since 2026-07-13, right after #5148 right-sized chainsaw `timeout:` values to measured duration + 60s.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
```release-note
NONE
```
