### PR TITLE
CORE-1328 | chore: add hpa and fix service ip resolution

### DIFF
--- a/api/k8sconsts/insights.go
+++ b/api/k8sconsts/insights.go
@@ -3,4 +3,11 @@ package k8sconsts
 const (
 	OdigosInsightsServiceName = "odigos-insights"
 	OdigosInsightsOTLPPort    = 4317
+
+	// OdigosInsightsHeadlessServiceName is a headless (ClusterIP: None)
+	// companion Service that fronts the insights pods on the OTLP gRPC port.
+	// The cluster gateway targets this name via the dns:/// resolver so it can
+	// client-side load balance (round_robin) across all insights replicas,
+	// instead of pinning to a single pod behind the regular ClusterIP VIP.
+	OdigosInsightsHeadlessServiceName = "odigos-insights-headless"
 )

--- a/api/k8sconsts/otlp_endpoints.go
+++ b/api/k8sconsts/otlp_endpoints.go
@@ -12,11 +12,12 @@ func UiOtlpGrpcEndpoint(namespace string) string {
 	return fmt.Sprintf("ui.%s:%d", namespace, commonconsts.OTLPPort)
 }
 
-// InsightsOtlpGrpcEndpoint returns the in-cluster OTLP gRPC host:port for the
-// sidecar service consumed by the optional side-channel trace pipeline on the
-// cluster gateway. Resolves via Kubernetes service DNS.
-func InsightsOtlpGrpcEndpoint(namespace string) string {
-	return fmt.Sprintf("%s.%s:%d", OdigosInsightsServiceName, namespace, OdigosInsightsOTLPPort)
+// InsightsOtlpGrpcDNSEndpoint returns the OTLP gRPC endpoint in dns:/// form
+// targeting the headless insights Service. The dns:/// resolver returns every
+// insights pod IP (not the single ClusterIP VIP), which lets the gateway's
+// gRPC client round_robin across all replicas instead of pinning one pod.
+func InsightsOtlpGrpcDNSEndpoint(namespace string) string {
+	return OtlpGrpcDNSEndpoint(OdigosInsightsHeadlessServiceName, namespace, OdigosInsightsOTLPPort)
 }
 
 // OtlpGrpcDNSEndpoint returns a gRPC client endpoint in dns:/// form for a Kubernetes Service

--- a/autoscaler/controllers/clustercollector/insights_exporter.go
+++ b/autoscaler/controllers/clustercollector/insights_exporter.go
@@ -27,10 +27,14 @@ func addInsightsGatewayExporter(c *config.Config, odigosNs string, insights *com
 		c.Exporters = config.GenericMap{}
 	}
 
+	// Target the headless insights Service via the dns:/// resolver and enable
+	// round_robin so the gateway's gRPC client fans out across every insights
+	// pod instead of pinning one behind the ClusterIP VIP.
 	c.Exporters[commonconf.InsightsGatewayExporter] = config.GenericMap{
-		"endpoint":    k8sconsts.InsightsOtlpGrpcEndpoint(odigosNs),
-		"tls":         config.GenericMap{"insecure": true},
-		"compression": "none",
+		"endpoint":      k8sconsts.InsightsOtlpGrpcDNSEndpoint(odigosNs),
+		"balancer_name": "round_robin",
+		"tls":           config.GenericMap{"insecure": true},
+		"compression":   "none",
 		"retry_on_failure": config.GenericMap{
 			"enabled": false,
 		},

--- a/autoscaler/controllers/clustercollector/insights_exporter_test.go
+++ b/autoscaler/controllers/clustercollector/insights_exporter_test.go
@@ -74,7 +74,11 @@ func TestAddInsightsGatewayExporter_EnabledAppendsExporterToRootPipeline(t *test
 
 	exp, ok := c.Exporters[commonconf.InsightsGatewayExporter].(config.GenericMap)
 	require.True(t, ok, "exporter must be registered")
-	assert.Equal(t, k8sconsts.InsightsOtlpGrpcEndpoint("odigos-system"), exp["endpoint"])
+	// Must target the headless Service via dns:/// with round_robin so the
+	// gateway load balances across insights replicas instead of pinning one pod.
+	assert.Equal(t, k8sconsts.InsightsOtlpGrpcDNSEndpoint("odigos-system"), exp["endpoint"])
+	assert.Equal(t, "dns:///odigos-insights-headless.odigos-system:4317", exp["endpoint"])
+	assert.Equal(t, "round_robin", exp["balancer_name"])
 	assert.Equal(t, "none", exp["compression"])
 	tls, _ := exp["tls"].(config.GenericMap)
 	assert.Equal(t, true, tls["insecure"])

--- a/helm/odigos/templates/insights/deployment.yaml
+++ b/helm/odigos/templates/insights/deployment.yaml
@@ -8,10 +8,10 @@ metadata:
     app.kubernetes.io/name: odigos-insights
     odigos.io/system-object: "true"
 spec:
-  # Replicas can scale freely: the schema is applied once by the migration Job
-  # (not per-replica), and baseline writes are additive/idempotent in ClickHouse,
-  # so multiple replicas converge without coordination.
-  replicas: {{ .Values.insights.replicas }}
+  # No replicas field: the HPA (templates/insights/hpa.yaml) always owns the
+  # replica count, so setting it here would make helm and the HPA fight over it
+  # on every reconcile. Replicas scale freely anyway — schema migrations run once
+  # via a separate Job and baseline writes are idempotent in ClickHouse.
   selector:
     matchLabels:
       app.kubernetes.io/name: odigos-insights

--- a/helm/odigos/templates/insights/hpa.yaml
+++ b/helm/odigos/templates/insights/hpa.yaml
@@ -1,0 +1,83 @@
+{{- if and .Values.insights.enabled (include "odigos.secretExists" .) }}
+{{- /*
+  min/max default to the gateway bounds (unless overridden in values); scale
+  behavior is hardcoded to mirror the gateway (fast up, slow down).
+*/}}
+{{- $ac := .Values.insights.autoscaling -}}
+{{- $minReplicas := int (include "collector.gateway.minReplicas" .) -}}
+{{- if hasKey $ac "minReplicas" -}}{{- $minReplicas = int $ac.minReplicas -}}{{- end -}}
+{{- $maxReplicas := int (include "collector.gateway.maxReplicas" .) -}}
+{{- if hasKey $ac "maxReplicas" -}}{{- $maxReplicas = int $ac.maxReplicas -}}{{- end -}}
+{{- if gt $minReplicas $maxReplicas -}}
+  {{- fail (printf "insights.autoscaling: resolved minReplicas (%d) must be <= maxReplicas (%d)" $minReplicas $maxReplicas) -}}
+{{- end -}}
+{{- $vk := .Capabilities.KubeVersion.Version -}}
+{{- if semverCompare "<1.23-0" $vk }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: odigos-insights
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: odigos-insights
+    odigos.io/system-object: "true"
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: odigos-insights
+  minReplicas: {{ $minReplicas }}
+  maxReplicas: {{ $maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.insights.autoscaling.cpuTargetUtilization }}
+{{- else }}
+{{- if semverCompare "<1.25-0" $vk }}
+apiVersion: autoscaling/v2beta2
+{{- else }}
+apiVersion: autoscaling/v2
+{{- end }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: odigos-insights
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: odigos-insights
+    odigos.io/system-object: "true"
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: odigos-insights
+  minReplicas: {{ $minReplicas }}
+  maxReplicas: {{ $maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.insights.autoscaling.cpuTargetUtilization }}
+  # Fast scale-up, slow scale-down — mirrors the gateway HPA to avoid oscillation.
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      selectPolicy: Max
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 15
+    scaleDown:
+      stabilizationWindowSeconds: 900
+      selectPolicy: Min
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+        - type: Percent
+          value: 25
+          periodSeconds: 60
+{{- end }}
+{{- end }}

--- a/helm/odigos/templates/insights/service-headless.yaml
+++ b/helm/odigos/templates/insights/service-headless.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.insights.enabled (include "odigos.secretExists" .) }}
+# Headless companion Service (clusterIP: None) for the insights OTLP gRPC port.
+# The cluster gateway exports to this name via the dns:/// resolver so its gRPC
+# client can round_robin across every insights pod IP. A regular ClusterIP
+# Service resolves to a single VIP, which pins the long-lived HTTP/2 connection
+# to one pod and starves the other replicas (breaking any HPA). The regular
+# odigos-insights ClusterIP Service still fronts the HTTP :8080 API/metrics.
+apiVersion: v1
+kind: Service
+metadata:
+  name: odigos-insights-headless
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: odigos-insights
+    odigos.io/system-object: "true"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: odigos-insights
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+{{- end }}

--- a/helm/odigos/templates/insights/service.yaml
+++ b/helm/odigos/templates/insights/service.yaml
@@ -8,6 +8,9 @@ metadata:
     app.kubernetes.io/name: odigos-insights
     odigos.io/system-object: "true"
 spec:
+  # ClusterIP VIP front door for the HTTP API + /metrics. The OTLP gRPC port
+  # lives on the odigos-insights-headless Service instead, so the gateway can
+  # round_robin across pods; nothing should dial this Service on :4317.
   type: ClusterIP
   selector:
     app.kubernetes.io/name: odigos-insights
@@ -15,9 +18,5 @@ spec:
     - name: http
       port: 8080
       targetPort: 8080
-      protocol: TCP
-    - name: otlp-grpc
-      port: 4317
-      targetPort: 4317
       protocol: TCP
 {{- end }}

--- a/helm/odigos/values.schema.json
+++ b/helm/odigos/values.schema.json
@@ -624,6 +624,36 @@
           "required": [],
           "title": "affinity"
         },
+        "autoscaling": {
+          "additionalProperties": false,
+          "description": "CPU-based HorizontalPodAutoscaler for insights (always on; requires\nmetrics-server). The HPA owns the replica count. min/max replicas default\nto the gateway's values.",
+          "properties": {
+            "cpuTargetUtilization": {
+              "default": "80",
+              "description": "Target average CPU utilization percentage.",
+              "maximum": 100,
+              "minimum": 1,
+              "required": [],
+              "title": "cpuTargetUtilization"
+            },
+            "maxReplicas": {
+              "default": "10",
+              "description": "Max replicas. Defaults to the gateway's maximum; uncomment to override.",
+              "minimum": 1,
+              "required": [],
+              "title": "maxReplicas"
+            },
+            "minReplicas": {
+              "default": "2",
+              "description": "Min replicas. Defaults to the gateway's minimum; uncomment to override.",
+              "minimum": 1,
+              "required": [],
+              "title": "minReplicas"
+            }
+          },
+          "required": [],
+          "title": "autoscaling"
+        },
         "clickhouse": {
           "additionalProperties": false,
           "description": "Hand-rolled ClickHouse deployed alongside the insights service. Skeleton\nonly — single replica, single PVC, no replication, no backups. Most\nknobs (image, user, db, resources) are hardcoded in the templates;\nonly the storage size and class are values-driven because those are\nthe ones that vary per cluster.",
@@ -669,13 +699,6 @@
           "description": "Priority class name. Set to use your existing cluster priority classes.",
           "required": [],
           "title": "priorityClassName"
-        },
-        "replicas": {
-          "default": "2",
-          "description": "Number of insights service replicas. Safe to scale above 1: schema\nmigrations run once via a separate Job (not per-replica), and baseline\nwrites are additive/idempotent in ClickHouse, so replicas converge without\ncoordination.",
-          "minimum": 1,
-          "required": [],
-          "title": "replicas"
         },
         "resources": {
           "additionalProperties": false,

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -1185,13 +1185,29 @@ insights:
 
   # @schema
   # description: |-
-  #   Number of insights service replicas. Safe to scale above 1: schema
-  #   migrations run once via a separate Job (not per-replica), and baseline
-  #   writes are additive/idempotent in ClickHouse, so replicas converge without
-  #   coordination.
-  # minimum: 1
+  #   CPU-based HorizontalPodAutoscaler for insights (always on; requires
+  #   metrics-server). The HPA owns the replica count. min/max replicas default
+  #   to the gateway's values.
   # @schema
-  replicas: 2
+  autoscaling:
+    # @schema
+    # description: Target average CPU utilization percentage.
+    # minimum: 1
+    # maximum: 100
+    # @schema
+    cpuTargetUtilization: 80
+
+    # @schema
+    # description: Min replicas. Defaults to the gateway's minimum; uncomment to override.
+    # minimum: 1
+    # @schema
+    # minReplicas: 2
+
+    # @schema
+    # description: Max replicas. Defaults to the gateway's maximum; uncomment to override.
+    # minimum: 1
+    # @schema
+    # maxReplicas: 10
 
   resources:
     requests:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Insights now scales horizontally out of the box. We added an always-on CPU-based HorizontalPodAutoscaler for the odigos-insights service, **with min/max replicas defaulting to the gateway's sizing (and overridable via Helm)** so capacity tracks load automatically. To make that scaling actually effective, we fixed a gRPC connection-pinning issue where the gateway pinned all telemetry to a single insights pod: the gateway now targets a new headless Service via the dns:/// resolver with round_robin, fanning traffic evenly across every replica. This means as trace volume grows, insights adds pods and the load is distributed across them instead of overwhelming one. Requires metrics-server in the cluster for the HPA to read CPU utilization.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
