### PR TITLE
RUN-934 | chore: upgrade base image to v1.18

### DIFF
--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -1,4 +1,4 @@
-ARG ODIGLET_BASE_IMAGE=registry.odigos.io/odiglet-base:v1.17
+ARG ODIGLET_BASE_IMAGE=registry.odigos.io/odiglet-base:v1.18
 
 FROM --platform=$BUILDPLATFORM busybox:1.36.1 AS dotnet-builder
 WORKDIR /dotnet-instrumentation

--- a/odiglet/debug.Dockerfile
+++ b/odiglet/debug.Dockerfile
@@ -1,4 +1,4 @@
-ARG ODIGLET_BASE_IMAGE=registry.odigos.io/odiglet-base:v1.17
+ARG ODIGLET_BASE_IMAGE=registry.odigos.io/odiglet-base:v1.18
 
 
 ######### python Native Community Agent #########


### PR DESCRIPTION

```release-note
chore: upgrade base image to v1.18
```
