### PR TITLE
feat: add category and subtitle to the action catalog (PLAT-1339)

### DIFF
--- a/actions/data/addclusterinfo.yaml
+++ b/actions/data/addclusterinfo.yaml
@@ -3,8 +3,10 @@ kind: Action
 metadata:
   type: AddClusterInfo
   displayName: Add Cluster Info
+  category: enrichment
 spec:
   docsUrl: https://docs.odigos.io/pipeline/actions/attributes/addclusterinfo
+  subtitle: Add static cluster-scoped attributes to your data.
   description: This action adds static resource attributes to spans, metrics data points and log records. It is useful to add cluster-wide attributes to all telemetry signals.
   signals:
     traces:

--- a/actions/data/dbquerytemplatization.yaml
+++ b/actions/data/dbquerytemplatization.yaml
@@ -3,8 +3,10 @@ kind: Action
 metadata:
   type: DbQueryTemplatization
   displayName: DB Query Templatization
+  category: normalization
 spec:
   docsUrl: https://docs.odigos.io/pipeline/actions/attributes/dbquerytemplatization
+  subtitle: Replace query literals with placeholders.
   description: Templatizes database query text by replacing number and string literals with placeholders (e.g. SELECT * FROM users WHERE id = 1 -> SELECT * FROM users WHERE id = ?), reducing cardinality of query attributes and span names.
   signals:
     traces:

--- a/actions/data/deleteattribute.yaml
+++ b/actions/data/deleteattribute.yaml
@@ -3,8 +3,10 @@ kind: Action
 metadata:
   type: DeleteAttribute
   displayName: Delete Attribute
+  category: privacy
 spec:
   docsUrl: https://docs.odigos.io/pipeline/actions/attributes/deleteattribute
+  subtitle: Delete attributes from logs, metrics, and traces.
   description: This action will delete the specified attributes from all telemetry signals that are specified in the signals field, regardless of the source, or any other condition.
   signals:
     traces:

--- a/actions/data/extractattribute.yaml
+++ b/actions/data/extractattribute.yaml
@@ -3,8 +3,10 @@ kind: Action
 metadata:
   type: ExtractAttribute
   displayName: Extract Attribute
+  category: enrichment
 spec:
   docsUrl: https://docs.odigos.io/pipeline/actions/attributes/extractattribute
+  subtitle: Extract values from existing attributes into new ones.
   description: Extracts a value from an existing span attribute into a new attribute on the same span. The value can be located by combining a lookup key with a pre-set data format (JSON, SQL, or resource path), or by supplying a custom regular expression that uses a single capture group.
   signals:
     traces:

--- a/actions/data/inferdbattributes.yaml
+++ b/actions/data/inferdbattributes.yaml
@@ -3,8 +3,10 @@ kind: Action
 metadata:
   type: InferDbAttributes
   displayName: Infer DB Attributes
+  category: enrichment
 spec:
   docsUrl: https://docs.odigos.io/pipeline/actions/attributes/inferdbattributes
+  subtitle: Infer database operation and collection attributes.
   description: Parses database query text on spans and adds attributes such as db.operation.name and db.collection.name.
   signals:
     traces:

--- a/actions/data/k8sattributes.yaml
+++ b/actions/data/k8sattributes.yaml
@@ -3,8 +3,10 @@ kind: Action
 metadata:
   type: K8sAttributesResolver
   displayName: Kubernetes Attributes
+  category: enrichment
 spec:
   docsUrl: https://docs.odigos.io/pipeline/actions/attributes/k8sattributes
+  subtitle: Add dynamic k8s resource attributes to your data.
   description: This action adds kubernetes related resource attributes to spans, metrics data points and log records.
   signals:
     traces:

--- a/actions/data/piimasking.yaml
+++ b/actions/data/piimasking.yaml
@@ -3,8 +3,10 @@ kind: Action
 metadata:
   type: PiiMasking
   displayName: PII Masking
+  category: privacy
 spec:
   docsUrl: https://docs.odigos.io/pipeline/actions/attributes/piimasking
+  subtitle: Mask PII data in your traces.
   description: This action processes a list of PII categories to be masked from the traces.
   signals:
     traces:

--- a/actions/data/renameattribute.yaml
+++ b/actions/data/renameattribute.yaml
@@ -3,8 +3,10 @@ kind: Action
 metadata:
   type: RenameAttribute
   displayName: Rename Attribute
+  category: normalization
 spec:
   docsUrl: https://docs.odigos.io/pipeline/actions/attributes/renameattribute
+  subtitle: Rename attributes in logs, metrics, and traces.
   description: This action will rename the specified attributes from all telemetry signals that are specified in the signals field, regardless of the source, or any other condition.
   signals:
     traces:

--- a/actions/data/urltemplatization.yaml
+++ b/actions/data/urltemplatization.yaml
@@ -3,8 +3,10 @@ kind: Action
 metadata:
   type: URLTemplatization
   displayName: URL Templatization
+  category: normalization
 spec:
   docsUrl: https://docs.odigos.io/pipeline/actions/attributes/urltemplatization
+  subtitle: Replace dynamic URL path segments with named placeholders.
   description: Normalizes HTTP URL paths by replacing dynamic segments (IDs, UUIDs, dates) with named placeholders (e.g. /user/1234 -> /user/{id}). Reduces cardinality of http.route and span names, improving usability in telemetry backends.
   signals:
     traces:

--- a/actions/model.go
+++ b/actions/model.go
@@ -16,10 +16,16 @@ type Metadata struct {
 	// Type must match the GraphQL ActionType enum value (e.g. "K8sAttributesResolver").
 	Type        string `yaml:"type"`
 	DisplayName string `yaml:"displayName"`
+	// Category groups related actions in the action picker (e.g. "enrichment").
+	// The UI resolves the human-readable section title from this slug.
+	Category string `yaml:"category"`
 }
 
 type Spec struct {
-	// Description is a short, human-readable summary shown in the action picker.
+	// Subtitle is a one-line summary shown under the action title in the
+	// action picker list.
+	Subtitle string `yaml:"subtitle"`
+	// Description is the longer summary shown at the top of the action form.
 	Description string `yaml:"description"`
 	// Signals declares which telemetry signals this action can process. Mirrors
 	// the destinations catalog (odigos/destinations) so the YAML authoring format

--- a/frontend/graph/actions.graphqls
+++ b/frontend/graph/actions.graphqls
@@ -50,6 +50,12 @@ type ActionFieldYamlProperties {
 type ActionTypeOption {
   type: String!
   displayName: String!
+  # Slug grouping related actions in the action picker (e.g. "enrichment").
+  # The UI resolves the human-readable section title from this slug.
+  category: String!
+  # One-line summary shown under the title in the action picker list.
+  subtitle: String!
+  # Longer summary shown at the top of the action form.
   description: String!
   allowedSignals: [SignalType!]!
   docsUrl: String!

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -101,10 +101,12 @@ type ComplexityRoot struct {
 
 	ActionTypeOption struct {
 		AllowedSignals func(childComplexity int) int
+		Category       func(childComplexity int) int
 		Description    func(childComplexity int) int
 		DisplayName    func(childComplexity int) int
 		DocsURL        func(childComplexity int) int
 		Fields         func(childComplexity int) int
+		Subtitle       func(childComplexity int) int
 		Type           func(childComplexity int) int
 	}
 
@@ -1915,6 +1917,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ActionTypeOption.AllowedSignals(childComplexity), true
 
+	case "ActionTypeOption.category":
+		if e.complexity.ActionTypeOption.Category == nil {
+			break
+		}
+
+		return e.complexity.ActionTypeOption.Category(childComplexity), true
+
 	case "ActionTypeOption.description":
 		if e.complexity.ActionTypeOption.Description == nil {
 			break
@@ -1942,6 +1951,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ActionTypeOption.Fields(childComplexity), true
+
+	case "ActionTypeOption.subtitle":
+		if e.complexity.ActionTypeOption.Subtitle == nil {
+			break
+		}
+
+		return e.complexity.ActionTypeOption.Subtitle(childComplexity), true
 
 	case "ActionTypeOption.type":
 		if e.complexity.ActionTypeOption.Type == nil {
@@ -12446,6 +12462,94 @@ func (ec *executionContext) _ActionTypeOption_displayName(ctx context.Context, f
 }
 
 func (ec *executionContext) fieldContext_ActionTypeOption_displayName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ActionTypeOption",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ActionTypeOption_category(ctx context.Context, field graphql.CollectedField, obj *model.ActionTypeOption) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ActionTypeOption_category(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Category, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ActionTypeOption_category(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ActionTypeOption",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ActionTypeOption_subtitle(ctx context.Context, field graphql.CollectedField, obj *model.ActionTypeOption) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ActionTypeOption_subtitle(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Subtitle, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ActionTypeOption_subtitle(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "ActionTypeOption",
 		Field:      field,
@@ -46250,6 +46354,10 @@ func (ec *executionContext) fieldContext_Query_actionTypes(_ context.Context, fi
 				return ec.fieldContext_ActionTypeOption_type(ctx, field)
 			case "displayName":
 				return ec.fieldContext_ActionTypeOption_displayName(ctx, field)
+			case "category":
+				return ec.fieldContext_ActionTypeOption_category(ctx, field)
+			case "subtitle":
+				return ec.fieldContext_ActionTypeOption_subtitle(ctx, field)
 			case "description":
 				return ec.fieldContext_ActionTypeOption_description(ctx, field)
 			case "allowedSignals":
@@ -59206,6 +59314,16 @@ func (ec *executionContext) _ActionTypeOption(ctx context.Context, sel ast.Selec
 			}
 		case "displayName":
 			out.Values[i] = ec._ActionTypeOption_displayName(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "category":
+			out.Values[i] = ec._ActionTypeOption_category(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "subtitle":
+			out.Values[i] = ec._ActionTypeOption_subtitle(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -81,6 +81,8 @@ type ActionInput struct {
 type ActionTypeOption struct {
 	Type           string                       `json:"type"`
 	DisplayName    string                       `json:"displayName"`
+	Category       string                       `json:"category"`
+	Subtitle       string                       `json:"subtitle"`
 	Description    string                       `json:"description"`
 	AllowedSignals []SignalType                 `json:"allowedSignals"`
 	DocsURL        string                       `json:"docsUrl"`

--- a/frontend/services/action_types.go
+++ b/frontend/services/action_types.go
@@ -57,11 +57,13 @@ func ActionConfigToTypeOption(actionConfig actions.Action) model.ActionTypeOptio
 	}
 
 	return model.ActionTypeOption{
-		Type:            actionConfig.Metadata.Type,
-		DisplayName:     actionConfig.Metadata.DisplayName,
-		Description:     actionConfig.Spec.Description,
-		AllowedSignals:  allowedSignals,
-		DocsURL:         actionConfig.Spec.DocsURL,
-		Fields:          fields,
+		Type:           actionConfig.Metadata.Type,
+		DisplayName:    actionConfig.Metadata.DisplayName,
+		Category:       actionConfig.Metadata.Category,
+		Subtitle:       actionConfig.Spec.Subtitle,
+		Description:    actionConfig.Spec.Description,
+		AllowedSignals: allowedSignals,
+		DocsURL:        actionConfig.Spec.DocsURL,
+		Fields:         fields,
 	}
 }

--- a/frontend/webapp/graphql/queries/actions.ts
+++ b/frontend/webapp/graphql/queries/actions.ts
@@ -5,6 +5,8 @@ export const GET_ACTION_TYPES = gql`
     actionTypes {
       type
       displayName
+      category
+      subtitle
       description
       allowedSignals
       docsUrl

--- a/frontend/webapp/package.json
+++ b/frontend/webapp/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@apollo/client": "^4.2.8",
-    "@odigos/ui-kit": "0.0.273",
+    "@odigos/ui-kit": "0.0.274",
     "graphql": "^16.14.2",
     "next": "15.5.21",
     "react": "19.2.7",

--- a/frontend/webapp/yarn.lock
+++ b/frontend/webapp/yarn.lock
@@ -583,10 +583,10 @@
   resolved "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
-"@odigos/ui-kit@0.0.273":
-  version "0.0.273"
-  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.273.tgz#8fad47495b1e5019d9bfd288aa6914a3c16cc86e"
-  integrity sha512-j9y7P3pWvYYhd8tWC9depWdQOysd8nBbYtkB2EZ6eBN+vqhDkA9UU64buooEDv/kmdVvZni2CPrk5jro3MhWgQ==
+"@odigos/ui-kit@0.0.274":
+  version "0.0.274"
+  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.274.tgz#c37d9797cd8e60e7520e836be2bbad15e10ea0c6"
+  integrity sha512-IZYEJBiiWNIflm3PEVNSZuDsfkXf9I6U8cDQt8/ern7gmzRZtbYnTz9Zv0zkXyqprOCvPZwelfMV5CP06I3FOw==
   dependencies:
     "@xyflow/react" "^12.11.2"
     elkjs "^0.12.0"


### PR DESCRIPTION
Add `category` and `subtitle` to the YAML action catalog so the Add Action drawer can group actions and show short menu copy separately from the form description.

#### What this PR does / why we need it:
The Add Action UI redesign groups actions into Enrichment / Normalization / Privacy & Governance and shows a one-line subtitle under each title in the picker, while the longer description stays on the form. This PR adds those fields to the embedded action catalog, GraphQL `ActionTypeOption`, and the webapp `GET_ACTION_TYPES` selection so the UI can consume them from the backend (with a hard-coded fallback remaining in ui-kit for older clusters).

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
Add category and subtitle metadata to the action catalog for the redesigned Add Action picker.
```