### PR TITLE
CORE-1351: expand root .dockerignore to shrink build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,52 @@
-frontend/webapp/node_modules
+# VCS / IDE / local tooling
 .git/
+.github/
+.vscode/
+.cursor/
+.devcontainer/
+.tools/
+**/.tools/
+
+# Workspace / credentials
+go.work
+go.work.sum
+go.work.bak
+go.work.sum.bak
+gha-creds-*.json
+.env
+kubeconfig
+
+# Docs and non-build trees (root-context builds never COPY these)
+docs/
+scripts/
+hooks/
+own-observability/
+tests/
+tests-infrastructure/
+
+# Local build / test artifacts
+**/bin/
+**/testbin/
+**/dist/
+**/artifacts/
+**/__debug_bin*
+**/*.log
+**/*.logs
+**/cover.out
+**/.DS_Store
+
+# CLI host binary (rebuilt inside the image)
+cli/odigos
+/odigos
+
+# Frontend: deps and host build outputs (yarn build runs in the image)
+**/node_modules/
+frontend/webapp/.next/
+frontend/webapp/out/
+frontend/webapp/cypress/
+
+# Dockerfiles are read via -f from the host; keep them out of the context
 Dockerfile
 odiglet/Dockerfile
 odiglet/base.Dockerfile
 odiglet/debug.Dockerfile
-tests # not needed in context for odigos components builds
-go.work
-go.work.sum
-gha-creds-*.json


### PR DESCRIPTION
#### What this PR does / why we need it:
Expand the root `.dockerignore` so root-context Docker builds exclude local artifacts and unrelated trees (`docs/`, `.tools/`, `**/bin/`, `cli/odigos`, frontend host outputs, etc.). This cuts measured build context from ~328MiB to ~19MiB and speeds up image builds.

Linear: https://linear.app/odigos/issue/CORE-1351/expand-root-dockerignore-to-shrink-docker-build-context

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
```release-note
NONE
```