### PR TITLE
fix: odigostrafficmetrics processor breaks profiles pipeline on gateway startup

### DIFF
--- a/autoscaler/controllers/clustercollector/configmap.go
+++ b/autoscaler/controllers/clustercollector/configmap.go
@@ -411,6 +411,10 @@ func isOdigosTrafficMetricsProcessorRelevant(name string, destinationPipelines [
 	if name == "metrics/otelcol" {
 		return false
 	}
+	// the odigostrafficmetrics processor does not support the profiles signal in the pinned collector build.
+	if strings.HasPrefix(name, "profiles/") {
+		return false
+	}
 	// we should add the odigostrafficmetrics processor to all destination pipelines
 	if slices.Contains(destinationPipelines, name) {
 		return true

--- a/autoscaler/controllers/clustercollector/configmap_test.go
+++ b/autoscaler/controllers/clustercollector/configmap_test.go
@@ -132,3 +132,24 @@ func TestAddSelfTelemetryPipeline(t *testing.T) {
 		})
 	}
 }
+
+func TestAddSelfTelemetryPipeline_ProfilesPipelineExcludesTrafficMetrics(t *testing.T) {
+	// the odigostrafficmetrics processor does not support the profiles signal,
+	// so it must not be appended to profiles destination pipelines.
+	c := &config.Config{
+		Receivers: config.GenericMap{"otlp": struct{}{}},
+		Exporters: config.GenericMap{"otlp_grpc/local": config.GenericMap{}},
+		Service: config.Service{
+			Pipelines: map[string]config.Pipeline{
+				"profiles/generic-dest": {
+					Receivers: []string{"otlp"},
+					Exporters: []string{"otlp_grpc/local"},
+				},
+			},
+		},
+	}
+
+	err := addSelfTelemetryPipeline(c, k8sconsts.OdigosNodeCollectorOwnTelemetryPortDefault, []string{"profiles/generic-dest"}, []string{})
+	assert.NoError(t, err)
+	assert.NotContains(t, c.Service.Pipelines["profiles/generic-dest"].Processors, "odigostrafficmetrics")
+}


### PR DESCRIPTION
## Summary
- `odigos-gateway` was crash-looping on startup with `failed to create "odigostrafficmetrics" processor, in pipeline "profiles/...": telemetry type is not supported`.
- `odigostrafficmetrics`'s factory (`collector/processors/odigostrafficmetrics/factory.go`) only registers `WithTraces`/`WithLogs`/`WithMetrics` — no `WithProfiles` — but `isOdigosTrafficMetricsProcessorRelevant` in `autoscaler/controllers/clustercollector/configmap.go` was appending it to every destination pipeline, including `profiles/*` ones.
- Same class of bug already had a precedent fix for the batch processor in `common/pipelinegen/config_builder.go` (profiles pipelines are explicitly skipped there since the batch processor doesn't support profiles in the pinned collector build either). Applied the same exclusion pattern here.

## Root cause
`autoscaler/controllers/clustercollector/configmap.go`'s `isOdigosTrafficMetricsProcessorRelevant` treated all destination pipelines uniformly and didn't account for the profiles signal not being supported by this processor, so any destination with profiles enabled produced an invalid collector config and the gateway failed `setupConfigurationComponents` on boot.

## Fix
Exclude `profiles/`-prefixed pipelines from getting the `odigostrafficmetrics` processor appended, mirroring the existing exclusion for the batch processor.

## Test plan
- [x] Added `TestAddSelfTelemetryPipeline_ProfilesPipelineExcludesTrafficMetrics`; confirmed it fails without the fix and passes with it.
- [x] `go build ./...` and `go test ./...` pass in the `autoscaler` module (pre-existing unrelated envtest failure locally due to missing `kubebuilder`/`etcd` binary, not caused by this change).
- [x] Confirmed no other module in this repo or in `odigos-enterprise` duplicates this pipeline-building logic — this is the only place the fix is needed.

```release-note
Fix odigos-gateway crash-looping on startup when a profiles destination is configured, caused by adding a processor that doesn't support the profiles signal to the profiles pipeline.
```
