### PR TITLE
RUN-933 | chore: update base image to golang 1.26.5

### DIFF
--- a/odiglet/base.Dockerfile
+++ b/odiglet/base.Dockerfile
@@ -22,7 +22,7 @@ RUN wget https://download.samba.org/pub/rsync/src/rsync-${RSYNC_VERSION}.tar.gz 
     && cd .. \
     && rm -rf rsync-${RSYNC_VERSION}*
 
-FROM golang:1.26.4-trixie
+FROM golang:1.26.5-trixie
 
 # goreleaser is used to build vmagent
 RUN echo "deb [trusted=yes] https://repo.goreleaser.com/apt/ /" > /etc/apt/sources.list.d/goreleaser.list


### PR DESCRIPTION
resolve vulns, stay frosty
```release-note
chore: upgrade base image to 1.26.5
```
