### PR TITLE
Add Dockerfile-based CLI image build and extract CLI make targets.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,52 +1,10 @@
-# VCS / IDE / local tooling
+frontend/webapp/node_modules
 .git/
-.github/
-.vscode/
-.cursor/
-.devcontainer/
-.tools/
-**/.tools/
-
-# Workspace / credentials
-go.work
-go.work.sum
-go.work.bak
-go.work.sum.bak
-gha-creds-*.json
-.env
-kubeconfig
-
-# Docs and non-build trees (root-context builds never COPY these)
-docs/
-scripts/
-hooks/
-own-observability/
-tests/
-tests-infrastructure/
-
-# Local build / test artifacts
-**/bin/
-**/testbin/
-**/dist/
-**/artifacts/
-**/__debug_bin*
-**/*.log
-**/*.logs
-**/cover.out
-**/.DS_Store
-
-# CLI host binary (rebuilt inside the image)
-cli/odigos
-/odigos
-
-# Frontend: deps and host build outputs (yarn build runs in the image)
-**/node_modules/
-frontend/webapp/.next/
-frontend/webapp/out/
-frontend/webapp/cypress/
-
-# Dockerfiles are read via -f from the host; keep them out of the context
 Dockerfile
 odiglet/Dockerfile
 odiglet/base.Dockerfile
 odiglet/debug.Dockerfile
+tests # not needed in context for odigos components builds
+go.work
+go.work.sum
+gha-creds-*.json

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,52 @@
-frontend/webapp/node_modules
+# VCS / IDE / local tooling
 .git/
+.github/
+.vscode/
+.cursor/
+.devcontainer/
+.tools/
+**/.tools/
+
+# Workspace / credentials
+go.work
+go.work.sum
+go.work.bak
+go.work.sum.bak
+gha-creds-*.json
+.env
+kubeconfig
+
+# Docs and non-build trees (root-context builds never COPY these)
+docs/
+scripts/
+hooks/
+own-observability/
+tests/
+tests-infrastructure/
+
+# Local build / test artifacts
+**/bin/
+**/testbin/
+**/dist/
+**/artifacts/
+**/__debug_bin*
+**/*.log
+**/*.logs
+**/cover.out
+**/.DS_Store
+
+# CLI host binary (rebuilt inside the image)
+cli/odigos
+/odigos
+
+# Frontend: deps and host build outputs (yarn build runs in the image)
+**/node_modules/
+frontend/webapp/.next/
+frontend/webapp/out/
+frontend/webapp/cypress/
+
+# Dockerfiles are read via -f from the host; keep them out of the context
 Dockerfile
 odiglet/Dockerfile
 odiglet/base.Dockerfile
 odiglet/debug.Dockerfile
-tests # not needed in context for odigos components builds
-go.work
-go.work.sum
-gha-creds-*.json

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,7 @@ TARGET?=
 RHEL?=false
 BUILD_DIR=.
 
-# RHEL-certified CLI (ko + Dockerfile.rhel-base); matches .github/workflows/publish-modules-rhel publish-cli-rhel
-CLI_RHEL_IMAGE_NAME ?= odigos-cli-rhel-certified
-CLI_RHEL_KO_BASE_IMAGE ?= $(ORG)/odigos-cli-rhel-ko-base:$(TAG)
+include Makefile.cli
 
 ifeq ($(RHEL),true)
     IMG_SUFFIX=-rhel-certified
@@ -78,14 +76,6 @@ lint-fix:
 	MODULE=profiles make lint FIX_LINT=true
 	MODULE=destinations make lint FIX_LINT=true
 	MODULE=procdiscovery make lint FIX_LINT=true
-
-.PHONY: cli-docs
-cli-docs:
-	rm -rf docs/snippets/shared/cli/*
-	cd scripts/cli-docgen && KUBECONFIG=KUBECONFIG go run -tags embed_manifests main.go
-	for file in docs/snippets/shared/cli/*.md; do \
-		mv $${file} $${file%.md}.mdx; \
-	done
 
 .PHONY: rbac-docs
 rbac-docs:
@@ -355,50 +345,6 @@ check-clean-work-tree:
 		exit 1; \
 	fi
 
-# installs odigos from the local source, with local changes to api and cli directorie reflected in the odigos deployment
-.PHONY: cli-install
-cli-install:
-	@echo "Installing odigos from source. version: $(ODIGOS_CLI_VERSION)"
-	cd ./cli ; go run -tags=embed_manifests . install \
-		--version $(ODIGOS_CLI_VERSION) \
-		--nowait \
-		$(if $(CLUSTER_NAME),--cluster-name $(CLUSTER_NAME)) \
-		$(if $(CENTRAL_BACKEND_URL),--central-backend-url $(CENTRAL_BACKEND_URL)) \
-		$(FLAGS)
-
-
-.PHONY: cli-uninstall
-cli-uninstall:
-	@echo "Uninstalling odigos from source. version: $(ODIGOS_CLI_VERSION)"
-	cd ./cli ; go run -tags=embed_manifests . uninstall
-
-.PHONY: cli-upgrade
-cli-upgrade:
-	@echo "Upgrading odigos from source. version: $(ODIGOS_CLI_VERSION)"
-	cd ./cli ; go run -tags=embed_manifests . upgrade --version $(ODIGOS_CLI_VERSION) --yes
-
-.PHONY: cli-build
-cli-build:
-	@echo "Building the cli executable for tests"
-	TAG=0.0.0-e2e-test; \
-	TMPDIR=$$(mktemp -d); \
-	cp -r ./helm/odigos $$TMPDIR/odigos; \
-	sed -i.bak -E 's/^version:.*/version: '"$${TAG#v}"'/' $$TMPDIR/odigos/Chart.yaml; \
-	helm package $$TMPDIR/odigos -d cli/pkg/helm/embedded; \
-	cp -r ./helm/odigos-central $$TMPDIR/odigos-central; \
-	sed -i.bak -E 's/^version:.*/version: '"$${TAG#v}"'/' $$TMPDIR/odigos-central/Chart.yaml; \
-	helm package $$TMPDIR/odigos-central -d cli/pkg/helm/embedded; \
-	cd cli && go build -tags=embed_manifests \
-	  -ldflags "-X github.com/odigos-io/odigos/cli/pkg/helm.OdigosChartVersion=$${TAG#v}" \
-	  -o odigos .; \
-	rm -rf $$TMPDIR
-
-
-.PHONY: cli-diagnose
-cli-diagnose:
-	@echo "Diagnosing cluster data for debugging"
-	cd ./cli ; go run -tags=embed_manifests . diagnose
-
 .PHONY: helm-install
 helm-install:
 	@echo "Installing odigos using helm"
@@ -537,57 +483,6 @@ publish-to-ecr:
 	make -j 3 build-tag-push-ecr-image/collector DOCKERFILE=collector/$(DOCKERFILE) SUMMARY="Odigos Collector" DESCRIPTION="The Odigos build of the OpenTelemetry Collector." TAG=$(TAG) ORG=$(ORG) IMG_SUFFIX=$(IMG_SUFFIX)
 	make -j 3 build-tag-push-ecr-image/ui DOCKERFILE=frontend/$(DOCKERFILE) SUMMARY="UI for Odigos" DESCRIPTION="UI provides the frontend webapp for managing an Odigos installation." TAG=$(TAG) ORG=$(ORG) IMG_SUFFIX=$(IMG_SUFFIX)
 	echo "✅ Deployed Odigos to EKS, now install the CLI"
-
-.PHONY: build-cli-image
-build-cli-image:
-	cd cli && \
-	KO_DOCKER_REPO=$(ORG)/odigos-cli$(IMG_SUFFIX) \
-	VERSION=$(TAG) \
-	SHORT_COMMIT=$(shell git rev-parse --short HEAD) \
-	DATE=$(shell date -u +'%Y-%m-%d_%H:%M:%S') \
-	ko build --bare --tags $(TAG) --local .
-
-.PHONY: build-cli-image-rhel
-build-cli-image-rhel:
-	cd cli && $(MAKE) licenses
-	cd cli && docker build -f Dockerfile.rhel-base -t $(CLI_RHEL_KO_BASE_IMAGE) .
-	cd cli && \
-	KO_DOCKER_REPO=$(ORG)/$(CLI_RHEL_IMAGE_NAME) \
-	KO_DEFAULTBASEIMAGE=$(CLI_RHEL_KO_BASE_IMAGE) \
-	KO_CONFIG_PATH=./.ko.yaml \
-	VERSION=$(TAG) \
-	SHORT_COMMIT=$(shell git rev-parse --short HEAD) \
-	DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ") \
-	ko build --bare --tags $(TAG) --local .
-
-.PHONY: push-cli-image-rhel
-push-cli-image-rhel:
-	@if [ "$(PUSH_IMAGE)" != "true" ]; then \
-		echo "this command will push the image to the public registry; set PUSH_IMAGE=true" >&2; \
-		exit 1; \
-	fi
-	cd cli && $(MAKE) licenses
-	docker buildx build --platform linux/amd64,linux/arm64 \
-		-f cli/Dockerfile.rhel-base \
-		-t $(CLI_RHEL_KO_BASE_IMAGE) \
-		--push \
-		cli
-	cd cli && \
-	KO_DOCKER_REPO=$(ORG)/$(CLI_RHEL_IMAGE_NAME) \
-	KO_DEFAULTBASEIMAGE=$(CLI_RHEL_KO_BASE_IMAGE) \
-	KO_CONFIG_PATH=./.ko.yaml \
-	VERSION=$(TAG) \
-	SHORT_COMMIT=$(shell git rev-parse --short HEAD) \
-	DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ") \
-	ko build --bare --tags $(TAG) \
-		--image-label name=odigos-cli \
-		--image-label vendor=Odigos \
-		--image-label maintainer=Odigos \
-		--image-label version=$(TAG) \
-		--image-label release=$(TAG) \
-		--image-label summary="Odigos CLI" \
-		--image-label description="Odigos CLI to install and manage Odigos in your Kubernetes cluster." \
-		--platform=all .
 
 # install gatekeeper to prevent:
 # 1. privileged containers

--- a/Makefile.cli
+++ b/Makefile.cli
@@ -1,0 +1,148 @@
+# CLI-related targets. Included from the root Makefile.
+# Shared vars from the parent Makefile:
+#   TAG                 - image / version tag (auto-detected from cluster/cli/helm if unset)
+#   ORG                 - registry org (default: registry.odigos.io); STAGING_ORG=true for staging GCR
+#   IMG_SUFFIX          - image name suffix (empty by default; -rhel-certified when RHEL=true)
+#   ODIGOS_CLI_VERSION  - version passed to install/upgrade (default: `odigos version --cli`)
+#   CLUSTER_NAME        - cluster name for install (default: local-dev-cluster)
+#   CENTRAL_BACKEND_URL - optional central backend URL for install
+#   FLAGS               - extra CLI flags appended to cli-install
+
+CLI_IMAGE ?= $(ORG)/odigos-cli$(IMG_SUFFIX):$(TAG)
+
+# RHEL-certified CLI (ko + Dockerfile.rhel-base); matches .github/workflows/publish-modules-rhel publish-cli-rhel
+CLI_RHEL_IMAGE_NAME ?= odigos-cli-rhel-certified
+CLI_RHEL_KO_BASE_IMAGE ?= $(ORG)/odigos-cli-rhel-ko-base:$(TAG)
+
+# Regenerate Mintlify CLI docs snippets under docs/snippets/shared/cli from cobra commands.
+.PHONY: cli-docs
+cli-docs:
+	rm -rf docs/snippets/shared/cli/*
+	cd scripts/cli-docgen && KUBECONFIG=KUBECONFIG go run -tags embed_manifests main.go
+	for file in docs/snippets/shared/cli/*.md; do \
+		mv $${file} $${file%.md}.mdx; \
+	done
+
+# Install Odigos from local cli/ source (go run), reflecting local api/cli changes.
+# Defaults: --version=$(ODIGOS_CLI_VERSION) --nowait --cluster-name=$(CLUSTER_NAME).
+# Override: make cli-install ODIGOS_CLI_VERSION=v1.2.3 CLUSTER_NAME=my-cluster FLAGS='--set image.tag=...'
+# Set CENTRAL_BACKEND_URL to pass --central-backend-url for proxy/central setups.
+.PHONY: cli-install
+cli-install:
+	@echo "Installing odigos from source. version: $(ODIGOS_CLI_VERSION)"
+	cd ./cli ; go run -tags=embed_manifests . install \
+		--version $(ODIGOS_CLI_VERSION) \
+		--nowait \
+		$(if $(CLUSTER_NAME),--cluster-name $(CLUSTER_NAME)) \
+		$(if $(CENTRAL_BACKEND_URL),--central-backend-url $(CENTRAL_BACKEND_URL)) \
+		$(FLAGS)
+
+# Uninstall Odigos from the current cluster using local cli/ source.
+.PHONY: cli-uninstall
+cli-uninstall:
+	@echo "Uninstalling odigos from source. version: $(ODIGOS_CLI_VERSION)"
+	cd ./cli ; go run -tags=embed_manifests . uninstall
+
+# Upgrade an existing install using local cli/ source.
+# Defaults: --version=$(ODIGOS_CLI_VERSION) --yes.
+# Override: make cli-upgrade ODIGOS_CLI_VERSION=v1.2.3
+.PHONY: cli-upgrade
+cli-upgrade:
+	@echo "Upgrading odigos from source. version: $(ODIGOS_CLI_VERSION)"
+	cd ./cli ; go run -tags=embed_manifests . upgrade --version $(ODIGOS_CLI_VERSION) --yes
+
+# Build the cli/odigos binary for local/e2e use, with helm charts embedded.
+# Hardcodes chart/binary version to 0.0.0-e2e-test (not TAG). Output: cli/odigos.
+.PHONY: cli-build
+cli-build:
+	@echo "Building the cli executable for tests"
+	TAG=0.0.0-e2e-test; \
+	TMPDIR=$$(mktemp -d); \
+	cp -r ./helm/odigos $$TMPDIR/odigos; \
+	sed -i.bak -E 's/^version:.*/version: '"$${TAG#v}"'/' $$TMPDIR/odigos/Chart.yaml; \
+	helm package $$TMPDIR/odigos -d cli/pkg/helm/embedded; \
+	cp -r ./helm/odigos-central $$TMPDIR/odigos-central; \
+	sed -i.bak -E 's/^version:.*/version: '"$${TAG#v}"'/' $$TMPDIR/odigos-central/Chart.yaml; \
+	helm package $$TMPDIR/odigos-central -d cli/pkg/helm/embedded; \
+	cd cli && go build -tags=embed_manifests \
+	  -ldflags "-X github.com/odigos-io/odigos/cli/pkg/helm.OdigosChartVersion=$${TAG#v}" \
+	  -o odigos .; \
+	rm -rf $$TMPDIR
+
+# Collect cluster diagnostics via local cli/ source (`odigos diagnose`).
+.PHONY: cli-diagnose
+cli-diagnose:
+	@echo "Diagnosing cluster data for debugging"
+	cd ./cli ; go run -tags=embed_manifests . diagnose
+
+# Build the CLI container image with docker (cli/Dockerfile).
+# Default tag: $(CLI_IMAGE) = $(ORG)/odigos-cli$(IMG_SUFFIX):$(TAG)
+# Override: make build-cli-image TAG=e2e-test
+#           make build-cli-image CLI_IMAGE=my.registry/odigos-cli:dev
+# Embeds whatever charts are already present under cli/pkg/helm/embedded/.
+.PHONY: build-cli-image
+build-cli-image:
+	docker build -t $(CLI_IMAGE) -f cli/Dockerfile . \
+		--build-arg VERSION=$(TAG) \
+		--build-arg SHORT_COMMIT=$(shell git rev-parse --short HEAD) \
+		--build-arg DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+# Extract the /odigos binary from a CLI image to cli/odigos for use on the host.
+# Default image: $(CLI_IMAGE). Requires the image to be local or pullable.
+# Override: make extract-cli CLI_IMAGE=registry.odigos.io/odigos-cli:v1.2.3
+# Use after build-cli-image, or in CI once the image is available for the runner arch.
+.PHONY: extract-cli
+extract-cli:
+	@cid=$$(docker create $(CLI_IMAGE)); \
+	docker cp $$cid:/odigos cli/odigos; \
+	docker rm $$cid >/dev/null; \
+	chmod +x cli/odigos
+	@echo "Extracted $(CLI_IMAGE) -> cli/odigos"
+
+# Build the RHEL-certified CLI image locally with ko (not pushed).
+# Builds Dockerfile.rhel-base then ko-builds onto it. Tag: $(TAG).
+# Override: make build-cli-image-rhel TAG=v1.2.3 ORG=registry.odigos.io
+.PHONY: build-cli-image-rhel
+build-cli-image-rhel:
+	cd cli && $(MAKE) licenses
+	cd cli && docker build -f Dockerfile.rhel-base -t $(CLI_RHEL_KO_BASE_IMAGE) .
+	cd cli && \
+	KO_DOCKER_REPO=$(ORG)/$(CLI_RHEL_IMAGE_NAME) \
+	KO_DEFAULTBASEIMAGE=$(CLI_RHEL_KO_BASE_IMAGE) \
+	KO_CONFIG_PATH=./.ko.yaml \
+	VERSION=$(TAG) \
+	SHORT_COMMIT=$(shell git rev-parse --short HEAD) \
+	DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ") \
+	ko build --bare --tags $(TAG) --local .
+
+# Multi-arch build and push of the RHEL-certified CLI image (amd64+arm64).
+# Requires PUSH_IMAGE=true (safety guard). Pushes base + certified image to $(ORG).
+# Override: make push-cli-image-rhel PUSH_IMAGE=true TAG=v1.2.3 ORG=...
+.PHONY: push-cli-image-rhel
+push-cli-image-rhel:
+	@if [ "$(PUSH_IMAGE)" != "true" ]; then \
+		echo "this command will push the image to the public registry; set PUSH_IMAGE=true" >&2; \
+		exit 1; \
+	fi
+	cd cli && $(MAKE) licenses
+	docker buildx build --platform linux/amd64,linux/arm64 \
+		-f cli/Dockerfile.rhel-base \
+		-t $(CLI_RHEL_KO_BASE_IMAGE) \
+		--push \
+		cli
+	cd cli && \
+	KO_DOCKER_REPO=$(ORG)/$(CLI_RHEL_IMAGE_NAME) \
+	KO_DEFAULTBASEIMAGE=$(CLI_RHEL_KO_BASE_IMAGE) \
+	KO_CONFIG_PATH=./.ko.yaml \
+	VERSION=$(TAG) \
+	SHORT_COMMIT=$(shell git rev-parse --short HEAD) \
+	DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ") \
+	ko build --bare --tags $(TAG) \
+		--image-label name=odigos-cli \
+		--image-label vendor=Odigos \
+		--image-label maintainer=Odigos \
+		--image-label version=$(TAG) \
+		--image-label release=$(TAG) \
+		--image-label summary="Odigos CLI" \
+		--image-label description="Odigos CLI to install and manage Odigos in your Kubernetes cluster." \
+		--platform=all .

--- a/Makefile.cli
+++ b/Makefile.cli
@@ -9,6 +9,10 @@
 #   FLAGS               - extra CLI flags appended to cli-install
 
 CLI_IMAGE ?= $(ORG)/odigos-cli$(IMG_SUFFIX):$(TAG)
+CLI_SUMMARY ?= Odigos CLI
+CLI_DESCRIPTION ?= Odigos CLI to install and manage Odigos in your Kubernetes cluster.
+SHORT_COMMIT ?= $(shell git rev-parse --short HEAD)
+DATE ?= $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 
 # RHEL-certified CLI (ko + Dockerfile.rhel-base); matches .github/workflows/publish-modules-rhel publish-cli-rhel
 CLI_RHEL_IMAGE_NAME ?= odigos-cli-rhel-certified
@@ -79,13 +83,18 @@ cli-diagnose:
 # Default tag: $(CLI_IMAGE) = $(ORG)/odigos-cli$(IMG_SUFFIX):$(TAG)
 # Override: make build-cli-image TAG=e2e-test
 #           make build-cli-image CLI_IMAGE=my.registry/odigos-cli:dev
+# RHEL via Dockerfile target: make build-cli-image RHEL=true
 # Embeds whatever charts are already present under cli/pkg/helm/embedded/.
 .PHONY: build-cli-image
 build-cli-image:
-	docker build -t $(CLI_IMAGE) -f cli/Dockerfile . \
+	docker build $(DOCKER_BUILD_OPTS) $(TARGET_FLAG) -t $(CLI_IMAGE) -f cli/Dockerfile . \
 		--build-arg VERSION=$(TAG) \
-		--build-arg SHORT_COMMIT=$(shell git rev-parse --short HEAD) \
-		--build-arg DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+		--build-arg RELEASE=$(TAG) \
+		--build-arg SUMMARY="$(CLI_SUMMARY)" \
+		--build-arg DESCRIPTION="$(CLI_DESCRIPTION)" \
+		--build-arg SHORT_COMMIT=$(SHORT_COMMIT) \
+		--build-arg DATE=$(DATE) \
+		--build-arg RHEL=$(RHEL)
 
 # Extract the /odigos binary from a CLI image to cli/odigos for use on the host.
 # Default image: $(CLI_IMAGE). Requires the image to be local or pullable.

--- a/Makefile.depot
+++ b/Makefile.depot
@@ -67,6 +67,7 @@ define depot-build
 		--build-arg ODIGOS_VERSION="$(IMAGE_TAG)" \
 		--build-arg VERSION="$(IMAGE_TAG)" \
 		--build-arg RELEASE="$(IMAGE_TAG)" \
+		$(3) \
 		$(OUTPUT_FLAG) \
 		$(if $(SAVE_TAG),--save --save-tag $(SAVE_TAG)) \
 		$(BUILD_DIR)
@@ -83,6 +84,18 @@ depot-build-scheduler:
 .PHONY: depot-build-collector
 depot-build-collector:
 	$(call depot-build,collector/Dockerfile,collector)
+
+# CLI image build-args (cli/Dockerfile). Overridable so CI can pass stable values and
+# avoid cache misses when commit/date change every run but the values are unused.
+# VERSION/ODIGOS_VERSION/RELEASE come from IMAGE_TAG via depot-build.
+# Defaults: current git short SHA and UTC timestamp.
+# CI example: make -f Makefile.depot depot-build-cli IMAGE_TAG=v0.0.0 SHORT_COMMIT=ci DATE=ci
+SHORT_COMMIT ?= $(shell git rev-parse --short HEAD)
+DATE ?= $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+.PHONY: depot-build-cli
+depot-build-cli:
+	$(call depot-build,cli/Dockerfile,cli,--build-arg SHORT_COMMIT=$(SHORT_COMMIT) --build-arg DATE=$(DATE))
 
 .PHONY: depot-build-all
 depot-build-all: depot-build-autoscaler depot-build-scheduler depot-build-collector

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -4,6 +4,7 @@ ARG TARGETARCH
 ARG VERSION
 ARG SHORT_COMMIT
 ARG DATE
+ARG RHEL=false
 
 WORKDIR /workspace
 
@@ -31,12 +32,39 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
     CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
     go build -tags=embed_manifests -a -o odigos \
-    -ldflags="-X github.com/odigos-io/odigos/cli/cmd.OdigosVersion=${VERSION} \
+    -ldflags="-s -w \
+              -X github.com/odigos-io/odigos/cli/cmd.OdigosVersion=${VERSION} \
               -X github.com/odigos-io/odigos/cli/pkg/helm.OdigosChartVersion=${VERSION} \
               -X github.com/odigos-io/odigos/cli/cmd.OdigosCommit=${SHORT_COMMIT} \
               -X github.com/odigos-io/odigos/cli/cmd.OdigosDate=${DATE}" \
     .
+RUN if [ "$RHEL" = "true" ] ; then \
+      make licenses ; \
+    fi
 
+######## RHEL Image ########
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest AS rhel
+ARG VERSION
+ARG RELEASE
+ARG SUMMARY
+ARG DESCRIPTION
+LABEL "name"="odigos-cli"
+LABEL "vendor"="Odigos"
+LABEL "maintainer"="Odigos"
+LABEL "version"=$VERSION
+LABEL "release"=$RELEASE
+LABEL "summary"=$SUMMARY
+LABEL "description"=$DESCRIPTION
+WORKDIR /
+COPY --from=builder /workspace/cli/odigos /odigos
+COPY --from=builder /workspace/cli/licenses /licenses
+COPY --from=builder /workspace/cli/LICENSE /licenses/.
+USER 65532:65532
+ENTRYPOINT ["/odigos"]
+
+######### Final Image #########
+# Use distroless as minimal base image to package the CLI binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/cli/odigos /odigos

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,0 +1,44 @@
+FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION
+ARG SHORT_COMMIT
+ARG DATE
+
+WORKDIR /workspace
+
+COPY api/go.mod api/go.sum api/
+COPY common/go.mod common/go.sum common/
+COPY k8sutils/go.mod k8sutils/go.sum k8sutils/
+COPY profiles/go.mod profiles/go.sum profiles/
+COPY odigosauth/go.mod odigosauth/go.sum odigosauth/
+COPY cli/go.mod cli/go.sum cli/
+
+WORKDIR /workspace/cli
+RUN --mount=type=cache,target=/go/pkg \
+    go mod download
+
+WORKDIR /workspace
+COPY api/ api/
+COPY common/ common/
+COPY k8sutils/ k8sutils/
+COPY profiles/ profiles/
+COPY odigosauth/ odigosauth/
+COPY cli/ cli/
+
+WORKDIR /workspace/cli
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
+    go build -tags=embed_manifests -a -o odigos \
+    -ldflags="-X github.com/odigos-io/odigos/cli/cmd.OdigosVersion=${VERSION} \
+              -X github.com/odigos-io/odigos/cli/pkg/helm.OdigosChartVersion=${VERSION} \
+              -X github.com/odigos-io/odigos/cli/cmd.OdigosCommit=${SHORT_COMMIT} \
+              -X github.com/odigos-io/odigos/cli/cmd.OdigosDate=${DATE}" \
+    .
+
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /workspace/cli/odigos /odigos
+USER 65532:65532
+ENTRYPOINT ["/odigos"]


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: CORE-1318

Move CLI make targets into Makefile.cli, add cli/Dockerfile, and support depot-build-cli with overridable SHORT_COMMIT/DATE for cache-friendly CI builds.

Currently still  using the existing build (with `ko`) for what we publish, so it's a safe change. can only affect CI.
This is done to align cli to be built using dockerfile, so we can leverage it in CI to use depot build machine and also consistent workflows for all components

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
