### PR TITLE
CORE-1347: Fix Observe destination

### DIFF
--- a/common/config/observe.go
+++ b/common/config/observe.go
@@ -6,6 +6,7 @@ import (
 
 const (
 	OBSERVE_CUSTOMER_ID = "OBSERVE_CUSTOMER_ID"
+	OBSERVE_ENDPOINT    = "OBSERVE_ENDPOINT"
 )
 
 type Observe struct{}
@@ -19,20 +20,37 @@ func (j *Observe) ModifyConfig(dest ExporterConfigurer, cfg *Config) ([]string, 
 	uniqueUri := "observe-" + dest.GetID()
 	var pipelineNames []string
 
-	customerId, exists := config[OBSERVE_CUSTOMER_ID]
-	if !exists {
-		return nil, errorMissingKey(OBSERVE_CUSTOMER_ID)
+	// OBSERVE_ENDPOINT lets users provide the full collection endpoint directly (e.g. for regional
+	// tenants such as "https://<customer_id>.collect.eu1.observeinc.com/v2/otel"). When it is not set,
+	// the endpoint is derived from the customer ID for the default (US) region.
+	endpoint := config[OBSERVE_ENDPOINT]
+	if endpoint == "" {
+		customerId, exists := config[OBSERVE_CUSTOMER_ID]
+		if !exists {
+			return nil, errorMissingKey(OBSERVE_CUSTOMER_ID)
+		}
+		endpoint = "https://" + customerId + ".collect.observeinc.com/v2/otel"
 	}
 
-	exporterName := "otlp_http/" + uniqueUri
-	cfg.Exporters[exporterName] = GenericMap{
-		"endpoint": "https://" + customerId + ".collect.observeinc.com/v2/otel",
-		"headers": GenericMap{
-			"Authorization": "Bearer ${OBSERVE_TOKEN}",
-		},
+	// Observe routes OTLP data to a Datastream using the "x-observe-target-package" header.
+	// Without it the collect endpoint rejects requests with HTTP 415 "no datastream can process
+	// the request". The value selects the Observe app that models the data and differs per signal,
+	// so each signal needs its own exporter. See
+	// https://docs.observeinc.com/docs/configure-your-own-otel-collector
+	newExporter := func(signal, targetPackage string) string {
+		exporterName := "otlp_http/" + signal + "-" + uniqueUri
+		cfg.Exporters[exporterName] = GenericMap{
+			"endpoint": endpoint,
+			"headers": GenericMap{
+				"authorization":            "Bearer ${OBSERVE_TOKEN}",
+				"x-observe-target-package": targetPackage,
+			},
+		}
+		return exporterName
 	}
 
 	if isTracingEnabled(dest) {
+		exporterName := newExporter("traces", "Tracing")
 		pipeName := "traces/" + uniqueUri
 		cfg.Service.Pipelines[pipeName] = Pipeline{
 			Exporters: []string{exporterName},
@@ -41,6 +59,7 @@ func (j *Observe) ModifyConfig(dest ExporterConfigurer, cfg *Config) ([]string, 
 	}
 
 	if isMetricsEnabled(dest) {
+		exporterName := newExporter("metrics", "Metrics")
 		pipeName := "metrics/" + uniqueUri
 		cfg.Service.Pipelines[pipeName] = Pipeline{
 			Exporters: []string{exporterName},
@@ -49,6 +68,7 @@ func (j *Observe) ModifyConfig(dest ExporterConfigurer, cfg *Config) ([]string, 
 	}
 
 	if isLoggingEnabled(dest) {
+		exporterName := newExporter("logs", "Host Explorer")
 		pipeName := "logs/" + uniqueUri
 		cfg.Service.Pipelines[pipeName] = Pipeline{
 			Exporters: []string{exporterName},

--- a/destinations/data/observe.yaml
+++ b/destinations/data/observe.yaml
@@ -30,9 +30,18 @@ spec:
       componentProps:
         type: password
         required: true
-        tooltip: You can create a token in your Observe dashboard, under "Datastreams".
+        tooltip: A Datastream ingest token (not a user/API token). Create one in the Observe UI under "Datastreams". See https://docs.observeinc.com/docs/configure-your-own-otel-collector-in-a-non-kubernetes-environment for how to create an ingest token.
+    - name: OBSERVE_ENDPOINT
+      displayName: Collection Endpoint
+      componentType: input
+      componentProps:
+        type: text
+        required: false
+        placeholder: https://<customer_id>.collect.observeinc.com/v2/otel
+        tooltip: 'Optional. The full OTLP/HTTP collection endpoint. Set this to override the default, for example for a regional tenant such as `https://<customer_id>.collect.eu1.observeinc.com/v2/otel`. When empty, it is derived from the Customer ID. See https://docs.observeinc.com/docs/configure-your-own-otel-collector for the endpoint format.'
   note:
     type: Check
     content: |
-      We handle the endpoint internally, so you don't need to provide it.
-      - The endpoint is `https://${OBSERVE_CUSTOMER_ID}.collect.observeinc.com/v2/otel`
+      By default the endpoint is derived from your Customer ID as `https://${OBSERVE_CUSTOMER_ID}.collect.observeinc.com/v2/otel`.
+      To send to a different endpoint (for example a regional tenant), set the optional `OBSERVE_ENDPOINT` field.
+      For details on the collection endpoint and creating an ingest token, see Observe's guides for [configuring your own OTel collector](https://docs.observeinc.com/docs/configure-your-own-otel-collector) and [configuring it without Kubernetes](https://docs.observeinc.com/docs/configure-your-own-otel-collector-in-a-non-kubernetes-environment).

--- a/docs/snippets/shared/backends/observe.mdx
+++ b/docs/snippets/shared/backends/observe.mdx
@@ -24,6 +24,12 @@ icon: 'signal-stream'
     !! START CUSTOM EDIT !!
 */}
 
+**Creating an ingest token**<br />
+Data is sent to Observe's OTLP collection endpoint, which requires a **Datastream ingest token** (a user/API token will be rejected with `401`). Create one in the Observe UI under **Datastreams**, following [Configure your own OTel collector without Kubernetes](https://docs.observeinc.com/docs/configure-your-own-otel-collector-in-a-non-kubernetes-environment).
+
+**Collection endpoint**<br />
+By default the endpoint is `https://<customer_id>.collect.observeinc.com/v2/otel`. For regional tenants or other overrides, set the optional `OBSERVE_ENDPOINT` field. See [Configure your own OTel collector](https://docs.observeinc.com/docs/configure-your-own-otel-collector) for the endpoint format.
+
 {/*
     !! Do not remove this comment, this acts as a key indicator in `docs/sync-dest-doc.py` !!
     !! END CUSTOM EDIT !!
@@ -40,12 +46,16 @@ icon: 'signal-stream'
 
 - **OBSERVE_CUSTOMER_ID** `string` : Customer ID. The Customer ID is the first part of your Observe URL. For example, if your Observe URL is `https://<customer_id>.observe.com`, then the Customer ID is `<customer_id>`.
   - This field is required
-- **OBSERVE_TOKEN** `string` : Token. You can create a token in your Observe dashboard, under "Datastreams".
+- **OBSERVE_TOKEN** `string` : Token. A Datastream ingest token (not a user/API token). Create one in the Observe UI under "Datastreams". See https://docs.observeinc.com/docs/configure-your-own-otel-collector-in-a-non-kubernetes-environment for how to create an ingest token.
   - This field is required
+- **OBSERVE_ENDPOINT** `string` : Collection Endpoint. Optional. The full OTLP/HTTP collection endpoint. Set this to override the default, for example for a regional tenant such as `https://<customer_id>.collect.eu1.observeinc.com/v2/otel`. When empty, it is derived from the Customer ID. See https://docs.observeinc.com/docs/configure-your-own-otel-collector for the endpoint format.
+  - This field is optional
+  - Example: `https://<customer_id>.collect.observeinc.com/v2/otel`
 
 <Check>
-  We handle the endpoint internally, so you don't need to provide it.
-  - The endpoint is `https://${OBSERVE_CUSTOMER_ID}.collect.observeinc.com/v2/otel`
+  By default the endpoint is derived from your Customer ID as `https://${OBSERVE_CUSTOMER_ID}.collect.observeinc.com/v2/otel`.
+  To send to a different endpoint (for example a regional tenant), set the optional `OBSERVE_ENDPOINT` field.
+  For details on the collection endpoint and creating an ingest token, see Observe's guides for [configuring your own OTel collector](https://docs.observeinc.com/docs/configure-your-own-otel-collector) and [configuring it without Kubernetes](https://docs.observeinc.com/docs/configure-your-own-otel-collector-in-a-non-kubernetes-environment).
 </Check>
 
 ### Adding Destination to Odigos
@@ -80,6 +90,8 @@ There are two primary methods for configuring destinations in Odigos:
     spec:
       data:
         OBSERVE_CUSTOMER_ID: <Customer ID>
+        # Note: The commented fields below are optional.
+        # OBSERVE_ENDPOINT: <Collection Endpoint>
       destinationName: observe
       secretRef:
         name: observe-secret


### PR DESCRIPTION
#### What this PR does / why we need it:
The Observe endpoint needs 3 things:

* observe endpoint
* ingest token header
* x-observe-target-package header

We are currently using the default US observe endpoint for every customer, so this updates the Observe destination to support a full endpoint url.

We are also missing the target-package header which is signal specific, this adds that.

Observe's own docs aren't very great about this setup, but there are some key pages so I updated the destination docs to point to those.

cherry-pick:v1.32

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
fix(destinations): Observe destination add target-package header and support full endpoint url
```
