### PR TITLE
ci: guard release-lane workflows against tags on unexpected branches

### DIFF
--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -26,6 +26,31 @@ jobs:
       skip: ${{ steps.decide.outputs.skip }}
       tag:  ${{ steps.decide.outputs.tag }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag is reachable from an allowed branch
+        env:
+          TAG: ${{ inputs.tag != '' && inputs.tag || github.ref_name }}
+        run: |
+          # A v* tag push (or a manual dispatch pointing at one) is a repo-wide
+          # trigger — GitHub gives no way to scope it to a branch. This guards
+          # against a stray tag on a feature branch firing the full production
+          # release cascade (real registries, real Slack alerts, Homebrew tap
+          # updates for -rcN tags).
+          git fetch origin +refs/heads/*:refs/remotes/origin/* --quiet
+          if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $TAG not found"
+            exit 1
+          fi
+          if ! git branch -r --contains "$TAG" | grep -qE 'origin/(main|releases/)'; then
+            echo "::error::Tag $TAG is not reachable from main or releases/** — refusing to run the release pipeline from an arbitrary branch."
+            exit 1
+          fi
+          echo "Tag $TAG verified on an allowed branch."
+
       - id: decide
         env:
           # Prefer manual input for dispatch; otherwise use the pushed tag


### PR DESCRIPTION
## Why

`publish-modules.yml` triggers on `push: tags: v*` with no branch restriction — GitHub Actions can't scope a tag-push trigger to a branch. Today, a `v*`-shaped tag pushed to any branch (a feature branch, a fork, anywhere) fires the full production release pipeline: real image pushes to GCR/DockerHub/GHCR, real Slack alerts, and for `-rcN` tags, a real Homebrew tap update.

## What

Adds a check at the top of the `decide` job: verifies the pushed (or dispatched) tag is reachable from `main` or `releases/**` before anything downstream runs. Fails fast with a clear error otherwise.

## Companion PR

Same guardrail mirrored in `odigos-enterprise`'s `release-images.yml` (separate PR).

Part of the CI/CD pipeline hardening work discussed in CORE-1221.