### PR TITLE
fix: warning in datacollection

### DIFF
--- a/autoscaler/controllers/clustercollector/configmap.go
+++ b/autoscaler/controllers/clustercollector/configmap.go
@@ -130,8 +130,10 @@ func addSelfTelemetryPipeline(c *config.Config, ownTelemetryPort int32, destinat
 				},
 			},
 		},
-		Resource: map[string]*string{
-			string(semconv.K8SPodNameKey): &podNameFromEnv,
+		Resource: &config.TelemetryResource{
+			Attributes: []config.ResourceAttribute{
+				{Name: string(semconv.K8SPodNameKey), Value: podNameFromEnv},
+			},
 		},
 	}
 

--- a/autoscaler/controllers/nodecollector/collectorconfig/ownmetrics-ui.go
+++ b/autoscaler/controllers/nodecollector/collectorconfig/ownmetrics-ui.go
@@ -118,14 +118,11 @@ func serviceTelemetryConfigForOwnMetricsUi(ownMetricsPort int32) config.Telemetr
 			Level:   "detailed",
 			Readers: []config.GenericMap{reader},
 		},
-		Resource: map[string]*string{
-			// The collector add "otelcol" as a service name, so we need to remove it
-			// to avoid duplication, since we are interested in the instrumented services.
-			string(semconv.ServiceNameKey): nil,
-			// The collector adds its own version as a service version, which is not needed currently.
-			string(semconv.ServiceVersionKey): nil,
-			string(semconv.K8SPodNameKey):     &podNameFromEnv,
-			string(semconv.K8SNodeNameKey):    &nodeNameFromEnv,
+		Resource: &config.TelemetryResource{
+			Attributes: []config.ResourceAttribute{
+				{Name: string(semconv.K8SNodeNameKey), Value: nodeNameFromEnv},
+				{Name: string(semconv.K8SPodNameKey), Value: podNameFromEnv},
+			},
 		},
 	}
 }

--- a/autoscaler/controllers/nodecollector/testdata/logs_included.yaml
+++ b/autoscaler/controllers/nodecollector/testdata/logs_included.yaml
@@ -214,7 +214,8 @@ service:
               host: 0.0.0.0
               port: 55682
     resource:
-      k8s.node.name: ${NODE_NAME}
-      k8s.pod.name: ${POD_NAME}
-      service.name: null
-      service.version: null
+      attributes:
+      - name: k8s.node.name
+        value: ${NODE_NAME}
+      - name: k8s.pod.name
+        value: ${POD_NAME}

--- a/autoscaler/controllers/nodecollector/testdata/traces_only_no_loadbalancing.yaml
+++ b/autoscaler/controllers/nodecollector/testdata/traces_only_no_loadbalancing.yaml
@@ -131,7 +131,8 @@ service:
               host: 0.0.0.0
               port: 55682
     resource:
-      k8s.node.name: ${NODE_NAME}
-      k8s.pod.name: ${POD_NAME}
-      service.name: null
-      service.version: null
+      attributes:
+      - name: k8s.node.name
+        value: ${NODE_NAME}
+      - name: k8s.pod.name
+        value: ${POD_NAME}

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -51,7 +51,19 @@ type LogsConfig struct {
 type Telemetry struct {
 	Metrics  MetricsConfig      `json:"metrics,omitempty"`
 	Logs     LogsConfig         `json:"logs,omitempty"`
-	Resource map[string]*string `json:"resource,omitempty"`
+	Resource *TelemetryResource `json:"resource,omitempty" yaml:"resource,omitempty"`
+}
+
+// TelemetryResource holds user-defined resource attributes attached to the collector's
+// own telemetry. It uses the otelconf declarative schema (service.telemetry.resource.attributes),
+// which replaced the deprecated inline map format.
+type TelemetryResource struct {
+	Attributes []ResourceAttribute `json:"attributes,omitempty"`
+}
+
+type ResourceAttribute struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 type Service struct {
@@ -144,21 +156,19 @@ func mergeMetricsLevel(level1 string, level2 string) (string, error) {
 	}
 }
 
-func mergeTelemetryResource(resource1 map[string]*string, resource2 map[string]*string) map[string]*string {
-	if len(resource1) == 0 { // shortcut for common cases
+func mergeTelemetryResource(resource1 *TelemetryResource, resource2 *TelemetryResource) *TelemetryResource {
+	if resource1 == nil || len(resource1.Attributes) == 0 { // shortcut for common cases
 		return resource2
-	} else if len(resource2) == 0 {
+	} else if resource2 == nil || len(resource2.Attributes) == 0 {
 		return resource1
 	}
 
-	mergedResource := make(map[string]*string, len(resource1)+len(resource2))
-	for k, v := range resource1 {
-		mergedResource[k] = v
+	merged := &TelemetryResource{
+		Attributes: make([]ResourceAttribute, 0, len(resource1.Attributes)+len(resource2.Attributes)),
 	}
-	for k, v := range resource2 {
-		mergedResource[k] = v
-	}
-	return mergedResource
+	merged.Attributes = append(merged.Attributes, resource1.Attributes...)
+	merged.Attributes = append(merged.Attributes, resource2.Attributes...)
+	return merged
 }
 
 func mergeTelemetryReaders(readers1 []GenericMap, readers2 []GenericMap) []GenericMap {

--- a/common/config/testdata/debugexporter.yaml
+++ b/common/config/testdata/debugexporter.yaml
@@ -55,4 +55,3 @@ service:
       readers: []
     logs:
       level: ""
-    resource: {}

--- a/common/config/testdata/destnosources.yaml
+++ b/common/config/testdata/destnosources.yaml
@@ -64,4 +64,3 @@ service:
       readers: []
     logs:
       level: ""
-    resource: {}

--- a/common/config/testdata/minimal.yaml
+++ b/common/config/testdata/minimal.yaml
@@ -35,4 +35,3 @@ service:
       readers: []
     logs:
       level: ""
-    resource: {}

--- a/common/config/testdata/sourcesnodest.yaml
+++ b/common/config/testdata/sourcesnodest.yaml
@@ -43,4 +43,3 @@ service:
       readers: []
     logs:
       level: ""
-    resource: {}

--- a/common/config/testdata/withbaseminimal.yaml
+++ b/common/config/testdata/withbaseminimal.yaml
@@ -17,4 +17,3 @@ service:
       readers: []
     logs:
       level: ""
-    resource: {}

--- a/common/config/testdata/withdatastream.yaml
+++ b/common/config/testdata/withdatastream.yaml
@@ -64,4 +64,3 @@ service:
       readers: []
     logs:
       level: ""
-    resource: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Data collection and gateway log warnings due to some deprecation upstream did.

```
2026-07-26T08:01:49.116Z	warn	otelconftelemetry/logger.go:133	Using legacy service.telemetry.resource inline map format; prefer service.telemetry.resource.attributes (array of maps with `name` and `value` keys)	{"resource": {"k8s.node.name": "kind-control-plane", "k8s.pod.name": "odiglet-nk9c5", "service.instance.id": "5ab66382-4253-4946-9f5d-76bb1ab8aaa0"}, "legacy_resource_attributes": ["k8s.node.name", "k8s.pod.name", "service.name", "service.version"]}
```

The warning is emitted by the collector's telemetry factory (otelconftelemetry, part of go.opentelemetry.io/collector/service v0.151.0). It fires whenever service.telemetry.resource is provided as the legacy inline map instead of the newer service.telemetry.resource.attributes array.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
