### PR TITLE
CORE-1307 | fix: aggregate symtab-size-skip warnings instead of logging per binary

### DIFF
--- a/collector/processors/odigossymbolizeprocessor/internal/symbolize/memory_bound_test.go
+++ b/collector/processors/odigossymbolizeprocessor/internal/symbolize/memory_bound_test.go
@@ -12,8 +12,13 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // buildBigTestLib compiles a shared library with n trivial exported functions,
@@ -182,4 +187,70 @@ func TestSymbolCacheStaysWithinByteBudget(t *testing.T) {
 	}
 	t.Logf("after 512 inserts of %d-byte entries under a %d-byte budget: cachedBytes=%d, entries=%d",
 		entryBytes, budget, s.cachedBytes, len(s.symbolCache))
+}
+
+// TestSymtabSkipsAreAggregatedNotPerBinary proves the noise-reduction fix: N
+// distinct binaries tripping the max_symtab_bytes gate produce zero Warn logs
+// from parseAndCache itself (only Debug, one per binary), and a single sweep
+// drains the count into exactly one Warn — so a busy node with many oversized
+// libraries, or one restarting across many pods, can't turn into a
+// per-binary/per-restart warning storm.
+func TestSymtabSkipsAreAggregatedNotPerBinary(t *testing.T) {
+	so := buildBigTestLib(t, 8000)
+	symBytes := symtabSectionBytes(t, so)
+	if symBytes < 128<<10 {
+		t.Skipf("fixture .symtab too small (%d bytes)", symBytes)
+	}
+
+	// Copy the same oversized binary to N distinct paths: parseAndCache dedups by
+	// path, so this simulates N distinct binaries (or the same one across N
+	// container instances) all tripping the gate.
+	const n = 3
+	dir := t.TempDir()
+	paths := make([]string, n)
+	data, err := os.ReadFile(so)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range paths {
+		p := filepath.Join(dir, "lib"+strconv.Itoa(i)+".so")
+		if err := os.WriteFile(p, data, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		paths[i] = p
+	}
+
+	core, logs := observer.New(zap.DebugLevel)
+	s := New(WithMaxSymtabBytes(32<<10), WithLogger(zap.New(core)))
+	defer s.Close()
+
+	for _, p := range paths {
+		s.parseAndCache(p)
+	}
+
+	if got := s.symtabSkips.Load(); got != n {
+		t.Fatalf("symtabSkips = %d, want %d after %d skipped binaries", got, n, n)
+	}
+	if warns := logs.FilterLevelExact(zapcore.WarnLevel).Len(); warns != 0 {
+		t.Fatalf("parseAndCache must not log Warn per binary, got %d Warn entries", warns)
+	}
+	if debugs := logs.FilterLevelExact(zapcore.DebugLevel).Len(); debugs != n {
+		t.Fatalf("expected %d per-binary Debug entries, got %d", n, debugs)
+	}
+
+	// One sweep drains the counter into exactly one Warn carrying the count.
+	s.reportSymtabSkips()
+	warnEntries := logs.FilterLevelExact(zapcore.WarnLevel).All()
+	if len(warnEntries) != 1 {
+		t.Fatalf("expected exactly 1 Warn after the sweep, got %d", len(warnEntries))
+	}
+	if got := warnEntries[0].ContextMap()["count"]; got != int64(n) {
+		t.Fatalf("summary Warn count = %v, want %d", got, n)
+	}
+
+	// A second sweep with nothing new skipped must log nothing further.
+	s.reportSymtabSkips()
+	if warns := logs.FilterLevelExact(zapcore.WarnLevel).Len(); warns != 1 {
+		t.Fatalf("expected still exactly 1 Warn total after an empty sweep, got %d", warns)
+	}
 }

--- a/collector/processors/odigossymbolizeprocessor/internal/symbolize/symbolize.go
+++ b/collector/processors/odigossymbolizeprocessor/internal/symbolize/symbolize.go
@@ -68,6 +68,12 @@ type Symbolizer struct {
 
 	clock atomic.Uint64 // monotonic counter driving LRU "last used"
 
+	// symtabSkips counts binaries skipped for exceeding max_symtab_bytes since the
+	// last sweep; runSweeper drains it into one periodic Warn instead of one per
+	// binary, so a busy node with many oversized libraries can't turn into a
+	// per-restart warning storm. Per-binary detail still logs at Debug.
+	symtabSkips atomic.Int64
+
 	maxSymbols      int
 	maxSymbolBytes  int64
 	maxMaps         int
@@ -393,10 +399,12 @@ func (s *Symbolizer) parseAndCache(path string) {
 		return
 	}
 	if es.symtabSkippedForSize {
-		// Visible at Warn (not Debug): this binary's native frames will show as
-		// module+offset, not names, until max_symtab_bytes is raised — an operator
-		// should know why, not just wonder why an app isn't fully symbolized.
-		s.log.Warn("symbolize: symbol table exceeds max_symtab_bytes, skipping decode; native frames for this binary will stay unresolved",
+		// Counted into the periodic sweep summary (Warn, bounded rate) instead of
+		// logged here directly — a busy node can have many distinct oversized
+		// binaries, one per restart/container, and that must not become a
+		// per-binary warning storm. Per-binary detail stays available at Debug.
+		s.symtabSkips.Add(1)
+		s.log.Debug("symbolize: symbol table exceeds max_symtab_bytes, skipping decode; native frames for this binary will stay unresolved",
 			zap.String("path", path), zap.Int64("max_symtab_bytes", s.limits.maxSymtabBytes))
 	}
 	e := &cachedSymbols{symbols: es, modTime: fi.ModTime().UnixNano(), size: fi.Size(), heapBytes: es.heapBytes}
@@ -437,7 +445,18 @@ func (s *Symbolizer) runSweeper() {
 			return
 		case <-t.C:
 			s.evictExitedProcesses()
+			s.reportSymtabSkips()
 		}
+	}
+}
+
+// reportSymtabSkips drains the symtab-size-skip counter into one Warn per sweep
+// interval (rather than one per binary) so the signal stays visible without
+// scaling with pod/binary churn. See symtabSkips' doc comment.
+func (s *Symbolizer) reportSymtabSkips() {
+	if n := s.symtabSkips.Swap(0); n > 0 {
+		s.log.Warn("symbolize: binaries skipped for exceeding max_symtab_bytes since last report; their native frames stayed unresolved (enable debug logging for per-binary detail)",
+			zap.Int64("count", n), zap.Duration("since", s.sweepEvery), zap.Int64("max_symtab_bytes", s.limits.maxSymtabBytes))
 	}
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Follow-up to #5302. The Warn added there logged once per binary that tripped
`max_symtab_bytes` — but that's deduped only by the symbol cache's lifetime, not
by content, so a busy node with many oversized native libraries (or the same
library across many restarting containers, each resolving to its own path) could
turn into a per-binary, per-restart warning storm. That's worst exactly where
operators dial `maxMemoryMiB` down to protect a constrained node — the case that
skips the most binaries also logs the most.

Per-binary detail moves to `Debug`; a counter now feeds one `Warn` per sweep
interval (the existing 30s sweeper) naming how many binaries were skipped since
the last report — a bounded, constant-rate signal regardless of churn.

#### Changelog entry:

```release-note
NONE
```