### PR TITLE
DEVOPS-57: Fix CHART_VER ldflags expansion in CLI Docker build

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -59,7 +59,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     go build -tags=embed_manifests -a -o odigos \
     -ldflags="-s -w \
               -X github.com/odigos-io/odigos/cli/cmd.OdigosVersion=${VERSION} \
-              -X github.com/odigos-io/odigos/cli/pkg/helm.OdigosChartVersion=$${CHART_VER} \
+              -X github.com/odigos-io/odigos/cli/pkg/helm.OdigosChartVersion=${CHART_VER} \
               -X github.com/odigos-io/odigos/cli/cmd.OdigosCommit=${SHORT_COMMIT} \
               -X github.com/odigos-io/odigos/cli/cmd.OdigosDate=${DATE}" \
     .


### PR DESCRIPTION
#### What this PR does / why we need it:

Linear:
https://linear.app/odigos/issue/DEVOPS-57/fix-chart-ver-ldflags-expansion-in-cli-docker-build

Follow-up to DEVOPS-56 / #5368: the CLI Docker build escaped `CHART_VER` as `$${CHART_VER}` in the Go ldflags that set `OdigosChartVersion`. That prevented the shell variable (set earlier in the same `RUN` after SemVer normalization) from being embedded correctly. Use `${CHART_VER}` so the baked chart version matches the build arg.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
NONE
```

Made with [Cursor](https://cursor.com)