### PR TITLE
CORE-1348 | fix: odigostrafficmetrics processor breaks profiles pipeline on gateway startup

### DIFF
--- a/autoscaler/controllers/actions/profiles_actions_test.go
+++ b/autoscaler/controllers/actions/profiles_actions_test.go
@@ -126,6 +126,7 @@ func TestE2E_ProfilesActions_ActionToRenderedConfig(t *testing.T) {
 		commonconf.ProfilingNodeOdigosProfilesProcessor,
 		commonconf.ProfilingNodeSymbolizeProcessor,
 		commonconf.ProfilingNodeServiceNameProcessor,
+		"odigostrafficmetrics",
 	}, nodeCfg.Service.Pipelines["profiles"].Processors)
 }
 

--- a/autoscaler/controllers/clustercollector/configmap_test.go
+++ b/autoscaler/controllers/clustercollector/configmap_test.go
@@ -132,3 +132,24 @@ func TestAddSelfTelemetryPipeline(t *testing.T) {
 		})
 	}
 }
+
+func TestAddSelfTelemetryPipeline_ProfilesPipelineIncludesTrafficMetrics(t *testing.T) {
+	// the odigostrafficmetrics processor supports the profiles signal,
+	// so it should be appended to profiles destination pipelines like any other signal.
+	c := &config.Config{
+		Receivers: config.GenericMap{"otlp": struct{}{}},
+		Exporters: config.GenericMap{"otlp_grpc/local": config.GenericMap{}},
+		Service: config.Service{
+			Pipelines: map[string]config.Pipeline{
+				"profiles/generic-dest": {
+					Receivers: []string{"otlp"},
+					Exporters: []string{"otlp_grpc/local"},
+				},
+			},
+		},
+	}
+
+	err := addSelfTelemetryPipeline(c, k8sconsts.OdigosNodeCollectorOwnTelemetryPortDefault, []string{"profiles/generic-dest"}, []string{})
+	assert.NoError(t, err)
+	assert.Contains(t, c.Service.Pipelines["profiles/generic-dest"].Processors, "odigostrafficmetrics")
+}

--- a/autoscaler/controllers/nodecollector/collectorconfig/profiles.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/profiles.go
@@ -41,6 +41,7 @@ func ProfilingPipelineConfig(odigosNamespace string, profiling *common.Profiling
 	}
 	pipelineProcessors = append(pipelineProcessors, commonconf.ProfilingNodeServiceNameProcessor)
 	pipelineProcessors = append(pipelineProcessors, manifestProcessorNames...)
+	pipelineProcessors = append(pipelineProcessors, odigosTrafficMetricsProcessorName) // keep traffic metrics last for most accurate tracking
 
 	return config.Config{
 		Receivers: config.GenericMap{

--- a/autoscaler/controllers/nodecollector/collectorconfig/profiles_test.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/profiles_test.go
@@ -44,6 +44,7 @@ func TestProfilingPipelineConfig_Enabled(t *testing.T) {
 		commonconf.ProfilingNodeOdigosProfilesProcessor,
 		commonconf.ProfilingNodeSymbolizeProcessor,
 		commonconf.ProfilingNodeServiceNameProcessor,
+		odigosTrafficMetricsProcessorName,
 	}, pl.Processors)
 	assert.Equal(t, []string{commonconf.ProfilingNodeToGatewayExporter}, pl.Exporters)
 
@@ -74,6 +75,7 @@ func TestProfilingPipelineConfig_UserProcessorsAppended(t *testing.T) {
 		commonconf.ProfilingNodeServiceNameProcessor,
 		"resource/addclusterinfo",
 		"transform/rename",
+		odigosTrafficMetricsProcessorName,
 	}, pl.Processors)
 }
 
@@ -93,5 +95,6 @@ func TestProfilingPipelineConfig_NativeSymbolizationDisabled(t *testing.T) {
 		commonconf.ProfilingNodeK8sAttributesProcessor,
 		commonconf.ProfilingNodeOdigosProfilesProcessor,
 		commonconf.ProfilingNodeServiceNameProcessor,
+		odigosTrafficMetricsProcessorName,
 	}, pl.Processors)
 }

--- a/collector/odigosotelcol/config_smoketest_test.go
+++ b/collector/odigosotelcol/config_smoketest_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap"
+	envprovider "go.opentelemetry.io/collector/confmap/provider/envprovider"
+	fileprovider "go.opentelemetry.io/collector/confmap/provider/fileprovider"
+	"go.opentelemetry.io/collector/otelcol"
+)
+
+// TestFullSignalConfigStartsSuccessfully builds a real Collector — using the actual
+// component registry from components(), not fakes — from a config that puts the
+// odigostrafficmetrics processor in a pipeline for every signal, including profiles.
+//
+// This reproduces, at test time, the exact failure mode that crash-looped odigos-gateway
+// in production: a processor added to a pipeline for a signal its factory doesn't support
+// only surfaces as "telemetry type is not supported" deep inside service.New, which neither
+// per-processor unit tests nor otelcoltest.LoadConfigAndValidate (schema validation only,
+// against Nop factories in existing usages) can catch.
+func TestFullSignalConfigStartsSuccessfully(t *testing.T) {
+	set := otelcol.CollectorSettings{
+		BuildInfo: component.NewDefaultBuildInfo(),
+		Factories: components,
+		ConfigProviderSettings: otelcol.ConfigProviderSettings{
+			ResolverSettings: confmap.ResolverSettings{
+				URIs: []string{"testdata/full-signal-config.yaml"},
+				ProviderFactories: []confmap.ProviderFactory{
+					fileprovider.NewFactory(),
+					envprovider.NewFactory(),
+				},
+				DefaultScheme: "env",
+			},
+		},
+	}
+
+	col, err := otelcol.NewCollector(set)
+	require.NoError(t, err)
+
+	runErrCh := make(chan error, 1)
+	go func() {
+		runErrCh <- col.Run(context.Background())
+	}()
+
+	require.Eventually(t, func() bool {
+		state := col.GetState()
+		return state == otelcol.StateRunning || state == otelcol.StateClosed
+	}, 10*time.Second, 50*time.Millisecond, "collector did not reach a running or closed state")
+
+	if col.GetState() == otelcol.StateRunning {
+		col.Shutdown()
+	}
+
+	select {
+	case err := <-runErrCh:
+		assert.NoError(t, err, "collector failed to build pipelines for a config where every "+
+			"signal (traces/metrics/logs/profiles) routes through odigostrafficmetrics — "+
+			"this is the exact error class that crash-looped odigos-gateway in production")
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for collector shutdown")
+	}
+}

--- a/collector/odigosotelcol/testdata/full-signal-config.yaml
+++ b/collector/odigosotelcol/testdata/full-signal-config.yaml
@@ -1,0 +1,33 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 127.0.0.1:0
+      http:
+        endpoint: 127.0.0.1:0
+
+processors:
+  odigostrafficmetrics:
+    sampling_ratio: 1.0
+
+exporters:
+  nop:
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [odigostrafficmetrics]
+      exporters: [nop]
+    metrics:
+      receivers: [otlp]
+      processors: [odigostrafficmetrics]
+      exporters: [nop]
+    logs:
+      receivers: [otlp]
+      processors: [odigostrafficmetrics]
+      exporters: [nop]
+    profiles/test-dest:
+      receivers: [otlp]
+      processors: [odigostrafficmetrics]
+      exporters: [nop]

--- a/collector/processors/odigostrafficmetrics/documentation.md
+++ b/collector/processors/odigostrafficmetrics/documentation.md
@@ -22,6 +22,14 @@ Number of data points passed through the processor.
 | ---- | ----------- | ---------- | --------- | --------- |
 | {datapoints} | Sum | Int | true | Development |
 
+### otelcol_odigos_accepted_profile_samples
+
+Number of profile samples passed through the processor.
+
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| {samples} | Sum | Int | true | Development |
+
 ### otelcol_odigos_accepted_spans
 
 Number of spans passed through the processor.
@@ -41,6 +49,14 @@ Total size of log data passed to the processor
 ### otelcol_odigos_metric_data_size
 
 Total size of metric data passed to the processor
+
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| By | Sum | Int | true | Development |
+
+### otelcol_odigos_profile_data_size
+
+Total size of profile data passed to the processor
 
 | Unit | Metric Type | Value Type | Monotonic | Stability |
 | ---- | ----------- | ---------- | --------- | --------- |

--- a/collector/processors/odigostrafficmetrics/factory.go
+++ b/collector/processors/odigostrafficmetrics/factory.go
@@ -6,8 +6,11 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/odigos/processor/odigostrafficmetrics/internal/metadata"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/xconsumer"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processorhelper"
+	"go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper"
+	"go.opentelemetry.io/collector/processor/xprocessor"
 )
 
 //go:generate mdatagen metadata.yaml
@@ -15,13 +18,14 @@ import (
 var consumerCapabilities = consumer.Capabilities{MutatesData: false}
 
 // NewFactory creates a new ProcessorFactory with default configuration
-func NewFactory() processor.Factory {
-	return processor.NewFactory(
+func NewFactory() xprocessor.Factory {
+	return xprocessor.NewFactory(
 		metadata.Type,
 		createDefaultConfig,
-		processor.WithTraces(createTracesProcessor, metadata.TracesStability),
-		processor.WithLogs(createLogsProcessor, metadata.LogsStability),
-		processor.WithMetrics(createMetricsProcessor, metadata.MetricsStability),
+		xprocessor.WithTraces(createTracesProcessor, metadata.TracesStability),
+		xprocessor.WithLogs(createLogsProcessor, metadata.LogsStability),
+		xprocessor.WithMetrics(createMetricsProcessor, metadata.MetricsStability),
+		xprocessor.WithProfiles(createProfilesProcessor, metadata.ProfilesStability),
 	)
 }
 
@@ -74,4 +78,19 @@ func createMetricsProcessor(
 	}
 
 	return processorhelper.NewMetrics(ctx, set, cfg, nextConsumer, tmp.processMetrics, processorhelper.WithCapabilities(consumerCapabilities))
+}
+
+func createProfilesProcessor(
+	ctx context.Context,
+	set processor.Settings,
+	cfg component.Config,
+	nextConsumer xconsumer.Profiles,
+) (xprocessor.Profiles, error) {
+	oCfg := cfg.(*Config)
+	tmp, err := newThroughputMeasurementProcessor(set, oCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return xprocessorhelper.NewProfiles(ctx, set, cfg, nextConsumer, tmp.processProfiles, xprocessorhelper.WithCapabilities(consumerCapabilities))
 }

--- a/collector/processors/odigostrafficmetrics/generated_component_test.go
+++ b/collector/processors/odigostrafficmetrics/generated_component_test.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processortest"
+	"go.opentelemetry.io/collector/processor/xprocessor"
 )
 
 var typ = component.MustNewType("odigostrafficmetrics")
@@ -56,6 +57,13 @@ func TestComponentLifecycle(t *testing.T) {
 			name: "traces",
 			createFn: func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error) {
 				return factory.CreateTraces(ctx, set, cfg, consumertest.NewNop())
+			},
+		},
+
+		{
+			name: "profiles",
+			createFn: func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error) {
+				return factory.(xprocessor.Factory).CreateProfiles(ctx, set, cfg, consumertest.NewNop())
 			},
 		},
 	}

--- a/collector/processors/odigostrafficmetrics/go.mod
+++ b/collector/processors/odigostrafficmetrics/go.mod
@@ -11,10 +11,14 @@ require (
 	go.opentelemetry.io/collector/confmap/xconfmap v0.151.0
 	go.opentelemetry.io/collector/consumer v1.57.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.151.0
+	go.opentelemetry.io/collector/consumer/xconsumer v0.151.0
 	go.opentelemetry.io/collector/pdata v1.57.0
+	go.opentelemetry.io/collector/pdata/pprofile v0.151.0
 	go.opentelemetry.io/collector/processor v1.57.0
 	go.opentelemetry.io/collector/processor/processorhelper v0.151.0
+	go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper v0.151.0
 	go.opentelemetry.io/collector/processor/processortest v0.151.0
+	go.opentelemetry.io/collector/processor/xprocessor v0.151.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
@@ -44,14 +48,11 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/component/componentstatus v0.151.0 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.151.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.57.0 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.151.0 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.151.0 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.151.0 // indirect
 	go.opentelemetry.io/collector/pdata/xpdata v0.151.0 // indirect
 	go.opentelemetry.io/collector/pipeline v1.57.0 // indirect
-	go.opentelemetry.io/collector/processor/xprocessor v0.151.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/collector/processors/odigostrafficmetrics/go.sum
+++ b/collector/processors/odigostrafficmetrics/go.sum
@@ -95,6 +95,8 @@ go.opentelemetry.io/collector/processor v1.57.0 h1:EyW3f4pvt/gsfM3JKgRn2WZEyknGz
 go.opentelemetry.io/collector/processor v1.57.0/go.mod h1:EdKVhK9Oj8Cj2EdYqD/rDKdklLcdwpfSM/q6+KZOMbc=
 go.opentelemetry.io/collector/processor/processorhelper v0.151.0 h1:Q0RU7BM46GjLC2KPxyk8jHaud9XOVaDjp98hkL1uF38=
 go.opentelemetry.io/collector/processor/processorhelper v0.151.0/go.mod h1:+WKnK3S2itxLll8XxgTiCt8o2YA9amYpCFTm51l3zV0=
+go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper v0.151.0 h1:fA8Y1JaHsH1rurDx2l3RTbnjTGRQv45dMfP66kxoq0E=
+go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper v0.151.0/go.mod h1:jJks3b5tofZm2ta3dlQNkWq/R8fsCiuQjBiFSg8GA4k=
 go.opentelemetry.io/collector/processor/processortest v0.151.0 h1:J+7wLfpyO+gE/yfct11Sy1F6e+/KkLe1/gnh6jDbvbE=
 go.opentelemetry.io/collector/processor/processortest v0.151.0/go.mod h1:SKl5FdxTH4bsi90E8e1W79Q94Uoh+OfEMq7yoZqUYVE=
 go.opentelemetry.io/collector/processor/xprocessor v0.151.0 h1:TQhnUOP1vbdQ7zKD7SXfjtpthnfwWg23r8a6yeXDN84=

--- a/collector/processors/odigostrafficmetrics/internal/metadata/generated_status.go
+++ b/collector/processors/odigostrafficmetrics/internal/metadata/generated_status.go
@@ -14,7 +14,8 @@ var (
 )
 
 const (
-	LogsStability    = component.StabilityLevelBeta
-	MetricsStability = component.StabilityLevelBeta
-	TracesStability  = component.StabilityLevelBeta
+	ProfilesStability = component.StabilityLevelAlpha
+	LogsStability     = component.StabilityLevelBeta
+	MetricsStability  = component.StabilityLevelBeta
+	TracesStability   = component.StabilityLevelBeta
 )

--- a/collector/processors/odigostrafficmetrics/internal/metadata/generated_telemetry.go
+++ b/collector/processors/odigostrafficmetrics/internal/metadata/generated_telemetry.go
@@ -23,15 +23,17 @@ func Tracer(settings component.TelemetrySettings) trace.Tracer {
 // TelemetryBuilder provides an interface for components to report telemetry
 // as defined in metadata and user config.
 type TelemetryBuilder struct {
-	meter                      metric.Meter
-	mu                         sync.Mutex
-	registrations              []metric.Registration
-	OdigosAcceptedLogRecords   metric.Int64Counter
-	OdigosAcceptedMetricPoints metric.Int64Counter
-	OdigosAcceptedSpans        metric.Int64Counter
-	OdigosLogDataSize          metric.Int64Counter
-	OdigosMetricDataSize       metric.Int64Counter
-	OdigosTraceDataSize        metric.Int64Counter
+	meter                        metric.Meter
+	mu                           sync.Mutex
+	registrations                []metric.Registration
+	OdigosAcceptedLogRecords     metric.Int64Counter
+	OdigosAcceptedMetricPoints   metric.Int64Counter
+	OdigosAcceptedProfileSamples metric.Int64Counter
+	OdigosAcceptedSpans          metric.Int64Counter
+	OdigosLogDataSize            metric.Int64Counter
+	OdigosMetricDataSize         metric.Int64Counter
+	OdigosProfileDataSize        metric.Int64Counter
+	OdigosTraceDataSize          metric.Int64Counter
 }
 
 // TelemetryBuilderOption applies changes to default builder.
@@ -75,6 +77,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		metric.WithUnit("{datapoints}"),
 	)
 	errs = errors.Join(errs, err)
+	builder.OdigosAcceptedProfileSamples, err = builder.meter.Int64Counter(
+		"otelcol_odigos_accepted_profile_samples",
+		metric.WithDescription("Number of profile samples passed through the processor. [Development]"),
+		metric.WithUnit("{samples}"),
+	)
+	errs = errors.Join(errs, err)
 	builder.OdigosAcceptedSpans, err = builder.meter.Int64Counter(
 		"otelcol_odigos_accepted_spans",
 		metric.WithDescription("Number of spans passed through the processor. [Development]"),
@@ -90,6 +98,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	builder.OdigosMetricDataSize, err = builder.meter.Int64Counter(
 		"otelcol_odigos_metric_data_size",
 		metric.WithDescription("Total size of metric data passed to the processor [Development]"),
+		metric.WithUnit("By"),
+	)
+	errs = errors.Join(errs, err)
+	builder.OdigosProfileDataSize, err = builder.meter.Int64Counter(
+		"otelcol_odigos_profile_data_size",
+		metric.WithDescription("Total size of profile data passed to the processor [Development]"),
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)

--- a/collector/processors/odigostrafficmetrics/internal/metadatatest/generated_telemetrytest.go
+++ b/collector/processors/odigostrafficmetrics/internal/metadatatest/generated_telemetrytest.go
@@ -53,6 +53,22 @@ func AssertEqualOdigosAcceptedMetricPoints(t *testing.T, tt *componenttest.Telem
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
+func AssertEqualOdigosAcceptedProfileSamples(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_odigos_accepted_profile_samples",
+		Description: "Number of profile samples passed through the processor. [Development]",
+		Unit:        "{samples}",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_odigos_accepted_profile_samples")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
 func AssertEqualOdigosAcceptedSpans(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_odigos_accepted_spans",
@@ -97,6 +113,22 @@ func AssertEqualOdigosMetricDataSize(t *testing.T, tt *componenttest.Telemetry, 
 		},
 	}
 	got, err := tt.GetMetric("otelcol_odigos_metric_data_size")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualOdigosProfileDataSize(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_odigos_profile_data_size",
+		Description: "Total size of profile data passed to the processor [Development]",
+		Unit:        "By",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_odigos_profile_data_size")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }

--- a/collector/processors/odigostrafficmetrics/internal/metadatatest/generated_telemetrytest_test.go
+++ b/collector/processors/odigostrafficmetrics/internal/metadatatest/generated_telemetrytest_test.go
@@ -21,14 +21,19 @@ func TestSetupTelemetry(t *testing.T) {
 	defer tb.Shutdown()
 	tb.OdigosAcceptedLogRecords.Add(context.Background(), 1)
 	tb.OdigosAcceptedMetricPoints.Add(context.Background(), 1)
+	tb.OdigosAcceptedProfileSamples.Add(context.Background(), 1)
 	tb.OdigosAcceptedSpans.Add(context.Background(), 1)
 	tb.OdigosLogDataSize.Add(context.Background(), 1)
 	tb.OdigosMetricDataSize.Add(context.Background(), 1)
+	tb.OdigosProfileDataSize.Add(context.Background(), 1)
 	tb.OdigosTraceDataSize.Add(context.Background(), 1)
 	AssertEqualOdigosAcceptedLogRecords(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualOdigosAcceptedMetricPoints(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualOdigosAcceptedProfileSamples(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualOdigosAcceptedSpans(t, testTel,
@@ -38,6 +43,9 @@ func TestSetupTelemetry(t *testing.T) {
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualOdigosMetricDataSize(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualOdigosProfileDataSize(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualOdigosTraceDataSize(t, testTel,

--- a/collector/processors/odigostrafficmetrics/metadata.yaml
+++ b/collector/processors/odigostrafficmetrics/metadata.yaml
@@ -3,6 +3,7 @@ status:
   class: processor
   stability:
     beta: [logs, metrics, traces]
+    alpha: [profiles]
   distributions: [contrib]
   codeowners:
     active: [RonFed]
@@ -22,6 +23,15 @@ telemetry:
       enabled: true
       description: Number of data points passed through the processor.
       unit: "{datapoints}"
+      sum:
+        value_type: int
+        monotonic: true
+      stability: development
+
+    odigos_accepted_profile_samples:
+      enabled: true
+      description: Number of profile samples passed through the processor.
+      unit: "{samples}"
       sum:
         value_type: int
         monotonic: true
@@ -48,6 +58,15 @@ telemetry:
     odigos_metric_data_size:
       enabled: true
       description: "Total size of metric data passed to the processor"
+      unit: "By"
+      sum:
+        value_type: int
+        monotonic: true
+      stability: development
+
+    odigos_profile_data_size:
+      enabled: true
+      description: "Total size of profile data passed to the processor"
       unit: "By"
       sum:
         value_type: int

--- a/collector/processors/odigostrafficmetrics/processor.go
+++ b/collector/processors/odigostrafficmetrics/processor.go
@@ -9,6 +9,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/pprofile"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/otel/attribute"
@@ -21,6 +22,7 @@ type dataSizesMetricsProcessor struct {
 	tracesSizer             *ptrace.ProtoMarshaler
 	metricsSizer            *pmetric.ProtoMarshaler
 	logsSizer               *plog.ProtoMarshaler
+	profilesSizer           *pprofile.ProtoMarshaler
 	resAttrsKeys            []string
 	samplingFraction        float64
 	inverseSamplingFraction int64
@@ -50,6 +52,7 @@ func newThroughputMeasurementProcessor(set processor.Settings, cfg *Config) (*da
 		tracesSizer:             &ptrace.ProtoMarshaler{},
 		metricsSizer:            &pmetric.ProtoMarshaler{},
 		logsSizer:               &plog.ProtoMarshaler{},
+		profilesSizer:           &pprofile.ProtoMarshaler{},
 		resAttrsKeys:            cfg.ResourceAttributesKeys,
 		samplingFraction:        samplingFraction,
 		inverseSamplingFraction: inverseSamplingFraction,
@@ -96,6 +99,21 @@ func (p *dataSizesMetricsProcessor) processLogs(ctx context.Context, ld plog.Log
 		p.obsrep.OdigosAcceptedLogRecords.Add(ctx, int64(ld.LogRecordCount()))
 	}
 	return ld, nil
+}
+
+func (p *dataSizesMetricsProcessor) processProfiles(ctx context.Context, pd pprofile.Profiles) (pprofile.Profiles, error) {
+	if p.samplingFraction != 0 && rand.Float64() < p.samplingFraction {
+		resProfiles := pd.ResourceProfiles()
+		for i := 0; i < resProfiles.Len(); i++ {
+			res := resProfiles.At(i).Resource()
+			p.obsrep.OdigosProfileDataSize.Add(ctx,
+				int64(p.profilesSizer.ResourceProfilesSize(resProfiles.At(i)))*p.inverseSamplingFraction,
+				metric.WithAttributeSet(p.attributeSetFromResource(res)),
+			)
+		}
+		p.obsrep.OdigosAcceptedProfileSamples.Add(ctx, int64(pd.SampleCount()))
+	}
+	return pd, nil
 }
 
 func (p *dataSizesMetricsProcessor) processMetrics(ctx context.Context, md pmetric.Metrics) (pmetric.Metrics, error) {

--- a/collector/processors/odigostrafficmetrics/processor_test.go
+++ b/collector/processors/odigostrafficmetrics/processor_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/pprofiletest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/ptracetest"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pprofile"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/processor/processortest"
 	"go.opentelemetry.io/otel/sdk/metric"
@@ -37,6 +39,70 @@ func TestProcessor_Logs(t *testing.T) {
 }
 
 func TestProcessor_Metrics(t *testing.T) {
+}
+
+func generateProfileData(serviceNames ...string) pprofile.Profiles {
+	pd := pprofile.NewProfiles()
+	pd.Dictionary().StringTable().Append("")
+	for _, serviceName := range serviceNames {
+		rp := pd.ResourceProfiles().AppendEmpty()
+		rp.Resource().Attributes().PutStr(string(semconv.ServiceNameKey), serviceName)
+		prof := rp.ScopeProfiles().AppendEmpty().Profiles().AppendEmpty()
+		prof.Samples().AppendEmpty()
+	}
+	return pd
+}
+
+func TestProcessor_Profiles(t *testing.T) {
+	metricsReader := metric.NewManualReader()
+	defer metricsReader.Shutdown(context.Background())
+
+	metricProvider := metric.NewMeterProvider(
+		metric.WithReader(metricsReader),
+	)
+	defer metricProvider.Shutdown(context.Background())
+
+	set := processortest.NewNopSettings(processortest.NopType)
+	set.MeterProvider = metricProvider
+
+	tmp, err := newThroughputMeasurementProcessor(set, &Config{
+		ResourceAttributesKeys: []string{"service.name"},
+		SamplingRatio:          1,
+	})
+	require.NoError(t, err)
+
+	profiles := generateProfileData("service-name1", "service-name2")
+
+	processedProfiles, err := tmp.processProfiles(context.Background(), profiles)
+	require.NoError(t, err)
+
+	// Output profiles should be the same as input profiles (passthrough check)
+	require.NoError(t, pprofiletest.CompareProfiles(profiles, processedProfiles))
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, metricsReader.Collect(context.Background(), &rm))
+
+	var sawDataSize, sawAcceptedSamples bool
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			switch m.Name {
+			case "otelcol_odigos_profile_data_size":
+				sawDataSize = true
+				sum := m.Data.(metricdata.Sum[int64])
+				require.Equal(t, 2, len(sum.DataPoints))
+				for i := range 2 {
+					require.Greater(t, sum.DataPoints[i].Value, int64(0))
+				}
+			case "otelcol_odigos_accepted_profile_samples":
+				sawAcceptedSamples = true
+				sum := m.Data.(metricdata.Sum[int64])
+				require.Equal(t, 1, len(sum.DataPoints))
+				require.Equal(t, int64(2), sum.DataPoints[0].Value)
+			}
+		}
+	}
+	require.True(t, sawDataSize, "expected otelcol_odigos_profile_data_size metric")
+	require.True(t, sawAcceptedSamples, "expected otelcol_odigos_accepted_profile_samples metric")
 }
 
 func TestProcessor_Traces(t *testing.T) {


### PR DESCRIPTION
#### What this PR does / why we need it:
`odigos-gateway` was crash-looping on startup with a profiles destination configured:

```
failed to build pipelines: failed to create "odigostrafficmetrics" processor, in pipeline "profiles/...": telemetry type is not supported
```

`odigostrafficmetrics` gets added to every destination pipeline to track throughput, but its factory never registered support for profiles, so the config was invalid from the start.


Two smaller things while I was in there:
- fix processor's factory 
- Node-collector's profiles pipeline was missing `odigostrafficmetrics` too, unlike traces/logs/metrics
- Improved testing

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
Fix odigos-gateway crash-looping on startup when a profiles destination is configured, by adding profiles signal support to the odigostrafficmetrics processor.
```
