### PR TITLE
sqlquery: handle cassandra as SQL best effort

### DIFF
--- a/collector/processors/odigossqlqueryprocessor/dialect.go
+++ b/collector/processors/odigossqlqueryprocessor/dialect.go
@@ -37,8 +37,14 @@ var dbmsBySystem = map[string]sqllexer.DBMSType{
 // nonSQLSystems are db.system / db.system.name values that are known not to be SQL
 // and should skip literal redaction and attribute inference.
 var nonSQLSystems = map[string]struct{}{
+
+	// cassandra is CQL, not SQL
+	// sometimes the tokenizer will work but not always.
+	// for now we treat it as SQL and we should consider to have CQL tokenizer later on.
+	//
+	// semconv.DBSystemCassandra.Value.AsString(): {},
+
 	// db.system (semconv v1.26)
-	semconv.DBSystemCassandra.Value.AsString():     {},
 	semconv.DBSystemHBase.Value.AsString():         {},
 	semconv.DBSystemMongoDB.Value.AsString():       {},
 	semconv.DBSystemRedis.Value.AsString():         {},
@@ -53,7 +59,6 @@ var nonSQLSystems = map[string]struct{}{
 	semconv.DBSystemOpensearch.Value.AsString():    {},
 
 	// db.system.name (semconv v1.37+)
-	semconv137.DBSystemNameCassandra.Value.AsString():     {},
 	semconv137.DBSystemNameHBase.Value.AsString():         {},
 	semconv137.DBSystemNameMongoDB.Value.AsString():       {},
 	semconv137.DBSystemNameRedis.Value.AsString():         {},

--- a/collector/processors/odigossqlqueryprocessor/processor.go
+++ b/collector/processors/odigossqlqueryprocessor/processor.go
@@ -18,7 +18,11 @@ import (
 	"github.com/odigos-io/odigos/common/collector"
 )
 
-const dbStatementKey = "db.statement"
+const (
+	dbStatementKey = "db.statement"
+	dbOperationKey = "db.operation"
+	dbSQLTableKey  = "db.sql.table"
+)
 
 type sqlQueryProcessor struct {
 	logger     *zap.Logger
@@ -114,14 +118,6 @@ func (p *sqlQueryProcessor) resolveSourceConfig(resource pcommon.Resource) (*com
 func (p *sqlQueryProcessor) processSpan(span ptrace.Span, inferAttributes, redactLiterals bool) {
 	attrs := span.Attributes()
 
-	opAttr, hasOperation := attrs.Get(string(semconv.DBOperationNameKey))
-	collAttr, hasCollection := attrs.Get(string(semconv.DBCollectionNameKey))
-	inferNeeded := inferAttributes && !(hasOperation && hasCollection)
-
-	if !inferNeeded && !redactLiterals {
-		return
-	}
-
 	dbms, skip := resolveDBMS(attrs)
 	if skip {
 		return
@@ -132,6 +128,10 @@ func (p *sqlQueryProcessor) processSpan(span ptrace.Span, inferAttributes, redac
 		return
 	}
 
+	operation, hasOperation := operationFromAttributes(attrs)
+	collection, hasCollection := collectionFromAttributes(attrs)
+	inferNeeded := inferAttributes && !(hasOperation && hasCollection)
+
 	switch {
 	case redactLiterals && inferNeeded:
 		normalized, meta, err := p.obfuscateAndNormalize(query, dbms)
@@ -141,7 +141,7 @@ func (p *sqlQueryProcessor) processSpan(span ptrace.Span, inferAttributes, redac
 			return
 		}
 		attrs.PutStr(queryKey, normalized)
-		p.enhanceFromMetadata(span, opAttr, hasOperation, collAttr, hasCollection, meta)
+		p.enhanceFromMetadata(span, operation, hasOperation, collection, hasCollection, meta)
 	case redactLiterals:
 		attrs.PutStr(queryKey, p.obfuscate(query, dbms))
 	case inferNeeded:
@@ -150,7 +150,7 @@ func (p *sqlQueryProcessor) processSpan(span ptrace.Span, inferAttributes, redac
 			p.logger.Debug("failed to normalize SQL query", zap.Error(err))
 			return
 		}
-		p.enhanceFromMetadata(span, opAttr, hasOperation, collAttr, hasCollection, meta)
+		p.enhanceFromMetadata(span, operation, hasOperation, collection, hasCollection, meta)
 	}
 }
 
@@ -179,9 +179,9 @@ func (p *sqlQueryProcessor) normalize(query string, dbms sqllexer.DBMSType) (*sq
 
 func (p *sqlQueryProcessor) enhanceFromMetadata(
 	span ptrace.Span,
-	opAttr pcommon.Value,
+	operation string,
 	hasOperation bool,
-	collAttr pcommon.Value,
+	collection string,
 	hasCollection bool,
 	meta *sqllexer.StatementMetadata,
 ) {
@@ -193,19 +193,13 @@ func (p *sqlQueryProcessor) enhanceFromMetadata(
 	ops := sqlOperations(meta.Commands)
 	added := false
 
-	operation := ""
-	if hasOperation {
-		operation = opAttr.Str()
-	} else if len(ops) == 1 {
+	if !hasOperation && len(ops) == 1 {
 		operation = ops[0]
 		attrs.PutStr(string(semconv.DBOperationNameKey), operation)
 		added = true
 	}
 
-	collection := ""
-	if hasCollection {
-		collection = collAttr.Str()
-	} else if len(meta.Tables) == 1 {
+	if !hasCollection && len(meta.Tables) == 1 {
 		collection = meta.Tables[0]
 		attrs.PutStr(string(semconv.DBCollectionNameKey), collection)
 		added = true
@@ -236,16 +230,42 @@ func spanNameAlreadyHas(name, operation, collection string) bool {
 
 func sqlQueryFromAttributes(attrs pcommon.Map) (query string, key string, ok bool) {
 	for _, attrKey := range []string{string(semconv.DBQueryTextKey), dbStatementKey} {
-		val, found := attrs.Get(attrKey)
-		if !found || val.Type() != pcommon.ValueTypeStr {
-			continue
-		}
-		query = val.Str()
-		if query != "" {
+		query, ok = stringAttrFromAttributes(attrs, attrKey)
+		if ok {
 			return query, attrKey, true
 		}
 	}
 	return "", "", false
+}
+
+func operationFromAttributes(attrs pcommon.Map) (string, bool) {
+	for _, attrKey := range []string{string(semconv.DBOperationNameKey), dbOperationKey} {
+		if op, ok := stringAttrFromAttributes(attrs, attrKey); ok {
+			return op, true
+		}
+	}
+	return "", false
+}
+
+func collectionFromAttributes(attrs pcommon.Map) (string, bool) {
+	for _, attrKey := range []string{string(semconv.DBCollectionNameKey), dbSQLTableKey} {
+		if coll, ok := stringAttrFromAttributes(attrs, attrKey); ok {
+			return coll, true
+		}
+	}
+	return "", false
+}
+
+func stringAttrFromAttributes(attrs pcommon.Map, key string) (string, bool) {
+	val, found := attrs.Get(key)
+	if !found || val.Type() != pcommon.ValueTypeStr {
+		return "", false
+	}
+	s := val.Str()
+	if s == "" {
+		return "", false
+	}
+	return s, true
 }
 
 // sqlOperations returns SQL commands suitable for db.operation.name,

--- a/collector/processors/odigossqlqueryprocessor/processor.go
+++ b/collector/processors/odigossqlqueryprocessor/processor.go
@@ -10,18 +10,13 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/processor"
+	semconv125 "go.opentelemetry.io/otel/semconv/v1.25.0"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.uber.org/zap"
 
 	commonapi "github.com/odigos-io/odigos/common/api"
 	"github.com/odigos-io/odigos/common/api/actions"
 	"github.com/odigos-io/odigos/common/collector"
-)
-
-const (
-	dbStatementKey = "db.statement"
-	dbOperationKey = "db.operation"
-	dbSQLTableKey  = "db.sql.table"
 )
 
 type sqlQueryProcessor struct {
@@ -229,7 +224,7 @@ func spanNameAlreadyHas(name, operation, collection string) bool {
 }
 
 func sqlQueryFromAttributes(attrs pcommon.Map) (query string, key string, ok bool) {
-	for _, attrKey := range []string{string(semconv.DBQueryTextKey), dbStatementKey} {
+	for _, attrKey := range []string{string(semconv.DBQueryTextKey), string(semconv125.DBStatementKey)} {
 		query, ok = stringAttrFromAttributes(attrs, attrKey)
 		if ok {
 			return query, attrKey, true
@@ -239,7 +234,7 @@ func sqlQueryFromAttributes(attrs pcommon.Map) (query string, key string, ok boo
 }
 
 func operationFromAttributes(attrs pcommon.Map) (string, bool) {
-	for _, attrKey := range []string{string(semconv.DBOperationNameKey), dbOperationKey} {
+	for _, attrKey := range []string{string(semconv.DBOperationNameKey), string(semconv125.DBOperationKey)} {
 		if op, ok := stringAttrFromAttributes(attrs, attrKey); ok {
 			return op, true
 		}
@@ -248,7 +243,7 @@ func operationFromAttributes(attrs pcommon.Map) (string, bool) {
 }
 
 func collectionFromAttributes(attrs pcommon.Map) (string, bool) {
-	for _, attrKey := range []string{string(semconv.DBCollectionNameKey), dbSQLTableKey} {
+	for _, attrKey := range []string{string(semconv.DBCollectionNameKey), string(semconv125.DBSQLTableKey)} {
 		if coll, ok := stringAttrFromAttributes(attrs, attrKey); ok {
 			return coll, true
 		}

--- a/collector/processors/odigossqlqueryprocessor/processor_test.go
+++ b/collector/processors/odigossqlqueryprocessor/processor_test.go
@@ -8,6 +8,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/processor/processortest"
+	semconv125 "go.opentelemetry.io/otel/semconv/v1.25.0"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 
 	commonapi "github.com/odigos-io/odigos/common/api"
@@ -56,7 +57,7 @@ func TestInferAttributes_FromDbQueryText(t *testing.T) {
 func TestInferAttributes_FromDbStatement(t *testing.T) {
 	proc := newTestProcessor(t, &Config{InferAttributes: true})
 	traces := generateTestTrace(map[string]string{
-		dbStatementKey: "INSERT INTO orders VALUES (1)",
+		string(semconv125.DBStatementKey): "INSERT INTO orders VALUES (1)",
 	})
 
 	out, err := proc.processTraces(context.Background(), traces)
@@ -76,8 +77,8 @@ func TestInferAttributes_FromDbStatement(t *testing.T) {
 func TestInferAttributes_PrefersDbQueryTextOverDbStatement(t *testing.T) {
 	proc := newTestProcessor(t, &Config{InferAttributes: true})
 	traces := generateTestTrace(map[string]string{
-		string(semconv.DBQueryTextKey): "SELECT * FROM users",
-		dbStatementKey:                 "DELETE FROM orders",
+		string(semconv.DBQueryTextKey):    "SELECT * FROM users",
+		string(semconv125.DBStatementKey): "DELETE FROM orders",
 	})
 
 	out, err := proc.processTraces(context.Background(), traces)
@@ -266,14 +267,14 @@ func TestRedactLiterals_WhenAttributesAlreadyPresent(t *testing.T) {
 func TestRedactLiterals_DbStatement(t *testing.T) {
 	proc := newTestProcessor(t, &Config{RedactLiterals: true})
 	traces := generateTestTrace(map[string]string{
-		dbStatementKey: "INSERT INTO orders VALUES (1, 'x')",
+		string(semconv125.DBStatementKey): "INSERT INTO orders VALUES (1, 'x')",
 	})
 
 	out, err := proc.processTraces(context.Background(), traces)
 	require.NoError(t, err)
 
 	span := out.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
-	query, ok := span.Attributes().Get(dbStatementKey)
+	query, ok := span.Attributes().Get(string(semconv125.DBStatementKey))
 	require.True(t, ok)
 	require.Equal(t, "INSERT INTO orders VALUES (?, ?)", query.Str())
 }

--- a/tests/common/apply/kind-config.yaml
+++ b/tests/common/apply/kind-config.yaml
@@ -4,3 +4,9 @@ nodes:
   - role: control-plane
   - role: worker
 
+kubeadmConfigPatches:
+- |
+  apiVersion: kubelet.config.k8s.io/v1beta1
+  kind: KubeletConfiguration
+  serializeImagePulls: false
+  maxParallelImagePulls: 5


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: RUN-909

handle cassandra as SQL db for the db infere attributes and db templatization.
they are CQL but will be tokenize as SQL which will work most of the times (but not always).

in future PR we will improve cassandra sql processor handling

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
process cassandra as sql for infer db attributes and db query templatization
```
