### PR TITLE
CORE-1268 | feat: Send serviceGraph metrics OTLP metrics also to Clickhouse DB (Insight)

### DIFF
--- a/autoscaler/controllers/clustercollector/configmap.go
+++ b/autoscaler/controllers/clustercollector/configmap.go
@@ -197,6 +197,12 @@ func syncConfigMap(enabledDests *odigosv1.DestinationList, allProcessors *odigos
 	}
 	// When on, pipelinegen installs groupbytrace on traces/in so the exporter sees full traces.
 	gatewayOptions.Insights = insightsCfg
+	// Provide the insights OTLP endpoint so pipelinegen (in the common module, which
+	// cannot import api/k8sconsts) can wire the servicegraph metrics side-channel to
+	// insights for the blast-radius topology.
+	if odigoscommon.InsightsPipelineActive(insightsCfg) {
+		gatewayOptions.InsightsOtlpEndpoint = k8sconsts.InsightsOtlpGrpcEndpoint(env.GetCurrentNamespace())
+	}
 	// Insights can trigger groupbytrace without tail sampling on, in which case
 	// the scheduler hasn't resolved TraceAggregationWaitDuration. Fall back to the
 	// canonical default so we never feed groupbytrace a nil wait_duration.

--- a/autoscaler/controllers/clustercollector/configmap.go
+++ b/autoscaler/controllers/clustercollector/configmap.go
@@ -198,8 +198,8 @@ func syncConfigMap(enabledDests *odigosv1.DestinationList, allProcessors *odigos
 	// When on, pipelinegen installs groupbytrace on traces/in so the exporter sees full traces.
 	gatewayOptions.Insights = insightsCfg
 	// Provide the insights OTLP endpoint so pipelinegen (in the common module, which
-	// cannot import api/k8sconsts) can wire the servicegraph metrics side-channel to
-	// insights for the blast-radius topology.
+	// cannot import api/k8sconsts) can add an OTLP exporter to metrics/servicegraph
+	// for the blast-radius topology.
 	if odigoscommon.InsightsPipelineActive(insightsCfg) {
 		gatewayOptions.InsightsOtlpEndpoint = k8sconsts.InsightsOtlpGrpcEndpoint(env.GetCurrentNamespace())
 	}

--- a/common/config/root_test.go
+++ b/common/config/root_test.go
@@ -316,8 +316,8 @@ func baseConfigWithSelfMetrics() *config.Config {
 }
 
 // TestServiceGraphInsights verifies that when insights is active the gateway
-// gets the dedicated servicegraph->insights OTLP pipeline (leaving the UI's
-// prometheus/servicegraph pipeline intact) and forces the k8s.namespace.name
+// adds the insights OTLP exporter to the existing metrics/servicegraph pipeline
+// (alongside prometheus/servicegraph) and forces the k8s.namespace.name
 // dimension so edges can be joined to anomalies keyed by (namespace, service).
 func TestServiceGraphInsights(t *testing.T) {
 	on := true
@@ -334,17 +334,17 @@ func TestServiceGraphInsights(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// The dedicated insights pipeline + exporter exist, and the UI's prometheus
-	// pipeline is still present (untouched).
-	assert.Contains(t, out, "metrics/servicegraph-insights:")
+	// One pipeline, two exporters: prometheus (UI) + OTLP (insights).
+	assert.Contains(t, out, "metrics/servicegraph:")
+	assert.Contains(t, out, "prometheus/servicegraph")
 	assert.Contains(t, out, "otlp_grpc/servicegraph-insights:")
 	assert.Contains(t, out, "odigos-insights.odigos-system:4317")
-	assert.Contains(t, out, "metrics/servicegraph:")
+	assert.NotContains(t, out, "metrics/servicegraph-insights:")
 	// Namespace dimension is forced on so edges carry it.
 	assert.Contains(t, out, "- k8s.namespace.name\n")
 }
 
-// TestServiceGraphInsightsDisabled verifies the insights side-channel is absent
+// TestServiceGraphInsightsDisabled verifies the insights exporter is absent
 // when insights is not active, so the default service-graph path is unchanged.
 func TestServiceGraphInsightsDisabled(t *testing.T) {
 	gatewayOptions := pipelinegen.GatewayConfigOptions{OdigosNamespace: "odigos-system"}
@@ -355,8 +355,8 @@ func TestServiceGraphInsightsDisabled(t *testing.T) {
 		nil, nil, &gatewayOptions,
 	)
 	require.NoError(t, err)
-	assert.NotContains(t, out, "metrics/servicegraph-insights:")
 	assert.NotContains(t, out, "otlp_grpc/servicegraph-insights:")
+	assert.NotContains(t, out, "metrics/servicegraph-insights:")
 }
 
 func TestServiceGraphOptions(t *testing.T) {

--- a/common/config/root_test.go
+++ b/common/config/root_test.go
@@ -315,6 +315,50 @@ func baseConfigWithSelfMetrics() *config.Config {
 	return base
 }
 
+// TestServiceGraphInsights verifies that when insights is active the gateway
+// gets the dedicated servicegraph->insights OTLP pipeline (leaving the UI's
+// prometheus/servicegraph pipeline intact) and forces the k8s.namespace.name
+// dimension so edges can be joined to anomalies keyed by (namespace, service).
+func TestServiceGraphInsights(t *testing.T) {
+	on := true
+	gatewayOptions := pipelinegen.GatewayConfigOptions{
+		OdigosNamespace:      "odigos-system",
+		Insights:             &common.InsightsConfiguration{Enabled: &on},
+		InsightsOtlpEndpoint: "odigos-insights.odigos-system:4317",
+	}
+	out, err, _, _ := pipelinegen.CalculateGatewayConfig(
+		baseConfigWithSelfMetrics(),
+		[]config.ExporterConfigurer{DummyTraceDestination{ID: "t1"}},
+		[]config.ProcessorConfigurer{},
+		nil, nil, &gatewayOptions,
+	)
+	require.NoError(t, err)
+
+	// The dedicated insights pipeline + exporter exist, and the UI's prometheus
+	// pipeline is still present (untouched).
+	assert.Contains(t, out, "metrics/servicegraph-insights:")
+	assert.Contains(t, out, "otlp_grpc/servicegraph-insights:")
+	assert.Contains(t, out, "odigos-insights.odigos-system:4317")
+	assert.Contains(t, out, "metrics/servicegraph:")
+	// Namespace dimension is forced on so edges carry it.
+	assert.Contains(t, out, "- k8s.namespace.name\n")
+}
+
+// TestServiceGraphInsightsDisabled verifies the insights side-channel is absent
+// when insights is not active, so the default service-graph path is unchanged.
+func TestServiceGraphInsightsDisabled(t *testing.T) {
+	gatewayOptions := pipelinegen.GatewayConfigOptions{OdigosNamespace: "odigos-system"}
+	out, err, _, _ := pipelinegen.CalculateGatewayConfig(
+		baseConfigWithSelfMetrics(),
+		[]config.ExporterConfigurer{DummyTraceDestination{ID: "t1"}},
+		[]config.ProcessorConfigurer{},
+		nil, nil, &gatewayOptions,
+	)
+	require.NoError(t, err)
+	assert.NotContains(t, out, "metrics/servicegraph-insights:")
+	assert.NotContains(t, out, "otlp_grpc/servicegraph-insights:")
+}
+
 func TestServiceGraphOptions(t *testing.T) {
 	tests := []struct {
 		name                       string

--- a/common/consts/consts.go
+++ b/common/consts/consts.go
@@ -60,6 +60,15 @@ const (
 	ServiceGraphConnectorName = "servicegraph"
 	ServiceGraphEndpointPort  = 9090
 
+	// ServiceGraphInsightsExporterName is the OTLP gRPC exporter that ships the
+	// servicegraph connector's metrics to the odigos-insights service so it can
+	// build the blast-radius topology. Only wired when insights is active.
+	ServiceGraphInsightsExporterName = "otlp_grpc/servicegraph-insights"
+	// ServiceGraphInsightsPipelineName is the dedicated metrics pipeline that
+	// fans the servicegraph connector output to insights, kept separate from the
+	// prometheus/servicegraph pipeline that feeds the UI so that path is untouched.
+	ServiceGraphInsightsPipelineName = "metrics/servicegraph-insights"
+
 	// Custom attribute to distinguish workload types that share the same semconv key (e.g., DeploymentConfig uses k8s.deployment.name)
 	// This allows the UI to distinguish between DeploymentConfig and Deployment, and construct the correct Source workload.
 	// Since DeploymentConfig uses k8s.deployment.name as the semconv key, we need to add this attribute to the list of attributes to be collected.

--- a/common/consts/consts.go
+++ b/common/consts/consts.go
@@ -62,12 +62,9 @@ const (
 
 	// ServiceGraphInsightsExporterName is the OTLP gRPC exporter that ships the
 	// servicegraph connector's metrics to the odigos-insights service so it can
-	// build the blast-radius topology. Only wired when insights is active.
+	// build the blast-radius topology. Added as a second exporter on the existing
+	// metrics/servicegraph pipeline when insights is active.
 	ServiceGraphInsightsExporterName = "otlp_grpc/servicegraph-insights"
-	// ServiceGraphInsightsPipelineName is the dedicated metrics pipeline that
-	// fans the servicegraph connector output to insights, kept separate from the
-	// prometheus/servicegraph pipeline that feeds the UI so that path is untouched.
-	ServiceGraphInsightsPipelineName = "metrics/servicegraph-insights"
 
 	// Custom attribute to distinguish workload types that share the same semconv key (e.g., DeploymentConfig uses k8s.deployment.name)
 	// This allows the UI to distinguish between DeploymentConfig and Deployment, and construct the correct Source workload.

--- a/common/pipelinegen/config_builder.go
+++ b/common/pipelinegen/config_builder.go
@@ -34,6 +34,13 @@ type GatewayConfigOptions struct {
 	// Passed as the full config (not a bool) so future toggles on the same
 	// feature can be added without changing this surface.
 	Insights *common.InsightsConfiguration
+
+	// InsightsOtlpEndpoint is the in-cluster OTLP gRPC host:port of the
+	// odigos-insights service (e.g. odigos-insights.<ns>:4317). Set by the
+	// caller so pipelinegen (in the common module) does not depend on the api
+	// module for the endpoint helper. When insights is active this is the
+	// destination for the servicegraph metrics side-channel.
+	InsightsOtlpEndpoint string
 }
 
 func GetGatewayConfig(
@@ -230,7 +237,7 @@ func CalculateGatewayConfig(
 	// - ServiceGraph.Disabled: assume false (enabled) if nil
 	// - ClusterMetricsEnabled: assume false (disabled) if nil
 	if tracesEnabled && (gatewayOptions.ServiceGraph.Disabled == nil || !*gatewayOptions.ServiceGraph.Disabled) {
-		insertServiceGraphPipeline(currentConfig, gatewayOptions.ServiceGraph.ExtraDimensions, gatewayOptions.ServiceGraph.VirtualNodePeerAttributes)
+		insertServiceGraphPipeline(currentConfig, gatewayOptions)
 	}
 	if metricsEnabled && gatewayOptions.ClusterMetricsEnabled != nil && *gatewayOptions.ClusterMetricsEnabled {
 		insertClusterMetricsResources(currentConfig, gatewayOptions.OdigosNamespace)
@@ -291,7 +298,11 @@ func applyRootPipelineForSignal(currentConfig *config.Config, signal common.Obse
 	}
 }
 
-func insertServiceGraphPipeline(currentConfig *config.Config, extraDimensions []string, virtualNodePeerAttributes []string) {
+func insertServiceGraphPipeline(currentConfig *config.Config, gatewayOptions *GatewayConfigOptions) {
+	extraDimensions := gatewayOptions.ServiceGraph.ExtraDimensions
+	virtualNodePeerAttributes := gatewayOptions.ServiceGraph.VirtualNodePeerAttributes
+	insightsOn := common.InsightsPipelineActive(gatewayOptions.Insights) && gatewayOptions.InsightsOtlpEndpoint != ""
+
 	// Add the service graph exporter to expose the service graph metrics to prometheus
 	currentConfig.Exporters["prometheus/servicegraph"] = config.GenericMap{
 		"endpoint":  fmt.Sprintf("localhost:%d", consts.ServiceGraphEndpointPort),
@@ -307,6 +318,14 @@ func insertServiceGraphPipeline(currentConfig *config.Config, extraDimensions []
 	// Build dimensions: always include service.name as the base, then append any extras
 	dimensions := []string{string(semconv.ServiceNameKey)}
 	dimensions = append(dimensions, extraDimensions...)
+
+	// When insights is active, the emitted edges must carry the namespace so the
+	// blast-radius topology can be joined to anomalies keyed by (namespace, service).
+	// service.name alone is ambiguous across namespaces, so force k8s.namespace.name
+	// into the connector dimensions (deduped against user-provided extras).
+	if insightsOn && !slices.Contains(dimensions, string(semconv.K8SNamespaceNameKey)) {
+		dimensions = append(dimensions, string(semconv.K8SNamespaceNameKey))
+	}
 
 	// Add the service graph connector to receive the service graph metrics from the root traces pipeline
 	// Retain incomplete edges for up to 15s to allow delayed span matching
@@ -331,6 +350,43 @@ func insertServiceGraphPipeline(currentConfig *config.Config, extraDimensions []
 	currentConfig.Service.Pipelines["metrics/servicegraph"] = config.Pipeline{
 		Receivers: []string{consts.ServiceGraphConnectorName},
 		Exporters: []string{"prometheus/servicegraph"},
+	}
+
+	// When insights is active, fan the same connector metrics to the insights
+	// service over OTLP on a dedicated pipeline. Kept separate from the
+	// prometheus/servicegraph pipeline above so the UI service-map path is
+	// entirely unaffected. A connector may be used as a receiver in multiple
+	// pipelines, so each consumer gets its own copy of the metrics.
+	if insightsOn {
+		// Stamp the gateway pod name onto the metrics resource so per-pod
+		// cumulative counters don't overwrite each other in ClickHouse (trace
+		// load balancing spreads an edge's spans across gateway pods). Reuse the
+		// self-telemetry processor when present, otherwise define it here so the
+		// pipeline is always valid even if self-telemetry wasn't applied.
+		if _, ok := currentConfig.Processors["resource/pod-name"]; !ok {
+			currentConfig.Processors["resource/pod-name"] = config.GenericMap{
+				"attributes": []config.GenericMap{
+					{
+						"key":    string(semconv.K8SPodNameKey),
+						"value":  "${POD_NAME}",
+						"action": "upsert",
+					},
+				},
+			}
+		}
+		currentConfig.Exporters[consts.ServiceGraphInsightsExporterName] = config.GenericMap{
+			"endpoint":    gatewayOptions.InsightsOtlpEndpoint,
+			"tls":         config.GenericMap{"insecure": true},
+			"compression": "none",
+			"retry_on_failure": config.GenericMap{
+				"enabled": false,
+			},
+		}
+		currentConfig.Service.Pipelines[consts.ServiceGraphInsightsPipelineName] = config.Pipeline{
+			Receivers:  []string{consts.ServiceGraphConnectorName},
+			Processors: []string{"resource/pod-name"},
+			Exporters:  []string{consts.ServiceGraphInsightsExporterName},
+		}
 	}
 
 	// Add the service graph exporter to the root traces pipeline

--- a/common/pipelinegen/config_builder.go
+++ b/common/pipelinegen/config_builder.go
@@ -39,7 +39,7 @@ type GatewayConfigOptions struct {
 	// odigos-insights service (e.g. odigos-insights.<ns>:4317). Set by the
 	// caller so pipelinegen (in the common module) does not depend on the api
 	// module for the endpoint helper. When insights is active this is the
-	// destination for the servicegraph metrics side-channel.
+	// destination for the OTLP exporter added to metrics/servicegraph.
 	InsightsOtlpEndpoint string
 }
 
@@ -346,23 +346,21 @@ func insertServiceGraphPipeline(currentConfig *config.Config, gatewayOptions *Ga
 
 	currentConfig.Connectors[consts.ServiceGraphConnectorName] = connectorCfg
 
-	// Add the service graph pipeline to receive the service graph metrics from the root traces pipeline
-	currentConfig.Service.Pipelines["metrics/servicegraph"] = config.Pipeline{
-		Receivers: []string{consts.ServiceGraphConnectorName},
-		Exporters: []string{"prometheus/servicegraph"},
-	}
-
-	// When insights is active, fan the same connector metrics to the insights
-	// service over OTLP on a dedicated pipeline. Kept separate from the
-	// prometheus/servicegraph pipeline above so the UI service-map path is
-	// entirely unaffected. A connector may be used as a receiver in multiple
-	// pipelines, so each consumer gets its own copy of the metrics.
+	// metrics/servicegraph receives the connector's metrics and exports them to
+	// the local prometheus/servicegraph endpoint (scraped back for the UI
+	// service map). When insights is active, the same pipeline also fans out
+	// to odigos-insights over OTLP — one connector, one pipeline, two exporters.
+	exporters := []string{"prometheus/servicegraph"}
+	var processors []string
 	if insightsOn {
 		// Stamp the gateway pod name onto the metrics resource so per-pod
 		// cumulative counters don't overwrite each other in ClickHouse (trace
 		// load balancing spreads an edge's spans across gateway pods). Reuse the
 		// self-telemetry processor when present, otherwise define it here so the
 		// pipeline is always valid even if self-telemetry wasn't applied.
+		// Harmless on the Prometheus path: resource_to_telemetry_conversion is
+		// off by default, so k8s.pod.name stays a resource attribute and never
+		// becomes a scrape label on the UI metrics.
 		if _, ok := currentConfig.Processors["resource/pod-name"]; !ok {
 			currentConfig.Processors["resource/pod-name"] = config.GenericMap{
 				"attributes": []config.GenericMap{
@@ -374,6 +372,7 @@ func insertServiceGraphPipeline(currentConfig *config.Config, gatewayOptions *Ga
 				},
 			}
 		}
+		processors = []string{"resource/pod-name"}
 		currentConfig.Exporters[consts.ServiceGraphInsightsExporterName] = config.GenericMap{
 			"endpoint":    gatewayOptions.InsightsOtlpEndpoint,
 			"tls":         config.GenericMap{"insecure": true},
@@ -382,11 +381,12 @@ func insertServiceGraphPipeline(currentConfig *config.Config, gatewayOptions *Ga
 				"enabled": false,
 			},
 		}
-		currentConfig.Service.Pipelines[consts.ServiceGraphInsightsPipelineName] = config.Pipeline{
-			Receivers:  []string{consts.ServiceGraphConnectorName},
-			Processors: []string{"resource/pod-name"},
-			Exporters:  []string{consts.ServiceGraphInsightsExporterName},
-		}
+		exporters = append(exporters, consts.ServiceGraphInsightsExporterName)
+	}
+	currentConfig.Service.Pipelines["metrics/servicegraph"] = config.Pipeline{
+		Receivers:  []string{consts.ServiceGraphConnectorName},
+		Processors: processors,
+		Exporters:  exporters,
 	}
 
 	// Add the service graph exporter to the root traces pipeline

--- a/docs/snippets/shared/pipeline/service-graph.mdx
+++ b/docs/snippets/shared/pipeline/service-graph.mdx
@@ -20,6 +20,7 @@ Instrumented services
        ▼
  Cluster Gateway Collector
        ├──► servicegraph connector ──► Odigos UI (topology map)
+       └──► servicegraph connector ──► odigos-insights (blast radius) [Enterprise, when insights is enabled]
 ```
 
 1. The **servicegraph connector** receives every trace that passes through the gateway.
@@ -91,5 +92,25 @@ collectorGateway:
     - db.name           # database index (rarely useful for Redis — most apps use index 0)
     - db.system         # technology name (e.g. "redis") — last resort, not instance-specific
 ```
+
+## Blast Radius (Enterprise)
+
+When the enterprise **Insights** feature is enabled (`insights.enabled=true`), Odigos also
+ships the service-graph metrics to the `odigos-insights` service over OTLP, on a dedicated
+gateway pipeline that is kept separate from the UI's topology path (so the standard Service
+Map is unaffected).
+
+`odigos-insights` aggregates the edges into a topology table and exposes a **Blast Radius**
+view in the UI: for a detected anomaly on a service, it draws the neighborhood of upstream
+callers and downstream callees (including virtual/uninstrumented dependencies) that could be
+affected. To join edges to anomalies — which are keyed by `(namespace, service)` — Odigos
+automatically forces `k8s.namespace.name` into the service-graph dimensions while insights is
+active, so `service.name` alone is never ambiguous across namespaces.
+
+<Note>
+  This side-channel and the Blast Radius view are only active when the enterprise insights
+  feature is enabled. With insights off, the service graph behaves exactly as described above
+  (UI topology map only) and no metrics are sent to `odigos-insights`.
+</Note>
 
 <GettingHelp />

--- a/docs/snippets/shared/pipeline/service-graph.mdx
+++ b/docs/snippets/shared/pipeline/service-graph.mdx
@@ -19,8 +19,9 @@ Instrumented services
        │ (OTLP traces)
        ▼
  Cluster Gateway Collector
-       ├──► servicegraph connector ──► Odigos UI (topology map)
-       └──► servicegraph connector ──► odigos-insights (blast radius) [Enterprise, when insights is enabled]
+       │
+       └──► servicegraph connector ──► metrics/servicegraph pipeline
+                                            ├──► prometheus ──► Odigos UI (topology map)
 ```
 
 1. The **servicegraph connector** receives every trace that passes through the gateway.
@@ -92,25 +93,5 @@ collectorGateway:
     - db.name           # database index (rarely useful for Redis — most apps use index 0)
     - db.system         # technology name (e.g. "redis") — last resort, not instance-specific
 ```
-
-## Blast Radius (Enterprise)
-
-When the enterprise **Insights** feature is enabled (`insights.enabled=true`), Odigos also
-ships the service-graph metrics to the `odigos-insights` service over OTLP, on a dedicated
-gateway pipeline that is kept separate from the UI's topology path (so the standard Service
-Map is unaffected).
-
-`odigos-insights` aggregates the edges into a topology table and exposes a **Blast Radius**
-view in the UI: for a detected anomaly on a service, it draws the neighborhood of upstream
-callers and downstream callees (including virtual/uninstrumented dependencies) that could be
-affected. To join edges to anomalies — which are keyed by `(namespace, service)` — Odigos
-automatically forces `k8s.namespace.name` into the service-graph dimensions while insights is
-active, so `service.name` alone is never ambiguous across namespaces.
-
-<Note>
-  This side-channel and the Blast Radius view are only active when the enterprise insights
-  feature is enabled. With insights off, the service graph behaves exactly as described above
-  (UI topology map only) and no metrics are sent to `odigos-insights`.
-</Note>
 
 <GettingHelp />


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Send servicegraph metrics to Clickhouse DB if Odigos Insights is active.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
