### PR TITLE
CORE-1155: add grpc appprotocol to collector ports

### DIFF
--- a/autoscaler/controllers/clustercollector/service.go
+++ b/autoscaler/controllers/clustercollector/service.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -70,10 +71,11 @@ func syncService(gateway *odigosv1.CollectorsGroup, ctx context.Context, c clien
 func updateGatewaySvc(svc *v1.Service, collectorsGroup *odigosv1.CollectorsGroup) {
 	svc.Spec.Ports = []v1.ServicePort{
 		{
-			Name:       "otlp",
-			Protocol:   "TCP",
-			Port:       4317,
-			TargetPort: intstr.FromInt(4317),
+			Name:        "otlp",
+			Protocol:    "TCP",
+			AppProtocol: ptr.To("grpc"),
+			Port:        4317,
+			TargetPort:  intstr.FromInt(4317),
 		},
 		{
 			Name:       "otlphttp",

--- a/autoscaler/controllers/manager.go
+++ b/autoscaler/controllers/manager.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-logr/logr"
 
 	apiactions "github.com/odigos-io/odigos/api/actions/v1alpha1"
+	"github.com/odigos-io/odigos/api/k8sconsts"
 	"github.com/odigos-io/odigos/autoscaler/controllers/actions"
 	"github.com/odigos-io/odigos/autoscaler/controllers/clustercollector"
 	"github.com/odigos-io/odigos/autoscaler/controllers/loglevel"
@@ -15,6 +16,7 @@ import (
 	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -53,6 +55,19 @@ func CreateManager(opts KubeManagerOptions) (ctrl.Manager, error) {
 	odigosNs := env.GetCurrentNamespace()
 	nsSelector := client.InNamespace(odigosNs).AsSelector()
 	clusterCollectorLabelSelector := labels.Set(clustercollector.ClusterCollectorGateway).AsSelector()
+
+	collectorRoleReq, err := labels.NewRequirement(
+		k8sconsts.OdigosCollectorRoleLabel,
+		selection.In,
+		[]string{
+			string(k8sconsts.CollectorsRoleClusterGateway),
+			string(k8sconsts.CollectorsRoleNodeCollector),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	collectorServiceLabelSelector := labels.NewSelector().Add(*collectorRoleReq)
 
 	mgrOptions := ctrl.Options{
 		Scheme: scheme,
@@ -97,7 +112,7 @@ func CreateManager(opts KubeManagerOptions) (ctrl.Manager, error) {
 					Field: nsSelector,
 				},
 				&corev1.Service{}: {
-					Label: clusterCollectorLabelSelector,
+					Label: collectorServiceLabelSelector,
 					Field: nsSelector,
 				},
 				&corev1.Pod{}: {

--- a/autoscaler/controllers/nodecollector/service.go
+++ b/autoscaler/controllers/nodecollector/service.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 var (
@@ -34,16 +34,20 @@ func (b *nodeCollectorBaseReconciler) syncService(ctx context.Context, dc *odigo
 
 	localTrafficPolicy := v1.ServiceInternalTrafficPolicyLocal
 	dcService := &v1.Service{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "Service",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      k8sconsts.OdigosNodeCollectorLocalTrafficServiceName,
 			Namespace: dc.Namespace,
 			Labels:    ClusterCollectorGateway,
 		},
-		Spec: v1.ServiceSpec{
+	}
+
+	if err := ctrl.SetControllerReference(dc, dcService, b.scheme); err != nil {
+		logger.Error(err, "failed to set controller reference")
+		return err
+	}
+
+	_, err := controllerutil.CreateOrPatch(ctx, b.Client, dcService, func() error {
+		dcService.Spec = v1.ServiceSpec{
 			Selector: map[string]string{
 				k8sconsts.OdigosCollectorRoleLabel: string(k8sconsts.CollectorsRoleNodeCollector),
 			},
@@ -69,23 +73,8 @@ func (b *nodeCollectorBaseReconciler) syncService(ctx context.Context, dc *odigo
 				},
 			},
 			InternalTrafficPolicy: &localTrafficPolicy,
-		},
-	}
-
-	if err := ctrl.SetControllerReference(dc, dcService, b.scheme); err != nil {
-		logger.Error(err, "failed to set controller reference")
-		return err
-	}
-
-	// Use server-side apply instead of create/update: the autoscaler cache only caches
-	// Services labeled as the cluster gateway, so this node collector Service is not in the
-	// cache and a cached Get would always miss. SSA writes directly to the API server and
-	// reconciles the desired spec on both create and update (e.g. adding the grpc appProtocol
-	// to an existing Service).
-	if err := b.Client.Patch(ctx, dcService, client.Apply, client.ForceOwnership, client.FieldOwner("autoscaler")); err != nil {
-		logger.Error(err, "failed to apply node collector service")
-		return err
-	}
-
-	return nil
+		}
+		return nil
+	})
+	return err
 }

--- a/autoscaler/controllers/nodecollector/service.go
+++ b/autoscaler/controllers/nodecollector/service.go
@@ -10,6 +10,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -33,6 +34,10 @@ func (b *nodeCollectorBaseReconciler) syncService(ctx context.Context, dc *odigo
 
 	localTrafficPolicy := v1.ServiceInternalTrafficPolicyLocal
 	dcService := &v1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      k8sconsts.OdigosNodeCollectorLocalTrafficServiceName,
 			Namespace: dc.Namespace,
@@ -44,10 +49,11 @@ func (b *nodeCollectorBaseReconciler) syncService(ctx context.Context, dc *odigo
 			},
 			Ports: []v1.ServicePort{
 				{
-					Name:       "otlp",
-					Protocol:   "TCP",
-					Port:       4317,
-					TargetPort: intstr.FromInt(4317),
+					Name:        "otlp",
+					Protocol:    "TCP",
+					AppProtocol: ptr.To("grpc"),
+					Port:        4317,
+					TargetPort:  intstr.FromInt(4317),
 				},
 				{
 					Name:       "otlphttp",
@@ -71,6 +77,15 @@ func (b *nodeCollectorBaseReconciler) syncService(ctx context.Context, dc *odigo
 		return err
 	}
 
-	err := b.Client.Create(ctx, dcService)
-	return client.IgnoreAlreadyExists(err)
+	// Use server-side apply instead of create/update: the autoscaler cache only caches
+	// Services labeled as the cluster gateway, so this node collector Service is not in the
+	// cache and a cached Get would always miss. SSA writes directly to the API server and
+	// reconciles the desired spec on both create and update (e.g. adding the grpc appProtocol
+	// to an existing Service).
+	if err := b.Client.Patch(ctx, dcService, client.Apply, client.ForceOwnership, client.FieldOwner("autoscaler")); err != nil {
+		logger.Error(err, "failed to apply node collector service")
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
Problem When Istio's OpenTelemetry tracer is pointed at odigos-data-collection-local-traffic:4317 over gRPC, all exports fail (rq_error = rq_total, rq_success: 0). OTLP/HTTP on 4318 works. Net effect: no Istio/Envoy spans reach Odigos when gRPC is used.

Root cause The service defines port 4317 as Name: "otlp" with no appProtocol. Istio only marks an upstream cluster as HTTP/2 (required for gRPC) when the port's appProtocol is grpc or the port name is grpc/grpc-*. With neither, Istio falls back to use_downstream_protocol_config; the tracer's internal gRPC client has no downstream to mirror and degrades to HTTP/1.1, which the collector's gRPC receiver rejects. The collector isn't in the mesh, so there's no ALPN to negotiate h2c.

Fix Add AppProtocol: ptr.To("grpc") to the 4317 port in autoscaler/controllers/nodecollector/service.go. (Same pattern applies to the gateway service in k8sutils/pkg/service/service.go if gRPC to the gateway is also wanted.)

This also updates the data collection service handler to patch (previously just created), which the gateway service handler already does

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
fix(collector): support Istio otel tracer on data collection local traffic service
```
