### PR TITLE
WIP: add URL templatization UI

### DIFF
--- a/api/k8sconsts/resources.go
+++ b/api/k8sconsts/resources.go
@@ -14,10 +14,15 @@ const (
 	// and use the label to identify the resources that needs to be deleted.
 	OdigosProfilesHashLabel = "odigos.io/profiles-hash"
 
-	// this label is used to mark resources that are managed by a profile.
+	// OdigosProfilesManagedByLabel is used to mark resources that are managed by a profile.
 	// when reconciling profiles, we can use this label to know which profiles needs to be deleted.
 	OdigosProfilesManagedByLabel = "odigos.io/managed-by"
 	OdigosProfilesManagedByValue = "profile"
+
+	// OdigosCreatedByLabel marks resources created by a specific Odigos component/surface.
+	// Used to distinguish UI-created Actions from YAML / GitOps managed ones.
+	OdigosCreatedByLabel       = "odigos.io/created-by"
+	OdigosCreatedByOdigosUIValue = "odigos-ui"
 
 	// for resources auto created by a profile, this annotation will record
 	// the name of the profile that created them.

--- a/frontend/graph/actions.graphqls
+++ b/frontend/graph/actions.graphqls
@@ -82,6 +82,7 @@ input ActionFieldsInput {
   customRegexMaskings: [CustomRegexMaskingInput!]
 
   urlTemplatizationRulesGroups: [UrlTemplatizationRulesGroupInput!]
+  urlTemplatizationDefaultGroups: [UrlTemplatizationDefaultGroupInput!]
 
   extractAttribute: ExtractAttributeInput
 
@@ -167,6 +168,9 @@ type Action {
   disabled: Boolean!
   signals: [SignalType!]!
   fields: ActionFields!
+  # True when this Action was created from the Odigos UI
+  # (metadata label odigos.io/created-by=odigos-ui).
+  uiGenerated: Boolean!
   conditions: [Condition!]
   # Desired-state statuses derived from Action CR status conditions
   # (e.g. TransformedToProcessor, AddedToCollectorConfig).
@@ -190,6 +194,7 @@ type ActionFields {
   customRegexMaskings: [CustomRegexMasking!]
 
   urlTemplatizationRulesGroups: [UrlTemplatizationRulesGroup!]
+  urlTemplatizationDefaultGroups: [UrlTemplatizationDefaultGroup!]
 
   extractAttribute: ExtractAttribute
 
@@ -238,6 +243,28 @@ type UrlTemplatizationRulesGroup {
   workloadFilters: [TemplatizationWorkloadFilter!]
   templatizationRules: [URLTemplatizationRule!]!
   notes: String
+}
+
+type UrlTemplatizationDefaultSkipPolicy {
+  skipForNonSuccessCodes: Boolean
+  skipHttpStatusCodes: [Int!]
+}
+
+type UrlTemplatizationDefaultGroup {
+  scopes: SourcesScopes
+  disabled: Boolean
+  skipPolicy: UrlTemplatizationDefaultSkipPolicy
+}
+
+input UrlTemplatizationDefaultSkipPolicyInput {
+  skipForNonSuccessCodes: Boolean
+  skipHttpStatusCodes: [Int!]
+}
+
+input UrlTemplatizationDefaultGroupInput {
+  scopes: SourcesScopesInput
+  disabled: Boolean
+  skipPolicy: UrlTemplatizationDefaultSkipPolicyInput
 }
 
 type K8sLabelAttribute {

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -59,15 +59,16 @@ type DirectiveRoot struct {
 
 type ComplexityRoot struct {
 	Action struct {
-		Conditions func(childComplexity int) int
-		Disabled   func(childComplexity int) int
-		Fields     func(childComplexity int) int
-		ID         func(childComplexity int) int
-		Name       func(childComplexity int) int
-		Notes      func(childComplexity int) int
-		Signals    func(childComplexity int) int
-		Statuses   func(childComplexity int) int
-		Type       func(childComplexity int) int
+		Conditions  func(childComplexity int) int
+		Disabled    func(childComplexity int) int
+		Fields      func(childComplexity int) int
+		ID          func(childComplexity int) int
+		Name        func(childComplexity int) int
+		Notes       func(childComplexity int) int
+		Signals     func(childComplexity int) int
+		Statuses    func(childComplexity int) int
+		Type        func(childComplexity int) int
+		UIGenerated func(childComplexity int) int
 	}
 
 	ActionFieldYamlProperties struct {
@@ -80,23 +81,24 @@ type ComplexityRoot struct {
 	}
 
 	ActionFields struct {
-		AnnotationsAttributes        func(childComplexity int) int
-		AttributeNamesToDelete       func(childComplexity int) int
-		ClusterAttributes            func(childComplexity int) int
-		CollectClusterID             func(childComplexity int) int
-		CollectContainerAttributes   func(childComplexity int) int
-		CollectReplicaSetAttributes  func(childComplexity int) int
-		CollectWorkloadID            func(childComplexity int) int
-		CustomFormatMaskings         func(childComplexity int) int
-		CustomRegexMaskings          func(childComplexity int) int
-		ExtractAttribute             func(childComplexity int) int
-		LabelsAttributes             func(childComplexity int) int
-		OverwriteExistingValues      func(childComplexity int) int
-		PiiCategories                func(childComplexity int) int
-		Renames                      func(childComplexity int) int
-		Scopes                       func(childComplexity int) int
-		TemplatizeLiterals           func(childComplexity int) int
-		URLTemplatizationRulesGroups func(childComplexity int) int
+		AnnotationsAttributes          func(childComplexity int) int
+		AttributeNamesToDelete         func(childComplexity int) int
+		ClusterAttributes              func(childComplexity int) int
+		CollectClusterID               func(childComplexity int) int
+		CollectContainerAttributes     func(childComplexity int) int
+		CollectReplicaSetAttributes    func(childComplexity int) int
+		CollectWorkloadID              func(childComplexity int) int
+		CustomFormatMaskings           func(childComplexity int) int
+		CustomRegexMaskings            func(childComplexity int) int
+		ExtractAttribute               func(childComplexity int) int
+		LabelsAttributes               func(childComplexity int) int
+		OverwriteExistingValues        func(childComplexity int) int
+		PiiCategories                  func(childComplexity int) int
+		Renames                        func(childComplexity int) int
+		Scopes                         func(childComplexity int) int
+		TemplatizeLiterals             func(childComplexity int) int
+		URLTemplatizationDefaultGroups func(childComplexity int) int
+		URLTemplatizationRulesGroups   func(childComplexity int) int
 	}
 
 	ActionTypeOption struct {
@@ -1506,6 +1508,17 @@ type ComplexityRoot struct {
 		Template func(childComplexity int) int
 	}
 
+	UrlTemplatizationDefaultGroup struct {
+		Disabled   func(childComplexity int) int
+		Scopes     func(childComplexity int) int
+		SkipPolicy func(childComplexity int) int
+	}
+
+	UrlTemplatizationDefaultSkipPolicy struct {
+		SkipForNonSuccessCodes func(childComplexity int) int
+		SkipHTTPStatusCodes    func(childComplexity int) int
+	}
+
 	UrlTemplatizationRulesGroup struct {
 		FilterK8sNamespace        func(childComplexity int) int
 		FilterK8sWorkloadKind     func(childComplexity int) int
@@ -1747,6 +1760,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Action.Type(childComplexity), true
 
+	case "Action.uiGenerated":
+		if e.complexity.Action.UIGenerated == nil {
+			break
+		}
+
+		return e.complexity.Action.UIGenerated(childComplexity), true
+
 	case "ActionFieldYamlProperties.componentProperties":
 		if e.complexity.ActionFieldYamlProperties.ComponentProperties == nil {
 			break
@@ -1900,6 +1920,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ActionFields.TemplatizeLiterals(childComplexity), true
+
+	case "ActionFields.urlTemplatizationDefaultGroups":
+		if e.complexity.ActionFields.URLTemplatizationDefaultGroups == nil {
+			break
+		}
+
+		return e.complexity.ActionFields.URLTemplatizationDefaultGroups(childComplexity), true
 
 	case "ActionFields.urlTemplatizationRulesGroups":
 		if e.complexity.ActionFields.URLTemplatizationRulesGroups == nil {
@@ -8238,6 +8265,41 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.URLTemplatizationRule.Template(childComplexity), true
 
+	case "UrlTemplatizationDefaultGroup.disabled":
+		if e.complexity.UrlTemplatizationDefaultGroup.Disabled == nil {
+			break
+		}
+
+		return e.complexity.UrlTemplatizationDefaultGroup.Disabled(childComplexity), true
+
+	case "UrlTemplatizationDefaultGroup.scopes":
+		if e.complexity.UrlTemplatizationDefaultGroup.Scopes == nil {
+			break
+		}
+
+		return e.complexity.UrlTemplatizationDefaultGroup.Scopes(childComplexity), true
+
+	case "UrlTemplatizationDefaultGroup.skipPolicy":
+		if e.complexity.UrlTemplatizationDefaultGroup.SkipPolicy == nil {
+			break
+		}
+
+		return e.complexity.UrlTemplatizationDefaultGroup.SkipPolicy(childComplexity), true
+
+	case "UrlTemplatizationDefaultSkipPolicy.skipForNonSuccessCodes":
+		if e.complexity.UrlTemplatizationDefaultSkipPolicy.SkipForNonSuccessCodes == nil {
+			break
+		}
+
+		return e.complexity.UrlTemplatizationDefaultSkipPolicy.SkipForNonSuccessCodes(childComplexity), true
+
+	case "UrlTemplatizationDefaultSkipPolicy.skipHttpStatusCodes":
+		if e.complexity.UrlTemplatizationDefaultSkipPolicy.SkipHTTPStatusCodes == nil {
+			break
+		}
+
+		return e.complexity.UrlTemplatizationDefaultSkipPolicy.SkipHTTPStatusCodes(childComplexity), true
+
 	case "UrlTemplatizationRulesGroup.filterK8sNamespace":
 		if e.complexity.UrlTemplatizationRulesGroup.FilterK8sNamespace == nil {
 			break
@@ -8375,6 +8437,8 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputTemplatizationWorkloadFilterInput,
 		ec.unmarshalInputTraceCorrelationsTimeRangeInput,
 		ec.unmarshalInputURLTemplatizationRuleInput,
+		ec.unmarshalInputUrlTemplatizationDefaultGroupInput,
+		ec.unmarshalInputUrlTemplatizationDefaultSkipPolicyInput,
 		ec.unmarshalInputUrlTemplatizationRulesGroupInput,
 		ec.unmarshalInputWorkloadFilter,
 	)
@@ -11225,6 +11289,8 @@ func (ec *executionContext) fieldContext_Action_fields(_ context.Context, field 
 				return ec.fieldContext_ActionFields_customRegexMaskings(ctx, field)
 			case "urlTemplatizationRulesGroups":
 				return ec.fieldContext_ActionFields_urlTemplatizationRulesGroups(ctx, field)
+			case "urlTemplatizationDefaultGroups":
+				return ec.fieldContext_ActionFields_urlTemplatizationDefaultGroups(ctx, field)
 			case "extractAttribute":
 				return ec.fieldContext_ActionFields_extractAttribute(ctx, field)
 			case "scopes":
@@ -11233,6 +11299,50 @@ func (ec *executionContext) fieldContext_Action_fields(_ context.Context, field 
 				return ec.fieldContext_ActionFields_templatizeLiterals(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ActionFields", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Action_uiGenerated(ctx context.Context, field graphql.CollectedField, obj *model.Action) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Action_uiGenerated(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UIGenerated, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Action_uiGenerated(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Action",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -12230,6 +12340,55 @@ func (ec *executionContext) fieldContext_ActionFields_urlTemplatizationRulesGrou
 				return ec.fieldContext_UrlTemplatizationRulesGroup_notes(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type UrlTemplatizationRulesGroup", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ActionFields_urlTemplatizationDefaultGroups(ctx context.Context, field graphql.CollectedField, obj *model.ActionFields) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ActionFields_urlTemplatizationDefaultGroups(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.URLTemplatizationDefaultGroups, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.URLTemplatizationDefaultGroup)
+	fc.Result = res
+	return ec.marshalOUrlTemplatizationDefaultGroup2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationDefaultGroupᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ActionFields_urlTemplatizationDefaultGroups(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ActionFields",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "scopes":
+				return ec.fieldContext_UrlTemplatizationDefaultGroup_scopes(ctx, field)
+			case "disabled":
+				return ec.fieldContext_UrlTemplatizationDefaultGroup_disabled(ctx, field)
+			case "skipPolicy":
+				return ec.fieldContext_UrlTemplatizationDefaultGroup_skipPolicy(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UrlTemplatizationDefaultGroup", field.Name)
 		},
 	}
 	return fc, nil
@@ -16334,6 +16493,8 @@ func (ec *executionContext) fieldContext_ComputePlatform_actions(_ context.Conte
 				return ec.fieldContext_Action_signals(ctx, field)
 			case "fields":
 				return ec.fieldContext_Action_fields(ctx, field)
+			case "uiGenerated":
+				return ec.fieldContext_Action_uiGenerated(ctx, field)
 			case "conditions":
 				return ec.fieldContext_Action_conditions(ctx, field)
 			case "statuses":
@@ -39435,6 +39596,8 @@ func (ec *executionContext) fieldContext_Mutation_createAction(ctx context.Conte
 				return ec.fieldContext_Action_signals(ctx, field)
 			case "fields":
 				return ec.fieldContext_Action_fields(ctx, field)
+			case "uiGenerated":
+				return ec.fieldContext_Action_uiGenerated(ctx, field)
 			case "conditions":
 				return ec.fieldContext_Action_conditions(ctx, field)
 			case "statuses":
@@ -39510,6 +39673,8 @@ func (ec *executionContext) fieldContext_Mutation_updateAction(ctx context.Conte
 				return ec.fieldContext_Action_signals(ctx, field)
 			case "fields":
 				return ec.fieldContext_Action_fields(ctx, field)
+			case "uiGenerated":
+				return ec.fieldContext_Action_uiGenerated(ctx, field)
 			case "conditions":
 				return ec.fieldContext_Action_conditions(ctx, field)
 			case "statuses":
@@ -53555,6 +53720,225 @@ func (ec *executionContext) fieldContext_URLTemplatizationRule_examples(_ contex
 	return fc, nil
 }
 
+func (ec *executionContext) _UrlTemplatizationDefaultGroup_scopes(ctx context.Context, field graphql.CollectedField, obj *model.URLTemplatizationDefaultGroup) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UrlTemplatizationDefaultGroup_scopes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Scopes, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.SourcesScopes)
+	fc.Result = res
+	return ec.marshalOSourcesScopes2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScopes(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UrlTemplatizationDefaultGroup_scopes(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UrlTemplatizationDefaultGroup",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "sources":
+				return ec.fieldContext_SourcesScopes_sources(ctx, field)
+			case "namespaces":
+				return ec.fieldContext_SourcesScopes_namespaces(ctx, field)
+			case "languages":
+				return ec.fieldContext_SourcesScopes_languages(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SourcesScopes", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UrlTemplatizationDefaultGroup_disabled(ctx context.Context, field graphql.CollectedField, obj *model.URLTemplatizationDefaultGroup) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UrlTemplatizationDefaultGroup_disabled(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Disabled, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*bool)
+	fc.Result = res
+	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UrlTemplatizationDefaultGroup_disabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UrlTemplatizationDefaultGroup",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UrlTemplatizationDefaultGroup_skipPolicy(ctx context.Context, field graphql.CollectedField, obj *model.URLTemplatizationDefaultGroup) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UrlTemplatizationDefaultGroup_skipPolicy(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SkipPolicy, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.URLTemplatizationDefaultSkipPolicy)
+	fc.Result = res
+	return ec.marshalOUrlTemplatizationDefaultSkipPolicy2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationDefaultSkipPolicy(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UrlTemplatizationDefaultGroup_skipPolicy(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UrlTemplatizationDefaultGroup",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "skipForNonSuccessCodes":
+				return ec.fieldContext_UrlTemplatizationDefaultSkipPolicy_skipForNonSuccessCodes(ctx, field)
+			case "skipHttpStatusCodes":
+				return ec.fieldContext_UrlTemplatizationDefaultSkipPolicy_skipHttpStatusCodes(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UrlTemplatizationDefaultSkipPolicy", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UrlTemplatizationDefaultSkipPolicy_skipForNonSuccessCodes(ctx context.Context, field graphql.CollectedField, obj *model.URLTemplatizationDefaultSkipPolicy) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UrlTemplatizationDefaultSkipPolicy_skipForNonSuccessCodes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SkipForNonSuccessCodes, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*bool)
+	fc.Result = res
+	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UrlTemplatizationDefaultSkipPolicy_skipForNonSuccessCodes(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UrlTemplatizationDefaultSkipPolicy",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UrlTemplatizationDefaultSkipPolicy_skipHttpStatusCodes(ctx context.Context, field graphql.CollectedField, obj *model.URLTemplatizationDefaultSkipPolicy) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UrlTemplatizationDefaultSkipPolicy_skipHttpStatusCodes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SkipHTTPStatusCodes, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]int)
+	fc.Result = res
+	return ec.marshalOInt2ᚕintᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UrlTemplatizationDefaultSkipPolicy_skipHttpStatusCodes(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UrlTemplatizationDefaultSkipPolicy",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _UrlTemplatizationRulesGroup_filterK8sNamespace(ctx context.Context, field graphql.CollectedField, obj *model.URLTemplatizationRulesGroup) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_UrlTemplatizationRulesGroup_filterK8sNamespace(ctx, field)
 	if err != nil {
@@ -55899,7 +56283,7 @@ func (ec *executionContext) unmarshalInputActionFieldsInput(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"collectContainerAttributes", "collectReplicaSetAttributes", "collectWorkloadId", "collectClusterId", "labelsAttributes", "annotationsAttributes", "clusterAttributes", "overwriteExistingValues", "attributeNamesToDelete", "renames", "piiCategories", "customFormatMaskings", "customRegexMaskings", "urlTemplatizationRulesGroups", "extractAttribute", "scopes", "templatizeLiterals"}
+	fieldsInOrder := [...]string{"collectContainerAttributes", "collectReplicaSetAttributes", "collectWorkloadId", "collectClusterId", "labelsAttributes", "annotationsAttributes", "clusterAttributes", "overwriteExistingValues", "attributeNamesToDelete", "renames", "piiCategories", "customFormatMaskings", "customRegexMaskings", "urlTemplatizationRulesGroups", "urlTemplatizationDefaultGroups", "extractAttribute", "scopes", "templatizeLiterals"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -56004,6 +56388,13 @@ func (ec *executionContext) unmarshalInputActionFieldsInput(ctx context.Context,
 				return it, err
 			}
 			it.URLTemplatizationRulesGroups = data
+		case "urlTemplatizationDefaultGroups":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("urlTemplatizationDefaultGroups"))
+			data, err := ec.unmarshalOUrlTemplatizationDefaultGroupInput2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationDefaultGroupInputᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.URLTemplatizationDefaultGroups = data
 		case "extractAttribute":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("extractAttribute"))
 			data, err := ec.unmarshalOExtractAttributeInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐExtractAttributeInput(ctx, v)
@@ -58861,6 +59252,81 @@ func (ec *executionContext) unmarshalInputURLTemplatizationRuleInput(ctx context
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputUrlTemplatizationDefaultGroupInput(ctx context.Context, obj any) (model.URLTemplatizationDefaultGroupInput, error) {
+	var it model.URLTemplatizationDefaultGroupInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"scopes", "disabled", "skipPolicy"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "scopes":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("scopes"))
+			data, err := ec.unmarshalOSourcesScopesInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScopesInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Scopes = data
+		case "disabled":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("disabled"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Disabled = data
+		case "skipPolicy":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("skipPolicy"))
+			data, err := ec.unmarshalOUrlTemplatizationDefaultSkipPolicyInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationDefaultSkipPolicyInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SkipPolicy = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputUrlTemplatizationDefaultSkipPolicyInput(ctx context.Context, obj any) (model.URLTemplatizationDefaultSkipPolicyInput, error) {
+	var it model.URLTemplatizationDefaultSkipPolicyInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"skipForNonSuccessCodes", "skipHttpStatusCodes"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "skipForNonSuccessCodes":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("skipForNonSuccessCodes"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SkipForNonSuccessCodes = data
+		case "skipHttpStatusCodes":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("skipHttpStatusCodes"))
+			data, err := ec.unmarshalOInt2ᚕintᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SkipHTTPStatusCodes = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputUrlTemplatizationRulesGroupInput(ctx context.Context, obj any) (model.URLTemplatizationRulesGroupInput, error) {
 	var it model.URLTemplatizationRulesGroupInput
 	asMap := map[string]any{}
@@ -59026,6 +59492,11 @@ func (ec *executionContext) _Action(ctx context.Context, sel ast.SelectionSet, o
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "uiGenerated":
+			out.Values[i] = ec._Action_uiGenerated(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "conditions":
 			out.Values[i] = ec._Action_conditions(ctx, field, obj)
 		case "statuses":
@@ -59159,6 +59630,8 @@ func (ec *executionContext) _ActionFields(ctx context.Context, sel ast.Selection
 			out.Values[i] = ec._ActionFields_customRegexMaskings(ctx, field, obj)
 		case "urlTemplatizationRulesGroups":
 			out.Values[i] = ec._ActionFields_urlTemplatizationRulesGroups(ctx, field, obj)
+		case "urlTemplatizationDefaultGroups":
+			out.Values[i] = ec._ActionFields_urlTemplatizationDefaultGroups(ctx, field, obj)
 		case "extractAttribute":
 			out.Values[i] = ec._ActionFields_extractAttribute(ctx, field, obj)
 		case "scopes":
@@ -70292,6 +70765,84 @@ func (ec *executionContext) _URLTemplatizationRule(ctx context.Context, sel ast.
 	return out
 }
 
+var urlTemplatizationDefaultGroupImplementors = []string{"UrlTemplatizationDefaultGroup"}
+
+func (ec *executionContext) _UrlTemplatizationDefaultGroup(ctx context.Context, sel ast.SelectionSet, obj *model.URLTemplatizationDefaultGroup) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, urlTemplatizationDefaultGroupImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("UrlTemplatizationDefaultGroup")
+		case "scopes":
+			out.Values[i] = ec._UrlTemplatizationDefaultGroup_scopes(ctx, field, obj)
+		case "disabled":
+			out.Values[i] = ec._UrlTemplatizationDefaultGroup_disabled(ctx, field, obj)
+		case "skipPolicy":
+			out.Values[i] = ec._UrlTemplatizationDefaultGroup_skipPolicy(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var urlTemplatizationDefaultSkipPolicyImplementors = []string{"UrlTemplatizationDefaultSkipPolicy"}
+
+func (ec *executionContext) _UrlTemplatizationDefaultSkipPolicy(ctx context.Context, sel ast.SelectionSet, obj *model.URLTemplatizationDefaultSkipPolicy) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, urlTemplatizationDefaultSkipPolicyImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("UrlTemplatizationDefaultSkipPolicy")
+		case "skipForNonSuccessCodes":
+			out.Values[i] = ec._UrlTemplatizationDefaultSkipPolicy_skipForNonSuccessCodes(ctx, field, obj)
+		case "skipHttpStatusCodes":
+			out.Values[i] = ec._UrlTemplatizationDefaultSkipPolicy_skipHttpStatusCodes(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var urlTemplatizationRulesGroupImplementors = []string{"UrlTemplatizationRulesGroup"}
 
 func (ec *executionContext) _UrlTemplatizationRulesGroup(ctx context.Context, sel ast.SelectionSet, obj *model.URLTemplatizationRulesGroup) graphql.Marshaler {
@@ -74725,6 +75276,21 @@ func (ec *executionContext) unmarshalNURLTemplatizationRuleInput2ᚖgithubᚗcom
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) marshalNUrlTemplatizationDefaultGroup2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationDefaultGroup(ctx context.Context, sel ast.SelectionSet, v *model.URLTemplatizationDefaultGroup) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._UrlTemplatizationDefaultGroup(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNUrlTemplatizationDefaultGroupInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationDefaultGroupInput(ctx context.Context, v any) (*model.URLTemplatizationDefaultGroupInput, error) {
+	res, err := ec.unmarshalInputUrlTemplatizationDefaultGroupInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) marshalNUrlTemplatizationRulesGroup2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationRulesGroup(ctx context.Context, sel ast.SelectionSet, v *model.URLTemplatizationRulesGroup) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -76122,6 +76688,42 @@ func (ec *executionContext) marshalOInstrumentorConfig2ᚖgithubᚗcomᚋodigos�
 		return graphql.Null
 	}
 	return ec._InstrumentorConfig(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOInt2ᚕintᚄ(ctx context.Context, v any) ([]int, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]int, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNInt2int(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalOInt2ᚕintᚄ(ctx context.Context, sel ast.SelectionSet, v []int) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	for i := range v {
+		ret[i] = ec.marshalNInt2int(ctx, sel, v[i])
+	}
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) unmarshalOInt2ᚖint(ctx context.Context, v any) (*int, error) {
@@ -78115,6 +78717,86 @@ func (ec *executionContext) marshalOUiMode2ᚖgithubᚗcomᚋodigosᚑioᚋodigo
 		return graphql.Null
 	}
 	return v
+}
+
+func (ec *executionContext) marshalOUrlTemplatizationDefaultGroup2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationDefaultGroupᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.URLTemplatizationDefaultGroup) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNUrlTemplatizationDefaultGroup2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationDefaultGroup(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) unmarshalOUrlTemplatizationDefaultGroupInput2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationDefaultGroupInputᚄ(ctx context.Context, v any) ([]*model.URLTemplatizationDefaultGroupInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]*model.URLTemplatizationDefaultGroupInput, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNUrlTemplatizationDefaultGroupInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationDefaultGroupInput(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalOUrlTemplatizationDefaultSkipPolicy2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationDefaultSkipPolicy(ctx context.Context, sel ast.SelectionSet, v *model.URLTemplatizationDefaultSkipPolicy) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._UrlTemplatizationDefaultSkipPolicy(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOUrlTemplatizationDefaultSkipPolicyInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationDefaultSkipPolicyInput(ctx context.Context, v any) (*model.URLTemplatizationDefaultSkipPolicyInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputUrlTemplatizationDefaultSkipPolicyInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalOUrlTemplatizationRulesGroup2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationRulesGroupᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.URLTemplatizationRulesGroup) graphql.Marshaler {

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -9,15 +9,16 @@ import (
 )
 
 type Action struct {
-	ID         string                    `json:"id"`
-	Type       ActionType                `json:"type"`
-	Name       *string                   `json:"name,omitempty"`
-	Notes      *string                   `json:"notes,omitempty"`
-	Disabled   bool                      `json:"disabled"`
-	Signals    []SignalType              `json:"signals"`
-	Fields     *ActionFields             `json:"fields"`
-	Conditions []*Condition              `json:"conditions,omitempty"`
-	Statuses   []*DesiredConditionStatus `json:"statuses"`
+	ID          string                    `json:"id"`
+	Type        ActionType                `json:"type"`
+	Name        *string                   `json:"name,omitempty"`
+	Notes       *string                   `json:"notes,omitempty"`
+	Disabled    bool                      `json:"disabled"`
+	Signals     []SignalType              `json:"signals"`
+	Fields      *ActionFields             `json:"fields"`
+	UIGenerated bool                      `json:"uiGenerated"`
+	Conditions  []*Condition              `json:"conditions,omitempty"`
+	Statuses    []*DesiredConditionStatus `json:"statuses"`
 }
 
 type ActionFieldYamlProperties struct {
@@ -30,43 +31,45 @@ type ActionFieldYamlProperties struct {
 }
 
 type ActionFields struct {
-	CollectContainerAttributes   *bool                          `json:"collectContainerAttributes,omitempty"`
-	CollectReplicaSetAttributes  *bool                          `json:"collectReplicaSetAttributes,omitempty"`
-	CollectWorkloadID            *bool                          `json:"collectWorkloadId,omitempty"`
-	CollectClusterID             *bool                          `json:"collectClusterId,omitempty"`
-	LabelsAttributes             []*K8sLabelAttribute           `json:"labelsAttributes,omitempty"`
-	AnnotationsAttributes        []*K8sAnnotationAttribute      `json:"annotationsAttributes,omitempty"`
-	ClusterAttributes            []*ClusterAttribute            `json:"clusterAttributes,omitempty"`
-	OverwriteExistingValues      *bool                          `json:"overwriteExistingValues,omitempty"`
-	AttributeNamesToDelete       []string                       `json:"attributeNamesToDelete,omitempty"`
-	Renames                      *string                        `json:"renames,omitempty"`
-	PiiCategories                []string                       `json:"piiCategories,omitempty"`
-	CustomFormatMaskings         []*CustomFormatMasking         `json:"customFormatMaskings,omitempty"`
-	CustomRegexMaskings          []*CustomRegexMasking          `json:"customRegexMaskings,omitempty"`
-	URLTemplatizationRulesGroups []*URLTemplatizationRulesGroup `json:"urlTemplatizationRulesGroups,omitempty"`
-	ExtractAttribute             *ExtractAttribute              `json:"extractAttribute,omitempty"`
-	Scopes                       *SourcesScopes                 `json:"scopes,omitempty"`
-	TemplatizeLiterals           *bool                          `json:"templatizeLiterals,omitempty"`
+	CollectContainerAttributes     *bool                            `json:"collectContainerAttributes,omitempty"`
+	CollectReplicaSetAttributes    *bool                            `json:"collectReplicaSetAttributes,omitempty"`
+	CollectWorkloadID              *bool                            `json:"collectWorkloadId,omitempty"`
+	CollectClusterID               *bool                            `json:"collectClusterId,omitempty"`
+	LabelsAttributes               []*K8sLabelAttribute             `json:"labelsAttributes,omitempty"`
+	AnnotationsAttributes          []*K8sAnnotationAttribute        `json:"annotationsAttributes,omitempty"`
+	ClusterAttributes              []*ClusterAttribute              `json:"clusterAttributes,omitempty"`
+	OverwriteExistingValues        *bool                            `json:"overwriteExistingValues,omitempty"`
+	AttributeNamesToDelete         []string                         `json:"attributeNamesToDelete,omitempty"`
+	Renames                        *string                          `json:"renames,omitempty"`
+	PiiCategories                  []string                         `json:"piiCategories,omitempty"`
+	CustomFormatMaskings           []*CustomFormatMasking           `json:"customFormatMaskings,omitempty"`
+	CustomRegexMaskings            []*CustomRegexMasking            `json:"customRegexMaskings,omitempty"`
+	URLTemplatizationRulesGroups   []*URLTemplatizationRulesGroup   `json:"urlTemplatizationRulesGroups,omitempty"`
+	URLTemplatizationDefaultGroups []*URLTemplatizationDefaultGroup `json:"urlTemplatizationDefaultGroups,omitempty"`
+	ExtractAttribute               *ExtractAttribute                `json:"extractAttribute,omitempty"`
+	Scopes                         *SourcesScopes                   `json:"scopes,omitempty"`
+	TemplatizeLiterals             *bool                            `json:"templatizeLiterals,omitempty"`
 }
 
 type ActionFieldsInput struct {
-	CollectContainerAttributes   *bool                               `json:"collectContainerAttributes,omitempty"`
-	CollectReplicaSetAttributes  *bool                               `json:"collectReplicaSetAttributes,omitempty"`
-	CollectWorkloadID            *bool                               `json:"collectWorkloadId,omitempty"`
-	CollectClusterID             *bool                               `json:"collectClusterId,omitempty"`
-	LabelsAttributes             []*K8sLabelAttributeInput           `json:"labelsAttributes,omitempty"`
-	AnnotationsAttributes        []*K8sAnnotationAttributeInput      `json:"annotationsAttributes,omitempty"`
-	ClusterAttributes            []*ClusterAttributeInput            `json:"clusterAttributes,omitempty"`
-	OverwriteExistingValues      *bool                               `json:"overwriteExistingValues,omitempty"`
-	AttributeNamesToDelete       []string                            `json:"attributeNamesToDelete,omitempty"`
-	Renames                      *string                             `json:"renames,omitempty"`
-	PiiCategories                []string                            `json:"piiCategories,omitempty"`
-	CustomFormatMaskings         []*CustomFormatMaskingInput         `json:"customFormatMaskings,omitempty"`
-	CustomRegexMaskings          []*CustomRegexMaskingInput          `json:"customRegexMaskings,omitempty"`
-	URLTemplatizationRulesGroups []*URLTemplatizationRulesGroupInput `json:"urlTemplatizationRulesGroups,omitempty"`
-	ExtractAttribute             *ExtractAttributeInput              `json:"extractAttribute,omitempty"`
-	Scopes                       *SourcesScopesInput                 `json:"scopes,omitempty"`
-	TemplatizeLiterals           *bool                               `json:"templatizeLiterals,omitempty"`
+	CollectContainerAttributes     *bool                                 `json:"collectContainerAttributes,omitempty"`
+	CollectReplicaSetAttributes    *bool                                 `json:"collectReplicaSetAttributes,omitempty"`
+	CollectWorkloadID              *bool                                 `json:"collectWorkloadId,omitempty"`
+	CollectClusterID               *bool                                 `json:"collectClusterId,omitempty"`
+	LabelsAttributes               []*K8sLabelAttributeInput             `json:"labelsAttributes,omitempty"`
+	AnnotationsAttributes          []*K8sAnnotationAttributeInput        `json:"annotationsAttributes,omitempty"`
+	ClusterAttributes              []*ClusterAttributeInput              `json:"clusterAttributes,omitempty"`
+	OverwriteExistingValues        *bool                                 `json:"overwriteExistingValues,omitempty"`
+	AttributeNamesToDelete         []string                              `json:"attributeNamesToDelete,omitempty"`
+	Renames                        *string                               `json:"renames,omitempty"`
+	PiiCategories                  []string                              `json:"piiCategories,omitempty"`
+	CustomFormatMaskings           []*CustomFormatMaskingInput           `json:"customFormatMaskings,omitempty"`
+	CustomRegexMaskings            []*CustomRegexMaskingInput            `json:"customRegexMaskings,omitempty"`
+	URLTemplatizationRulesGroups   []*URLTemplatizationRulesGroupInput   `json:"urlTemplatizationRulesGroups,omitempty"`
+	URLTemplatizationDefaultGroups []*URLTemplatizationDefaultGroupInput `json:"urlTemplatizationDefaultGroups,omitempty"`
+	ExtractAttribute               *ExtractAttributeInput                `json:"extractAttribute,omitempty"`
+	Scopes                         *SourcesScopesInput                   `json:"scopes,omitempty"`
+	TemplatizeLiterals             *bool                                 `json:"templatizeLiterals,omitempty"`
 }
 
 type ActionInput struct {
@@ -1824,6 +1827,28 @@ type URLTemplatizationRuleInput struct {
 	Template string   `json:"template"`
 	Notes    *string  `json:"notes,omitempty"`
 	Examples []string `json:"examples,omitempty"`
+}
+
+type URLTemplatizationDefaultGroup struct {
+	Scopes     *SourcesScopes                      `json:"scopes,omitempty"`
+	Disabled   *bool                               `json:"disabled,omitempty"`
+	SkipPolicy *URLTemplatizationDefaultSkipPolicy `json:"skipPolicy,omitempty"`
+}
+
+type URLTemplatizationDefaultGroupInput struct {
+	Scopes     *SourcesScopesInput                      `json:"scopes,omitempty"`
+	Disabled   *bool                                    `json:"disabled,omitempty"`
+	SkipPolicy *URLTemplatizationDefaultSkipPolicyInput `json:"skipPolicy,omitempty"`
+}
+
+type URLTemplatizationDefaultSkipPolicy struct {
+	SkipForNonSuccessCodes *bool `json:"skipForNonSuccessCodes,omitempty"`
+	SkipHTTPStatusCodes    []int `json:"skipHttpStatusCodes,omitempty"`
+}
+
+type URLTemplatizationDefaultSkipPolicyInput struct {
+	SkipForNonSuccessCodes *bool `json:"skipForNonSuccessCodes,omitempty"`
+	SkipHTTPStatusCodes    []int `json:"skipHttpStatusCodes,omitempty"`
 }
 
 type URLTemplatizationRulesGroup struct {

--- a/frontend/services/action.go
+++ b/frontend/services/action.go
@@ -44,6 +44,9 @@ func deriveTypeFromAction(action *model.Action, crd *v1alpha1.Action) model.Acti
 	if action.Fields.PiiCategories != nil || action.Fields.CustomFormatMaskings != nil || action.Fields.CustomRegexMaskings != nil {
 		return model.ActionTypePiiMasking
 	}
+	if crd.Spec.URLTemplatization != nil {
+		return model.ActionTypeURLTemplatization
+	}
 	if action.Fields.URLTemplatizationRulesGroups != nil {
 		return model.ActionTypeURLTemplatization
 	}
@@ -103,6 +106,9 @@ func CreateAction(ctx context.Context, input model.ActionInput) (*model.Action, 
 	payload := &v1alpha1.Action{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "action-",
+			Labels: map[string]string{
+				k8sconsts.OdigosCreatedByLabel: k8sconsts.OdigosCreatedByOdigosUIValue,
+			},
 		},
 		Spec: *spec,
 	}
@@ -465,6 +471,7 @@ func convertActionToModel(action *v1alpha1.Action) (*model.Action, error) {
 	}
 
 	urlTemplatizationGroups := convertUrlTemplatizationToModel(action.Spec.URLTemplatization)
+	urlTemplatizationDefaultGroups := convertUrlTemplatizationDefaultToModel(action.Spec.URLTemplatization)
 	extractAttribute := convertExtractAttributeToModel(action.Spec.ExtractAttribute)
 	scopes, templatizeLiterals := convertDbActionFieldsToModel(action)
 
@@ -476,8 +483,9 @@ func convertActionToModel(action *v1alpha1.Action) (*model.Action, error) {
 		PiiCategories:                piiCategories,
 		CustomFormatMaskings:         customFormatMaskings,
 		CustomRegexMaskings:          customRegexMaskings,
-		URLTemplatizationRulesGroups: urlTemplatizationGroups,
-		ExtractAttribute:             extractAttribute,
+		URLTemplatizationRulesGroups:   urlTemplatizationGroups,
+		URLTemplatizationDefaultGroups: urlTemplatizationDefaultGroups,
+		ExtractAttribute:               extractAttribute,
 		Scopes:                       scopes,
 		TemplatizeLiterals:           templatizeLiterals,
 	}
@@ -512,12 +520,13 @@ func convertActionToModel(action *v1alpha1.Action) (*model.Action, error) {
 	}
 
 	response := &model.Action{
-		ID:       action.Name,
-		Name:     &action.Spec.ActionName,
-		Notes:    &action.Spec.Notes,
-		Disabled: action.Spec.Disabled,
-		Signals:  signals,
-		Fields:   responseFields,
+		ID:          action.Name,
+		Name:        &action.Spec.ActionName,
+		Notes:       &action.Spec.Notes,
+		Disabled:    action.Spec.Disabled,
+		Signals:     signals,
+		Fields:      responseFields,
+		UIGenerated: isActionUiGenerated(action),
 	}
 
 	response.Type = deriveTypeFromAction(response, action)
@@ -525,6 +534,13 @@ func convertActionToModel(action *v1alpha1.Action) (*model.Action, error) {
 	response.Statuses = graphstatus.ConvertActionConditionsToStatuses(action.Status.Conditions, action.Generation)
 
 	return response, nil
+}
+
+func isActionUiGenerated(action *v1alpha1.Action) bool {
+	if action == nil || action.Labels == nil {
+		return false
+	}
+	return action.Labels[k8sconsts.OdigosCreatedByLabel] == k8sconsts.OdigosCreatedByOdigosUIValue
 }
 
 func convertLabelsAttributesToModel(labelsAttributes []actionsv1.K8sLabelAttribute) []*model.K8sLabelAttribute {
@@ -644,77 +660,114 @@ func stringifyMap(m map[string]string) (string, error) {
 }
 
 func convertUrlTemplatizationFromInput(details *model.ActionFieldsInput, existingAction *v1alpha1.Action) *apiactions.URLTemplatizationConfig {
-	if details.URLTemplatizationRulesGroups == nil {
+	if details.URLTemplatizationRulesGroups == nil && details.URLTemplatizationDefaultGroups == nil {
 		if existingAction != nil && existingAction.Spec.URLTemplatization != nil {
 			return existingAction.Spec.URLTemplatization
 		}
 		return nil
 	}
 
-	rules := make([]apiactions.UrlTemplatizationRule, 0, len(details.URLTemplatizationRulesGroups))
-	for _, g := range details.URLTemplatizationRulesGroups {
-		group := apiactions.UrlTemplatizationRule{}
+	var rules []apiactions.UrlTemplatizationRule
+	if details.URLTemplatizationRulesGroups != nil {
+		rules = make([]apiactions.UrlTemplatizationRule, 0, len(details.URLTemplatizationRulesGroups))
+		for _, g := range details.URLTemplatizationRulesGroups {
+			group := apiactions.UrlTemplatizationRule{}
 
-		// Fold the URL-templatization filter form into the tri-list SourcesScopes shape:
-		//   * Each WorkloadFilter row → one PodWorkload appended to Sources (with namespace baked in).
-		//   * Singleton fallback path: build one PodWorkload if a workload identity is given,
-		//     otherwise fall back to a namespace-only entry.
-		//   * FilterProgrammingLanguage → Languages.
-		scopes := &k8sconsts.SourcesScopes{}
-		if len(g.WorkloadFilters) > 0 {
-			for _, wf := range g.WorkloadFilters {
-				pw := k8sconsts.PodWorkload{}
-				if g.FilterK8sNamespace != nil {
-					pw.Namespace = *g.FilterK8sNamespace
+			// Fold the URL-templatization filter form into the tri-list SourcesScopes shape:
+			//   * Each WorkloadFilter row → one PodWorkload appended to Sources (with namespace baked in).
+			//   * Singleton fallback path: build one PodWorkload if a workload identity is given,
+			//     otherwise fall back to a namespace-only entry.
+			//   * FilterProgrammingLanguage → Languages.
+			scopes := &k8sconsts.SourcesScopes{}
+			if len(g.WorkloadFilters) > 0 {
+				for _, wf := range g.WorkloadFilters {
+					pw := k8sconsts.PodWorkload{}
+					if g.FilterK8sNamespace != nil {
+						pw.Namespace = *g.FilterK8sNamespace
+					}
+					if wf.Kind != nil {
+						pw.Kind = k8sconsts.WorkloadKind(*wf.Kind)
+					}
+					if wf.Name != nil {
+						pw.Name = *wf.Name
+					}
+					scopes.Sources = append(scopes.Sources, pw)
 				}
-				if wf.Kind != nil {
-					pw.Kind = k8sconsts.WorkloadKind(*wf.Kind)
+			} else if g.FilterK8sNamespace != nil || g.FilterK8sWorkloadKind != nil || g.FilterK8sWorkloadName != nil {
+				if g.FilterK8sWorkloadKind != nil || g.FilterK8sWorkloadName != nil {
+					pw := k8sconsts.PodWorkload{}
+					if g.FilterK8sNamespace != nil {
+						pw.Namespace = *g.FilterK8sNamespace
+					}
+					if g.FilterK8sWorkloadKind != nil {
+						pw.Kind = k8sconsts.WorkloadKind(*g.FilterK8sWorkloadKind)
+					}
+					if g.FilterK8sWorkloadName != nil {
+						pw.Name = *g.FilterK8sWorkloadName
+					}
+					scopes.Sources = append(scopes.Sources, pw)
+				} else if g.FilterK8sNamespace != nil {
+					scopes.Namespaces = append(scopes.Namespaces, *g.FilterK8sNamespace)
 				}
-				if wf.Name != nil {
-					pw.Name = *wf.Name
-				}
-				scopes.Sources = append(scopes.Sources, pw)
 			}
-		} else if g.FilterK8sNamespace != nil || g.FilterK8sWorkloadKind != nil || g.FilterK8sWorkloadName != nil {
-			if g.FilterK8sWorkloadKind != nil || g.FilterK8sWorkloadName != nil {
-				pw := k8sconsts.PodWorkload{}
-				if g.FilterK8sNamespace != nil {
-					pw.Namespace = *g.FilterK8sNamespace
-				}
-				if g.FilterK8sWorkloadKind != nil {
-					pw.Kind = k8sconsts.WorkloadKind(*g.FilterK8sWorkloadKind)
-				}
-				if g.FilterK8sWorkloadName != nil {
-					pw.Name = *g.FilterK8sWorkloadName
-				}
-				scopes.Sources = append(scopes.Sources, pw)
-			} else if g.FilterK8sNamespace != nil {
-				scopes.Namespaces = append(scopes.Namespaces, *g.FilterK8sNamespace)
+			if g.FilterProgrammingLanguage != nil {
+				scopes.Languages = append(scopes.Languages, common.ProgrammingLanguage(*g.FilterProgrammingLanguage))
 			}
-		}
-		if g.FilterProgrammingLanguage != nil {
-			scopes.Languages = append(scopes.Languages, common.ProgrammingLanguage(*g.FilterProgrammingLanguage))
-		}
-		if len(scopes.Sources) > 0 || len(scopes.Namespaces) > 0 || len(scopes.Languages) > 0 {
-			group.Scopes = scopes
-		}
+			if len(scopes.Sources) > 0 || len(scopes.Namespaces) > 0 || len(scopes.Languages) > 0 {
+				group.Scopes = scopes
+			}
 
-		for _, rule := range g.TemplatizationRules {
-			group.Templates = append(group.Templates, rule.Template)
+			for _, rule := range g.TemplatizationRules {
+				group.Templates = append(group.Templates, rule.Template)
+			}
+			rules = append(rules, group)
 		}
-		rules = append(rules, group)
+	} else if existingAction != nil && existingAction.Spec.URLTemplatization != nil {
+		rules = existingAction.Spec.URLTemplatization.Rules
 	}
 
 	config := &apiactions.URLTemplatizationConfig{
 		Rules: rules,
 	}
-	// The GraphQL/UI shape only exposes the rule groups, not the default templatization groups.
-	// Preserve any YAML-managed default templatization from the existing Action so that updating
+	// Prefer explicit default groups from the GraphQL input when provided. Otherwise preserve
+	// any YAML-managed default templatization from the existing Action so that updating
 	// rules through the UI does not silently drop it.
-	if existingAction != nil && existingAction.Spec.URLTemplatization != nil {
+	if details.URLTemplatizationDefaultGroups != nil {
+		config.Default = convertUrlTemplatizationDefaultFromInput(details.URLTemplatizationDefaultGroups)
+	} else if existingAction != nil && existingAction.Spec.URLTemplatization != nil {
 		config.Default = existingAction.Spec.URLTemplatization.Default
 	}
 	return config
+}
+
+func convertUrlTemplatizationDefaultFromInput(groups []*model.URLTemplatizationDefaultGroupInput) []apiactions.URLTemplatizationDefaultTemplatizationGroup {
+	if groups == nil {
+		return nil
+	}
+	out := make([]apiactions.URLTemplatizationDefaultTemplatizationGroup, 0, len(groups))
+	for _, g := range groups {
+		if g == nil {
+			continue
+		}
+		group := apiactions.URLTemplatizationDefaultTemplatizationGroup{
+			Scopes: SourcesScopesInputToCRD(g.Scopes),
+		}
+		if g.Disabled != nil {
+			group.Disabled = *g.Disabled
+		}
+		if g.SkipPolicy != nil {
+			skip := &actionsapi.DefaultTemplatizationSkipPolicyConfig{}
+			if g.SkipPolicy.SkipForNonSuccessCodes != nil {
+				skip.SkipForNonSuccessCodes = *g.SkipPolicy.SkipForNonSuccessCodes
+			}
+			if len(g.SkipPolicy.SkipHTTPStatusCodes) > 0 {
+				skip.SkipHttpStatusCodes = append([]int(nil), g.SkipPolicy.SkipHTTPStatusCodes...)
+			}
+			group.SkipPolicy = skip
+		}
+		out = append(out, group)
+	}
+	return out
 }
 
 func convertUrlTemplatizationToModel(cfg *apiactions.URLTemplatizationConfig) []*model.URLTemplatizationRulesGroup {
@@ -763,6 +816,36 @@ func convertUrlTemplatizationToModel(cfg *apiactions.URLTemplatizationConfig) []
 			group.TemplatizationRules = append(group.TemplatizationRules, &model.URLTemplatizationRule{
 				Template: rule,
 			})
+		}
+		result = append(result, group)
+	}
+	return result
+}
+
+func convertUrlTemplatizationDefaultToModel(cfg *apiactions.URLTemplatizationConfig) []*model.URLTemplatizationDefaultGroup {
+	if cfg == nil || len(cfg.Default) == 0 {
+		return nil
+	}
+
+	result := make([]*model.URLTemplatizationDefaultGroup, 0, len(cfg.Default))
+	for _, g := range cfg.Default {
+		group := &model.URLTemplatizationDefaultGroup{
+			Scopes: SourcesScopesCRDToModel(g.Scopes),
+		}
+		if g.Disabled {
+			disabled := true
+			group.Disabled = &disabled
+		}
+		if g.SkipPolicy != nil {
+			skipPolicy := &model.URLTemplatizationDefaultSkipPolicy{}
+			if g.SkipPolicy.SkipForNonSuccessCodes {
+				v := true
+				skipPolicy.SkipForNonSuccessCodes = &v
+			}
+			if len(g.SkipPolicy.SkipHttpStatusCodes) > 0 {
+				skipPolicy.SkipHTTPStatusCodes = append([]int(nil), g.SkipPolicy.SkipHttpStatusCodes...)
+			}
+			group.SkipPolicy = skipPolicy
 		}
 		result = append(result, group)
 	}

--- a/frontend/services/action.go
+++ b/frontend/services/action.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	actionsv1 "github.com/odigos-io/odigos/api/actions/v1alpha1"
 	"github.com/odigos-io/odigos/api/k8sconsts"
@@ -671,50 +672,8 @@ func convertUrlTemplatizationFromInput(details *model.ActionFieldsInput, existin
 	if details.URLTemplatizationRulesGroups != nil {
 		rules = make([]apiactions.UrlTemplatizationRule, 0, len(details.URLTemplatizationRulesGroups))
 		for _, g := range details.URLTemplatizationRulesGroups {
-			group := apiactions.UrlTemplatizationRule{}
-
-			// Fold the URL-templatization filter form into the tri-list SourcesScopes shape:
-			//   * Each WorkloadFilter row → one PodWorkload appended to Sources (with namespace baked in).
-			//   * Singleton fallback path: build one PodWorkload if a workload identity is given,
-			//     otherwise fall back to a namespace-only entry.
-			//   * FilterProgrammingLanguage → Languages.
-			scopes := &k8sconsts.SourcesScopes{}
-			if len(g.WorkloadFilters) > 0 {
-				for _, wf := range g.WorkloadFilters {
-					pw := k8sconsts.PodWorkload{}
-					if g.FilterK8sNamespace != nil {
-						pw.Namespace = *g.FilterK8sNamespace
-					}
-					if wf.Kind != nil {
-						pw.Kind = k8sconsts.WorkloadKind(*wf.Kind)
-					}
-					if wf.Name != nil {
-						pw.Name = *wf.Name
-					}
-					scopes.Sources = append(scopes.Sources, pw)
-				}
-			} else if g.FilterK8sNamespace != nil || g.FilterK8sWorkloadKind != nil || g.FilterK8sWorkloadName != nil {
-				if g.FilterK8sWorkloadKind != nil || g.FilterK8sWorkloadName != nil {
-					pw := k8sconsts.PodWorkload{}
-					if g.FilterK8sNamespace != nil {
-						pw.Namespace = *g.FilterK8sNamespace
-					}
-					if g.FilterK8sWorkloadKind != nil {
-						pw.Kind = k8sconsts.WorkloadKind(*g.FilterK8sWorkloadKind)
-					}
-					if g.FilterK8sWorkloadName != nil {
-						pw.Name = *g.FilterK8sWorkloadName
-					}
-					scopes.Sources = append(scopes.Sources, pw)
-				} else if g.FilterK8sNamespace != nil {
-					scopes.Namespaces = append(scopes.Namespaces, *g.FilterK8sNamespace)
-				}
-			}
-			if g.FilterProgrammingLanguage != nil {
-				scopes.Languages = append(scopes.Languages, common.ProgrammingLanguage(*g.FilterProgrammingLanguage))
-			}
-			if len(scopes.Sources) > 0 || len(scopes.Namespaces) > 0 || len(scopes.Languages) > 0 {
-				group.Scopes = scopes
+			group := apiactions.UrlTemplatizationRule{
+				Scopes: urlTemplatizationRulesGroupInputToScopes(g),
 			}
 
 			for _, rule := range g.TemplatizationRules {
@@ -778,39 +737,7 @@ func convertUrlTemplatizationToModel(cfg *apiactions.URLTemplatizationConfig) []
 	var result []*model.URLTemplatizationRulesGroup
 	for _, g := range cfg.Rules {
 		group := &model.URLTemplatizationRulesGroup{}
-
-		// Unfold tri-list SourcesScopes back into the URL-templatization filter form.
-		// The GraphQL shape exposes only single-value FilterK8sNamespace and
-		// FilterProgrammingLanguage, so multi-namespace/multi-language scopes are
-		// projected to the first entry (best-effort; the wire format predates the list).
-		if g.Scopes != nil {
-			for _, src := range g.Scopes.Sources {
-				if src.Kind != "" || src.Name != "" {
-					filter := &model.TemplatizationWorkloadFilter{}
-					if src.Kind != "" {
-						kind := model.K8sResourceKind(src.Kind)
-						filter.Kind = &kind
-					}
-					if src.Name != "" {
-						name := src.Name
-						filter.Name = &name
-					}
-					group.WorkloadFilters = append(group.WorkloadFilters, filter)
-				}
-				if src.Namespace != "" && group.FilterK8sNamespace == nil {
-					ns := src.Namespace
-					group.FilterK8sNamespace = &ns
-				}
-			}
-			if group.FilterK8sNamespace == nil && len(g.Scopes.Namespaces) > 0 {
-				ns := g.Scopes.Namespaces[0]
-				group.FilterK8sNamespace = &ns
-			}
-			if len(g.Scopes.Languages) > 0 {
-				lang := string(g.Scopes.Languages[0])
-				group.FilterProgrammingLanguage = &lang
-			}
-		}
+		encodeUrlTemplatizationScopesToRulesGroup(g.Scopes, group)
 
 		for _, rule := range g.Templates {
 			group.TemplatizationRules = append(group.TemplatizationRules, &model.URLTemplatizationRule{
@@ -820,6 +747,177 @@ func convertUrlTemplatizationToModel(cfg *apiactions.URLTemplatizationConfig) []
 		result = append(result, group)
 	}
 	return result
+}
+
+// urlTemplatizationNamespaceScopeSeparator separates per-source namespaces from
+// additional namespace-scope entries inside FilterK8sNamespace. Multi-value
+// lists are CSV-encoded so the existing GraphQL String fields can carry any
+// number of entities without a schema change.
+const urlTemplatizationNamespaceScopeSeparator = "||"
+
+func splitCSV(value string) []string {
+	if value == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+// splitCSVPreserveEmpty keeps blank slots so per-source namespace indices stay
+// aligned with WorkloadFilters when encoded as a parallel CSV list.
+func splitCSVPreserveEmpty(value string) []string {
+	if value == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	out := make([]string, len(parts))
+	for i, part := range parts {
+		out[i] = strings.TrimSpace(part)
+	}
+	return out
+}
+
+func joinCSV(values []string) string {
+	cleaned := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			cleaned = append(cleaned, trimmed)
+		}
+	}
+	return strings.Join(cleaned, ",")
+}
+
+func parseNamespaceFilterField(value *string) (sourceNamespaces []string, scopeNamespaces []string) {
+	if value == nil {
+		return nil, nil
+	}
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return nil, nil
+	}
+	parts := strings.SplitN(trimmed, urlTemplatizationNamespaceScopeSeparator, 2)
+	sourceNamespaces = splitCSVPreserveEmpty(parts[0])
+	if len(parts) == 2 {
+		scopeNamespaces = splitCSV(parts[1])
+	}
+	return sourceNamespaces, scopeNamespaces
+}
+
+func urlTemplatizationRulesGroupInputToScopes(g *model.URLTemplatizationRulesGroupInput) *k8sconsts.SourcesScopes {
+	if g == nil {
+		return nil
+	}
+
+	scopes := &k8sconsts.SourcesScopes{}
+	sourceNamespaces, scopeNamespaces := parseNamespaceFilterField(g.FilterK8sNamespace)
+
+	if len(g.WorkloadFilters) > 0 {
+		for i, wf := range g.WorkloadFilters {
+			if wf == nil {
+				continue
+			}
+			pw := k8sconsts.PodWorkload{}
+			if i < len(sourceNamespaces) {
+				pw.Namespace = sourceNamespaces[i]
+			} else if len(sourceNamespaces) == 1 {
+				pw.Namespace = sourceNamespaces[0]
+			}
+			if wf.Kind != nil {
+				pw.Kind = k8sconsts.WorkloadKind(*wf.Kind)
+			}
+			if wf.Name != nil {
+				pw.Name = *wf.Name
+			}
+			scopes.Sources = append(scopes.Sources, pw)
+		}
+		scopes.Namespaces = append(scopes.Namespaces, scopeNamespaces...)
+	} else if g.FilterK8sWorkloadKind != nil || g.FilterK8sWorkloadName != nil {
+		pw := k8sconsts.PodWorkload{}
+		if len(sourceNamespaces) > 0 {
+			pw.Namespace = sourceNamespaces[0]
+		}
+		if g.FilterK8sWorkloadKind != nil {
+			pw.Kind = k8sconsts.WorkloadKind(*g.FilterK8sWorkloadKind)
+		}
+		if g.FilterK8sWorkloadName != nil {
+			pw.Name = *g.FilterK8sWorkloadName
+		}
+		scopes.Sources = append(scopes.Sources, pw)
+		scopes.Namespaces = append(scopes.Namespaces, scopeNamespaces...)
+	} else {
+		// Namespace-only (or namespace + language) scope: all CSV entries are namespace filters.
+		allNamespaces := append([]string{}, sourceNamespaces...)
+		allNamespaces = append(allNamespaces, scopeNamespaces...)
+		scopes.Namespaces = append(scopes.Namespaces, allNamespaces...)
+	}
+
+	if g.FilterProgrammingLanguage != nil {
+		for _, lang := range splitCSV(*g.FilterProgrammingLanguage) {
+			scopes.Languages = append(scopes.Languages, common.ProgrammingLanguage(lang))
+		}
+	}
+
+	if len(scopes.Sources) == 0 && len(scopes.Namespaces) == 0 && len(scopes.Languages) == 0 {
+		return nil
+	}
+	return scopes
+}
+
+func encodeUrlTemplatizationScopesToRulesGroup(scopes *k8sconsts.SourcesScopes, group *model.URLTemplatizationRulesGroup) {
+	if scopes == nil || group == nil {
+		return
+	}
+
+	sourceNamespaces := make([]string, 0, len(scopes.Sources))
+	for _, src := range scopes.Sources {
+		if src.Kind != "" || src.Name != "" {
+			filter := &model.TemplatizationWorkloadFilter{}
+			if src.Kind != "" {
+				kind := model.K8sResourceKind(src.Kind)
+				filter.Kind = &kind
+			}
+			if src.Name != "" {
+				name := src.Name
+				filter.Name = &name
+			}
+			group.WorkloadFilters = append(group.WorkloadFilters, filter)
+		}
+		sourceNamespaces = append(sourceNamespaces, src.Namespace)
+	}
+
+	var filterNamespace string
+	if len(group.WorkloadFilters) > 0 {
+		// Preserve empty slots so decode can zip namespaces with workload filters.
+		sourcePart := strings.Join(sourceNamespaces, ",")
+		scopePart := joinCSV(scopes.Namespaces)
+		if scopePart != "" {
+			filterNamespace = sourcePart + urlTemplatizationNamespaceScopeSeparator + scopePart
+		} else {
+			filterNamespace = sourcePart
+		}
+	} else if len(scopes.Namespaces) > 0 {
+		filterNamespace = joinCSV(scopes.Namespaces)
+	}
+	if filterNamespace != "" {
+		group.FilterK8sNamespace = &filterNamespace
+	}
+
+	if len(scopes.Languages) > 0 {
+		langs := make([]string, 0, len(scopes.Languages))
+		for _, lang := range scopes.Languages {
+			langs = append(langs, string(lang))
+		}
+		joined := joinCSV(langs)
+		group.FilterProgrammingLanguage = &joined
+	}
 }
 
 func convertUrlTemplatizationDefaultToModel(cfg *apiactions.URLTemplatizationConfig) []*model.URLTemplatizationDefaultGroup {

--- a/frontend/services/action_ui_generated_test.go
+++ b/frontend/services/action_ui_generated_test.go
@@ -1,0 +1,48 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/odigos-io/odigos/api/k8sconsts"
+	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsActionUiGenerated(t *testing.T) {
+	require.False(t, isActionUiGenerated(nil))
+	require.False(t, isActionUiGenerated(&v1alpha1.Action{}))
+	require.False(t, isActionUiGenerated(&v1alpha1.Action{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{k8sconsts.OdigosCreatedByLabel: "helm"},
+		},
+	}))
+	require.True(t, isActionUiGenerated(&v1alpha1.Action{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				k8sconsts.OdigosCreatedByLabel: k8sconsts.OdigosCreatedByOdigosUIValue,
+			},
+		},
+	}))
+}
+
+func TestConvertActionToModelReportsUiGenerated(t *testing.T) {
+	action := &v1alpha1.Action{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "action-ui",
+			Labels: map[string]string{
+				k8sconsts.OdigosCreatedByLabel: k8sconsts.OdigosCreatedByOdigosUIValue,
+			},
+		},
+	}
+	modelAction, err := convertActionToModel(action)
+	require.NoError(t, err)
+	require.True(t, modelAction.UIGenerated)
+
+	yamlAction := &v1alpha1.Action{
+		ObjectMeta: metav1.ObjectMeta{Name: "action-yaml"},
+	}
+	modelYaml, err := convertActionToModel(yamlAction)
+	require.NoError(t, err)
+	require.False(t, modelYaml.UIGenerated)
+}

--- a/frontend/services/action_url_templatization_default_test.go
+++ b/frontend/services/action_url_templatization_default_test.go
@@ -1,0 +1,91 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	urlactions "github.com/odigos-io/odigos/api/odigos/v1alpha1/actions"
+	"github.com/odigos-io/odigos/common"
+	actionsapi "github.com/odigos-io/odigos/common/api/actions"
+	"github.com/odigos-io/odigos/frontend/graph/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertUrlTemplatizationDefaultToModel(t *testing.T) {
+	skipNonSuccess := true
+	groups := convertUrlTemplatizationDefaultToModel(&urlactions.URLTemplatizationConfig{
+		Default: []urlactions.URLTemplatizationDefaultTemplatizationGroup{
+			{
+				DefaultTemplatizationConfig: actionsapi.DefaultTemplatizationConfig{
+					SkipPolicy: &actionsapi.DefaultTemplatizationSkipPolicyConfig{
+						SkipForNonSuccessCodes: true,
+					},
+				},
+			},
+		},
+	})
+
+	require.Len(t, groups, 1)
+	require.NotNil(t, groups[0].SkipPolicy)
+	require.NotNil(t, groups[0].SkipPolicy.SkipForNonSuccessCodes)
+	require.True(t, *groups[0].SkipPolicy.SkipForNonSuccessCodes)
+	require.Equal(t, skipNonSuccess, *groups[0].SkipPolicy.SkipForNonSuccessCodes)
+}
+
+func TestConvertActionToModelIncludesUrlTemplatizationDefaultGroups(t *testing.T) {
+	action := &v1alpha1.Action{
+		Spec: v1alpha1.ActionSpec{
+			Signals: []common.ObservabilitySignal{common.TracesObservabilitySignal},
+			URLTemplatization: &urlactions.URLTemplatizationConfig{
+				Default: []urlactions.URLTemplatizationDefaultTemplatizationGroup{
+					{
+						DefaultTemplatizationConfig: actionsapi.DefaultTemplatizationConfig{
+							Disabled: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	modelAction, err := convertActionToModel(action)
+	require.NoError(t, err)
+	require.Equal(t, model.ActionTypeURLTemplatization, modelAction.Type)
+	require.Len(t, modelAction.Fields.URLTemplatizationDefaultGroups, 1)
+	require.NotNil(t, modelAction.Fields.URLTemplatizationDefaultGroups[0].Disabled)
+	require.True(t, *modelAction.Fields.URLTemplatizationDefaultGroups[0].Disabled)
+}
+
+func TestConvertUrlTemplatizationFromInputAcceptsDefaultGroups(t *testing.T) {
+	skipNonSuccess := true
+	existingAction := &v1alpha1.Action{
+		Spec: v1alpha1.ActionSpec{
+			URLTemplatization: &urlactions.URLTemplatizationConfig{
+				Rules: []urlactions.UrlTemplatizationRule{
+					{Templates: []string{"/existing/{id}"}},
+				},
+			},
+		},
+	}
+
+	cfg := convertUrlTemplatizationFromInput(&model.ActionFieldsInput{
+		URLTemplatizationDefaultGroups: []*model.URLTemplatizationDefaultGroupInput{
+			{
+				Scopes: &model.SourcesScopesInput{
+					Namespaces: []string{"prod"},
+				},
+				SkipPolicy: &model.URLTemplatizationDefaultSkipPolicyInput{
+					SkipForNonSuccessCodes: &skipNonSuccess,
+				},
+			},
+		},
+	}, existingAction)
+
+	require.NotNil(t, cfg)
+	require.Len(t, cfg.Rules, 1)
+	require.Equal(t, []string{"/existing/{id}"}, cfg.Rules[0].Templates)
+	require.Len(t, cfg.Default, 1)
+	require.Equal(t, []string{"prod"}, cfg.Default[0].Scopes.Namespaces)
+	require.NotNil(t, cfg.Default[0].SkipPolicy)
+	require.True(t, cfg.Default[0].SkipPolicy.SkipForNonSuccessCodes)
+}

--- a/frontend/webapp/app/(v2)/layout.tsx
+++ b/frontend/webapp/app/(v2)/layout.tsx
@@ -20,6 +20,8 @@ const ViewportColumn = styled(FlexColumn)`
 const ContentRow = styled(FlexRow)`
   flex: 1;
   min-height: 0;
+  align-items: stretch;
+  width: 100%;
 `;
 
 function InnerLayout({ children }: PropsWithChildren) {

--- a/frontend/webapp/app/(v2)/url-templating/action-default-group-update.ts
+++ b/frontend/webapp/app/(v2)/url-templating/action-default-group-update.ts
@@ -1,0 +1,279 @@
+import type { Action, SourcesScopes } from '@odigos/ui-kit/types';
+import { K8sResourceKind } from '@odigos/ui-kit/types';
+import type {
+  UrlTemplatizationActionFields,
+  UrlTemplatizationDefaultGroup,
+} from './url-templatization-aggregate';
+import { makeEmptySourcesScopes } from './action-group-templates-update';
+
+export type DefaultGroupSkipPolicyInput = {
+  skipForNonSuccessCodes?: boolean | null;
+  skipHttpStatusCodes?: number[] | null;
+};
+
+export type DefaultGroupEditInput = {
+  scopes: SourcesScopes;
+  disabled: boolean;
+  skipForNonSuccessCodes: boolean;
+  skipHttpStatusCodes: number[];
+};
+
+export type UpdateActionWithDefaultGroupsVars = {
+  id: string;
+  action: {
+    type: Action['type'];
+    name?: string | null;
+    notes?: string | null;
+    disabled?: boolean | null;
+    signals?: Action['signals'];
+    fields: {
+      urlTemplatizationDefaultGroups: UrlTemplatizationDefaultGroup[];
+    };
+  };
+};
+
+function parseWorkloadKind(kind: string | null | undefined): K8sResourceKind {
+  const trimmed = kind?.trim();
+  if (!trimmed) {
+    return K8sResourceKind.Deployment;
+  }
+  const values = Object.values(K8sResourceKind) as string[];
+  if (values.includes(trimmed)) {
+    return trimmed as K8sResourceKind;
+  }
+  return K8sResourceKind.Deployment;
+}
+
+export function defaultGroupScopesToSourcesScopes(
+  scopes: UrlTemplatizationDefaultGroup['scopes'],
+): SourcesScopes {
+  if (!scopes) {
+    return makeEmptySourcesScopes();
+  }
+  return {
+    namespaces: [...(scopes.namespaces ?? [])],
+    languages: [...(scopes.languages ?? [])],
+    sources: (scopes.sources ?? [])
+      .filter((source) => source?.name?.trim())
+      .map((source) => ({
+        namespace: source.namespace?.trim() || '',
+        kind: parseWorkloadKind(source.kind),
+        name: source.name?.trim() || '',
+      })),
+  };
+}
+
+export function sourcesScopesToDefaultGroupScopes(
+  scopes: SourcesScopes,
+): UrlTemplatizationDefaultGroup['scopes'] {
+  const namespaces = (scopes.namespaces ?? []).map((value) => value.trim()).filter(Boolean);
+  const languages = (scopes.languages ?? []).map((value) => value.trim()).filter(Boolean);
+  const sources = (scopes.sources ?? [])
+    .filter((source) => source.name?.trim())
+    .map((source) => ({
+      namespace: source.namespace?.trim() || null,
+      kind: source.kind || null,
+      name: source.name?.trim() || null,
+    }));
+
+  if (!namespaces.length && !languages.length && !sources.length) {
+    return null;
+  }
+
+  return {
+    namespaces: namespaces.length ? namespaces : null,
+    languages: languages.length ? languages : null,
+    sources: sources.length ? sources : null,
+  };
+}
+
+export function buildDefaultGroupFromEditInput(input: DefaultGroupEditInput): UrlTemplatizationDefaultGroup {
+  const skipHttpStatusCodes = input.skipForNonSuccessCodes
+    ? []
+    : input.skipHttpStatusCodes.filter((code) => Number.isFinite(code) && code > 0);
+
+  const hasSkipPolicy = input.skipForNonSuccessCodes || skipHttpStatusCodes.length > 0;
+
+  return {
+    scopes: sourcesScopesToDefaultGroupScopes(input.scopes),
+    disabled: input.disabled,
+    skipPolicy: hasSkipPolicy
+      ? {
+          skipForNonSuccessCodes: input.skipForNonSuccessCodes || null,
+          skipHttpStatusCodes: skipHttpStatusCodes.length ? skipHttpStatusCodes : null,
+        }
+      : null,
+  };
+}
+
+function actionUpdateEnvelope(
+  action: Action,
+  groups: UrlTemplatizationDefaultGroup[],
+): UpdateActionWithDefaultGroupsVars {
+  return {
+    id: action.id,
+    action: {
+      type: action.type,
+      name: action.name,
+      notes: action.notes,
+      disabled: action.disabled,
+      signals: action.signals,
+      fields: {
+        urlTemplatizationDefaultGroups: groups,
+      },
+    },
+  };
+}
+
+function cloneDefaultGroups(action: Action): UrlTemplatizationDefaultGroup[] {
+  const fields = (action.fields ?? {}) as UrlTemplatizationActionFields;
+  return [...(fields.urlTemplatizationDefaultGroups ?? [])].map((group) => ({
+    scopes: group.scopes
+      ? {
+          namespaces: group.scopes.namespaces ? [...group.scopes.namespaces] : null,
+          languages: group.scopes.languages ? [...group.scopes.languages] : null,
+          sources: group.scopes.sources
+            ? group.scopes.sources.map((source) => ({ ...source }))
+            : null,
+        }
+      : null,
+    disabled: group.disabled ?? null,
+    skipPolicy: group.skipPolicy
+      ? {
+          skipForNonSuccessCodes: group.skipPolicy.skipForNonSuccessCodes ?? null,
+          skipHttpStatusCodes: group.skipPolicy.skipHttpStatusCodes
+            ? [...group.skipPolicy.skipHttpStatusCodes]
+            : null,
+        }
+      : null,
+  }));
+}
+
+export function buildUpdateActionWithDefaultGroup(
+  action: Action,
+  groupIndex: number,
+  input: DefaultGroupEditInput,
+): UpdateActionWithDefaultGroupsVars {
+  const groups = cloneDefaultGroups(action);
+  if (groupIndex < 0 || groupIndex >= groups.length) {
+    throw new Error(`Default group index ${groupIndex} is out of range for action ${action.id}`);
+  }
+  groups[groupIndex] = buildDefaultGroupFromEditInput(input);
+  return actionUpdateEnvelope(action, groups);
+}
+
+export function buildUpdateActionWithDefaultGroupDeleted(
+  action: Action,
+  groupIndex: number,
+): UpdateActionWithDefaultGroupsVars {
+  const groups = cloneDefaultGroups(action);
+  if (groupIndex < 0 || groupIndex >= groups.length) {
+    throw new Error(`Default group index ${groupIndex} is out of range for action ${action.id}`);
+  }
+  groups.splice(groupIndex, 1);
+  return actionUpdateEnvelope(action, groups);
+}
+
+export const CLUSTER_WIDE_ENABLED_DEFAULT_GROUP: UrlTemplatizationDefaultGroup = {
+  scopes: null,
+  disabled: false,
+  skipPolicy: null,
+};
+
+export function buildUpdateActionWithAppendedDefaultGroup(
+  action: Action,
+  group: UrlTemplatizationDefaultGroup = CLUSTER_WIDE_ENABLED_DEFAULT_GROUP,
+): UpdateActionWithDefaultGroupsVars {
+  const groups = cloneDefaultGroups(action);
+  groups.push(group);
+  return actionUpdateEnvelope(action, groups);
+}
+
+/** Re-enable every cluster-wide default group that is currently disabled on this action. */
+export function buildUpdateActionReenablingClusterWideDefaults(
+  action: Action,
+): UpdateActionWithDefaultGroupsVars | null {
+  const groups = cloneDefaultGroups(action);
+  let changed = false;
+  for (const group of groups) {
+    if (isGlobalDefaultScope(group.scopes) && group.disabled) {
+      group.disabled = false;
+      changed = true;
+    }
+  }
+  if (!changed) {
+    return null;
+  }
+  return actionUpdateEnvelope(action, groups);
+}
+
+function isGlobalDefaultScope(scopes: UrlTemplatizationDefaultGroup['scopes']): boolean {
+  if (!scopes) {
+    return true;
+  }
+  const hasNamespaces = (scopes.namespaces?.length ?? 0) > 0;
+  const hasSources = (scopes.sources?.length ?? 0) > 0;
+  const hasLanguages = (scopes.languages?.length ?? 0) > 0;
+  return !hasNamespaces && !hasSources && !hasLanguages;
+}
+
+export function parseSkipHttpStatusCodesInput(value: string): { ok: true; codes: number[] } | { ok: false; error: string } {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return { ok: true, codes: [] };
+  }
+
+  const parts = trimmed.split(/[,\s]+/).map((part) => part.trim()).filter(Boolean);
+  const codes: number[] = [];
+  const seen = new Set<number>();
+
+  for (const part of parts) {
+    if (!/^\d{3}$/.test(part)) {
+      return { ok: false, error: `Invalid HTTP status code "${part}". Use 3-digit codes like 404.` };
+    }
+    const code = Number(part);
+    if (code < 100 || code > 599) {
+      return { ok: false, error: `HTTP status code ${code} is out of range (100–599).` };
+    }
+    if (!seen.has(code)) {
+      seen.add(code);
+      codes.push(code);
+    }
+  }
+
+  return { ok: true, codes };
+}
+
+export function formatSkipHttpStatusCodesInput(codes: number[]): string {
+  return codes.join(', ');
+}
+
+export function defaultGroupEditInputsEqual(a: DefaultGroupEditInput, b: DefaultGroupEditInput): boolean {
+  return JSON.stringify(normalizeEditInput(a)) === JSON.stringify(normalizeEditInput(b));
+}
+
+function normalizeEditInput(input: DefaultGroupEditInput): unknown {
+  return {
+    scopes: {
+      namespaces: [...input.scopes.namespaces].map((v) => v.trim()).filter(Boolean).sort(),
+      languages: [...input.scopes.languages].map((v) => v.trim()).filter(Boolean).sort(),
+      sources: [...input.scopes.sources]
+        .map((source) => ({
+          namespace: source.namespace?.trim() || '',
+          kind: source.kind || '',
+          name: source.name?.trim() || '',
+        }))
+        .filter((source) => source.name)
+        .sort((left, right) =>
+          `${left.namespace}/${left.kind}/${left.name}`.localeCompare(
+            `${right.namespace}/${right.kind}/${right.name}`,
+          ),
+        ),
+    },
+    disabled: input.disabled,
+    skipForNonSuccessCodes: input.skipForNonSuccessCodes,
+    skipHttpStatusCodes: input.skipForNonSuccessCodes
+      ? []
+      : [...input.skipHttpStatusCodes].filter((code) => Number.isFinite(code) && code > 0).sort((x, y) => x - y),
+  };
+}

--- a/frontend/webapp/app/(v2)/url-templating/action-group-templates-update.ts
+++ b/frontend/webapp/app/(v2)/url-templating/action-group-templates-update.ts
@@ -24,43 +24,46 @@ export type AppendRuleGroupInput = {
   templates: string[];
 };
 
+/** Separates per-source namespaces from additional namespace-scope entries in filterK8sNamespace. */
+export const RULE_GROUP_NAMESPACE_SCOPE_SEPARATOR = '||';
+
 export function makeEmptySourcesScopes(): SourcesScopes {
   return { sources: [], namespaces: [], languages: [] };
 }
 
+function joinCsv(values: string[]): string | null {
+  const cleaned = values.map((value) => value.trim()).filter(Boolean);
+  return cleaned.length ? cleaned.join(',') : null;
+}
+
 /**
- * Fold SourceScopeSection's SourcesScopes into the GraphQL URL-templatization
- * filter form (single namespace / language + workloadFilters). Multi-value
- * scopes are rejected so we do not silently drop entries on convert.
+ * Map SourceScopeSection's SourcesScopes into the existing GraphQL filter fields.
+ * Multi-value selections are encoded as CSV (and optional `||` for extra namespaces)
+ * so the API shape stays unchanged while any number of entities is allowed.
  */
 export function sourcesScopesToAppendRuleGroupFilters(
   scopes: SourcesScopes,
-): { ok: true; filters: Omit<AppendRuleGroupInput, 'templates' | 'notes'> } | { ok: false; error: string } {
-  const sources = scopes.sources ?? [];
-  const namespaces = scopes.namespaces ?? [];
-  const languages = scopes.languages ?? [];
+): { ok: true; filters: Omit<AppendRuleGroupInput, 'templates' | 'notes'> } {
+  const sources = (scopes.sources ?? []).filter((source) => source.name?.trim());
+  const namespaces = (scopes.namespaces ?? []).map((value) => value.trim()).filter(Boolean);
+  const languages = (scopes.languages ?? []).map((value) => value.trim()).filter(Boolean);
+
+  const filterProgrammingLanguage = joinCsv(languages);
 
   if (sources.length > 0) {
-    const distinctNamespaces = Array.from(
-      new Set(sources.map((source) => source.namespace?.trim()).filter(Boolean)),
-    );
-    if (distinctNamespaces.length > 1) {
-      return {
-        ok: false,
-        error: 'Selected sources must share a single namespace for URL templatization rule groups.',
-      };
-    }
-    if (namespaces.length > 0 || languages.length > 0) {
-      return {
-        ok: false,
-        error: 'Choose either sources, namespaces, or languages — not a combination.',
-      };
-    }
+    // Keep empty slots so namespace indices stay aligned with workloadFilters.
+    const sourceNamespaces = sources.map((source) => source.namespace?.trim() || '');
+    const sourceNsCsv = sourceNamespaces.join(',');
+    const extraNsCsv = joinCsv(namespaces);
+    const filterK8sNamespace = extraNsCsv
+      ? `${sourceNsCsv}${RULE_GROUP_NAMESPACE_SCOPE_SEPARATOR}${extraNsCsv}`
+      : sourceNsCsv || null;
+
     return {
       ok: true,
       filters: {
-        filterK8sNamespace: distinctNamespaces[0] ?? null,
-        filterProgrammingLanguage: null,
+        filterK8sNamespace,
+        filterProgrammingLanguage,
         workloadFilters: sources.map((source) => ({
           kind: source.kind || null,
           name: source.name || null,
@@ -69,51 +72,11 @@ export function sourcesScopesToAppendRuleGroupFilters(
     };
   }
 
-  if (namespaces.length > 0) {
-    if (namespaces.length > 1) {
-      return {
-        ok: false,
-        error: 'Select a single namespace for this rule group.',
-      };
-    }
-    if (languages.length > 0) {
-      return {
-        ok: false,
-        error: 'Choose either sources, namespaces, or languages — not a combination.',
-      };
-    }
-    return {
-      ok: true,
-      filters: {
-        filterK8sNamespace: namespaces[0]?.trim() || null,
-        filterProgrammingLanguage: null,
-        workloadFilters: null,
-      },
-    };
-  }
-
-  if (languages.length > 0) {
-    if (languages.length > 1) {
-      return {
-        ok: false,
-        error: 'Select a single programming language for this rule group.',
-      };
-    }
-    return {
-      ok: true,
-      filters: {
-        filterK8sNamespace: null,
-        filterProgrammingLanguage: languages[0]?.trim() || null,
-        workloadFilters: null,
-      },
-    };
-  }
-
   return {
     ok: true,
     filters: {
-      filterK8sNamespace: null,
-      filterProgrammingLanguage: null,
+      filterK8sNamespace: joinCsv(namespaces),
+      filterProgrammingLanguage,
       workloadFilters: null,
     },
   };

--- a/frontend/webapp/app/(v2)/url-templating/action-group-templates-update.ts
+++ b/frontend/webapp/app/(v2)/url-templating/action-group-templates-update.ts
@@ -1,0 +1,194 @@
+import type { Action, SourcesScopes } from '@odigos/ui-kit/types';
+import type { UrlTemplatizationActionFields, UrlTemplatizationRulesGroup } from './url-templatization-aggregate';
+import { sortUrlTemplates } from './template-sort';
+
+export type UpdateActionWithGroupTemplatesVars = {
+  id: string;
+  action: {
+    type: Action['type'];
+    name?: string | null;
+    notes?: string | null;
+    disabled?: boolean | null;
+    signals?: Action['signals'];
+    fields: {
+      urlTemplatizationRulesGroups: UrlTemplatizationRulesGroup[];
+    };
+  };
+};
+
+export type AppendRuleGroupInput = {
+  filterK8sNamespace?: string | null;
+  filterProgrammingLanguage?: string | null;
+  workloadFilters?: { kind?: string | null; name?: string | null }[] | null;
+  notes?: string | null;
+  templates: string[];
+};
+
+export function makeEmptySourcesScopes(): SourcesScopes {
+  return { sources: [], namespaces: [], languages: [] };
+}
+
+/**
+ * Fold SourceScopeSection's SourcesScopes into the GraphQL URL-templatization
+ * filter form (single namespace / language + workloadFilters). Multi-value
+ * scopes are rejected so we do not silently drop entries on convert.
+ */
+export function sourcesScopesToAppendRuleGroupFilters(
+  scopes: SourcesScopes,
+): { ok: true; filters: Omit<AppendRuleGroupInput, 'templates' | 'notes'> } | { ok: false; error: string } {
+  const sources = scopes.sources ?? [];
+  const namespaces = scopes.namespaces ?? [];
+  const languages = scopes.languages ?? [];
+
+  if (sources.length > 0) {
+    const distinctNamespaces = Array.from(
+      new Set(sources.map((source) => source.namespace?.trim()).filter(Boolean)),
+    );
+    if (distinctNamespaces.length > 1) {
+      return {
+        ok: false,
+        error: 'Selected sources must share a single namespace for URL templatization rule groups.',
+      };
+    }
+    if (namespaces.length > 0 || languages.length > 0) {
+      return {
+        ok: false,
+        error: 'Choose either sources, namespaces, or languages — not a combination.',
+      };
+    }
+    return {
+      ok: true,
+      filters: {
+        filterK8sNamespace: distinctNamespaces[0] ?? null,
+        filterProgrammingLanguage: null,
+        workloadFilters: sources.map((source) => ({
+          kind: source.kind || null,
+          name: source.name || null,
+        })),
+      },
+    };
+  }
+
+  if (namespaces.length > 0) {
+    if (namespaces.length > 1) {
+      return {
+        ok: false,
+        error: 'Select a single namespace for this rule group.',
+      };
+    }
+    if (languages.length > 0) {
+      return {
+        ok: false,
+        error: 'Choose either sources, namespaces, or languages — not a combination.',
+      };
+    }
+    return {
+      ok: true,
+      filters: {
+        filterK8sNamespace: namespaces[0]?.trim() || null,
+        filterProgrammingLanguage: null,
+        workloadFilters: null,
+      },
+    };
+  }
+
+  if (languages.length > 0) {
+    if (languages.length > 1) {
+      return {
+        ok: false,
+        error: 'Select a single programming language for this rule group.',
+      };
+    }
+    return {
+      ok: true,
+      filters: {
+        filterK8sNamespace: null,
+        filterProgrammingLanguage: languages[0]?.trim() || null,
+        workloadFilters: null,
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    filters: {
+      filterK8sNamespace: null,
+      filterProgrammingLanguage: null,
+      workloadFilters: null,
+    },
+  };
+}
+
+function rulesGroupWithTemplates(
+  group: UrlTemplatizationRulesGroup,
+  templateStrings: string[],
+): UrlTemplatizationRulesGroup {
+  const existingRules = group.templatizationRules ?? [];
+  const templatizationRules = templateStrings.map((template) => {
+    const trimmed = template.trim();
+    const match = existingRules.find((rule) => rule.template?.trim() === trimmed);
+    return match ? { ...match, template: trimmed } : { template: trimmed };
+  });
+
+  return {
+    ...group,
+    templatizationRules,
+  };
+}
+
+function actionUpdateEnvelope(
+  action: Action,
+  groups: UrlTemplatizationRulesGroup[],
+): UpdateActionWithGroupTemplatesVars {
+  return {
+    id: action.id,
+    action: {
+      type: action.type,
+      name: action.name,
+      notes: action.notes,
+      disabled: action.disabled,
+      signals: action.signals,
+      fields: {
+        urlTemplatizationRulesGroups: groups,
+      },
+    },
+  };
+}
+
+export function buildUpdateActionWithGroupTemplates(
+  action: Action,
+  groupIndex: number,
+  templateStrings: string[],
+): UpdateActionWithGroupTemplatesVars {
+  const fields = (action.fields ?? {}) as UrlTemplatizationActionFields;
+  const groups = [...(fields.urlTemplatizationRulesGroups ?? [])];
+
+  if (groupIndex < 0 || groupIndex >= groups.length) {
+    throw new Error(`Rule group index ${groupIndex} is out of range for action ${action.id}`);
+  }
+
+  const normalizedTemplates = sortUrlTemplates(templateStrings.map((t) => t.trim()).filter(Boolean));
+  groups[groupIndex] = rulesGroupWithTemplates(groups[groupIndex], normalizedTemplates);
+
+  return actionUpdateEnvelope(action, groups);
+}
+
+export function buildUpdateActionWithAppendedGroup(
+  action: Action,
+  groupInput: AppendRuleGroupInput,
+): UpdateActionWithGroupTemplatesVars {
+  const fields = (action.fields ?? {}) as UrlTemplatizationActionFields;
+  const groups = [...(fields.urlTemplatizationRulesGroups ?? [])];
+  const normalizedTemplates = sortUrlTemplates(groupInput.templates.map((t) => t.trim()).filter(Boolean));
+
+  const newGroup: UrlTemplatizationRulesGroup = {
+    filterK8sNamespace: groupInput.filterK8sNamespace?.trim() || null,
+    filterProgrammingLanguage: groupInput.filterProgrammingLanguage?.trim() || null,
+    workloadFilters: groupInput.workloadFilters?.length ? groupInput.workloadFilters : null,
+    notes: groupInput.notes?.trim() || null,
+    templatizationRules: normalizedTemplates.map((template) => ({ template })),
+  };
+
+  groups.push(newGroup);
+  return actionUpdateEnvelope(action, groups);
+}

--- a/frontend/webapp/app/(v2)/url-templating/action-origin-badge.tsx
+++ b/frontend/webapp/app/(v2)/url-templating/action-origin-badge.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import React from 'react';
+import { Badge } from '@odigos/ui-kit/components';
+import { StatusType } from '@odigos/ui-kit/types';
+
+export function isActionUiGenerated(action: unknown): boolean {
+  if (!action || typeof action !== 'object') {
+    return false;
+  }
+  return !!(action as { uiGenerated?: boolean | null }).uiGenerated;
+}
+
+export function actionOriginLabel(uiGenerated: boolean): string {
+  return uiGenerated ? 'UI' : 'External';
+}
+
+export function actionOriginTooltip(uiGenerated: boolean): string {
+  return uiGenerated
+    ? 'Created from the Odigos UI'
+    : 'Created outside the UI (GitOps or manual, for example YAML, Helm, or kubectl)';
+}
+
+export function actionOriginTitleBadge(uiGenerated: boolean): { label: string } {
+  return { label: actionOriginLabel(uiGenerated) };
+}
+
+export function ActionOriginBadge({ uiGenerated }: { uiGenerated: boolean }) {
+  return (
+    <Badge
+      label={actionOriginLabel(uiGenerated)}
+      tooltip={actionOriginTooltip(uiGenerated)}
+      status={uiGenerated ? StatusType.Info : StatusType.Default}
+      useSecondaryTone={!uiGenerated}
+    />
+  );
+}

--- a/frontend/webapp/app/(v2)/url-templating/create-group-templates-drawer.tsx
+++ b/frontend/webapp/app/(v2)/url-templating/create-group-templates-drawer.tsx
@@ -245,7 +245,6 @@ export function CreateGroupTemplatesDrawer({
   const templates = useMemo(() => sortUrlTemplates(normalizedTemplateValues(draftTemplates)), [draftTemplates]);
 
   const scopeMapping = useMemo(() => sourcesScopesToAppendRuleGroupFilters(scopes), [scopes]);
-  const scopeError = scopeMapping.ok ? null : scopeMapping.error;
 
   const validationError = useMemo(() => {
     if (templates.length === 0) {
@@ -261,27 +260,20 @@ export function CreateGroupTemplatesDrawer({
     return null;
   }, [templates]);
 
-  const canSave = !scopeError && !validationError && !saving && !!action && templates.length > 0;
+  const canSave = !validationError && !saving && !!action && templates.length > 0;
 
   const saveWarningMessage = useMemo(() => {
-    if (!templates.length || scopeError || validationError) {
+    if (!templates.length || validationError) {
       return undefined;
     }
     return buildCreateSaveWarning(templates.length);
-  }, [scopeError, templates.length, validationError]);
+  }, [templates.length, validationError]);
 
   const footerNotice = useMemo(() => {
     if (saveError) {
       return {
         status: StatusType.Error,
         message: saveError,
-        fullWidth: true as const,
-      };
-    }
-    if (scopeError) {
-      return {
-        status: StatusType.Warning,
-        message: scopeError,
         fullWidth: true as const,
       };
     }
@@ -300,7 +292,7 @@ export function CreateGroupTemplatesDrawer({
       };
     }
     return undefined;
-  }, [saveError, saveWarningMessage, scopeError, validationError]);
+  }, [saveError, saveWarningMessage, validationError]);
 
   const updateRow = useCallback((index: number, value: string) => {
     setDraftTemplates((rows) => withTrailingEmptyRow(rows.map((row, i) => (i === index ? { ...row, value } : row))));
@@ -312,7 +304,7 @@ export function CreateGroupTemplatesDrawer({
   }, []);
 
   const handleSave = async () => {
-    if (!action || !canSave || !scopeMapping.ok) {
+    if (!action || !canSave) {
       return;
     }
     setSaveError(null);

--- a/frontend/webapp/app/(v2)/url-templating/create-group-templates-drawer.tsx
+++ b/frontend/webapp/app/(v2)/url-templating/create-group-templates-drawer.tsx
@@ -1,0 +1,510 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import styled from 'styled-components';
+import { ActionIcon, TrashIcon } from '@odigos/ui-kit/icons';
+import type { Action, SourcesScopes } from '@odigos/ui-kit/types';
+import { StatusType } from '@odigos/ui-kit/types';
+import {
+  Badge,
+  Button,
+  ButtonSize,
+  ButtonVariants,
+  Drawer,
+  FlexColumn,
+  FlexRow,
+  IconButton,
+  IconButtonSize,
+  Input,
+  Note,
+  Typography,
+  TypographyColor,
+  TypographySize,
+} from '@odigos/ui-kit/components';
+import { useApiMutation, useOdigosApi } from '@odigos/ui-kit/contexts';
+import { SourceScopeSection } from '@odigos/ui-kit/snippets';
+import { actionOriginTitleBadge, ActionOriginBadge, isActionUiGenerated } from './action-origin-badge';
+import { TemplatePathSimulator } from './template-path-simulator';
+import {
+  buildUpdateActionWithAppendedGroup,
+  makeEmptySourcesScopes,
+  sourcesScopesToAppendRuleGroupFilters,
+} from './action-group-templates-update';
+import { sortUrlTemplates } from './template-sort';
+import { DrawerScrollEdgeHint, useCanScrollDown } from './drawer-scroll-edge-hint';
+import { ScopeTokens } from './scope-tokens';
+
+const DrawerBody = styled(FlexColumn)`
+  width: 100%;
+  padding: 0 24px 8px;
+  gap: 16px;
+`;
+
+const MetaPanel = styled(FlexColumn)`
+  width: 100%;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 8px;
+  background: ${({ theme }) => theme.v2.colors.silver[900]};
+  border: 1px solid ${({ theme }) => theme.v2.colors.silver[700]};
+`;
+
+const TemplatesPanel = styled(FlexColumn)`
+  width: 100%;
+  gap: 2px;
+  padding: 12px 14px;
+  border-radius: 8px;
+  background: ${({ theme }) => theme.v2.colors.silver[900]};
+  border: 1px solid ${({ theme }) => theme.v2.colors.silver[700]};
+`;
+
+const DetailBlock = styled(FlexColumn)`
+  width: 100%;
+  gap: 8px;
+`;
+
+const TemplateRow = styled(FlexRow)`
+  width: 100%;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+`;
+
+const TemplateRowMain = styled(FlexRow)<{ $selectable?: boolean }>`
+  flex: 1;
+  min-width: 0;
+  align-items: center;
+  cursor: ${({ $selectable }) => ($selectable ? 'pointer' : 'default')};
+`;
+
+const TemplateEntry = styled(FlexColumn)<{ $selected?: boolean }>`
+  width: 100%;
+  gap: 0;
+  padding: ${({ $selected }) => ($selected ? '6px 8px 8px' : '2px 8px')};
+  margin: 0 -8px;
+  border-radius: 8px;
+  background: ${({ theme, $selected }) => ($selected ? theme.v2.colors.silver[800] : 'transparent')};
+  border: 1px solid
+    ${({ theme, $selected }) => ($selected ? theme.v2.colors.blue[400] : 'transparent')};
+  box-shadow: ${({ theme, $selected }) =>
+    $selected ? `inset 0 1px 0 color-mix(in srgb, ${theme.v2.colors.white[500]} 8%, transparent)` : 'none'};
+  transition: background 0.12s ease, border-color 0.12s ease;
+`;
+
+const SelectedSimulatorRegion = styled(FlexColumn)`
+  width: 100%;
+  gap: 8px;
+  margin-top: 10px;
+  padding: 10px 10px 8px;
+  border-radius: 6px;
+  background: color-mix(
+    in srgb,
+    ${({ theme }) => theme.v2.colors.black[500]} 40%,
+    ${({ theme }) => theme.v2.colors.silver[800]}
+  );
+  border: 1px solid ${({ theme }) => theme.v2.colors.silver[700]};
+`;
+
+const DrawerSaveFooter = styled(FlexColumn)`
+  width: 100%;
+  gap: 12px;
+  padding: 16px 24px;
+  box-sizing: border-box;
+  border-top: 1px solid ${({ theme }) => theme.v2.colors.silver[700]};
+  background: ${({ theme }) => theme.v2.colors.black[500]};
+`;
+
+const DrawerSaveFooterActions = styled(FlexRow)`
+  width: 100%;
+  justify-content: flex-end;
+  gap: 12px;
+  flex-shrink: 0;
+`;
+
+type DraftTemplateRow = {
+  key: string;
+  value: string;
+};
+
+let draftRowKeyCounter = 0;
+
+function nextDraftRowKey(): string {
+  draftRowKeyCounter += 1;
+  return `create-draft-row-${draftRowKeyCounter}`;
+}
+
+function withTrailingEmptyRow(rows: DraftTemplateRow[]): DraftTemplateRow[] {
+  const copy = [...rows];
+  let trailingEmpty: DraftTemplateRow | null = null;
+  while (copy.length > 0 && !copy[copy.length - 1].value.trim()) {
+    trailingEmpty = copy.pop() ?? null;
+  }
+  // Keep row keys/order stable while typing so focus is not stolen by a remounted
+  // trailing empty input. Templates are sorted on save.
+  return [...copy, trailingEmpty ?? { key: nextDraftRowKey(), value: '' }];
+}
+
+function normalizedTemplateValues(rows: DraftTemplateRow[]): string[] {
+  return rows
+    .map((row) => row.value.trim())
+    .filter(Boolean);
+}
+
+function isTrailingEmptyInputRow(rows: DraftTemplateRow[], index: number): boolean {
+  const row = rows[index];
+  if (!row || row.value.trim()) {
+    return false;
+  }
+  return index === rows.length - 1;
+}
+
+type CreateGroupTemplatesDrawerProps = {
+  action: Action | null;
+  /** When true, scope is fixed to entire cluster (empty SourcesScopes). */
+  lockEntireClusterScope?: boolean;
+  onClose: () => void;
+  onSaved: () => void;
+};
+
+function buildCreateSaveWarning(templateCount: number): string {
+  const templates =
+    templateCount === 1 ? 'add 1 template as a new rule group' : `add ${templateCount} templates as a new rule group`;
+  return `On save: ${templates} — takes effect in the cluster immediately.`;
+}
+
+export function CreateGroupTemplatesDrawer({
+  action,
+  lockEntireClusterScope = false,
+  onClose,
+  onSaved,
+}: CreateGroupTemplatesDrawerProps) {
+  const { sourcesApi } = useOdigosApi();
+  const { items: sources = [] } = sourcesApi.useSources();
+
+  const [scopes, setScopes] = useState<SourcesScopes>(makeEmptySourcesScopes);
+  const [draftTemplates, setDraftTemplates] = useState<DraftTemplateRow[]>([]);
+  const [selectedRowKey, setSelectedRowKey] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const [updateAction, { loading: saving }] = useApiMutation('UPDATE_ACTION', {
+    refetchQueries: ['GetActions'],
+    awaitRefetchQueries: true,
+  });
+
+  const sourceOptions = useMemo(
+    () =>
+      sources.map(({ id }) => ({
+        id: `${id.namespace}/${id.kind}/${id.name}`,
+        label: id.name,
+        badge: id.kind,
+        secondaryLabel: id.namespace,
+      })),
+    [sources],
+  );
+
+  const namespaceOptions = useMemo(
+    () =>
+      Array.from(new Set(sources.map(({ id }) => id.namespace)))
+        .sort()
+        .map((namespace) => ({ id: namespace, label: namespace })),
+    [sources],
+  );
+
+  useEffect(() => {
+    if (!action) {
+      setScopes(makeEmptySourcesScopes());
+      setDraftTemplates([]);
+      setSelectedRowKey(null);
+      setSaveError(null);
+      return;
+    }
+    const rows = withTrailingEmptyRow([]);
+    setScopes(makeEmptySourcesScopes());
+    setDraftTemplates(rows);
+    setSelectedRowKey(rows[rows.length - 1]?.key ?? null);
+    setSaveError(null);
+  }, [action, lockEntireClusterScope]);
+
+  useEffect(() => {
+    if (!action) {
+      return undefined;
+    }
+    const timer = window.setTimeout(() => {
+      const input = document.querySelector(
+        'input[name="url-templating-create-new-template"]',
+      ) as HTMLInputElement | null;
+      if (!input) {
+        return;
+      }
+      input.focus();
+      input.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    }, 120);
+    return () => window.clearTimeout(timer);
+  }, [action]);
+
+  const templates = useMemo(() => sortUrlTemplates(normalizedTemplateValues(draftTemplates)), [draftTemplates]);
+
+  const scopeMapping = useMemo(() => sourcesScopesToAppendRuleGroupFilters(scopes), [scopes]);
+  const scopeError = scopeMapping.ok ? null : scopeMapping.error;
+
+  const validationError = useMemo(() => {
+    if (templates.length === 0) {
+      return 'Add at least one template before saving.';
+    }
+    const seen = new Set<string>();
+    for (const t of templates) {
+      if (seen.has(t)) {
+        return 'Each template must be unique within this rule group.';
+      }
+      seen.add(t);
+    }
+    return null;
+  }, [templates]);
+
+  const canSave = !scopeError && !validationError && !saving && !!action && templates.length > 0;
+
+  const saveWarningMessage = useMemo(() => {
+    if (!templates.length || scopeError || validationError) {
+      return undefined;
+    }
+    return buildCreateSaveWarning(templates.length);
+  }, [scopeError, templates.length, validationError]);
+
+  const footerNotice = useMemo(() => {
+    if (saveError) {
+      return {
+        status: StatusType.Error,
+        message: saveError,
+        fullWidth: true as const,
+      };
+    }
+    if (scopeError) {
+      return {
+        status: StatusType.Warning,
+        message: scopeError,
+        fullWidth: true as const,
+      };
+    }
+    if (validationError) {
+      return {
+        status: StatusType.Warning,
+        message: validationError,
+        fullWidth: true as const,
+      };
+    }
+    if (saveWarningMessage) {
+      return {
+        status: StatusType.Warning,
+        message: saveWarningMessage,
+        fullWidth: true as const,
+      };
+    }
+    return undefined;
+  }, [saveError, saveWarningMessage, scopeError, validationError]);
+
+  const updateRow = useCallback((index: number, value: string) => {
+    setDraftTemplates((rows) => withTrailingEmptyRow(rows.map((row, i) => (i === index ? { ...row, value } : row))));
+  }, []);
+
+  const removeRow = useCallback((index: number, rowKey: string) => {
+    setSelectedRowKey((current) => (current === rowKey ? null : current));
+    setDraftTemplates((rows) => withTrailingEmptyRow(rows.filter((_, i) => i !== index)));
+  }, []);
+
+  const handleSave = async () => {
+    if (!action || !canSave || !scopeMapping.ok) {
+      return;
+    }
+    setSaveError(null);
+    try {
+      const variables = buildUpdateActionWithAppendedGroup(action, {
+        ...scopeMapping.filters,
+        templates,
+      });
+      const { error } = await updateAction(variables);
+      if (error) {
+        setSaveError(error.message || 'Failed to create rule group');
+        return;
+      }
+      onSaved();
+      onClose();
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to create rule group');
+    }
+  };
+
+  const actionLabel = action?.name?.trim() || action?.id || '';
+  const headerBadges = action
+    ? [
+        actionOriginTitleBadge(isActionUiGenerated(action)),
+        ...(action.disabled ? [{ label: 'Disabled' as const }] : []),
+      ]
+    : undefined;
+
+  const scrollAnchorRef = useRef<HTMLDivElement>(null);
+  const scrollRefreshKey = useMemo(
+    () =>
+      JSON.stringify({
+        templates: draftTemplates.map((row) => row.value),
+        selectedRowKey,
+        scopes,
+        footerNotice,
+      }),
+    [draftTemplates, footerNotice, scopes, selectedRowKey],
+  );
+  const canScrollDown = useCanScrollDown(scrollAnchorRef, scrollRefreshKey);
+
+  return (
+    <Drawer
+      isOpen={!!action}
+      width="min(720px, 96vw)"
+      header={
+        action
+          ? {
+              icon: ActionIcon,
+              title: 'Add rule group templates',
+              subTitle: actionLabel,
+              titleBadges: headerBadges,
+              onClose,
+            }
+          : undefined
+      }
+      footer={
+        action
+          ? {
+              children: (
+                <DrawerSaveFooter $gap={12}>
+                  {footerNotice ? <Note {...footerNotice} /> : null}
+                  <DrawerSaveFooterActions $gap={12}>
+                    <Button
+                      label="Cancel"
+                      variant={ButtonVariants.Secondary}
+                      size={ButtonSize.S}
+                      onClick={onClose}
+                      disabled={saving}
+                    />
+                    <Button
+                      label="Save"
+                      variant={ButtonVariants.Primary}
+                      size={ButtonSize.S}
+                      onClick={() => {
+                        void handleSave();
+                      }}
+                      disabled={!canSave}
+                      loading={saving}
+                    />
+                  </DrawerSaveFooterActions>
+                </DrawerSaveFooter>
+              ),
+            }
+          : undefined
+      }
+    >
+      {action ? (
+        <DrawerBody $gap={16}>
+          <MetaPanel $gap={12}>
+            <DetailBlock $gap={8}>
+              <Typography size={TypographySize.XXS} color={TypographyColor.Secondary}>
+                Action
+              </Typography>
+              <FlexRow $gap={8} $alignItems="center" style={{ flexWrap: 'wrap' }}>
+                <Typography size={TypographySize.XS}>{actionLabel}</Typography>
+                <ActionOriginBadge uiGenerated={isActionUiGenerated(action)} />
+                {action.disabled ? <Badge label="Disabled" /> : null}
+              </FlexRow>
+            </DetailBlock>
+
+            {lockEntireClusterScope ? (
+              <DetailBlock $gap={8}>
+                <Typography size={TypographySize.XXS} color={TypographyColor.Secondary}>
+                  Scope
+                </Typography>
+                <ScopeTokens tokens={[{ type: 'entire_cluster' }]} />
+                <Note
+                  status={StatusType.Warning}
+                  message="Entire-cluster scope applies these templates to every span — prefer a narrower group when possible."
+                  fullWidth
+                  smallIcon
+                />
+              </DetailBlock>
+            ) : (
+              <SourceScopeSection
+                scopes={scopes}
+                onChange={setScopes}
+                sourceOptions={sourceOptions}
+                namespaceOptions={namespaceOptions}
+                dataIdPrefix="url-templating-create-scope"
+                slim
+                disabled={saving}
+              />
+            )}
+          </MetaPanel>
+
+          <TemplatesPanel $gap={2}>
+            <Typography size={TypographySize.XXS} color={TypographyColor.Secondary}>
+              Templates
+            </Typography>
+
+            {draftTemplates.map((row, index) => {
+              const trailingEmpty = isTrailingEmptyInputRow(draftTemplates, index);
+              const selected = selectedRowKey === row.key;
+              const templateForSimulator = row.value.trim();
+
+              return (
+                <TemplateEntry key={row.key} $gap={0} $selected={selected && !!templateForSimulator}>
+                  <TemplateRow $gap={8}>
+                    <TemplateRowMain
+                      $gap={8}
+                      $selectable={!!templateForSimulator}
+                      onClick={
+                        templateForSimulator
+                          ? () => setSelectedRowKey(row.key)
+                          : undefined
+                      }
+                    >
+                      <Input
+                        data-id={`url-templating-create-group-template-${index}`}
+                        name={
+                          trailingEmpty
+                            ? 'url-templating-create-new-template'
+                            : `url-templating-create-group-template-${index}`
+                        }
+                        value={row.value}
+                        onChange={(event) => updateRow(index, event.target.value)}
+                        onFocus={() => setSelectedRowKey(row.key)}
+                        placeholder="/api/users/{id}"
+                        width="100%"
+                        disabled={saving}
+                      />
+                    </TemplateRowMain>
+                    {trailingEmpty ? null : (
+                      <IconButton
+                        data-id={`url-templating-create-group-template-remove-${index}`}
+                        icon={TrashIcon}
+                        size={IconButtonSize.XS}
+                        onClick={() => removeRow(index, row.key)}
+                        disabled={saving}
+                      />
+                    )}
+                  </TemplateRow>
+                  {selected && templateForSimulator ? (
+                    <SelectedSimulatorRegion $gap={8}>
+                      <TemplatePathSimulator
+                        template={templateForSimulator}
+                        actionDisabled={!!action.disabled}
+                        embedded
+                      />
+                    </SelectedSimulatorRegion>
+                  ) : null}
+                </TemplateEntry>
+              );
+            })}
+          </TemplatesPanel>
+
+          <div ref={scrollAnchorRef} aria-hidden style={{ width: '100%', height: 1 }} />
+          <DrawerScrollEdgeHint visible={canScrollDown} />
+        </DrawerBody>
+      ) : null}
+    </Drawer>
+  );
+}

--- a/frontend/webapp/app/(v2)/url-templating/custom-template-tree.test.ts
+++ b/frontend/webapp/app/(v2)/url-templating/custom-template-tree.test.ts
@@ -1,0 +1,44 @@
+import { buildCustomTemplateTree } from './custom-template-tree';
+
+describe('buildCustomTemplateTree', () => {
+  it('groups templates by shared path segments', () => {
+    const tree = buildCustomTemplateTree([
+      {
+        template: '/users/{id}',
+        scopeTokens: [{ type: 'entire_cluster' }],
+        count: 1,
+        actionLabels: ['a'],
+        actionId: 'action-a',
+        actionDisplayName: null,
+        actionDisabled: false,
+        actionUiGenerated: false,
+      },
+      {
+        template: '/users/{id}/orders',
+        scopeTokens: [{ type: 'entire_cluster' }],
+        count: 1,
+        actionLabels: ['a'],
+        actionId: 'action-a',
+        actionDisplayName: null,
+        actionDisabled: false,
+        actionUiGenerated: false,
+      },
+      {
+        template: '/health',
+        scopeTokens: [{ type: 'entire_cluster' }],
+        count: 1,
+        actionLabels: ['a'],
+        actionId: 'action-a',
+        actionDisplayName: null,
+        actionDisabled: false,
+        actionUiGenerated: false,
+      },
+    ]);
+
+    expect(tree.map((node) => node.segment)).toEqual(['health', 'users']);
+    const users = tree.find((node) => node.segment === 'users');
+    expect(users?.children.map((node) => node.segment)).toEqual(['{id}']);
+    expect(users?.children[0]?.entries).toHaveLength(1);
+    expect(users?.children[0]?.children[0]?.segment).toBe('orders');
+  });
+});

--- a/frontend/webapp/app/(v2)/url-templating/custom-template-tree.ts
+++ b/frontend/webapp/app/(v2)/url-templating/custom-template-tree.ts
@@ -1,0 +1,74 @@
+import { parseTemplatePath, type TemplateSegmentKind } from './template-path';
+import type { AggregatedCustomTemplate } from './url-templatization-aggregate';
+
+export type CustomTemplateTreeNode = {
+  segment: string;
+  kind: TemplateSegmentKind;
+  children: CustomTemplateTreeNode[];
+  entries: AggregatedCustomTemplate[];
+};
+
+const KIND_SORT_ORDER: Record<TemplateSegmentKind, number> = {
+  static: 0,
+  variable: 1,
+  wildcard: 2,
+};
+
+function compareTreeNodes(a: CustomTemplateTreeNode, b: CustomTemplateTreeNode): number {
+  const kindDiff = KIND_SORT_ORDER[a.kind] - KIND_SORT_ORDER[b.kind];
+  if (kindDiff !== 0) {
+    return kindDiff;
+  }
+  return a.segment.localeCompare(b.segment);
+}
+
+function sortTreeNodes(nodes: CustomTemplateTreeNode[]): void {
+  nodes.sort(compareTreeNodes);
+  for (const node of nodes) {
+    sortTreeNodes(node.children);
+  }
+}
+
+function findOrCreateChild(
+  level: CustomTemplateTreeNode[],
+  segment: string,
+  kind: TemplateSegmentKind,
+): CustomTemplateTreeNode {
+  const existing = level.find((node) => node.segment === segment && node.kind === kind);
+  if (existing) {
+    return existing;
+  }
+  const created: CustomTemplateTreeNode = {
+    segment,
+    kind,
+    children: [],
+    entries: [],
+  };
+  level.push(created);
+  return created;
+}
+
+export function buildCustomTemplateTree(items: AggregatedCustomTemplate[]): CustomTemplateTreeNode[] {
+  const roots: CustomTemplateTreeNode[] = [];
+
+  for (const item of items) {
+    const segments = parseTemplatePath(item.template);
+    if (segments.length === 0) {
+      findOrCreateChild(roots, item.template, 'static').entries.push(item);
+      continue;
+    }
+
+    let level = roots;
+    for (let index = 0; index < segments.length; index += 1) {
+      const { kind, text } = segments[index];
+      const node = findOrCreateChild(level, text, kind);
+      if (index === segments.length - 1) {
+        node.entries.push(item);
+      }
+      level = node.children;
+    }
+  }
+
+  sortTreeNodes(roots);
+  return roots;
+}

--- a/frontend/webapp/app/(v2)/url-templating/custom-templates-view.tsx
+++ b/frontend/webapp/app/(v2)/url-templating/custom-templates-view.tsx
@@ -1,0 +1,635 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import styled, { css } from 'styled-components';
+import { ChevronRightIcon, EditIcon } from '@odigos/ui-kit/icons';
+import { Badge, FlexColumn, FlexRow, IconButton, IconButtonSize, Typography, TypographyColor, TypographySize } from '@odigos/ui-kit/components';
+import { ActionOriginBadge } from './action-origin-badge';
+import { buildCustomTemplateTree, type CustomTemplateTreeNode } from './custom-template-tree';
+import { ScopeTokens } from './scope-tokens';
+import { TemplatePath, type TemplatePathSegment, templatePathFromSegments } from './template-path';
+import type { AggregatedCustomTemplate, CustomTemplateCrGroup } from './url-templatization-aggregate';
+import { scopeTokensSortKey } from './url-templatization-aggregate';
+import { detailFromAggregatedTemplate, detailFromCrTemplate, type UrlTemplateDetail } from './template-detail-types';
+import { stopRowActivation, templateRowActivationProps } from './template-row-activation';
+
+export type EditGroupTemplatesOptions = {
+  focusNewTemplate?: boolean;
+};
+
+export type OnSelectUrlTemplate = (detail: UrlTemplateDetail) => void;
+
+const interactiveTemplateRow = css`
+  cursor: pointer;
+  border-radius: 6px;
+  margin-left: -6px;
+  margin-right: -6px;
+  padding-left: 6px;
+  padding-right: 6px;
+  transition: background 0.12s ease;
+
+  &:hover {
+    background: ${({ theme }) => theme.v2.colors.silver[800]};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.v2.colors.blue[400]};
+    outline-offset: 2px;
+  }
+`;
+
+const TreeRow = styled(FlexRow)<{ $depth: number; $interactive?: boolean }>`
+  width: 100%;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 0;
+  border-bottom: 1px solid ${({ theme }) => theme.v2.colors.silver[600]};
+  user-select: none;
+  ${({ $interactive }) => ($interactive ? interactiveTemplateRow : '')}
+  /* Keep depth indent after interactive styles (those set padding-left: 6px). */
+  padding-left: ${({ $depth, $interactive }) => $depth * 16 + ($interactive ? 6 : 0)}px;
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+const TreeRowLead = styled(FlexRow)<{ $clickable?: boolean }>`
+  flex-shrink: 0;
+  align-items: center;
+  width: 14px;
+  justify-content: center;
+  cursor: ${({ $clickable }) => ($clickable ? 'pointer' : 'default')};
+`;
+
+const TreeChevron = styled.span<{ $open: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transform: rotate(${({ $open }) => ($open ? '90deg' : '0deg')});
+  transition: transform 0.15s ease;
+  color: ${({ theme }) => theme.v2.colors.grey[400]};
+`;
+
+const TreePathAndScope = styled(FlexRow)`
+  flex: 1;
+  min-width: 0;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+`;
+
+const ListRow = styled(FlexRow)<{ $interactive?: boolean }>`
+  width: 100%;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid ${({ theme }) => theme.v2.colors.silver[600]};
+  ${({ $interactive }) => ($interactive ? interactiveTemplateRow : '')}
+
+  &:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+`;
+
+const ListRowMain = styled(FlexColumn)`
+  flex: 1;
+  min-width: 0;
+  gap: 4px;
+`;
+
+const ListRowTitleLine = styled(FlexRow)`
+  flex: 1;
+  min-width: 0;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+`;
+
+function customTemplateRowKey(item: AggregatedCustomTemplate): string {
+  return `${item.actionId}|${item.template}|${scopeTokensSortKey(item.scopeTokens)}`;
+}
+
+export function CustomTemplateListRow({
+  item,
+  onSelectTemplate,
+}: {
+  item: AggregatedCustomTemplate;
+  onSelectTemplate: OnSelectUrlTemplate;
+}) {
+  const openDetail = () => onSelectTemplate(detailFromAggregatedTemplate(item));
+
+  return (
+    <ListRow
+      $gap={12}
+      $interactive
+      title="View template details"
+      {...templateRowActivationProps(openDetail)}
+    >
+      <ListRowMain $gap={4}>
+        <ListRowTitleLine $gap={8}>
+          <TemplatePath template={item.template} disabled={item.actionDisabled} />
+          <span style={item.actionDisabled ? { opacity: 0.55 } : undefined}>
+            <ScopeTokens tokens={item.scopeTokens} />
+          </span>
+        </ListRowTitleLine>
+        <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+          In {item.actionLabels.join(', ')}
+        </Typography>
+      </ListRowMain>
+      <FlexRow $gap={6} $alignItems="center">
+        <ActionOriginBadge uiGenerated={item.actionUiGenerated} />
+        {item.actionDisabled ? <Badge label="Disabled" /> : null}
+        {item.count > 1 ? <Badge label={`×${item.count}`} /> : null}
+      </FlexRow>
+    </ListRow>
+  );
+}
+
+function TreeNodeRow({
+  depth,
+  fullPath,
+  entries,
+  expandable,
+  open,
+  onToggle,
+  onSelectTemplate,
+}: {
+  depth: number;
+  fullPath: string;
+  entries: AggregatedCustomTemplate[];
+  expandable: boolean;
+  open: boolean;
+  onToggle: () => void;
+  onSelectTemplate: OnSelectUrlTemplate;
+}) {
+  const actionsHint = entries
+    .flatMap((entry) => entry.actionLabels)
+    .filter((label, index, labels) => labels.indexOf(label) === index)
+    .join(', ');
+
+  const pathDisabled = entries.length > 0 && entries.every((entry) => entry.actionDisabled);
+
+  return (
+    <>
+      {entries.map((entry, entryIndex) => {
+        const openDetail = () => onSelectTemplate(detailFromAggregatedTemplate(entry));
+        const showChevron = entryIndex === 0 && expandable;
+
+        return (
+          <TreeRow
+            key={customTemplateRowKey(entry)}
+            $depth={depth}
+            $gap={12}
+            $interactive
+            title={actionsHint ? `In ${actionsHint}` : 'View template details'}
+            {...templateRowActivationProps(openDetail)}
+          >
+            <TreeRowLead
+              $clickable={showChevron}
+              onClick={
+                showChevron
+                  ? (event) => {
+                      stopRowActivation(event);
+                      onToggle();
+                    }
+                  : undefined
+              }
+              title={showChevron ? (open ? 'Collapse' : 'Expand') : undefined}
+            >
+              {showChevron ? (
+                <TreeChevron $open={open}>
+                  <ChevronRightIcon size={12} />
+                </TreeChevron>
+              ) : null}
+            </TreeRowLead>
+            <TreePathAndScope $gap={8}>
+              <TemplatePath template={fullPath} disabled={entry.actionDisabled || pathDisabled} />
+              <span style={entry.actionDisabled ? { opacity: 0.55 } : undefined}>
+                <ScopeTokens tokens={entry.scopeTokens} />
+              </span>
+              {entry.count > 1 ? <Badge label={`×${entry.count}`} /> : null}
+            </TreePathAndScope>
+          </TreeRow>
+        );
+      })}
+    </>
+  );
+}
+
+function TreeBranch({
+  node,
+  ancestorSegments,
+  depth,
+  onSelectTemplate,
+}: {
+  node: CustomTemplateTreeNode;
+  ancestorSegments: TemplatePathSegment[];
+  depth: number;
+  onSelectTemplate: OnSelectUrlTemplate;
+}) {
+  const [open, setOpen] = useState(true);
+  const nodeSegment: TemplatePathSegment = { kind: node.kind, text: node.segment };
+  const pathSegments = [...ancestorSegments, nodeSegment];
+  const fullPath = templatePathFromSegments(pathSegments);
+  const hasChildren = node.children.length > 0;
+  const hasEntries = node.entries.length > 0;
+
+  if (!hasEntries) {
+    if (!hasChildren) {
+      return null;
+    }
+    return (
+      <>
+        {node.children.map((child, index) => (
+          <TreeBranch
+            key={`${fullPath}/${child.kind}:${child.segment}:${index}`}
+            node={child}
+            ancestorSegments={pathSegments}
+            depth={depth}
+            onSelectTemplate={onSelectTemplate}
+          />
+        ))}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <TreeNodeRow
+        depth={depth}
+        fullPath={fullPath}
+        entries={node.entries}
+        expandable={hasChildren}
+        open={open}
+        onToggle={() => setOpen((value) => !value)}
+        onSelectTemplate={onSelectTemplate}
+      />
+      {hasChildren && open
+        ? node.children.map((child, index) => (
+            <TreeBranch
+              key={`${fullPath}/${child.kind}:${child.segment}:${index}`}
+              node={child}
+              ancestorSegments={pathSegments}
+              depth={depth + 1}
+              onSelectTemplate={onSelectTemplate}
+            />
+          ))
+        : null}
+    </>
+  );
+}
+
+export function CustomTemplateTreeView({
+  items,
+  onSelectTemplate,
+}: {
+  items: AggregatedCustomTemplate[];
+  onSelectTemplate: OnSelectUrlTemplate;
+}) {
+  const roots = useMemo(() => buildCustomTemplateTree(items), [items]);
+
+  if (!roots.length) {
+    return null;
+  }
+
+  return (
+    <FlexColumn $gap={0} style={{ width: '100%' }}>
+      {roots.map((node, index) => (
+        <TreeBranch
+          key={`${node.kind}:${node.segment}:${index}`}
+          node={node}
+          ancestorSegments={[]}
+          depth={0}
+          onSelectTemplate={onSelectTemplate}
+        />
+      ))}
+    </FlexColumn>
+  );
+}
+
+export function CustomTemplateListView({
+  items,
+  onSelectTemplate,
+}: {
+  items: AggregatedCustomTemplate[];
+  onSelectTemplate: OnSelectUrlTemplate;
+}) {
+  return (
+    <>
+      {items.map((item) => (
+        <CustomTemplateListRow key={customTemplateRowKey(item)} item={item} onSelectTemplate={onSelectTemplate} />
+      ))}
+    </>
+  );
+}
+
+const CrActionBlock = styled(FlexColumn)`
+  width: 100%;
+  gap: 12px;
+  padding: 16px 0;
+  border-bottom: 2px solid ${({ theme }) => theme.v2.colors.silver[500]};
+
+  &:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+`;
+
+const CrRuleGroupBlock = styled(FlexColumn)`
+  width: 100%;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: ${({ theme }) => theme.v2.colors.silver[900]};
+  border: 1px solid ${({ theme }) => theme.v2.colors.silver[700]};
+`;
+
+const CrGroupHeader = styled(FlexRow)`
+  width: 100%;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  user-select: none;
+  border-radius: 6px;
+  margin: -4px -6px;
+  padding: 4px 6px;
+
+  &:hover {
+    background: ${({ theme }) => theme.v2.colors.silver[800]};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.v2.colors.blue[400]};
+    outline-offset: 2px;
+  }
+`;
+
+const CrGroupChevron = styled.span<{ $open: boolean }>`
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  transform: rotate(${({ $open }) => ($open ? '90deg' : '0deg')});
+  transition: transform 0.15s ease;
+  color: ${({ theme }) => theme.v2.colors.grey[400]};
+`;
+
+const CrGroupHeaderMain = styled(FlexRow)`
+  flex: 1;
+  min-width: 0;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+`;
+
+const CrTemplateLine = styled(FlexRow)<{ $interactive?: boolean }>`
+  width: 100%;
+  align-items: center;
+  padding: 6px 8px;
+  margin-left: -8px;
+  border-left: 2px solid ${({ theme }) => theme.v2.colors.silver[600]};
+  ${({ $interactive }) => ($interactive ? interactiveTemplateRow : '')}
+`;
+
+const AddTemplatesLink = styled.button`
+  align-self: flex-start;
+  margin-top: 4px;
+  padding: 4px 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-family: ${({ theme }) => theme.font_family.primary};
+  font-size: ${({ theme }) => theme.v2.text.size.xxxs}px;
+  line-height: 1.4;
+  color: ${({ theme }) => theme.v2.colors.blue[400]};
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    text-decoration: none;
+  }
+`;
+
+const AddGroupButton = styled.button`
+  flex-shrink: 0;
+  padding: 3px 8px;
+  border-radius: 6px;
+  border: 1px solid ${({ theme }) => theme.v2.colors.silver[600]};
+  background: ${({ theme }) => theme.v2.colors.silver[800]};
+  cursor: pointer;
+  font-family: ${({ theme }) => theme.font_family.primary};
+  font-size: ${({ theme }) => theme.v2.text.size.xxxs}px;
+  line-height: 1.3;
+  color: ${({ theme }) => theme.v2.colors.white[500]};
+
+  &:hover {
+    background: ${({ theme }) => theme.v2.colors.silver[700]};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;
+
+function crGroupKey(group: CustomTemplateCrGroup): string {
+  return `${group.actionId}:${group.groupIndex}:${scopeTokensSortKey(group.scopeTokens)}`;
+}
+
+function CrRuleGroupCard({
+  group,
+  actionDisabled,
+  onSelectTemplate,
+  onEditGroupTemplates,
+}: {
+  group: CustomTemplateCrGroup;
+  actionDisabled: boolean;
+  onSelectTemplate: OnSelectUrlTemplate;
+  onEditGroupTemplates?: (group: CustomTemplateCrGroup, options?: EditGroupTemplatesOptions) => void;
+}) {
+  const [open, setOpen] = useState(true);
+  const groupKey = crGroupKey(group);
+
+  const toggleOpen = () => setOpen((value) => !value);
+
+  return (
+    <CrRuleGroupBlock $gap={8}>
+      <CrGroupHeader
+        $gap={8}
+        role="button"
+        tabIndex={0}
+        aria-expanded={open}
+        title={open ? 'Collapse rule group' : 'Expand rule group'}
+        onClick={toggleOpen}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            toggleOpen();
+          }
+        }}
+      >
+        <CrGroupChevron $open={open}>
+          <ChevronRightIcon size={12} />
+        </CrGroupChevron>
+        <CrGroupHeaderMain $gap={8}>
+          <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+            Group {group.groupIndex + 1}
+          </Typography>
+          {onEditGroupTemplates ? (
+            <IconButton
+              data-id={`url-templating-edit-group-${groupKey}`}
+              icon={EditIcon}
+              size={IconButtonSize.XS}
+              onClick={(event) => {
+                stopRowActivation(event);
+                onEditGroupTemplates(group);
+              }}
+            />
+          ) : null}
+          <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+            {group.templates.length} {group.templates.length === 1 ? 'template' : 'templates'}
+          </Typography>
+          <span style={actionDisabled ? { opacity: 0.55 } : undefined}>
+            <ScopeTokens tokens={group.scopeTokens} />
+          </span>
+        </CrGroupHeaderMain>
+      </CrGroupHeader>
+
+      {open ? (
+        <>
+          {group.groupNotes?.trim() ? (
+            <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+              {group.groupNotes.trim()}
+            </Typography>
+          ) : null}
+          <FlexColumn $gap={4}>
+            {group.templates.map((template) => {
+              const openDetail = () => onSelectTemplate(detailFromCrTemplate(group, template));
+              const rowActivation = templateRowActivationProps(openDetail);
+              return (
+                <CrTemplateLine
+                  key={`${groupKey}:${template}`}
+                  $gap={8}
+                  $interactive
+                  title="View template details"
+                  {...rowActivation}
+                  onClick={(event) => {
+                    stopRowActivation(event);
+                    rowActivation.onClick();
+                  }}
+                >
+                  <TemplatePath template={template} disabled={actionDisabled} />
+                </CrTemplateLine>
+              );
+            })}
+            {group.templates.length === 0 ? (
+              <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+                No templates configured
+              </Typography>
+            ) : null}
+          </FlexColumn>
+          {onEditGroupTemplates ? (
+            <AddTemplatesLink
+              type="button"
+              data-id={`url-templating-add-templates-${groupKey}`}
+              onClick={(event) => {
+                stopRowActivation(event);
+                onEditGroupTemplates(group, { focusNewTemplate: true });
+              }}
+            >
+              + Add New Templates
+            </AddTemplatesLink>
+          ) : null}
+        </>
+      ) : null}
+    </CrRuleGroupBlock>
+  );
+}
+
+export function CustomTemplateCrGroupsView({
+  groups,
+  onSelectTemplate,
+  onEditGroupTemplates,
+  onCreateGroup,
+}: {
+  groups: CustomTemplateCrGroup[];
+  onSelectTemplate: OnSelectUrlTemplate;
+  onEditGroupTemplates?: (group: CustomTemplateCrGroup, options?: EditGroupTemplatesOptions) => void;
+  onCreateGroup?: (actionId: string) => void;
+}) {
+  const actionSections = useMemo(() => {
+    const order: string[] = [];
+    const byAction = new Map<
+      string,
+      {
+        actionLabel: string;
+        actionDisabled: boolean;
+        actionUiGenerated: boolean;
+        groups: CustomTemplateCrGroup[];
+      }
+    >();
+
+    for (const group of groups) {
+      if (!byAction.has(group.actionId)) {
+        order.push(group.actionId);
+        byAction.set(group.actionId, {
+          actionLabel: group.actionLabel,
+          actionDisabled: group.actionDisabled,
+          actionUiGenerated: group.actionUiGenerated,
+          groups: [],
+        });
+      }
+      byAction.get(group.actionId)?.groups.push(group);
+    }
+
+    return order.map((actionId) => ({
+      actionId,
+      ...byAction.get(actionId)!,
+    }));
+  }, [groups]);
+
+  return (
+    <FlexColumn $gap={0} style={{ width: '100%' }}>
+      {actionSections.map(({ actionId, actionLabel, actionDisabled, actionUiGenerated, groups: actionGroups }) => (
+        <CrActionBlock key={actionId} $gap={12}>
+          <FlexRow $gap={8} $alignItems="center" style={{ flexWrap: 'wrap' }}>
+            <Typography size={TypographySize.XS}>{actionLabel}</Typography>
+            <ActionOriginBadge uiGenerated={actionUiGenerated} />
+            {actionDisabled ? <Badge label="Disabled" /> : null}
+            <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+              {actionGroups.length} {actionGroups.length === 1 ? 'rule group' : 'rule groups'}
+            </Typography>
+            {onCreateGroup ? (
+              <AddGroupButton
+                type="button"
+                data-id={`url-templating-create-group-${actionId}`}
+                onClick={(event) => {
+                  stopRowActivation(event);
+                  onCreateGroup(actionId);
+                }}
+              >
+                + Add group
+              </AddGroupButton>
+            ) : null}
+          </FlexRow>
+          {actionGroups.map((group) => (
+            <CrRuleGroupCard
+              key={crGroupKey(group)}
+              group={group}
+              actionDisabled={actionDisabled}
+              onSelectTemplate={onSelectTemplate}
+              onEditGroupTemplates={onEditGroupTemplates}
+            />
+          ))}
+        </CrActionBlock>
+      ))}
+    </FlexColumn>
+  );
+}

--- a/frontend/webapp/app/(v2)/url-templating/default-templatization-detail-drawer.tsx
+++ b/frontend/webapp/app/(v2)/url-templating/default-templatization-detail-drawer.tsx
@@ -1,0 +1,316 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import styled from 'styled-components';
+import { ActionIcon, EditIcon, TrashIcon } from '@odigos/ui-kit/icons';
+import type { Action } from '@odigos/ui-kit/types';
+import { StatusType } from '@odigos/ui-kit/types';
+import {
+  Badge,
+  Button,
+  ButtonSize,
+  ButtonVariants,
+  Divider,
+  Drawer,
+  FlexColumn,
+  FlexRow,
+  Note,
+  Typography,
+  TypographyColor,
+  TypographySize,
+  WarningModal,
+} from '@odigos/ui-kit/components';
+import { useApiMutation } from '@odigos/ui-kit/contexts';
+import { ActionOriginBadge, actionOriginTitleBadge } from './action-origin-badge';
+import { ScopeTokens } from './scope-tokens';
+import { SectionHelpButton } from './section-help-button';
+import { SKIP_POLICY_HELP } from './skip-policy-help';
+import { buildUpdateActionWithDefaultGroupDeleted } from './action-default-group-update';
+import type { DefaultTemplatizationCrGroup } from './url-templatization-aggregate';
+
+const DrawerBody = styled(FlexColumn)`
+  width: 100%;
+  padding: 0 24px 24px;
+  gap: 16px;
+`;
+
+const DetailBlock = styled(FlexColumn)`
+  width: 100%;
+  gap: 8px;
+`;
+
+const FieldList = styled(FlexColumn)`
+  width: 100%;
+  gap: 10px;
+`;
+
+const Field = styled(FlexColumn)`
+  width: 100%;
+  gap: 2px;
+`;
+
+const ResourceName = styled.span`
+  font-family: ${({ theme }) => theme.font_family.code ?? theme.font_family.primary};
+  font-size: ${({ theme }) => theme.v2.text.size.xs}px;
+  line-height: 1.4;
+  color: ${({ theme }) => theme.v2.colors.white[500]};
+  word-break: break-word;
+`;
+
+function DetailField({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <Field $gap={2}>
+      <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+        {label}
+      </Typography>
+      {children}
+    </Field>
+  );
+}
+
+type DefaultTemplatizationDetailDrawerProps = {
+  group: DefaultTemplatizationCrGroup | null;
+  action?: Action | null;
+  onEdit?: (group: DefaultTemplatizationCrGroup) => void;
+  onDeleted?: () => void;
+  onClose: () => void;
+};
+
+export function DefaultTemplatizationDetailDrawer({
+  group,
+  action = null,
+  onEdit,
+  onDeleted,
+  onClose,
+}: DefaultTemplatizationDetailDrawerProps) {
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const [updateAction, { loading: deleting }] = useApiMutation('UPDATE_ACTION', {
+    refetchQueries: ['GetActions'],
+    awaitRefetchQueries: true,
+  });
+
+  useEffect(() => {
+    setConfirmDeleteOpen(false);
+    setDeleteError(null);
+  }, [group]);
+
+  const headerBadges = useMemo(() => {
+    if (!group) {
+      return undefined;
+    }
+    const badges = [actionOriginTitleBadge(group.actionUiGenerated)];
+    if (group.actionDisabled) {
+      badges.push({ label: 'Action disabled' });
+    }
+    if (group.disabled) {
+      badges.push({ label: 'Default Templating Disabled' });
+    } else {
+      badges.push({ label: 'Default Templating Enabled' });
+    }
+    return badges;
+  }, [group]);
+
+  const canEdit = !!action && !!onEdit;
+  const canDelete = !!action && !!onDeleted;
+
+  const handleDelete = async () => {
+    if (!group || !action || !onDeleted) {
+      return;
+    }
+    setDeleteError(null);
+    try {
+      const variables = buildUpdateActionWithDefaultGroupDeleted(action, group.groupIndex);
+      const { error } = await updateAction(variables);
+      if (error) {
+        setDeleteError(error.message || 'Failed to delete default rule');
+        return;
+      }
+      setConfirmDeleteOpen(false);
+      onDeleted();
+      onClose();
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : 'Failed to delete default rule');
+    }
+  };
+
+  const headerActions = useMemo(() => {
+    if (!group) {
+      return undefined;
+    }
+    const actions = [];
+    if (canEdit) {
+      actions.push({
+        id: 'edit-default-rule',
+        label: 'Edit rule',
+        icon: EditIcon,
+        onClick: () => onEdit?.(group),
+      });
+    }
+    if (canDelete) {
+      actions.push({
+        id: 'delete-default-rule',
+        label: 'Delete rule',
+        icon: TrashIcon,
+        onClick: () => {
+          setDeleteError(null);
+          setConfirmDeleteOpen(true);
+        },
+      });
+    }
+    return actions.length ? actions : undefined;
+  }, [canDelete, canEdit, group, onEdit]);
+
+  return (
+    <>
+      <Drawer
+        isOpen={!!group}
+        width="min(720px, 96vw)"
+        header={
+          group
+            ? {
+                icon: ActionIcon,
+                title: 'Default templatization',
+                subTitle: group.actionLabel,
+                titleBadges: headerBadges,
+                actions: headerActions,
+                onClose,
+              }
+            : undefined
+        }
+      >
+        {group ? (
+          <DrawerBody $gap={16}>
+            <DetailBlock $gap={8}>
+              <Typography size={TypographySize.XXS} color={TypographyColor.Secondary}>
+                Scope
+              </Typography>
+              <ScopeTokens tokens={group.scopeTokens} />
+              <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+                Group {group.groupIndex + 1}
+              </Typography>
+            </DetailBlock>
+
+            <Divider />
+
+            <DetailBlock $gap={8}>
+              <Typography size={TypographySize.XXS} color={TypographyColor.Secondary}>
+                Status
+              </Typography>
+              {group.disabled ? <Badge label="Default Templating Disabled" /> : <Badge label="Default Templating Enabled" />}
+              <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+                {group.disabled
+                  ? 'Heuristic default templating is turned off for this scope. Custom templates still apply when they match.'
+                  : 'Spans try custom templates first; if none match, heuristic default templating is applied for this scope.'}
+              </Typography>
+            </DetailBlock>
+
+            <Divider />
+
+            <DetailBlock $gap={8}>
+              <FlexRow $gap={6} $alignItems="center">
+                <Typography size={TypographySize.XXS} color={TypographyColor.Secondary}>
+                  Skip policy
+                </Typography>
+                <SectionHelpButton
+                  data-id="url-templating-default-skip-policy-help"
+                  title={SKIP_POLICY_HELP.title}
+                  text={SKIP_POLICY_HELP.text}
+                />
+              </FlexRow>
+              {group.skipForNonSuccessCodes || group.skipHttpStatusCodes.length > 0 ? (
+                <>
+                  <FlexRow $gap={6} $alignItems="center" style={{ flexWrap: 'wrap' }}>
+                    {group.skipForNonSuccessCodes ? <Badge label="Skip non-2xx" /> : null}
+                    {group.skipHttpStatusCodes.length > 0 ? (
+                      <Badge label={`Skip HTTP ${group.skipHttpStatusCodes.join(', ')}`} />
+                    ) : null}
+                  </FlexRow>
+                  <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+                    {group.skipForNonSuccessCodes
+                      ? 'Heuristic default templating is skipped for non-2xx HTTP responses on server spans.'
+                      : `Heuristic default templating is skipped for HTTP status codes: ${group.skipHttpStatusCodes.join(', ')}.`}
+                  </Typography>
+                </>
+              ) : (
+                <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+                  No skip policy configured.
+                </Typography>
+              )}
+            </DetailBlock>
+
+            <Divider />
+
+            <DetailBlock $gap={8}>
+              <Typography size={TypographySize.XXS} color={TypographyColor.Secondary}>
+                Action
+              </Typography>
+              <FieldList $gap={10}>
+                <DetailField label="Display name">
+                  <Typography size={TypographySize.XS}>{group.actionLabel}</Typography>
+                </DetailField>
+                <DetailField label="Resource name">
+                  <ResourceName>{group.actionId}</ResourceName>
+                </DetailField>
+                <DetailField label="Origin">
+                  <ActionOriginBadge uiGenerated={group.actionUiGenerated} />
+                </DetailField>
+                {group.actionDisabled ? (
+                  <DetailField label="Action status">
+                    <Badge label="Disabled" />
+                  </DetailField>
+                ) : null}
+              </FieldList>
+            </DetailBlock>
+
+            {canEdit ? (
+              <>
+                <Divider />
+                <FlexRow $gap={8} style={{ justifyContent: 'flex-end' }}>
+                  <Button
+                    data-id="url-templating-default-detail-edit"
+                    label="Edit rule"
+                    variant={ButtonVariants.Primary}
+                    size={ButtonSize.S}
+                    onClick={() => onEdit?.(group)}
+                  />
+                </FlexRow>
+              </>
+            ) : null}
+          </DrawerBody>
+        ) : null}
+      </Drawer>
+
+      <WarningModal
+        isOpen={confirmDeleteOpen}
+        title="Delete this default rule?"
+        description="This default templatization rule will be removed from the action and take effect in the cluster immediately."
+        onClose={() => {
+          if (!deleting) {
+            setConfirmDeleteOpen(false);
+            setDeleteError(null);
+          }
+        }}
+        denyButton={{
+          label: 'Go Back',
+          onClick: () => {
+            setConfirmDeleteOpen(false);
+            setDeleteError(null);
+          },
+          disabled: deleting,
+        }}
+        approveButton={{
+          label: 'Delete Rule',
+          onClick: () => {
+            void handleDelete();
+          },
+          loading: deleting,
+          disabled: deleting,
+        }}
+      >
+        {deleteError ? <Note status={StatusType.Error} message={deleteError} fullWidth /> : null}
+      </WarningModal>
+    </>
+  );
+}

--- a/frontend/webapp/app/(v2)/url-templating/default-templatization-view.tsx
+++ b/frontend/webapp/app/(v2)/url-templating/default-templatization-view.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import styled from 'styled-components';
+import { ChevronRightIcon } from '@odigos/ui-kit/icons';
+import { Badge, FlexColumn, FlexRow, Typography, TypographyColor, TypographySize } from '@odigos/ui-kit/components';
+import { ActionOriginBadge } from './action-origin-badge';
+import { ScopeTokens } from './scope-tokens';
+import type { DefaultTemplatizationCrGroup } from './url-templatization-aggregate';
+import { scopeTokensSortKey } from './url-templatization-aggregate';
+
+const CrActionBlock = styled(FlexColumn)`
+  width: 100%;
+  gap: 12px;
+  padding: 16px 0;
+  border-bottom: 2px solid ${({ theme }) => theme.v2.colors.silver[500]};
+
+  &:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+`;
+
+const CrRuleGroupBlock = styled(FlexColumn)`
+  width: 100%;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: ${({ theme }) => theme.v2.colors.silver[900]};
+  border: 1px solid ${({ theme }) => theme.v2.colors.silver[700]};
+`;
+
+const CrGroupHeader = styled(FlexRow)`
+  width: 100%;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  user-select: none;
+  border-radius: 6px;
+  margin: -4px -6px;
+  padding: 4px 6px;
+
+  &:hover {
+    background: ${({ theme }) => theme.v2.colors.silver[800]};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.v2.colors.blue[400]};
+    outline-offset: 2px;
+  }
+`;
+
+const CrGroupChevron = styled.span<{ $open: boolean }>`
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  transform: rotate(${({ $open }) => ($open ? '90deg' : '0deg')});
+  transition: transform 0.15s ease;
+  color: ${({ theme }) => theme.v2.colors.grey[400]};
+`;
+
+const CrGroupHeaderMain = styled(FlexRow)`
+  flex: 1;
+  min-width: 0;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+`;
+
+function defaultGroupKey(group: DefaultTemplatizationCrGroup): string {
+  return `${group.actionId}:${group.groupIndex}:${scopeTokensSortKey(group.scopeTokens)}`;
+}
+
+function DefaultRuleGroupCard({
+  group,
+  actionDisabled,
+}: {
+  group: DefaultTemplatizationCrGroup;
+  actionDisabled: boolean;
+}) {
+  const [open, setOpen] = useState(true);
+  const muted = group.disabled || actionDisabled;
+
+  const toggleOpen = () => setOpen((value) => !value);
+
+  return (
+    <CrRuleGroupBlock $gap={8}>
+      <CrGroupHeader
+        $gap={8}
+        role="button"
+        tabIndex={0}
+        aria-expanded={open}
+        title={open ? 'Collapse rule group' : 'Expand rule group'}
+        onClick={toggleOpen}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            toggleOpen();
+          }
+        }}
+      >
+        <CrGroupChevron $open={open}>
+          <ChevronRightIcon size={12} />
+        </CrGroupChevron>
+        <CrGroupHeaderMain $gap={8}>
+          <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+            Group {group.groupIndex + 1}
+          </Typography>
+          <span style={actionDisabled ? { opacity: 0.55 } : undefined}>
+            <ScopeTokens tokens={group.scopeTokens} />
+          </span>
+          {group.disabled ? <Badge label="Disabled" /> : <Badge label="Enabled" />}
+        </CrGroupHeaderMain>
+      </CrGroupHeader>
+
+      {open ? (
+        <FlexColumn $gap={6}>
+          <Typography
+            size={TypographySize.XS}
+            color={muted ? TypographyColor.Secondary : undefined}
+          >
+            {group.configLabel}
+          </Typography>
+          <FlexRow $gap={6} $alignItems="center" style={{ flexWrap: 'wrap' }}>
+            {group.skipForNonSuccessCodes ? <Badge label="Skip non-2xx" /> : null}
+            {group.skipHttpStatusCodes.length > 0 ? (
+              <Badge label={`Skip HTTP ${group.skipHttpStatusCodes.join(', ')}`} />
+            ) : null}
+          </FlexRow>
+        </FlexColumn>
+      ) : null}
+    </CrRuleGroupBlock>
+  );
+}
+
+export function DefaultTemplatizationCrGroupsView({
+  groups,
+}: {
+  groups: DefaultTemplatizationCrGroup[];
+}) {
+  const actionSections = useMemo(() => {
+    const order: string[] = [];
+    const byAction = new Map<
+      string,
+      {
+        actionLabel: string;
+        actionDisabled: boolean;
+        actionUiGenerated: boolean;
+        groups: DefaultTemplatizationCrGroup[];
+      }
+    >();
+
+    for (const group of groups) {
+      if (!byAction.has(group.actionId)) {
+        order.push(group.actionId);
+        byAction.set(group.actionId, {
+          actionLabel: group.actionLabel,
+          actionDisabled: group.actionDisabled,
+          actionUiGenerated: group.actionUiGenerated,
+          groups: [],
+        });
+      }
+      byAction.get(group.actionId)?.groups.push(group);
+    }
+
+    return order.map((actionId) => ({
+      actionId,
+      ...byAction.get(actionId)!,
+    }));
+  }, [groups]);
+
+  return (
+    <FlexColumn $gap={0} style={{ width: '100%' }}>
+      {actionSections.map(({ actionId, actionLabel, actionDisabled, actionUiGenerated, groups: actionGroups }) => (
+        <CrActionBlock key={actionId} $gap={12}>
+          <FlexRow $gap={8} $alignItems="center" style={{ flexWrap: 'wrap' }}>
+            <Typography size={TypographySize.XS}>{actionLabel}</Typography>
+            <ActionOriginBadge uiGenerated={actionUiGenerated} />
+            {actionDisabled ? <Badge label="Disabled" /> : null}
+            <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+              {actionGroups.length} {actionGroups.length === 1 ? 'rule group' : 'rule groups'}
+            </Typography>
+          </FlexRow>
+          {actionGroups.map((group) => (
+            <DefaultRuleGroupCard
+              key={defaultGroupKey(group)}
+              group={group}
+              actionDisabled={actionDisabled}
+            />
+          ))}
+        </CrActionBlock>
+      ))}
+    </FlexColumn>
+  );
+}

--- a/frontend/webapp/app/(v2)/url-templating/default-templatization-view.tsx
+++ b/frontend/webapp/app/(v2)/url-templating/default-templatization-view.tsx
@@ -1,11 +1,21 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import styled from 'styled-components';
-import { ChevronRightIcon } from '@odigos/ui-kit/icons';
-import { Badge, FlexColumn, FlexRow, Typography, TypographyColor, TypographySize } from '@odigos/ui-kit/components';
+import { EditIcon } from '@odigos/ui-kit/icons';
+import {
+  Badge,
+  FlexColumn,
+  FlexRow,
+  IconButton,
+  IconButtonSize,
+  Typography,
+  TypographyColor,
+  TypographySize,
+} from '@odigos/ui-kit/components';
 import { ActionOriginBadge } from './action-origin-badge';
 import { ScopeTokens } from './scope-tokens';
+import { stopRowActivation, templateRowActivationProps } from './template-row-activation';
 import type { DefaultTemplatizationCrGroup } from './url-templatization-aggregate';
 import { scopeTokensSortKey } from './url-templatization-aggregate';
 
@@ -21,51 +31,27 @@ const CrActionBlock = styled(FlexColumn)`
   }
 `;
 
-const CrRuleGroupBlock = styled(FlexColumn)`
+const CrRuleGroupRow = styled(FlexRow)`
   width: 100%;
+  align-items: center;
   gap: 8px;
   padding: 10px 12px;
   border-radius: 8px;
   background: ${({ theme }) => theme.v2.colors.silver[900]};
   border: 1px solid ${({ theme }) => theme.v2.colors.silver[700]};
-`;
-
-const CrGroupHeader = styled(FlexRow)`
-  width: 100%;
-  align-items: center;
-  gap: 8px;
+  flex-wrap: wrap;
   cursor: pointer;
-  user-select: none;
-  border-radius: 6px;
-  margin: -4px -6px;
-  padding: 4px 6px;
+  transition: background 0.12s ease, border-color 0.12s ease;
 
   &:hover {
     background: ${({ theme }) => theme.v2.colors.silver[800]};
+    border-color: ${({ theme }) => theme.v2.colors.silver[600]};
   }
 
   &:focus-visible {
     outline: 2px solid ${({ theme }) => theme.v2.colors.blue[400]};
     outline-offset: 2px;
   }
-`;
-
-const CrGroupChevron = styled.span<{ $open: boolean }>`
-  display: inline-flex;
-  flex-shrink: 0;
-  align-items: center;
-  justify-content: center;
-  transform: rotate(${({ $open }) => ($open ? '90deg' : '0deg')});
-  transition: transform 0.15s ease;
-  color: ${({ theme }) => theme.v2.colors.grey[400]};
-`;
-
-const CrGroupHeaderMain = styled(FlexRow)`
-  flex: 1;
-  min-width: 0;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 8px;
 `;
 
 function defaultGroupKey(group: DefaultTemplatizationCrGroup): string {
@@ -75,69 +61,54 @@ function defaultGroupKey(group: DefaultTemplatizationCrGroup): string {
 function DefaultRuleGroupCard({
   group,
   actionDisabled,
+  onSelect,
+  onEdit,
 }: {
   group: DefaultTemplatizationCrGroup;
   actionDisabled: boolean;
+  onSelect: (group: DefaultTemplatizationCrGroup) => void;
+  onEdit?: (group: DefaultTemplatizationCrGroup) => void;
 }) {
-  const [open, setOpen] = useState(true);
   const muted = group.disabled || actionDisabled;
-
-  const toggleOpen = () => setOpen((value) => !value);
+  const groupKey = defaultGroupKey(group);
+  const activation = templateRowActivationProps(() => onSelect(group));
 
   return (
-    <CrRuleGroupBlock $gap={8}>
-      <CrGroupHeader
-        $gap={8}
-        role="button"
-        tabIndex={0}
-        aria-expanded={open}
-        title={open ? 'Collapse rule group' : 'Expand rule group'}
-        onClick={toggleOpen}
-        onKeyDown={(event) => {
-          if (event.key === 'Enter' || event.key === ' ') {
-            event.preventDefault();
-            toggleOpen();
-          }
-        }}
-      >
-        <CrGroupChevron $open={open}>
-          <ChevronRightIcon size={12} />
-        </CrGroupChevron>
-        <CrGroupHeaderMain $gap={8}>
-          <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
-            Group {group.groupIndex + 1}
-          </Typography>
-          <span style={actionDisabled ? { opacity: 0.55 } : undefined}>
-            <ScopeTokens tokens={group.scopeTokens} />
-          </span>
-          {group.disabled ? <Badge label="Disabled" /> : <Badge label="Enabled" />}
-        </CrGroupHeaderMain>
-      </CrGroupHeader>
-
-      {open ? (
-        <FlexColumn $gap={6}>
-          <Typography
-            size={TypographySize.XS}
-            color={muted ? TypographyColor.Secondary : undefined}
-          >
-            {group.configLabel}
-          </Typography>
-          <FlexRow $gap={6} $alignItems="center" style={{ flexWrap: 'wrap' }}>
-            {group.skipForNonSuccessCodes ? <Badge label="Skip non-2xx" /> : null}
-            {group.skipHttpStatusCodes.length > 0 ? (
-              <Badge label={`Skip HTTP ${group.skipHttpStatusCodes.join(', ')}`} />
-            ) : null}
-          </FlexRow>
-        </FlexColumn>
+    <CrRuleGroupRow $gap={8} title="View default templatization rule" {...activation}>
+      {onEdit ? (
+        <IconButton
+          data-id={`url-templating-edit-default-${groupKey}`}
+          icon={EditIcon}
+          size={IconButtonSize.XS}
+          onClick={(event) => {
+            stopRowActivation(event);
+            onEdit(group);
+          }}
+        />
       ) : null}
-    </CrRuleGroupBlock>
+      <Typography size={TypographySize.XS} color={muted ? TypographyColor.Secondary : undefined}>
+        {group.configLabel}
+      </Typography>
+      <span style={actionDisabled ? { opacity: 0.55 } : undefined}>
+        <ScopeTokens tokens={group.scopeTokens} />
+      </span>
+      {group.disabled ? <Badge label="Default Templating Disabled" /> : <Badge label="Default Templating Enabled" />}
+      {group.skipForNonSuccessCodes ? <Badge label="Skip non-2xx" /> : null}
+      {group.skipHttpStatusCodes.length > 0 ? (
+        <Badge label={`Skip HTTP ${group.skipHttpStatusCodes.join(', ')}`} />
+      ) : null}
+    </CrRuleGroupRow>
   );
 }
 
 export function DefaultTemplatizationCrGroupsView({
   groups,
+  onSelectGroup,
+  onEditGroup,
 }: {
   groups: DefaultTemplatizationCrGroup[];
+  onSelectGroup: (group: DefaultTemplatizationCrGroup) => void;
+  onEditGroup?: (group: DefaultTemplatizationCrGroup) => void;
 }) {
   const actionSections = useMemo(() => {
     const order: string[] = [];
@@ -187,6 +158,8 @@ export function DefaultTemplatizationCrGroupsView({
               key={defaultGroupKey(group)}
               group={group}
               actionDisabled={actionDisabled}
+              onSelect={onSelectGroup}
+              onEdit={onEditGroup}
             />
           ))}
         </CrActionBlock>

--- a/frontend/webapp/app/(v2)/url-templating/drawer-scroll-edge-hint.tsx
+++ b/frontend/webapp/app/(v2)/url-templating/drawer-scroll-edge-hint.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import React, { useEffect, useState, type RefObject } from 'react';
+import styled from 'styled-components';
+import { ChevronRightIcon } from '@odigos/ui-kit/icons';
+import { FlexRow, Typography, TypographyColor, TypographySize } from '@odigos/ui-kit/components';
+
+function findScrollableParent(element: HTMLElement | null): HTMLElement | null {
+  let node = element?.parentElement ?? null;
+  while (node && node !== document.body) {
+    const { overflowY } = getComputedStyle(node);
+    if (overflowY === 'auto' || overflowY === 'scroll') {
+      return node;
+    }
+    node = node.parentElement;
+  }
+  return null;
+}
+
+export function useCanScrollDown(
+  anchorRef: RefObject<HTMLElement | null>,
+  refreshKey: unknown,
+): boolean {
+  const [canScrollDown, setCanScrollDown] = useState(false);
+
+  useEffect(() => {
+    const anchor = anchorRef.current;
+    if (!anchor) {
+      return undefined;
+    }
+
+    const scrollEl = findScrollableParent(anchor);
+    if (!scrollEl) {
+      return undefined;
+    }
+
+    const update = () => {
+      setCanScrollDown(scrollEl.scrollHeight - scrollEl.scrollTop - scrollEl.clientHeight > 20);
+    };
+
+    update();
+    scrollEl.addEventListener('scroll', update, { passive: true });
+    const resizeObserver = new ResizeObserver(update);
+    resizeObserver.observe(scrollEl);
+    resizeObserver.observe(anchor);
+
+    return () => {
+      scrollEl.removeEventListener('scroll', update);
+      resizeObserver.disconnect();
+    };
+  }, [anchorRef, refreshKey]);
+
+  return canScrollDown;
+}
+
+const ScrollEdgeHintRoot = styled(FlexRow)<{ $visible: boolean }>`
+  position: sticky;
+  bottom: 0;
+  z-index: 2;
+  width: 100%;
+  min-height: 52px;
+  margin-top: -52px;
+  pointer-events: none;
+  align-items: flex-end;
+  justify-content: center;
+  padding-bottom: 8px;
+  opacity: ${({ $visible }) => ($visible ? 1 : 0)};
+  transition: opacity 0.15s ease;
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    ${({ theme }) => theme.v2.colors.black[500]}aa 45%,
+    ${({ theme }) => theme.v2.colors.black[500]} 100%
+  );
+`;
+
+const ScrollEdgeLabel = styled(FlexRow)`
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: ${({ theme }) => theme.v2.colors.silver[900]};
+  border: 1px solid ${({ theme }) => theme.v2.colors.silver[700]};
+`;
+
+const ScrollChevron = styled.span`
+  display: inline-flex;
+  transform: rotate(90deg);
+  color: ${({ theme }) => theme.v2.colors.grey[400]};
+`;
+
+type DrawerScrollEdgeHintProps = {
+  visible: boolean;
+};
+
+export function DrawerScrollEdgeHint({ visible }: DrawerScrollEdgeHintProps) {
+  return (
+    <ScrollEdgeHintRoot $visible={visible} $gap={4}>
+      <ScrollEdgeLabel $gap={4}>
+        <ScrollChevron>
+          <ChevronRightIcon size={12} />
+        </ScrollChevron>
+        <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+          Scroll for more
+        </Typography>
+      </ScrollEdgeLabel>
+    </ScrollEdgeHintRoot>
+  );
+}

--- a/frontend/webapp/app/(v2)/url-templating/edit-default-templatization-drawer.tsx
+++ b/frontend/webapp/app/(v2)/url-templating/edit-default-templatization-drawer.tsx
@@ -1,0 +1,532 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import styled from 'styled-components';
+import { ActionIcon, ChevronRightIcon, TrashIcon } from '@odigos/ui-kit/icons';
+import type { Action, SourcesScopes } from '@odigos/ui-kit/types';
+import { StatusType } from '@odigos/ui-kit/types';
+import {
+  Badge,
+  Button,
+  ButtonSize,
+  ButtonVariants,
+  Drawer,
+  FlexColumn,
+  FlexRow,
+  Input,
+  Note,
+  Toggle,
+  ToggleSize,
+  Typography,
+  TypographyColor,
+  TypographySize,
+  WarningModal,
+} from '@odigos/ui-kit/components';
+import { SourceScopeSection } from '@odigos/ui-kit/snippets';
+import { useApiMutation, useOdigosApi } from '@odigos/ui-kit/contexts';
+import { actionOriginTitleBadge } from './action-origin-badge';
+import { SectionHelpButton } from './section-help-button';
+import { SKIP_POLICY_HELP } from './skip-policy-help';
+import {
+  buildDefaultGroupFromEditInput,
+  buildUpdateActionWithAppendedDefaultGroup,
+  buildUpdateActionWithDefaultGroup,
+  buildUpdateActionWithDefaultGroupDeleted,
+  defaultGroupEditInputsEqual,
+  defaultGroupScopesToSourcesScopes,
+  formatSkipHttpStatusCodesInput,
+  parseSkipHttpStatusCodesInput,
+  type DefaultGroupEditInput,
+} from './action-default-group-update';
+import { makeEmptySourcesScopes } from './action-group-templates-update';
+import type { DefaultTemplatizationCrGroup } from './url-templatization-aggregate';
+
+const DrawerBody = styled(FlexColumn)`
+  width: 100%;
+  padding: 0 24px 24px;
+  gap: 16px;
+`;
+
+const MetaPanel = styled(FlexColumn)`
+  width: 100%;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 8px;
+  background: ${({ theme }) => theme.v2.colors.silver[900]};
+  border: 1px solid ${({ theme }) => theme.v2.colors.silver[700]};
+`;
+
+const DetailBlock = styled(FlexColumn)`
+  width: 100%;
+  gap: 8px;
+`;
+
+const CollapseHeader = styled(FlexRow)`
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 2px 0;
+  cursor: pointer;
+  user-select: none;
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.v2.colors.blue[400]};
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+`;
+
+const CollapseChevron = styled.span<{ $open: boolean }>`
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  transform: rotate(${({ $open }) => ($open ? '90deg' : '0deg')});
+  transition: transform 0.15s ease;
+  color: ${({ theme }) => theme.v2.colors.grey[400]};
+`;
+
+const CollapseBody = styled(FlexColumn)`
+  width: 100%;
+  gap: 8px;
+  padding-top: 8px;
+`;
+
+const DrawerSaveFooter = styled(FlexColumn)`
+  width: 100%;
+  gap: 12px;
+  padding: 16px 24px;
+  box-sizing: border-box;
+  border-top: 1px solid ${({ theme }) => theme.v2.colors.silver[700]};
+  background: ${({ theme }) => theme.v2.colors.black[500]};
+`;
+
+const DrawerSaveFooterActions = styled(FlexRow)`
+  width: 100%;
+  justify-content: flex-end;
+  gap: 12px;
+  flex-shrink: 0;
+`;
+
+type EditDefaultTemplatizationDrawerProps = {
+  group: DefaultTemplatizationCrGroup | null;
+  action: Action | null;
+  /** Open the drawer to create a new default rule on `action` (group is ignored). */
+  creating?: boolean;
+  onClose: () => void;
+  onSaved: () => void;
+};
+
+const EMPTY_CREATE_INPUT: DefaultGroupEditInput = {
+  scopes: { sources: [], namespaces: [], languages: [] },
+  disabled: false,
+  skipForNonSuccessCodes: false,
+  skipHttpStatusCodes: [],
+};
+
+function editInputFromGroup(group: DefaultTemplatizationCrGroup): DefaultGroupEditInput {
+  return {
+    scopes: defaultGroupScopesToSourcesScopes(group.scopes),
+    disabled: group.disabled,
+    skipForNonSuccessCodes: group.skipForNonSuccessCodes,
+    skipHttpStatusCodes: [...group.skipHttpStatusCodes],
+  };
+}
+
+export function EditDefaultTemplatizationDrawer({
+  group,
+  action,
+  creating = false,
+  onClose,
+  onSaved,
+}: EditDefaultTemplatizationDrawerProps) {
+  const isCreate = creating && !!action;
+  const isOpen = isCreate || !!group;
+
+  const { sourcesApi } = useOdigosApi();
+  const { items: sources = [] } = sourcesApi.useSources();
+
+  const [scopes, setScopes] = useState<SourcesScopes>(makeEmptySourcesScopes);
+  const [disabled, setDisabled] = useState(false);
+  const [skipForNonSuccessCodes, setSkipForNonSuccessCodes] = useState(false);
+  const [skipHttpStatusCodesText, setSkipHttpStatusCodesText] = useState('');
+  const [skipPolicyOpen, setSkipPolicyOpen] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const [updateAction, { loading: saving }] = useApiMutation('UPDATE_ACTION', {
+    refetchQueries: ['GetActions'],
+    awaitRefetchQueries: true,
+  });
+
+  useEffect(() => {
+    if (isCreate) {
+      setScopes(makeEmptySourcesScopes());
+      setDisabled(false);
+      setSkipForNonSuccessCodes(false);
+      setSkipHttpStatusCodesText('');
+      setSkipPolicyOpen(false);
+      setSaveError(null);
+      setConfirmDeleteOpen(false);
+      setDeleteError(null);
+      return;
+    }
+    if (!group) {
+      setScopes(makeEmptySourcesScopes());
+      setDisabled(false);
+      setSkipForNonSuccessCodes(false);
+      setSkipHttpStatusCodesText('');
+      setSkipPolicyOpen(false);
+      setSaveError(null);
+      setConfirmDeleteOpen(false);
+      setDeleteError(null);
+      return;
+    }
+    const initial = editInputFromGroup(group);
+    setScopes(initial.scopes);
+    setDisabled(initial.disabled);
+    setSkipForNonSuccessCodes(initial.skipForNonSuccessCodes);
+    setSkipHttpStatusCodesText(formatSkipHttpStatusCodesInput(initial.skipHttpStatusCodes));
+    setSkipPolicyOpen(false);
+    setSaveError(null);
+    setConfirmDeleteOpen(false);
+    setDeleteError(null);
+  }, [group, isCreate]);
+
+  const sourceOptions = useMemo(
+    () =>
+      sources.map(({ id }) => ({
+        id: `${id.namespace}/${id.kind}/${id.name}`,
+        label: id.name,
+        badge: id.kind,
+        secondaryLabel: id.namespace,
+      })),
+    [sources],
+  );
+
+  const namespaceOptions = useMemo(
+    () =>
+      Array.from(new Set(sources.map(({ id }) => id.namespace)))
+        .sort()
+        .map((namespace) => ({ id: namespace, label: namespace })),
+    [sources],
+  );
+
+  const parsedSkipCodes = useMemo(
+    () => parseSkipHttpStatusCodesInput(skipHttpStatusCodesText),
+    [skipHttpStatusCodesText],
+  );
+
+  const draftInput = useMemo<DefaultGroupEditInput>(
+    () => ({
+      scopes,
+      disabled,
+      skipForNonSuccessCodes,
+      skipHttpStatusCodes: parsedSkipCodes.ok ? parsedSkipCodes.codes : [],
+    }),
+    [disabled, parsedSkipCodes, scopes, skipForNonSuccessCodes],
+  );
+
+  const initialInput = useMemo(() => {
+    if (isCreate) {
+      return EMPTY_CREATE_INPUT;
+    }
+    return group ? editInputFromGroup(group) : null;
+  }, [group, isCreate]);
+
+  const dirty = useMemo(() => {
+    if (!initialInput) {
+      return false;
+    }
+    if (!parsedSkipCodes.ok && skipHttpStatusCodesText.trim()) {
+      return true;
+    }
+    return !defaultGroupEditInputsEqual(draftInput, initialInput);
+  }, [draftInput, initialInput, parsedSkipCodes.ok, skipHttpStatusCodesText]);
+
+  const validationError = useMemo(() => {
+    if (!skipForNonSuccessCodes && !parsedSkipCodes.ok) {
+      return parsedSkipCodes.error;
+    }
+    return null;
+  }, [parsedSkipCodes, skipForNonSuccessCodes]);
+
+  const canSave =
+    !validationError && !saving && !!action && (isCreate || (!!group && dirty));
+
+  const footerNotice = useMemo(() => {
+    if (saveError) {
+      return { status: StatusType.Error, message: saveError, fullWidth: true as const };
+    }
+    if (validationError) {
+      return { status: StatusType.Warning, message: validationError, fullWidth: true as const };
+    }
+    if (isCreate || dirty) {
+      return {
+        status: StatusType.Warning,
+        message: isCreate
+          ? 'On create: add this default rule — takes effect in the cluster immediately.'
+          : 'On save: update this default rule — takes effect in the cluster immediately.',
+        fullWidth: true as const,
+      };
+    }
+    return undefined;
+  }, [dirty, isCreate, saveError, validationError]);
+
+  const headerBadges = group
+    ? [
+        actionOriginTitleBadge(group.actionUiGenerated),
+        ...(group.actionDisabled ? [{ label: 'Disabled' as const }] : []),
+      ]
+    : action
+      ? [actionOriginTitleBadge(!!(action as Action & { uiGenerated?: boolean }).uiGenerated)]
+      : undefined;
+
+  const handleSave = async () => {
+    if (!action || !canSave) {
+      return;
+    }
+    setSaveError(null);
+    try {
+      const variables = isCreate
+        ? buildUpdateActionWithAppendedDefaultGroup(action, buildDefaultGroupFromEditInput(draftInput))
+        : buildUpdateActionWithDefaultGroup(action, group!.groupIndex, draftInput);
+      const { error } = await updateAction(variables);
+      if (error) {
+        setSaveError(error.message || (isCreate ? 'Failed to create default rule' : 'Failed to update default rule'));
+        return;
+      }
+      onSaved();
+      onClose();
+    } catch (err) {
+      setSaveError(
+        err instanceof Error
+          ? err.message
+          : isCreate
+            ? 'Failed to create default rule'
+            : 'Failed to update default rule',
+      );
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!group || !action || isCreate) {
+      return;
+    }
+    setDeleteError(null);
+    try {
+      const variables = buildUpdateActionWithDefaultGroupDeleted(action, group.groupIndex);
+      const { error } = await updateAction(variables);
+      if (error) {
+        setDeleteError(error.message || 'Failed to delete default rule');
+        return;
+      }
+      setConfirmDeleteOpen(false);
+      onSaved();
+      onClose();
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : 'Failed to delete default rule');
+    }
+  };
+
+  const actionLabel = group?.actionLabel || action?.name?.trim() || action?.id || '';
+
+  return (
+    <>
+      <Drawer
+        isOpen={isOpen}
+        width="min(720px, 96vw)"
+        header={
+          isOpen
+            ? {
+                icon: ActionIcon,
+                title: isCreate ? 'Create default templatization' : 'Edit default templatization',
+                subTitle: actionLabel,
+                titleBadges: headerBadges,
+                actions:
+                  !isCreate && action
+                    ? [
+                        {
+                          id: 'delete-default-rule',
+                          label: 'Delete rule',
+                          icon: TrashIcon,
+                          onClick: () => {
+                            setDeleteError(null);
+                            setConfirmDeleteOpen(true);
+                          },
+                        },
+                      ]
+                    : undefined,
+                onClose,
+              }
+            : undefined
+        }
+        footer={
+          isOpen
+            ? {
+                children: (
+                  <DrawerSaveFooter $gap={12}>
+                    {footerNotice ? <Note {...footerNotice} /> : null}
+                    <DrawerSaveFooterActions $gap={12}>
+                      <Button
+                        label="Cancel"
+                        variant={ButtonVariants.Secondary}
+                        size={ButtonSize.S}
+                        onClick={onClose}
+                        disabled={saving}
+                      />
+                      <Button
+                        label={isCreate ? 'Create' : 'Save'}
+                        variant={ButtonVariants.Primary}
+                        size={ButtonSize.S}
+                        onClick={() => {
+                          void handleSave();
+                        }}
+                        disabled={!canSave}
+                        loading={saving}
+                      />
+                    </DrawerSaveFooterActions>
+                  </DrawerSaveFooter>
+                ),
+              }
+            : undefined
+        }
+      >
+        {isOpen ? (
+          <DrawerBody $gap={16}>
+            <MetaPanel $gap={12}>
+              <SourceScopeSection
+                scopes={scopes}
+                onChange={setScopes}
+                sourceOptions={sourceOptions}
+                namespaceOptions={namespaceOptions}
+                dataIdPrefix={isCreate ? 'url-templating-create-default-scope' : 'url-templating-edit-default-scope'}
+                slim
+                disabled={saving}
+              />
+            </MetaPanel>
+
+            <MetaPanel $gap={12}>
+              <DetailBlock $gap={8}>
+                <Typography size={TypographySize.XXS} color={TypographyColor.Secondary}>
+                  Default templating
+                </Typography>
+                <Toggle
+                  name="url-templating-edit-default-enabled"
+                  size={ToggleSize.S}
+                  label="Enable default templating for this scope"
+                  tooltip="Applies heuristic templates when no custom rule matches."
+                  value={!disabled}
+                  onChange={(enabled) => setDisabled(!enabled)}
+                  disabled={saving}
+                />
+              </DetailBlock>
+            </MetaPanel>
+
+            <MetaPanel $gap={12}>
+              <DetailBlock $gap={0}>
+                <CollapseHeader
+                  $gap={12}
+                  role="button"
+                  tabIndex={0}
+                  aria-expanded={skipPolicyOpen}
+                  onClick={() => setSkipPolicyOpen((value) => !value)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      setSkipPolicyOpen((value) => !value);
+                    }
+                  }}
+                >
+                  <FlexRow $gap={6} $alignItems="center" style={{ flex: 1, minWidth: 0 }}>
+                    <Typography size={TypographySize.XXS} color={TypographyColor.Secondary}>
+                      Skip policy
+                    </Typography>
+                    <Badge label="Advanced" />
+                    <span
+                      onClick={(event) => event.stopPropagation()}
+                      onKeyDown={(event) => event.stopPropagation()}
+                    >
+                      <SectionHelpButton
+                        data-id="url-templating-edit-default-skip-policy-help"
+                        title={SKIP_POLICY_HELP.title}
+                        text={SKIP_POLICY_HELP.text}
+                      />
+                    </span>
+                  </FlexRow>
+                  <CollapseChevron $open={skipPolicyOpen}>
+                    <ChevronRightIcon size={14} />
+                  </CollapseChevron>
+                </CollapseHeader>
+                {skipPolicyOpen ? (
+                  <CollapseBody $gap={8}>
+                    <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+                      Skip heuristic default templating on selected error responses (server spans). Custom
+                      templates still match first.
+                    </Typography>
+                    <Toggle
+                      name="url-templating-edit-default-skip-non-2xx"
+                      size={ToggleSize.S}
+                      label="Skip for non-2xx responses"
+                      tooltip="When on, status-code list below is ignored."
+                      value={skipForNonSuccessCodes}
+                      onChange={(value) => {
+                        setSkipForNonSuccessCodes(value);
+                        if (value) {
+                          setSkipHttpStatusCodesText('');
+                        }
+                      }}
+                      disabled={saving || disabled}
+                    />
+                    <Input
+                      data-id="url-templating-edit-default-skip-codes"
+                      name="url-templating-edit-default-skip-codes"
+                      label="Skip specific HTTP status codes"
+                      placeholder="404, 401"
+                      value={skipHttpStatusCodesText}
+                      onChange={(event) => setSkipHttpStatusCodesText(event.target.value)}
+                      width="100%"
+                      disabled={saving || disabled || skipForNonSuccessCodes}
+                    />
+                  </CollapseBody>
+                ) : null}
+              </DetailBlock>
+            </MetaPanel>
+          </DrawerBody>
+        ) : null}
+      </Drawer>
+
+      <WarningModal
+        isOpen={confirmDeleteOpen}
+        title="Delete this default rule?"
+        description="This default templatization rule will be removed from the action and take effect in the cluster immediately."
+        onClose={() => {
+          if (!saving) {
+            setConfirmDeleteOpen(false);
+            setDeleteError(null);
+          }
+        }}
+        denyButton={{
+          label: 'Go Back',
+          onClick: () => {
+            setConfirmDeleteOpen(false);
+            setDeleteError(null);
+          },
+          disabled: saving,
+        }}
+        approveButton={{
+          label: 'Delete Rule',
+          onClick: () => {
+            void handleDelete();
+          },
+          loading: saving,
+          disabled: saving,
+        }}
+      >
+        {deleteError ? <Note status={StatusType.Error} message={deleteError} fullWidth /> : null}
+      </WarningModal>
+    </>
+  );
+}

--- a/frontend/webapp/app/(v2)/url-templating/edit-group-templates-drawer.tsx
+++ b/frontend/webapp/app/(v2)/url-templating/edit-group-templates-drawer.tsx
@@ -1,0 +1,532 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import styled from 'styled-components';
+import { ActionIcon, TrashIcon } from '@odigos/ui-kit/icons';
+import type { Action } from '@odigos/ui-kit/types';
+import { StatusType } from '@odigos/ui-kit/types';
+import {
+  Badge,
+  Button,
+  ButtonSize,
+  ButtonVariants,
+  Drawer,
+  FlexColumn,
+  FlexRow,
+  IconButton,
+  IconButtonSize,
+  Input,
+  Note,
+  Tooltip,
+  Typography,
+  TypographyColor,
+  TypographySize,
+} from '@odigos/ui-kit/components';
+import { useApiMutation } from '@odigos/ui-kit/contexts';
+import { ActionOriginBadge, actionOriginTitleBadge } from './action-origin-badge';
+import { ScopeTokens } from './scope-tokens';
+import { TemplatePath } from './template-path';
+import { TemplatePathSimulator } from './template-path-simulator';
+import { buildUpdateActionWithGroupTemplates } from './action-group-templates-update';
+import { sortUrlTemplates } from './template-sort';
+import type { CustomTemplateCrGroup } from './url-templatization-aggregate';
+import { DrawerScrollEdgeHint, useCanScrollDown } from './drawer-scroll-edge-hint';
+
+const DrawerBody = styled(FlexColumn)`
+  width: 100%;
+  padding: 0 24px 8px;
+  gap: 16px;
+`;
+
+const MetaPanel = styled(FlexColumn)`
+  width: 100%;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 8px;
+  background: ${({ theme }) => theme.v2.colors.silver[900]};
+  border: 1px solid ${({ theme }) => theme.v2.colors.silver[700]};
+`;
+
+const TemplatesPanel = styled(FlexColumn)`
+  width: 100%;
+  gap: 2px;
+  padding: 12px 14px;
+  border-radius: 8px;
+  background: ${({ theme }) => theme.v2.colors.silver[900]};
+  border: 1px solid ${({ theme }) => theme.v2.colors.silver[700]};
+`;
+
+const DetailBlock = styled(FlexColumn)`
+  width: 100%;
+  gap: 8px;
+`;
+
+const TemplateRow = styled(FlexRow)`
+  width: 100%;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+`;
+
+const TemplateRowMain = styled(FlexRow)<{ $selectable?: boolean }>`
+  flex: 1;
+  min-width: 0;
+  align-items: center;
+  cursor: ${({ $selectable }) => ($selectable ? 'pointer' : 'default')};
+`;
+
+const TemplateEntry = styled(FlexColumn)<{ $selected?: boolean }>`
+  width: 100%;
+  gap: 0;
+  padding: ${({ $selected }) => ($selected ? '6px 8px 8px' : '2px 8px')};
+  margin: 0 -8px;
+  border-radius: 8px;
+  background: ${({ theme, $selected }) => ($selected ? theme.v2.colors.silver[800] : 'transparent')};
+  border: 1px solid
+    ${({ theme, $selected }) => ($selected ? theme.v2.colors.blue[400] : 'transparent')};
+  box-shadow: ${({ theme, $selected }) =>
+    $selected ? `inset 0 1px 0 color-mix(in srgb, ${theme.v2.colors.white[500]} 8%, transparent)` : 'none'};
+  transition: background 0.12s ease, border-color 0.12s ease;
+`;
+
+const SelectedSimulatorRegion = styled(FlexColumn)`
+  width: 100%;
+  gap: 8px;
+  margin-top: 10px;
+  padding: 10px 10px 8px;
+  border-radius: 6px;
+  background: color-mix(
+    in srgb,
+    ${({ theme }) => theme.v2.colors.black[500]} 40%,
+    ${({ theme }) => theme.v2.colors.silver[800]}
+  );
+  border: 1px solid ${({ theme }) => theme.v2.colors.silver[700]};
+`;
+
+const DrawerSaveFooter = styled(FlexColumn)`
+  width: 100%;
+  gap: 12px;
+  padding: 16px 24px;
+  box-sizing: border-box;
+  border-top: 1px solid ${({ theme }) => theme.v2.colors.silver[700]};
+  background: ${({ theme }) => theme.v2.colors.black[500]};
+`;
+
+const DrawerSaveFooterActions = styled(FlexRow)`
+  width: 100%;
+  justify-content: flex-end;
+  gap: 12px;
+  flex-shrink: 0;
+`;
+
+type DraftTemplateRow = {
+  key: string;
+  value: string;
+  isExisting: boolean;
+};
+
+let draftRowKeyCounter = 0;
+
+function nextDraftRowKey(): string {
+  draftRowKeyCounter += 1;
+  return `draft-row-${draftRowKeyCounter}`;
+}
+
+function draftRowsFromTemplates(templates: string[]): DraftTemplateRow[] {
+  return templates.map((value) => ({
+    key: nextDraftRowKey(),
+    value,
+    isExisting: true,
+  }));
+}
+
+function withTrailingEmptyRow(rows: DraftTemplateRow[]): DraftTemplateRow[] {
+  const copy = [...rows];
+  let trailingEmpty: DraftTemplateRow | null = null;
+  while (copy.length > 0) {
+    const last = copy[copy.length - 1];
+    if (!last.isExisting && !last.value.trim()) {
+      trailingEmpty = copy.pop() ?? null;
+    } else {
+      break;
+    }
+  }
+  // Keep row keys/order stable while typing so focus is not stolen by a remounted
+  // trailing empty input. Templates are sorted on save / initial load.
+  return [...copy, trailingEmpty ?? { key: nextDraftRowKey(), value: '', isExisting: false }];
+}
+
+function draftRowValues(rows: DraftTemplateRow[]): string[] {
+  return rows.map((row) => row.value);
+}
+
+function normalizedTemplateValues(rows: DraftTemplateRow[]): string[] {
+  return draftRowValues(rows)
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
+
+function isTrailingEmptyInputRow(rows: DraftTemplateRow[], index: number): boolean {
+  const row = rows[index];
+  if (!row || row.isExisting || row.value.trim()) {
+    return false;
+  }
+  return index === rows.length - 1;
+}
+
+type EditGroupTemplatesDrawerProps = {
+  group: CustomTemplateCrGroup | null;
+  action: Action | null;
+  focusNewTemplate?: boolean;
+  onClose: () => void;
+  onSaved: () => void;
+};
+
+function templatesEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return a.every((value, index) => value === b[index]);
+}
+
+function templateChangeCounts(
+  initial: string[],
+  draft: string[],
+): {
+  added: number;
+  removed: number;
+} {
+  const initialSet = new Set(initial);
+  const draftSet = new Set(draft);
+  let added = 0;
+  for (const template of draft) {
+    if (!initialSet.has(template)) {
+      added += 1;
+    }
+  }
+  let removed = 0;
+  for (const template of initial) {
+    if (!draftSet.has(template)) {
+      removed += 1;
+    }
+  }
+  return { added, removed };
+}
+
+function buildSaveWarningMessage(added: number, removed: number): string {
+  const changes: string[] = [];
+  if (added > 0) {
+    changes.push(added === 1 ? 'add 1 template' : `add ${added} templates`);
+  }
+  if (removed > 0) {
+    changes.push(removed === 1 ? 'remove 1 template' : `remove ${removed} templates`);
+  }
+  const summary = changes.join(' and ');
+  return `On save: ${summary} — takes effect in the cluster immediately.`;
+}
+
+export function EditGroupTemplatesDrawer({
+  group,
+  action,
+  focusNewTemplate = false,
+  onClose,
+  onSaved,
+}: EditGroupTemplatesDrawerProps) {
+  const [draftTemplates, setDraftTemplates] = useState<DraftTemplateRow[]>([]);
+  const [selectedRowKey, setSelectedRowKey] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const [updateAction, { loading: saving }] = useApiMutation('UPDATE_ACTION', {
+    refetchQueries: ['GetActions'],
+    awaitRefetchQueries: true,
+  });
+
+  useEffect(() => {
+    if (!group) {
+      setDraftTemplates([]);
+      setSelectedRowKey(null);
+      setSaveError(null);
+      return;
+    }
+    const rows = withTrailingEmptyRow(
+      group.templates.length ? draftRowsFromTemplates(sortUrlTemplates(group.templates)) : [],
+    );
+    setDraftTemplates(rows);
+    setSelectedRowKey(focusNewTemplate ? (rows[rows.length - 1]?.key ?? null) : null);
+    setSaveError(null);
+  }, [group, focusNewTemplate]);
+
+  useEffect(() => {
+    if (!group || !focusNewTemplate) {
+      return undefined;
+    }
+    const timer = window.setTimeout(() => {
+      const input = document.querySelector(
+        'input[name="url-templating-new-template"]',
+      ) as HTMLInputElement | null;
+      if (!input) {
+        return;
+      }
+      input.focus();
+      input.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    }, 120);
+    return () => window.clearTimeout(timer);
+  }, [group, focusNewTemplate]);
+
+  const initialTemplates = useMemo(() => {
+    if (!group) {
+      return [];
+    }
+    return group.templates.length ? sortUrlTemplates(group.templates) : [];
+  }, [group]);
+
+  const dirty = useMemo(() => {
+    const normalizedDraft = sortUrlTemplates(normalizedTemplateValues(draftTemplates));
+    return !templatesEqual(normalizedDraft, initialTemplates);
+  }, [draftTemplates, initialTemplates]);
+
+  const validationError = useMemo(() => {
+    const normalized = normalizedTemplateValues(draftTemplates);
+    const seen = new Set<string>();
+    for (const t of normalized) {
+      if (seen.has(t)) {
+        return 'Each template must be unique within this rule group.';
+      }
+      seen.add(t);
+    }
+    return null;
+  }, [draftTemplates]);
+
+  const canSave = dirty && !validationError && !saving && !!action && !!group;
+
+  const saveWarningMessage = useMemo(() => {
+    if (!dirty) {
+      return undefined;
+    }
+    const draft = sortUrlTemplates(normalizedTemplateValues(draftTemplates));
+    const { added, removed } = templateChangeCounts(initialTemplates, draft);
+    return buildSaveWarningMessage(added, removed);
+  }, [dirty, draftTemplates, initialTemplates]);
+
+  const footerNotice = useMemo(() => {
+    if (saveError) {
+      return {
+        status: StatusType.Error,
+        message: saveError,
+        fullWidth: true as const,
+      };
+    }
+    if (dirty && validationError) {
+      return {
+        status: StatusType.Warning,
+        message: validationError,
+        fullWidth: true as const,
+      };
+    }
+    if (saveWarningMessage) {
+      return {
+        status: StatusType.Warning,
+        message: saveWarningMessage,
+        fullWidth: true as const,
+      };
+    }
+    return undefined;
+  }, [dirty, saveError, saveWarningMessage, validationError]);
+
+  const updateRow = useCallback((index: number, value: string) => {
+    setDraftTemplates((rows) => withTrailingEmptyRow(rows.map((row, i) => (i === index ? { ...row, value } : row))));
+  }, []);
+
+  const removeRow = useCallback((index: number, rowKey: string) => {
+    setSelectedRowKey((current) => (current === rowKey ? null : current));
+    setDraftTemplates((rows) => withTrailingEmptyRow(rows.filter((_, i) => i !== index)));
+  }, []);
+
+  const handleSave = async () => {
+    if (!group || !action || !canSave) {
+      return;
+    }
+    setSaveError(null);
+    try {
+      const variables = buildUpdateActionWithGroupTemplates(
+        action,
+        group.groupIndex,
+        normalizedTemplateValues(draftTemplates),
+      );
+      const { error } = await updateAction(variables);
+      if (error) {
+        setSaveError(error.message || 'Failed to update templates');
+        return;
+      }
+      onSaved();
+      onClose();
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to update templates');
+    }
+  };
+
+  const headerBadges = group
+    ? [
+        actionOriginTitleBadge(group.actionUiGenerated),
+        ...(group.actionDisabled ? [{ label: 'Disabled' as const }] : []),
+      ]
+    : undefined;
+
+  const scrollAnchorRef = useRef<HTMLDivElement>(null);
+  const scrollRefreshKey = useMemo(
+    () =>
+      JSON.stringify({
+        templates: draftTemplates.map((row) => row.value),
+        selectedRowKey,
+        saveWarningMessage,
+        footerNotice,
+        saveError,
+      }),
+    [draftTemplates, footerNotice, saveError, saveWarningMessage, selectedRowKey, validationError],
+  );
+  const canScrollDown = useCanScrollDown(scrollAnchorRef, scrollRefreshKey);
+
+  return (
+    <Drawer
+      isOpen={!!group}
+      width="min(720px, 96vw)"
+      header={
+        group
+          ? {
+              icon: ActionIcon,
+              title: 'Edit rule group templates',
+              subTitle: group.actionLabel,
+              titleBadges: headerBadges,
+              onClose,
+            }
+          : undefined
+      }
+      footer={
+        group
+          ? {
+              children: (
+                <DrawerSaveFooter $gap={12}>
+                  {footerNotice ? <Note {...footerNotice} /> : null}
+                  <DrawerSaveFooterActions $gap={12}>
+                    <Button
+                      label="Cancel"
+                      variant={ButtonVariants.Secondary}
+                      size={ButtonSize.S}
+                      onClick={onClose}
+                      disabled={saving}
+                    />
+                    <Button
+                      label="Save"
+                      variant={ButtonVariants.Primary}
+                      size={ButtonSize.S}
+                      onClick={() => {
+                        void handleSave();
+                      }}
+                      disabled={!canSave}
+                      loading={saving}
+                    />
+                  </DrawerSaveFooterActions>
+                </DrawerSaveFooter>
+              ),
+            }
+          : undefined
+      }
+    >
+      {group ? (
+        <DrawerBody $gap={16}>
+          <MetaPanel $gap={12}>
+            <DetailBlock $gap={8}>
+              <Typography size={TypographySize.XXS} color={TypographyColor.Secondary}>
+                Action
+              </Typography>
+              <FlexRow $gap={8} $alignItems="center" style={{ flexWrap: 'wrap' }}>
+                <Typography size={TypographySize.XS}>
+                  {group.actionDisplayName?.trim() || group.actionLabel}
+                </Typography>
+                <ActionOriginBadge uiGenerated={group.actionUiGenerated} />
+                {group.actionDisabled ? <Badge label="Disabled" /> : null}
+              </FlexRow>
+            </DetailBlock>
+
+            <DetailBlock $gap={8}>
+              <Tooltip text="Scope cannot be changed after a rule group is created." inline>
+                <Typography size={TypographySize.XXS} color={TypographyColor.Secondary}>
+                  Scope
+                </Typography>
+              </Tooltip>
+              <ScopeTokens tokens={group.scopeTokens} />
+              <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+                Group {group.groupIndex + 1}
+                {group.groupNotes?.trim() ? ` · ${group.groupNotes.trim()}` : ''}
+              </Typography>
+            </DetailBlock>
+          </MetaPanel>
+
+          <TemplatesPanel $gap={2}>
+            <Typography size={TypographySize.XXS} color={TypographyColor.Secondary}>
+              Templates
+            </Typography>
+
+            {draftTemplates.map((row, index) => {
+              const trailingEmpty = isTrailingEmptyInputRow(draftTemplates, index);
+              const selected = selectedRowKey === row.key;
+              const templateForSimulator = row.value.trim();
+
+              return (
+                <TemplateEntry key={row.key} $gap={0} $selected={selected && !!templateForSimulator}>
+                  <TemplateRow $gap={8}>
+                    <TemplateRowMain
+                      $gap={8}
+                      $selectable={!!templateForSimulator}
+                      onClick={
+                        templateForSimulator
+                          ? () => setSelectedRowKey(row.key)
+                          : undefined
+                      }
+                    >
+                      {row.isExisting ? (
+                        <TemplatePath template={row.value} disabled={group.actionDisabled} />
+                      ) : (
+                        <Input
+                          data-id={`url-templating-group-template-${index}`}
+                          name={trailingEmpty ? 'url-templating-new-template' : `url-templating-group-template-${index}`}
+                          value={row.value}
+                          onChange={(event) => updateRow(index, event.target.value)}
+                          onFocus={() => setSelectedRowKey(row.key)}
+                          placeholder="/api/users/{id}"
+                          width="100%"
+                          disabled={saving}
+                        />
+                      )}
+                    </TemplateRowMain>
+                    {trailingEmpty ? null : (
+                      <IconButton
+                        data-id={`url-templating-group-template-remove-${index}`}
+                        icon={TrashIcon}
+                        size={IconButtonSize.XS}
+                        onClick={() => removeRow(index, row.key)}
+                        disabled={saving}
+                      />
+                    )}
+                  </TemplateRow>
+                  {selected && templateForSimulator ? (
+                    <SelectedSimulatorRegion $gap={8}>
+                      <TemplatePathSimulator
+                        template={templateForSimulator}
+                        actionDisabled={group.actionDisabled}
+                        embedded
+                      />
+                    </SelectedSimulatorRegion>
+                  ) : null}
+                </TemplateEntry>
+              );
+            })}
+          </TemplatesPanel>
+
+          <div ref={scrollAnchorRef} aria-hidden style={{ width: '100%', height: 1 }} />
+          <DrawerScrollEdgeHint visible={canScrollDown} />
+        </DrawerBody>
+      ) : null}
+    </Drawer>
+  );
+}

--- a/frontend/webapp/app/(v2)/url-templating/new-custom-template-drawer.tsx
+++ b/frontend/webapp/app/(v2)/url-templating/new-custom-template-drawer.tsx
@@ -1,0 +1,489 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import styled from 'styled-components';
+import { ActionIcon, PlusIcon } from '@odigos/ui-kit/icons';
+import type { Action } from '@odigos/ui-kit/types';
+import { ActionType, SignalType, StatusType } from '@odigos/ui-kit/types';
+import {
+  Badge,
+  Button,
+  ButtonSize,
+  ButtonVariants,
+  Drawer,
+  DropDown,
+  FlexColumn,
+  FlexRow,
+  Input,
+  Note,
+  RadioCard,
+  Search,
+  Typography,
+  TypographyColor,
+  TypographySize,
+} from '@odigos/ui-kit/components';
+import { useApiMutation } from '@odigos/ui-kit/contexts';
+import { ActionOriginBadge, actionOriginLabel, isActionUiGenerated } from './action-origin-badge';
+import { ScopeTokens } from './scope-tokens';
+import type { CustomTemplateCrGroup } from './url-templatization-aggregate';
+import {
+  UI_TEMPLATE_RULES_ACTION_NAME,
+  customTemplateGroupSearchText,
+  findEntireClusterGroupForAction,
+  findUiTemplateRulesAction,
+} from './ui-template-rules';
+
+const DrawerBody = styled(FlexColumn)`
+  width: 100%;
+  padding: 0 24px 8px;
+  gap: 16px;
+`;
+
+const DrawerSaveFooter = styled(FlexColumn)`
+  width: 100%;
+  gap: 12px;
+  padding: 16px 24px;
+  box-sizing: border-box;
+  border-top: 1px solid ${({ theme }) => theme.v2.colors.silver[700]};
+  background: ${({ theme }) => theme.v2.colors.black[500]};
+`;
+
+const DrawerSaveFooterActions = styled(FlexRow)`
+  width: 100%;
+  justify-content: flex-end;
+  gap: 12px;
+  flex-shrink: 0;
+`;
+
+const OptionsColumn = styled(FlexColumn)`
+  width: 100%;
+  gap: 10px;
+`;
+
+const DetailPanel = styled(FlexColumn)`
+  width: 100%;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 8px;
+  background: ${({ theme }) => theme.v2.colors.silver[900]};
+  border: 1px solid ${({ theme }) => theme.v2.colors.silver[700]};
+`;
+
+const GroupOption = styled.button<{ $selected?: boolean }>`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+  text-align: left;
+  padding: 10px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  border: 1px solid
+    ${({ theme, $selected }) => ($selected ? theme.v2.colors.blue[400] : theme.v2.colors.silver[700])};
+  background: ${({ theme, $selected }) =>
+    $selected ? theme.v2.colors.silver[800] : theme.v2.colors.silver[900]};
+  color: inherit;
+  font: inherit;
+
+  &:hover {
+    background: ${({ theme }) => theme.v2.colors.silver[800]};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.v2.colors.blue[400]};
+    outline-offset: 2px;
+  }
+`;
+
+const GroupList = styled(FlexColumn)`
+  width: 100%;
+  gap: 8px;
+  max-height: 320px;
+  overflow-y: auto;
+`;
+
+const UI_TEMPLATE_RULES_OPTION_ID = '__ui_template_rules__';
+const NEW_ACTION_OPTION_ID = '__new_action__';
+
+export type NewCustomTemplatePath = 'existing' | 'new_group' | 'entire_cluster';
+
+export type NewCustomTemplateTarget =
+  | { kind: 'edit_group'; group: CustomTemplateCrGroup }
+  | { kind: 'create_group'; action: Action; lockEntireClusterScope?: boolean };
+
+type NewCustomTemplateDrawerProps = {
+  isOpen: boolean;
+  actions: Action[];
+  groups: CustomTemplateCrGroup[];
+  onClose: () => void;
+  onContinue: (target: NewCustomTemplateTarget) => void;
+};
+
+export function NewCustomTemplateDrawer({
+  isOpen,
+  actions,
+  groups,
+  onClose,
+  onContinue,
+}: NewCustomTemplateDrawerProps) {
+  const [path, setPath] = useState<NewCustomTemplatePath>('existing');
+  const [groupQuery, setGroupQuery] = useState('');
+  const [selectedGroupKey, setSelectedGroupKey] = useState<string | null>(null);
+  const [selectedActionId, setSelectedActionId] = useState(UI_TEMPLATE_RULES_OPTION_ID);
+  const [newActionName, setNewActionName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const [createAction, { loading: creatingAction }] = useApiMutation('CREATE_ACTION', {
+    refetchQueries: ['GetActions'],
+    awaitRefetchQueries: true,
+  });
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    setPath('existing');
+    setGroupQuery('');
+    setSelectedGroupKey(null);
+    setNewActionName('');
+    setError(null);
+    const uiAction = findUiTemplateRulesAction(actions);
+    setSelectedActionId(uiAction?.id ?? UI_TEMPLATE_RULES_OPTION_ID);
+  }, [isOpen, actions]);
+
+  const filteredGroups = useMemo(() => {
+    const query = groupQuery.trim().toLowerCase();
+    const sorted = [...groups].sort((a, b) => {
+      const actionCmp = a.actionLabel.localeCompare(b.actionLabel);
+      if (actionCmp !== 0) {
+        return actionCmp;
+      }
+      return a.groupIndex - b.groupIndex;
+    });
+    if (!query) {
+      return sorted;
+    }
+    return sorted.filter((group) => customTemplateGroupSearchText(group).includes(query));
+  }, [groupQuery, groups]);
+
+  const selectedGroup = useMemo(() => {
+    if (!selectedGroupKey) {
+      return null;
+    }
+    return groups.find((group) => groupKey(group) === selectedGroupKey) ?? null;
+  }, [groups, selectedGroupKey]);
+
+  const creatingNewAction = selectedActionId === NEW_ACTION_OPTION_ID;
+
+  const actionOptions = useMemo(() => {
+    const uiAction = findUiTemplateRulesAction(actions);
+    const options = actions.map((action) => ({
+      id: action.id,
+      label: action.name?.trim() || action.id,
+      badge: action.disabled ? 'Disabled' : actionOriginLabel(isActionUiGenerated(action)),
+    }));
+    if (!uiAction) {
+      options.unshift({
+        id: UI_TEMPLATE_RULES_OPTION_ID,
+        label: UI_TEMPLATE_RULES_ACTION_NAME,
+        badge: 'Create',
+      });
+    }
+    options.push({
+      id: NEW_ACTION_OPTION_ID,
+      label: 'Create new action…',
+      badge: 'New',
+    });
+    return options;
+  }, [actions]);
+
+  const createUrlTemplatizationAction = async (name: string, notes?: string): Promise<Action> => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      throw new Error('Enter a name for the new action.');
+    }
+    const { data, error: createError } = await createAction({
+      action: {
+        type: ActionType.URLTemplatization,
+        name: trimmed,
+        notes: notes ?? null,
+        disabled: false,
+        signals: [SignalType.Traces],
+        fields: {
+          urlTemplatizationRulesGroups: [],
+        },
+      },
+    });
+    if (createError) {
+      throw new Error(createError.message || `Failed to create action "${trimmed}"`);
+    }
+    const created = data?.createAction;
+    if (!created) {
+      throw new Error(`Failed to create action "${trimmed}"`);
+    }
+    return created;
+  };
+
+  const ensureUiTemplateRulesAction = async (): Promise<Action> => {
+    const existing = findUiTemplateRulesAction(actions);
+    if (existing) {
+      return existing;
+    }
+    return createUrlTemplatizationAction(
+      UI_TEMPLATE_RULES_ACTION_NAME,
+      'Default action for URL templates created from the Odigos UI.',
+    );
+  };
+
+  const resolveSelectedAction = async (): Promise<Action> => {
+    if (selectedActionId === UI_TEMPLATE_RULES_OPTION_ID) {
+      return ensureUiTemplateRulesAction();
+    }
+    if (selectedActionId === NEW_ACTION_OPTION_ID) {
+      return createUrlTemplatizationAction(newActionName);
+    }
+    const action = actions.find((candidate) => candidate.id === selectedActionId);
+    if (!action) {
+      throw new Error('Selected action was not found.');
+    }
+    return action;
+  };
+
+  const canContinue = useMemo(() => {
+    if (creatingAction) {
+      return false;
+    }
+    if (path === 'existing') {
+      return !!selectedGroup;
+    }
+    if (path === 'new_group') {
+      if (creatingNewAction) {
+        return !!newActionName.trim();
+      }
+      return !!selectedActionId;
+    }
+    return true;
+  }, [creatingAction, creatingNewAction, newActionName, path, selectedActionId, selectedGroup]);
+
+  const handleContinue = async () => {
+    if (!canContinue) {
+      return;
+    }
+    setError(null);
+    try {
+      if (path === 'existing') {
+        if (!selectedGroup) {
+          return;
+        }
+        onContinue({ kind: 'edit_group', group: selectedGroup });
+        onClose();
+        return;
+      }
+
+      if (path === 'new_group') {
+        const action = await resolveSelectedAction();
+        onContinue({ kind: 'create_group', action });
+        onClose();
+        return;
+      }
+
+      const action = await ensureUiTemplateRulesAction();
+      const existingClusterGroup = findEntireClusterGroupForAction(groups, action.id);
+      if (existingClusterGroup) {
+        onContinue({ kind: 'edit_group', group: existingClusterGroup });
+      } else {
+        onContinue({ kind: 'create_group', action, lockEntireClusterScope: true });
+      }
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to continue');
+    }
+  };
+
+  return (
+    <Drawer
+      isOpen={isOpen}
+      width="min(640px, 96vw)"
+      header={{
+        icon: PlusIcon,
+        title: 'New custom template',
+        subTitle: 'Choose where to add the template',
+        onClose,
+      }}
+      footer={{
+        children: (
+          <DrawerSaveFooter $gap={12}>
+            {error ? <Note status={StatusType.Error} message={error} fullWidth /> : null}
+            <DrawerSaveFooterActions $gap={12}>
+              <Button
+                label="Cancel"
+                variant={ButtonVariants.Secondary}
+                size={ButtonSize.S}
+                onClick={onClose}
+                disabled={creatingAction}
+              />
+              <Button
+                label="Continue"
+                variant={ButtonVariants.Primary}
+                size={ButtonSize.S}
+                onClick={() => {
+                  void handleContinue();
+                }}
+                disabled={!canContinue}
+                loading={creatingAction}
+              />
+            </DrawerSaveFooterActions>
+          </DrawerSaveFooter>
+        ),
+      }}
+    >
+      <DrawerBody $gap={16}>
+        <OptionsColumn $gap={10}>
+          <RadioCard
+            data-id="url-templating-new-template-existing"
+            title="Add to existing group"
+            description="Recommended — reuse a scoped group to keep matching cheaper and reduce template fan-out."
+            checked={path === 'existing'}
+            onChange={(checked) => {
+              if (checked) {
+                setPath('existing');
+              }
+            }}
+          />
+          <RadioCard
+            data-id="url-templating-new-template-new-group"
+            title="Create a new group with specific scope"
+            description={`Choose an action (defaults to "${UI_TEMPLATE_RULES_ACTION_NAME}"), then set namespace / workload / language scope.`}
+            checked={path === 'new_group'}
+            onChange={(checked) => {
+              if (checked) {
+                setPath('new_group');
+              }
+            }}
+          />
+          <RadioCard
+            data-id="url-templating-new-template-entire-cluster"
+            title="Add to entire cluster"
+            description={`Great for evaluation and quick velocity — apply templates cluster-wide in "${UI_TEMPLATE_RULES_ACTION_NAME}".`}
+            checked={path === 'entire_cluster'}
+            onChange={(checked) => {
+              if (checked) {
+                setPath('entire_cluster');
+              }
+            }}
+            footerNote={
+              path === 'entire_cluster' ? (
+                <Note
+                  status={StatusType.Info}
+                  message="Ideal when you want to try templates quickly across the cluster before narrowing scope."
+                  fullWidth
+                  smallIcon
+                />
+              ) : undefined
+            }
+          />
+        </OptionsColumn>
+
+        {path === 'existing' ? (
+          <DetailPanel $gap={12}>
+            <Typography size={TypographySize.XXS} color={TypographyColor.Secondary}>
+              Existing groups
+            </Typography>
+            <Search
+              data-id="url-templating-new-template-group-search"
+              value={groupQuery}
+              onChange={setGroupQuery}
+              placeholder="Search by scope, action, or template…"
+              width="100%"
+            />
+            {filteredGroups.length === 0 ? (
+              <Typography size={TypographySize.XXS} color={TypographyColor.Secondary}>
+                {groups.length === 0
+                  ? 'No rule groups yet. Create a new scoped group instead.'
+                  : `No groups match "${groupQuery.trim()}".`}
+              </Typography>
+            ) : (
+              <GroupList $gap={8}>
+                {filteredGroups.map((group) => {
+                  const key = groupKey(group);
+                  const selected = selectedGroupKey === key;
+                  return (
+                    <GroupOption
+                      key={key}
+                      type="button"
+                      $selected={selected}
+                      onClick={() => setSelectedGroupKey(key)}
+                    >
+                      <FlexRow $gap={8} $alignItems="center" style={{ flexWrap: 'wrap' }}>
+                        <Typography size={TypographySize.XS}>{group.actionLabel}</Typography>
+                        <ActionOriginBadge uiGenerated={group.actionUiGenerated} />
+                        {group.actionDisabled ? <Badge label="Disabled" /> : null}
+                        <Badge label={`${group.templates.length} templates`} />
+                      </FlexRow>
+                      <ScopeTokens tokens={group.scopeTokens} />
+                    </GroupOption>
+                  );
+                })}
+              </GroupList>
+            )}
+          </DetailPanel>
+        ) : null}
+
+        {path === 'new_group' ? (
+          <DetailPanel $gap={12}>
+            <Typography size={TypographySize.XXS} color={TypographyColor.Secondary}>
+              Action
+            </Typography>
+            <DropDown
+              data-id="url-templating-new-template-action"
+              label="URL templatization action"
+              options={actionOptions}
+              values={selectedActionId ? [selectedActionId] : []}
+              setValues={(values) => {
+                const next = values[0] ?? UI_TEMPLATE_RULES_OPTION_ID;
+                setSelectedActionId(next);
+                if (next !== NEW_ACTION_OPTION_ID) {
+                  setNewActionName('');
+                }
+              }}
+              placeholder="Select action"
+              width="100%"
+            />
+            {creatingNewAction ? (
+              <Input
+                data-id="url-templating-new-template-action-name"
+                name="url-templating-new-template-action-name"
+                label="New action name"
+                value={newActionName}
+                onChange={(event) => setNewActionName(event.target.value)}
+                placeholder="e.g. Checkout service URL templates"
+                width="100%"
+                disabled={creatingAction}
+              />
+            ) : null}
+            <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+              {`Defaults to "${UI_TEMPLATE_RULES_ACTION_NAME}". Actions can help keep templating rules organized, but they are optional — advanced users can create a separate action when useful.`}
+            </Typography>
+          </DetailPanel>
+        ) : null}
+
+        {path === 'entire_cluster' ? (
+          <DetailPanel $gap={8}>
+            <FlexRow $gap={8} $alignItems="center">
+              <ActionIcon size={16} />
+              <Typography size={TypographySize.XS}>{UI_TEMPLATE_RULES_ACTION_NAME}</Typography>
+            </FlexRow>
+            <ScopeTokens tokens={[{ type: 'entire_cluster' }]} />
+            <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+              Continues in the edit drawer if an entire-cluster group already exists, otherwise creates one.
+            </Typography>
+          </DetailPanel>
+        ) : null}
+      </DrawerBody>
+    </Drawer>
+  );
+}
+
+function groupKey(group: CustomTemplateCrGroup): string {
+  return `${group.actionId}:${group.groupIndex}`;
+}

--- a/frontend/webapp/app/(v2)/url-templating/page.tsx
+++ b/frontend/webapp/app/(v2)/url-templating/page.tsx
@@ -4,8 +4,8 @@ import React, { useMemo, useState, useCallback, type PropsWithChildren } from 'r
 import styled from 'styled-components';
 import { ActionIcon } from '@odigos/ui-kit/icons';
 import { RichTitle } from '@odigos/ui-kit/snippets';
-import { useApiQuery } from '@odigos/ui-kit/contexts';
-import { StatusType } from '@odigos/ui-kit/types';
+import { useApiMutation, useApiQuery } from '@odigos/ui-kit/contexts';
+import { ActionType, SignalType, StatusType } from '@odigos/ui-kit/types';
 import type { Action } from '@odigos/ui-kit/types';
 import {
   Button,
@@ -22,13 +22,17 @@ import {
   Segment,
   SegmentSize,
   SegmentVariant,
+  StatusCard,
   Typography,
   TypographyColor,
   TypographySize,
+  WarningModal,
 } from '@odigos/ui-kit/components';
 import { CustomTemplateCrGroupsView, CustomTemplateListView, CustomTemplateTreeView } from './custom-templates-view';
 import { CreateGroupTemplatesDrawer } from './create-group-templates-drawer';
 import { DefaultTemplatizationCrGroupsView } from './default-templatization-view';
+import { DefaultTemplatizationDetailDrawer } from './default-templatization-detail-drawer';
+import { EditDefaultTemplatizationDrawer } from './edit-default-templatization-drawer';
 import { EditGroupTemplatesDrawer } from './edit-group-templates-drawer';
 import { NewCustomTemplateDrawer, type NewCustomTemplateTarget } from './new-custom-template-drawer';
 import { SectionHelpButton } from './section-help-button';
@@ -42,7 +46,13 @@ import {
   isUrlTemplatizationAction,
   scopeTokensSortKey,
   type CustomTemplateCrGroup,
+  type DefaultTemplatizationCrGroup,
 } from './url-templatization-aggregate';
+import {
+  buildUpdateActionReenablingClusterWideDefaults,
+  buildUpdateActionWithAppendedDefaultGroup,
+} from './action-default-group-update';
+import { findUiTemplateRulesAction, UI_TEMPLATE_RULES_ACTION_NAME } from './ui-template-rules';
 import { useConfig } from '@/hooks';
 
 const PageRoot = styled(FlexColumn)`
@@ -95,7 +105,114 @@ const CustomTemplatesSearchWrap = styled.div`
   min-width: 200px;
 `;
 
+const StatusActions = styled(FlexRow)`
+  width: 100%;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+`;
+
+const StatusBannerWrap = styled.div`
+  flex: 0 0 auto;
+  width: 100%;
+  align-self: stretch;
+
+  /* StatusCard uses flex: 1; keep the page banner content-sized. */
+  & > * {
+    flex: 0 0 auto;
+  }
+`;
+
+const StatusPanel = styled(FlexColumn)<{ $status: StatusType }>`
+  flex: 0 0 auto;
+  width: 100%;
+  gap: 12px;
+  padding: 16px 18px;
+  border-radius: 12px;
+  border: 1px solid
+    ${({ theme, $status }) => {
+      if ($status === StatusType.Warning) {
+        return theme.v2.colors.yellow[600];
+      }
+      if ($status === StatusType.Success) {
+        return theme.v2.colors.green[600];
+      }
+      if ($status === StatusType.Info) {
+        return theme.v2.colors.blue[500];
+      }
+      return theme.v2.colors.silver[600];
+    }};
+  background: ${({ theme, $status }) => {
+    if ($status === StatusType.Warning) {
+      return `color-mix(in srgb, ${theme.v2.colors.yellow[600]} 10%, ${theme.v2.colors.silver[900]})`;
+    }
+    if ($status === StatusType.Success) {
+      return `color-mix(in srgb, ${theme.v2.colors.green[600]} 10%, ${theme.v2.colors.silver[900]})`;
+    }
+    if ($status === StatusType.Info) {
+      return `color-mix(in srgb, ${theme.v2.colors.blue[500]} 10%, ${theme.v2.colors.silver[900]})`;
+    }
+    return theme.v2.colors.silver[900];
+  }};
+`;
+
 export type CustomTemplateViewMode = 'list' | 'tree' | 'action';
+
+const ENABLE_CLUSTER_DEFAULT_WARNING =
+  'Default heuristic templating works for most URLs, but not always. Enabling it for the entire cluster can increase cardinality when unusual paths are templatized incorrectly.';
+
+function TemplatingStatusBanner({
+  status,
+  title,
+  description,
+  action,
+}: {
+  status: StatusType;
+  title: string;
+  description: string;
+  action?: React.ReactNode;
+}) {
+  if (!action) {
+    return (
+      <StatusBannerWrap>
+        <StatusCard status={status} title={title} description={description} />
+      </StatusBannerWrap>
+    );
+  }
+
+  return (
+    <StatusPanel $status={status} $gap={12}>
+      <FlexColumn $gap={4}>
+        <Typography size={TypographySize.XS}>{title}</Typography>
+        <Typography size={TypographySize.XXS} color={TypographyColor.Secondary}>
+          {description}
+        </Typography>
+      </FlexColumn>
+      <StatusActions $gap={12}>{action}</StatusActions>
+    </StatusPanel>
+  );
+}
+
+function pageSummaryStatus(
+  effect: { mode: string; disabledClusterWide: boolean },
+  enabledCustomRuleCount: number,
+  enabledActionCount: number,
+): StatusType {
+  if (enabledActionCount === 0) {
+    return StatusType.Disabled;
+  }
+  const defaultIsOff = effect.disabledClusterWide || effect.mode === 'none';
+  if (defaultIsOff && enabledCustomRuleCount === 0) {
+    return StatusType.Disabled;
+  }
+  if (defaultIsOff) {
+    return StatusType.Warning;
+  }
+  if (effect.mode === 'scoped') {
+    return StatusType.Info;
+  }
+  return StatusType.Success;
+}
 
 function PageShell({
   children,
@@ -127,11 +244,26 @@ export default function UrlTemplatingPage() {
   const [customTemplateQuery, setCustomTemplateQuery] = useState('');
   const [customTemplateView, setCustomTemplateView] = useState<CustomTemplateViewMode>('action');
   const [selectedTemplateDetail, setSelectedTemplateDetail] = useState<UrlTemplateDetail | null>(null);
+  const [selectedDefaultGroup, setSelectedDefaultGroup] = useState<DefaultTemplatizationCrGroup | null>(null);
+  const [editDefaultGroup, setEditDefaultGroup] = useState<DefaultTemplatizationCrGroup | null>(null);
+  const [createDefaultAction, setCreateDefaultAction] = useState<Action | null>(null);
   const [editTemplatesGroup, setEditTemplatesGroup] = useState<CustomTemplateCrGroup | null>(null);
   const [editFocusNewTemplate, setEditFocusNewTemplate] = useState(false);
   const [createGroupAction, setCreateGroupAction] = useState<Action | null>(null);
   const [createLockEntireClusterScope, setCreateLockEntireClusterScope] = useState(false);
   const [newTemplateOpen, setNewTemplateOpen] = useState(false);
+  const [confirmEnableClusterDefaultOpen, setConfirmEnableClusterDefaultOpen] = useState(false);
+  const [enableClusterDefaultError, setEnableClusterDefaultError] = useState<string | null>(null);
+
+  const [createAction, { loading: creatingAction }] = useApiMutation('CREATE_ACTION', {
+    refetchQueries: ['GetActions'],
+    awaitRefetchQueries: true,
+  });
+  const [updateAction, { loading: updatingAction }] = useApiMutation('UPDATE_ACTION', {
+    refetchQueries: ['GetActions'],
+    awaitRefetchQueries: true,
+  });
+  const enablingClusterDefault = creatingAction || updatingAction;
 
   const urlTemplatizationActions = useMemo(() => {
     const actions = data?.computePlatform?.actions ?? [];
@@ -140,6 +272,10 @@ export default function UrlTemplatingPage() {
 
   const aggregation = useMemo(() => aggregateUrlTemplatization(urlTemplatizationActions), [urlTemplatizationActions]);
 
+  const defaultTemplatizationOff =
+    aggregation.enabledActionCount === 0 ||
+    aggregation.clusterDefaultEffect.mode === 'none' ||
+    aggregation.clusterDefaultEffect.disabledClusterWide;
   const filteredCustomTemplates = useMemo(() => {
     const query = customTemplateQuery.trim().toLowerCase();
     if (!query) {
@@ -171,6 +307,47 @@ export default function UrlTemplatingPage() {
     }
     return urlTemplatizationActions.find((action) => action.id === selectedTemplateDetail.actionId) ?? null;
   }, [selectedTemplateDetail, urlTemplatizationActions]);
+
+  const selectedDefaultAction = useMemo(() => {
+    if (createDefaultAction) {
+      return createDefaultAction;
+    }
+    const group = editDefaultGroup ?? selectedDefaultGroup;
+    if (!group) {
+      return null;
+    }
+    return urlTemplatizationActions.find((action) => action.id === group.actionId) ?? null;
+  }, [createDefaultAction, editDefaultGroup, selectedDefaultGroup, urlTemplatizationActions]);
+
+  const handleOpenCreateDefaultRule = useCallback(async () => {
+    const enabledActions = urlTemplatizationActions.filter((action) => !action.disabled);
+    let target = findUiTemplateRulesAction(enabledActions) ?? enabledActions[0] ?? null;
+    if (!target) {
+      const { data: created, error: createError } = await createAction({
+        action: {
+          type: ActionType.URLTemplatization,
+          name: UI_TEMPLATE_RULES_ACTION_NAME,
+          notes: 'Default action for URL templates created from the Odigos UI.',
+          disabled: false,
+          signals: [SignalType.Traces],
+          fields: {
+            urlTemplatizationRulesGroups: [],
+            urlTemplatizationDefaultGroups: [],
+          },
+        },
+      });
+      if (createError) {
+        return;
+      }
+      if (!created?.createAction) {
+        return;
+      }
+      target = created.createAction;
+      void refetch();
+    }
+    setEditDefaultGroup(null);
+    setCreateDefaultAction(target);
+  }, [createAction, refetch, urlTemplatizationActions]);
 
   const drawerActionRuleGroups = useMemo(() => {
     if (!selectedTemplateDetail) {
@@ -228,6 +405,122 @@ export default function UrlTemplatingPage() {
     [handleEditGroupTemplates],
   );
 
+  const handleEnableClusterWideDefault = useCallback(async () => {
+    setEnableClusterDefaultError(null);
+    try {
+      const enabledActions = urlTemplatizationActions.filter((action) => !action.disabled);
+      let reenabledAny = false;
+      for (const action of enabledActions) {
+        const variables = buildUpdateActionReenablingClusterWideDefaults(action);
+        if (!variables) {
+          continue;
+        }
+        const { error: updateError } = await updateAction(variables);
+        if (updateError) {
+          throw new Error(updateError.message || 'Failed to enable default templating');
+        }
+        reenabledAny = true;
+      }
+      if (reenabledAny) {
+        setConfirmEnableClusterDefaultOpen(false);
+        void refetch();
+        return;
+      }
+
+      let target = findUiTemplateRulesAction(enabledActions) ?? enabledActions[0];
+      if (!target) {
+        const { data: created, error: createError } = await createAction({
+          action: {
+            type: ActionType.URLTemplatization,
+            name: UI_TEMPLATE_RULES_ACTION_NAME,
+            notes: 'Default action for URL templates created from the Odigos UI.',
+            disabled: false,
+            signals: [SignalType.Traces],
+            fields: {
+              urlTemplatizationRulesGroups: [],
+              urlTemplatizationDefaultGroups: [
+                {
+                  scopes: null,
+                  disabled: false,
+                  skipPolicy: null,
+                },
+              ],
+            },
+          },
+        });
+        if (createError) {
+          throw new Error(createError.message || 'Failed to enable default templating');
+        }
+        if (!created?.createAction) {
+          throw new Error('Failed to enable default templating');
+        }
+        setConfirmEnableClusterDefaultOpen(false);
+        void refetch();
+        return;
+      }
+
+      const { error: updateError } = await updateAction(buildUpdateActionWithAppendedDefaultGroup(target));
+      if (updateError) {
+        throw new Error(updateError.message || 'Failed to enable default templating');
+      }
+      setConfirmEnableClusterDefaultOpen(false);
+      void refetch();
+    } catch (err) {
+      setEnableClusterDefaultError(
+        err instanceof Error ? err.message : 'Failed to enable default templating',
+      );
+    }
+  }, [createAction, refetch, updateAction, urlTemplatizationActions]);
+
+  const enableClusterDefaultButton =
+    isReadonly || !defaultTemplatizationOff ? null : (
+      <Button
+        data-id="url-templating-enable-cluster-default"
+        label="Enable default templating for entire cluster"
+        variant={ButtonVariants.Primary}
+        size={ButtonSize.S}
+        onClick={() => {
+          setEnableClusterDefaultError(null);
+          setConfirmEnableClusterDefaultOpen(true);
+        }}
+        disabled={enablingClusterDefault}
+      />
+    );
+
+  const enableClusterDefaultModal = (
+    <WarningModal
+      isOpen={confirmEnableClusterDefaultOpen}
+      title="Enable default templating cluster-wide?"
+      description={ENABLE_CLUSTER_DEFAULT_WARNING}
+      onClose={() => {
+        if (!enablingClusterDefault) {
+          setConfirmEnableClusterDefaultOpen(false);
+          setEnableClusterDefaultError(null);
+        }
+      }}
+      denyButton={{
+        label: 'Cancel',
+        onClick: () => {
+          setConfirmEnableClusterDefaultOpen(false);
+          setEnableClusterDefaultError(null);
+        },
+        disabled: enablingClusterDefault,
+      }}
+      approveButton={{
+        label: 'Enable for entire cluster',
+        onClick: () => {
+          void handleEnableClusterWideDefault();
+        },
+        loading: enablingClusterDefault,
+        disabled: enablingClusterDefault,
+      }}
+    >
+      {enableClusterDefaultError ? (
+        <Note status={StatusType.Error} message={enableClusterDefaultError} fullWidth />
+      ) : null}
+    </WarningModal>
+  );
+
   const filteredCustomTemplateCrGroups = useMemo(() => {
     const query = customTemplateQuery.trim().toLowerCase();
     if (!query) {
@@ -255,6 +548,19 @@ export default function UrlTemplatingPage() {
       variant={ButtonVariants.Primary}
       size={ButtonSize.S}
       onClick={() => setNewTemplateOpen(true)}
+    />
+  );
+
+  const newDefaultRuleButton = isReadonly ? null : (
+    <Button
+      data-id="url-templating-new-default-rule"
+      label="+ New default rule"
+      variant={ButtonVariants.Primary}
+      size={ButtonSize.S}
+      onClick={() => {
+        void handleOpenCreateDefaultRule();
+      }}
+      disabled={enablingClusterDefault}
     />
   );
 
@@ -288,6 +594,38 @@ export default function UrlTemplatingPage() {
               }
         }
         onClose={() => setSelectedTemplateDetail(null)}
+      />
+      <DefaultTemplatizationDetailDrawer
+        group={selectedDefaultGroup}
+        action={isReadonly ? null : selectedDefaultAction}
+        onEdit={
+          isReadonly
+            ? undefined
+            : (group) => {
+                setSelectedDefaultGroup(null);
+                setEditDefaultGroup(group);
+              }
+        }
+        onDeleted={
+          isReadonly
+            ? undefined
+            : () => {
+                void refetch();
+              }
+        }
+        onClose={() => setSelectedDefaultGroup(null)}
+      />
+      <EditDefaultTemplatizationDrawer
+        group={editDefaultGroup}
+        action={isReadonly ? null : selectedDefaultAction}
+        creating={!!createDefaultAction && !editDefaultGroup}
+        onClose={() => {
+          setEditDefaultGroup(null);
+          setCreateDefaultAction(null);
+        }}
+        onSaved={() => {
+          void refetch();
+        }}
       />
       <EditGroupTemplatesDrawer
         group={editTemplatesGroup}
@@ -344,6 +682,12 @@ export default function UrlTemplatingPage() {
   if (!urlTemplatizationActions.length) {
     return (
       <PageShell headerAction={newTemplateButton}>
+        <TemplatingStatusBanner
+          status={StatusType.Disabled}
+          title="URL templating is OFF"
+          description="No URL templatization actions are configured in this cluster."
+          action={enableClusterDefaultButton}
+        />
         <CenterThis>
           <NoData
             icon={ActionIcon}
@@ -352,16 +696,27 @@ export default function UrlTemplatingPage() {
           />
         </CenterThis>
         {sharedDrawers}
+        {enableClusterDefaultModal}
       </PageShell>
     );
   }
 
-  const { clusterDefaultEffect } = aggregation;
+  const { clusterDefaultEffect, pageSummary } = aggregation;
 
   const customSectionSummary = customTemplatesSectionSummary(aggregation.totalCustomRuleInstances);
 
   return (
     <PageShell headerAction={newTemplateButton}>
+      <TemplatingStatusBanner
+        status={pageSummaryStatus(
+          clusterDefaultEffect,
+          aggregation.enabledCustomRuleInstances,
+          aggregation.enabledActionCount,
+        )}
+        title={pageSummary}
+        description={clusterDefaultEffect.description}
+        action={enableClusterDefaultButton}
+      />
       <DataCard
         bgTint="800"
         withCollapse
@@ -377,14 +732,25 @@ export default function UrlTemplatingPage() {
             />
           ),
         }}
+        renderOnRightSide={newDefaultRuleButton}
       >
         {defaultTemplatizationCrGroups.length === 0 ? (
           <Typography size={TypographySize.XXS} color={TypographyColor.Secondary}>
-            No default templatization scope groups configured. Built-in heuristic default
-            templatization still applies when no custom template matches.
+            No default templatization rules configured.
           </Typography>
         ) : (
-          <DefaultTemplatizationCrGroupsView groups={defaultTemplatizationCrGroups} />
+          <DefaultTemplatizationCrGroupsView
+            groups={defaultTemplatizationCrGroups}
+            onSelectGroup={setSelectedDefaultGroup}
+            onEditGroup={
+              isReadonly
+                ? undefined
+                : (group) => {
+                    setCreateDefaultAction(null);
+                    setEditDefaultGroup(group);
+                  }
+            }
+          />
         )}
       </DataCard>
 
@@ -470,6 +836,7 @@ export default function UrlTemplatingPage() {
         )}
       </DataCard>
       {sharedDrawers}
+      {enableClusterDefaultModal}
     </PageShell>
   );
 }

--- a/frontend/webapp/app/(v2)/url-templating/page.tsx
+++ b/frontend/webapp/app/(v2)/url-templating/page.tsx
@@ -1,0 +1,475 @@
+'use client';
+
+import React, { useMemo, useState, useCallback, type PropsWithChildren } from 'react';
+import styled from 'styled-components';
+import { ActionIcon } from '@odigos/ui-kit/icons';
+import { RichTitle } from '@odigos/ui-kit/snippets';
+import { useApiQuery } from '@odigos/ui-kit/contexts';
+import { StatusType } from '@odigos/ui-kit/types';
+import type { Action } from '@odigos/ui-kit/types';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariants,
+  CenterThis,
+  DataCard,
+  FlexColumn,
+  FlexRow,
+  Loader,
+  NoData,
+  Note,
+  Search,
+  Segment,
+  SegmentSize,
+  SegmentVariant,
+  Typography,
+  TypographyColor,
+  TypographySize,
+} from '@odigos/ui-kit/components';
+import { CustomTemplateCrGroupsView, CustomTemplateListView, CustomTemplateTreeView } from './custom-templates-view';
+import { CreateGroupTemplatesDrawer } from './create-group-templates-drawer';
+import { DefaultTemplatizationCrGroupsView } from './default-templatization-view';
+import { EditGroupTemplatesDrawer } from './edit-group-templates-drawer';
+import { NewCustomTemplateDrawer, type NewCustomTemplateTarget } from './new-custom-template-drawer';
+import { SectionHelpButton } from './section-help-button';
+import { TemplateDetailDrawer } from './template-detail-drawer';
+import type { UrlTemplateDetail } from './template-detail-types';
+import {
+  aggregateUrlTemplatization,
+  collectCustomTemplateCrGroups,
+  collectDefaultTemplatizationCrGroups,
+  customTemplatesSectionSummary,
+  isUrlTemplatizationAction,
+  scopeTokensSortKey,
+  type CustomTemplateCrGroup,
+} from './url-templatization-aggregate';
+import { useConfig } from '@/hooks';
+
+const PageRoot = styled(FlexColumn)`
+  flex: 1 1 0;
+  align-self: stretch;
+  width: 100%;
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
+  overflow: hidden;
+`;
+
+const PageScroll = styled(FlexColumn)`
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  padding: 24px;
+  overflow-x: hidden;
+  overflow-y: auto;
+`;
+
+const PageHeader = styled(FlexRow)`
+  width: 100%;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+`;
+
+const PageHeaderMain = styled.div`
+  flex: 1;
+  min-width: 240px;
+`;
+
+const CustomTemplatesToolbar = styled(FlexColumn)`
+  width: 100%;
+  gap: 12px;
+  padding-bottom: 8px;
+`;
+
+const CustomTemplatesToolbarRow = styled(FlexRow)`
+  width: 100%;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+`;
+
+const CustomTemplatesSearchWrap = styled.div`
+  flex: 1;
+  min-width: 200px;
+`;
+
+export type CustomTemplateViewMode = 'list' | 'tree' | 'action';
+
+function PageShell({
+  children,
+  headerAction,
+}: PropsWithChildren<{ headerAction?: React.ReactNode }>) {
+  return (
+    <PageRoot>
+      <PageScroll $gap={20}>
+        <PageHeader $gap={16}>
+          <PageHeaderMain>
+            <RichTitle
+              icon={ActionIcon}
+              iconWithWrapper
+              title="URL Templating"
+              subTitle="Custom URL templates and default templatization scopes across URL templatization actions."
+            />
+          </PageHeaderMain>
+          {headerAction}
+        </PageHeader>
+        {children}
+      </PageScroll>
+    </PageRoot>
+  );
+}
+
+export default function UrlTemplatingPage() {
+  const { isReadonly } = useConfig();
+  const { data, loading, error, unsupported, refetch } = useApiQuery('GET_ACTIONS');
+  const [customTemplateQuery, setCustomTemplateQuery] = useState('');
+  const [customTemplateView, setCustomTemplateView] = useState<CustomTemplateViewMode>('action');
+  const [selectedTemplateDetail, setSelectedTemplateDetail] = useState<UrlTemplateDetail | null>(null);
+  const [editTemplatesGroup, setEditTemplatesGroup] = useState<CustomTemplateCrGroup | null>(null);
+  const [editFocusNewTemplate, setEditFocusNewTemplate] = useState(false);
+  const [createGroupAction, setCreateGroupAction] = useState<Action | null>(null);
+  const [createLockEntireClusterScope, setCreateLockEntireClusterScope] = useState(false);
+  const [newTemplateOpen, setNewTemplateOpen] = useState(false);
+
+  const urlTemplatizationActions = useMemo(() => {
+    const actions = data?.computePlatform?.actions ?? [];
+    return actions.filter(isUrlTemplatizationAction);
+  }, [data]);
+
+  const aggregation = useMemo(() => aggregateUrlTemplatization(urlTemplatizationActions), [urlTemplatizationActions]);
+
+  const filteredCustomTemplates = useMemo(() => {
+    const query = customTemplateQuery.trim().toLowerCase();
+    if (!query) {
+      return aggregation.customTemplates;
+    }
+    return aggregation.customTemplates.filter((item) => item.template.toLowerCase().includes(query));
+  }, [aggregation.customTemplates, customTemplateQuery]);
+
+  const customTemplateCrGroups = useMemo(
+    () => collectCustomTemplateCrGroups(urlTemplatizationActions),
+    [urlTemplatizationActions],
+  );
+
+  const defaultTemplatizationCrGroups = useMemo(
+    () => collectDefaultTemplatizationCrGroups(urlTemplatizationActions),
+    [urlTemplatizationActions],
+  );
+
+  const editTemplatesAction = useMemo(() => {
+    if (!editTemplatesGroup) {
+      return null;
+    }
+    return urlTemplatizationActions.find((action) => action.id === editTemplatesGroup.actionId) ?? null;
+  }, [editTemplatesGroup, urlTemplatizationActions]);
+
+  const selectedTemplateAction = useMemo(() => {
+    if (!selectedTemplateDetail) {
+      return null;
+    }
+    return urlTemplatizationActions.find((action) => action.id === selectedTemplateDetail.actionId) ?? null;
+  }, [selectedTemplateDetail, urlTemplatizationActions]);
+
+  const drawerActionRuleGroups = useMemo(() => {
+    if (!selectedTemplateDetail) {
+      return [];
+    }
+    return customTemplateCrGroups
+      .filter((group) => group.actionId === selectedTemplateDetail.actionId)
+      .sort((a, b) => a.groupIndex - b.groupIndex);
+  }, [selectedTemplateDetail, customTemplateCrGroups]);
+
+  const handleSelectTemplate = useCallback(
+    (detail: UrlTemplateDetail) => {
+      if (detail.groupIndex === undefined) {
+        const group = customTemplateCrGroups.find(
+          (g) =>
+            g.actionId === detail.actionId &&
+            g.templates.includes(detail.template) &&
+            scopeTokensSortKey(g.scopeTokens) === scopeTokensSortKey(detail.scopeTokens),
+        );
+        if (group) {
+          setSelectedTemplateDetail({
+            ...detail,
+            groupIndex: group.groupIndex,
+            groupNotes: group.groupNotes,
+          });
+          return;
+        }
+      }
+      setSelectedTemplateDetail(detail);
+    },
+    [customTemplateCrGroups],
+  );
+
+  const handleEditGroupTemplates = useCallback(
+    (group: CustomTemplateCrGroup, options?: { focusNewTemplate?: boolean }) => {
+      const fullGroup =
+        customTemplateCrGroups.find(
+          (candidate) => candidate.actionId === group.actionId && candidate.groupIndex === group.groupIndex,
+        ) ?? group;
+      setEditFocusNewTemplate(!!options?.focusNewTemplate);
+      setEditTemplatesGroup(fullGroup);
+    },
+    [customTemplateCrGroups],
+  );
+
+  const handleNewCustomTemplateContinue = useCallback(
+    (target: NewCustomTemplateTarget) => {
+      if (target.kind === 'edit_group') {
+        handleEditGroupTemplates(target.group, { focusNewTemplate: true });
+        return;
+      }
+      setCreateLockEntireClusterScope(!!target.lockEntireClusterScope);
+      setCreateGroupAction(target.action);
+    },
+    [handleEditGroupTemplates],
+  );
+
+  const filteredCustomTemplateCrGroups = useMemo(() => {
+    const query = customTemplateQuery.trim().toLowerCase();
+    if (!query) {
+      return customTemplateCrGroups;
+    }
+    return customTemplateCrGroups
+      .map((group) => ({
+        ...group,
+        templates: group.templates.filter((template) => template.toLowerCase().includes(query)),
+      }))
+      .filter((group) => group.templates.length > 0);
+  }, [customTemplateCrGroups, customTemplateQuery]);
+
+  const filteredCustomTemplateCount = useMemo(() => {
+    if (customTemplateView === 'action') {
+      return filteredCustomTemplateCrGroups.reduce((sum, group) => sum + group.templates.length, 0);
+    }
+    return filteredCustomTemplates.length;
+  }, [customTemplateView, filteredCustomTemplateCrGroups, filteredCustomTemplates.length]);
+
+  const newTemplateButton = isReadonly ? null : (
+    <Button
+      data-id="url-templating-new-custom-template"
+      label="+ New custom template"
+      variant={ButtonVariants.Primary}
+      size={ButtonSize.S}
+      onClick={() => setNewTemplateOpen(true)}
+    />
+  );
+
+  const sharedDrawers = (
+    <>
+      <NewCustomTemplateDrawer
+        isOpen={newTemplateOpen}
+        actions={urlTemplatizationActions}
+        groups={customTemplateCrGroups}
+        onClose={() => setNewTemplateOpen(false)}
+        onContinue={handleNewCustomTemplateContinue}
+      />
+      <TemplateDetailDrawer
+        detail={selectedTemplateDetail}
+        action={isReadonly ? null : selectedTemplateAction}
+        actionRuleGroups={drawerActionRuleGroups}
+        onSelectTemplate={handleSelectTemplate}
+        onEditGroupTemplates={
+          isReadonly
+            ? undefined
+            : (group) => {
+                setSelectedTemplateDetail(null);
+                handleEditGroupTemplates(group);
+              }
+        }
+        onDeleted={
+          isReadonly
+            ? undefined
+            : () => {
+                void refetch();
+              }
+        }
+        onClose={() => setSelectedTemplateDetail(null)}
+      />
+      <EditGroupTemplatesDrawer
+        group={editTemplatesGroup}
+        action={editTemplatesAction}
+        focusNewTemplate={editFocusNewTemplate}
+        onClose={() => {
+          setEditTemplatesGroup(null);
+          setEditFocusNewTemplate(false);
+        }}
+        onSaved={() => {
+          void refetch();
+        }}
+      />
+      <CreateGroupTemplatesDrawer
+        action={createGroupAction}
+        lockEntireClusterScope={createLockEntireClusterScope}
+        onClose={() => {
+          setCreateGroupAction(null);
+          setCreateLockEntireClusterScope(false);
+        }}
+        onSaved={() => {
+          void refetch();
+        }}
+      />
+    </>
+  );
+
+  if (unsupported) {
+    return (
+      <PageShell>
+        <Note status={StatusType.Warning} message="Actions are not available in this environment." fullWidth />
+      </PageShell>
+    );
+  }
+
+  if (loading && !data) {
+    return (
+      <PageShell>
+        <CenterThis>
+          <Loader withSpinnerOld scaleSpinnerOld={2} />
+        </CenterThis>
+      </PageShell>
+    );
+  }
+
+  if (error) {
+    return (
+      <PageShell>
+        <Note status={StatusType.Error} message={error.message || 'Failed to load actions'} fullWidth />
+      </PageShell>
+    );
+  }
+
+  if (!urlTemplatizationActions.length) {
+    return (
+      <PageShell headerAction={newTemplateButton}>
+        <CenterThis>
+          <NoData
+            icon={ActionIcon}
+            title="No URL templatization actions"
+            subTitle="URL templatization actions configured in the cluster will appear here. Create a custom template to get started."
+          />
+        </CenterThis>
+        {sharedDrawers}
+      </PageShell>
+    );
+  }
+
+  const { clusterDefaultEffect } = aggregation;
+
+  const customSectionSummary = customTemplatesSectionSummary(aggregation.totalCustomRuleInstances);
+
+  return (
+    <PageShell headerAction={newTemplateButton}>
+      <DataCard
+        bgTint="800"
+        withCollapse
+        collapseIsDefaultOpen
+        richTitle={{
+          title: 'Default templatization',
+          subTitle: clusterDefaultEffect.sectionSummary,
+          children: (
+            <SectionHelpButton
+              data-id="url-templating-default-help"
+              title="Default templatization"
+              text="Default templatization is the built-in fallback that turns concrete URL paths into templates when no custom template matches. Use it to control heuristic behavior (enable, disable, or skip policies) for selected scopes."
+            />
+          ),
+        }}
+      >
+        {defaultTemplatizationCrGroups.length === 0 ? (
+          <Typography size={TypographySize.XXS} color={TypographyColor.Secondary}>
+            No default templatization scope groups configured. Built-in heuristic default
+            templatization still applies when no custom template matches.
+          </Typography>
+        ) : (
+          <DefaultTemplatizationCrGroupsView groups={defaultTemplatizationCrGroups} />
+        )}
+      </DataCard>
+
+      <DataCard
+        bgTint="800"
+        withCollapse
+        collapseIsDefaultOpen
+        richTitle={{
+          title: 'Custom templates',
+          subTitle: customSectionSummary,
+          children: (
+            <SectionHelpButton
+              data-id="url-templating-custom-help"
+              title="Custom templates"
+              text="Custom templates are explicit URL patterns you define (for example /users/{id}). They take precedence over default templatization and are grouped by scope so matching stays targeted and efficient."
+            />
+          ),
+        }}
+      >
+        {aggregation.customTemplates.length === 0 ? (
+          <Typography size={TypographySize.XXS} color={TypographyColor.Secondary}>
+            No custom template rules configured.
+          </Typography>
+        ) : (
+          <>
+            <CustomTemplatesToolbar $gap={12}>
+              <CustomTemplatesToolbarRow $gap={12}>
+                <CustomTemplatesSearchWrap>
+                  <Search
+                    data-id="url-templating-custom-template-search"
+                    value={customTemplateQuery}
+                    onChange={setCustomTemplateQuery}
+                    placeholder="Search templates…"
+                    width="100%"
+                  />
+                </CustomTemplatesSearchWrap>
+                <Segment<CustomTemplateViewMode>
+                  data-id="url-templating-custom-template-view"
+                  size={SegmentSize.S}
+                  variant={SegmentVariant.Filled}
+                  selected={customTemplateView}
+                  setSelected={setCustomTemplateView}
+                  options={[
+                    { value: 'action', label: 'Groups' },
+                    { value: 'tree', label: 'Tree' },
+                    { value: 'list', label: 'List' },
+                  ]}
+                />
+              </CustomTemplatesToolbarRow>
+              {customTemplateQuery.trim() ? (
+                <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+                  {filteredCustomTemplateCount} of {aggregation.totalCustomRuleInstances} templates
+                </Typography>
+              ) : null}
+            </CustomTemplatesToolbar>
+            {filteredCustomTemplateCount === 0 ? (
+              <Typography size={TypographySize.XXS} color={TypographyColor.Secondary}>
+                {`No templates match "${customTemplateQuery.trim()}".`}
+              </Typography>
+            ) : customTemplateView === 'tree' ? (
+              <CustomTemplateTreeView items={filteredCustomTemplates} onSelectTemplate={handleSelectTemplate} />
+            ) : customTemplateView === 'action' ? (
+              <CustomTemplateCrGroupsView
+                groups={filteredCustomTemplateCrGroups}
+                onSelectTemplate={handleSelectTemplate}
+                onEditGroupTemplates={isReadonly ? undefined : handleEditGroupTemplates}
+                onCreateGroup={
+                  isReadonly
+                    ? undefined
+                    : (actionId) => {
+                        const action = urlTemplatizationActions.find((candidate) => candidate.id === actionId);
+                        if (action) {
+                          setCreateLockEntireClusterScope(false);
+                          setCreateGroupAction(action);
+                        }
+                      }
+                }
+              />
+            ) : (
+              <CustomTemplateListView items={filteredCustomTemplates} onSelectTemplate={handleSelectTemplate} />
+            )}
+          </>
+        )}
+      </DataCard>
+      {sharedDrawers}
+    </PageShell>
+  );
+}

--- a/frontend/webapp/app/(v2)/url-templating/scope-token-types.ts
+++ b/frontend/webapp/app/(v2)/url-templating/scope-token-types.ts
@@ -1,0 +1,9 @@
+export type ScopeToken =
+  | { type: 'entire_cluster' }
+  | { type: 'namespace'; values: string[] }
+  | { type: 'language'; values: string[] }
+  | { type: 'workload'; groups: { kind: string; namespaceNames: string[] }[] };
+
+export function scopeTokensSortKey(tokens: ScopeToken[]): string {
+  return JSON.stringify(tokens);
+}

--- a/frontend/webapp/app/(v2)/url-templating/scope-tokens.tsx
+++ b/frontend/webapp/app/(v2)/url-templating/scope-tokens.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import React from 'react';
+import styled, { type DefaultTheme } from 'styled-components';
+import { FlexRow, Typography, TypographyColor, TypographySize } from '@odigos/ui-kit/components';
+import type { ScopeToken } from './scope-token-types';
+
+const chipTintByVariant: Record<ScopeToken['type'], (theme: DefaultTheme) => string> = {
+  entire_cluster: (theme) => theme.v2.colors.purple[500],
+  namespace: (theme) => theme.v2.colors.blue[500],
+  language: (theme) => theme.v2.colors.green[500],
+  workload: (theme) => theme.v2.colors.yellow[600],
+};
+
+const subjectColorByVariant: Record<ScopeToken['type'], (theme: DefaultTheme) => string> = {
+  entire_cluster: (theme) => theme.v2.colors.purple[300],
+  namespace: (theme) => theme.v2.colors.blue[400],
+  language: (theme) => theme.v2.colors.green[600],
+  workload: (theme) => theme.v2.colors.yellow[700],
+};
+
+const TokenChip = styled.span<{ $variant: ScopeToken['type'] }>`
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0;
+  max-width: 100%;
+  padding: 1px 6px;
+  border-radius: 4px;
+  border: 1px solid
+    ${({ theme, $variant }) =>
+      `color-mix(in srgb, ${chipTintByVariant[$variant](theme)} 18%, ${theme.v2.colors.silver[600]})`};
+  background: ${({ theme, $variant }) =>
+    `color-mix(in srgb, ${chipTintByVariant[$variant](theme)} 10%, ${theme.v2.colors.silver[800]})`};
+  color: ${({ theme }) => theme.v2.colors.grey[400]};
+  font-family: ${({ theme }) => theme.font_family.primary};
+  font-size: ${({ theme }) => theme.v2.text.size.xxxs}px;
+  line-height: 1.3;
+  letter-spacing: 0.01em;
+`;
+
+const TokenSubject = styled.span<{ $variant: ScopeToken['type'] }>`
+  font-weight: 500;
+  color: ${({ theme, $variant }) => subjectColorByVariant[$variant](theme)};
+`;
+
+const TokenValue = styled.span`
+  font-weight: 400;
+  color: inherit;
+`;
+
+const WorkloadGroupSeparator = styled.span`
+  display: inline-block;
+  width: 6px;
+`;
+
+function formatListValues(values: string[]): string {
+  return values.join(' / ');
+}
+
+function ScopeTokenChip({ token }: { token: ScopeToken }) {
+  switch (token.type) {
+    case 'entire_cluster':
+      return (
+        <TokenChip $variant={token.type}>
+          <TokenSubject $variant="entire_cluster">Entire cluster</TokenSubject>
+        </TokenChip>
+      );
+    case 'namespace':
+      return (
+        <TokenChip $variant={token.type}>
+          <TokenSubject $variant="namespace">namespace:</TokenSubject>
+          <TokenValue> {formatListValues(token.values)}</TokenValue>
+        </TokenChip>
+      );
+    case 'language':
+      return (
+        <TokenChip $variant={token.type}>
+          <TokenSubject $variant="language">language:</TokenSubject>
+          <TokenValue> {formatListValues(token.values)}</TokenValue>
+        </TokenChip>
+      );
+    case 'workload':
+      return (
+        <TokenChip $variant={token.type}>
+          {token.groups.map((group, groupIndex) => (
+            <React.Fragment key={`${group.kind}-${groupIndex}`}>
+              {groupIndex > 0 && <WorkloadGroupSeparator />}
+              <TokenSubject $variant="workload">{group.kind}:</TokenSubject>
+              <TokenValue> {group.namespaceNames.join(', ')}</TokenValue>
+            </React.Fragment>
+          ))}
+        </TokenChip>
+      );
+    default:
+      return null;
+  }
+}
+
+export function ScopeTokens({ tokens }: { tokens: ScopeToken[] }) {
+  if (!tokens.length) {
+    return null;
+  }
+
+  return (
+    <FlexRow $gap={4} $alignItems="center" style={{ flexWrap: 'wrap' }}>
+      {tokens.map((token, index) => (
+        <React.Fragment key={`${token.type}-${index}-${scopeTokenReactKey(token)}`}>
+          {index > 0 && (
+            <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+              AND
+            </Typography>
+          )}
+          <ScopeTokenChip token={token} />
+        </React.Fragment>
+      ))}
+    </FlexRow>
+  );
+}
+
+function scopeTokenReactKey(token: ScopeToken): string {
+  switch (token.type) {
+    case 'entire_cluster':
+      return 'cluster';
+    case 'namespace':
+      return token.values.join(',');
+    case 'language':
+      return token.values.join(',');
+    case 'workload':
+      return token.groups.map((g) => `${g.kind}:${g.namespaceNames.join(',')}`).join('|');
+    default:
+      return '';
+  }
+}

--- a/frontend/webapp/app/(v2)/url-templating/section-help-button.tsx
+++ b/frontend/webapp/app/(v2)/url-templating/section-help-button.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import React, { useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import styled from 'styled-components';
+import { QuestionCircleIcon } from '@odigos/ui-kit/icons';
+
+const Trigger = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  color: ${({ theme }) => theme.v2.colors.grey[400]};
+  cursor: help;
+
+  &:hover {
+    color: ${({ theme }) => theme.v2.colors.white[500]};
+  }
+`;
+
+const Popup = styled.div`
+  position: fixed;
+  z-index: ${({ theme }) => theme.v2.zIndex.tooltip};
+  box-sizing: border-box;
+  width: min(420px, calc(100vw - 32px));
+  padding: 12px 14px;
+  border-radius: 8px;
+  pointer-events: none;
+  background: ${({ theme }) => theme.v2.colors.silver[200]};
+  border: 1px solid ${({ theme }) => theme.v2.colors.silver[400]};
+  box-shadow: 0 8px 20px color-mix(in srgb, ${({ theme }) => theme.v2.colors.black[500]} 22%, transparent);
+`;
+
+const PopupTitle = styled.div`
+  margin: 0 0 6px;
+  font-family: ${({ theme }) => theme.font_family.primary};
+  font-size: ${({ theme }) => theme.v2.text.size.xs}px;
+  font-weight: 600;
+  line-height: 1.35;
+  color: ${({ theme }) => theme.v2.colors.grey[900]};
+`;
+
+const PopupBody = styled.div`
+  margin: 0;
+  font-family: ${({ theme }) => theme.font_family.primary};
+  font-size: ${({ theme }) => theme.v2.text.size.xxs}px;
+  font-weight: 400;
+  line-height: 1.5;
+  color: ${({ theme }) => theme.v2.colors.grey[800]};
+`;
+
+type SectionHelpButtonProps = {
+  'data-id'?: string;
+  title: string;
+  text: string;
+};
+
+export function SectionHelpButton({ 'data-id': dataId, title, text }: SectionHelpButtonProps) {
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
+
+  useLayoutEffect(() => {
+    if (!open || !triggerRef.current) {
+      return;
+    }
+    const rect = triggerRef.current.getBoundingClientRect();
+    const width = Math.min(420, window.innerWidth - 32);
+    const left = Math.min(Math.max(16, rect.left), window.innerWidth - width - 16);
+    const top = Math.min(rect.bottom + 8, window.innerHeight - 16);
+    setPosition({ top, left });
+  }, [open]);
+
+  return (
+    <>
+      <Trigger
+        ref={triggerRef}
+        data-id={dataId}
+        aria-label={`Help: ${title}`}
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        tabIndex={0}
+      >
+        <QuestionCircleIcon size={14} />
+      </Trigger>
+      {open && position
+        ? createPortal(
+            <Popup role="tooltip" style={{ top: position.top, left: position.left }}>
+              <PopupTitle>{title}</PopupTitle>
+              <PopupBody>{text}</PopupBody>
+            </Popup>,
+            document.body,
+          )
+        : null}
+    </>
+  );
+}

--- a/frontend/webapp/app/(v2)/url-templating/skip-policy-help.ts
+++ b/frontend/webapp/app/(v2)/url-templating/skip-policy-help.ts
@@ -1,0 +1,5 @@
+/** Help copy for skip-policy UI (see odigosurltemplateprocessor README). */
+export const SKIP_POLICY_HELP = {
+  title: 'Skip default templatization on HTTP errors',
+  text: 'For internet-exposed services, bot and scanner traffic often hits random paths that return error status codes (for example 404). Default heuristic templatization would turn each of those into a distinct route and cause high cardinality. Custom templates are still evaluated first; skip policy only affects the default heuristic step when no custom rule matched. Use “Skip for non-2xx” to skip any status outside 2xx, or list specific codes such as 404 or 401.',
+} as const;

--- a/frontend/webapp/app/(v2)/url-templating/template-detail-drawer.tsx
+++ b/frontend/webapp/app/(v2)/url-templating/template-detail-drawer.tsx
@@ -1,0 +1,620 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import styled from 'styled-components';
+import { ActionIcon, ChevronRightIcon, EditIcon, TrashIcon } from '@odigos/ui-kit/icons';
+import type { Action } from '@odigos/ui-kit/types';
+import { StatusType } from '@odigos/ui-kit/types';
+import {
+  Divider,
+  Drawer,
+  FlexColumn,
+  FlexRow,
+  IconButton,
+  IconButtonSize,
+  Note,
+  Tooltip,
+  Typography,
+  TypographyColor,
+  TypographySize,
+  WarningModal,
+} from '@odigos/ui-kit/components';
+import { useApiMutation } from '@odigos/ui-kit/contexts';
+import { ActionOriginBadge, actionOriginTitleBadge } from './action-origin-badge';
+import { ScopeTokens } from './scope-tokens';
+import { parseTemplatePath, TemplatePath, TemplatePathSegmentLabel } from './template-path';
+import { sortUrlTemplates } from './template-sort';
+import { scopeTokensSortKey } from './scope-token-types';
+import type { UrlTemplateDetail } from './template-detail-types';
+import {
+  detailFromCrGroup,
+  detailFromCrTemplate,
+  isActiveRuleGroup,
+  type CrTemplateGroupRef,
+} from './template-detail-types';
+import { TemplatePathSimulator } from './template-path-simulator';
+import { templateRowActivationProps } from './template-row-activation';
+import { buildUpdateActionWithGroupTemplates } from './action-group-templates-update';
+
+const DrawerBody = styled(FlexColumn)`
+  width: 100%;
+  padding: 0 24px 24px;
+  gap: 16px;
+`;
+
+const DetailBlock = styled(FlexColumn)`
+  width: 100%;
+  gap: 8px;
+`;
+
+const FieldList = styled(FlexColumn)`
+  width: 100%;
+  gap: 10px;
+`;
+
+const Field = styled(FlexColumn)`
+  width: 100%;
+  gap: 2px;
+`;
+
+const ResourceName = styled.span`
+  font-family: ${({ theme }) => theme.font_family.code ?? theme.font_family.primary};
+  font-size: ${({ theme }) => theme.v2.text.size.xs}px;
+  line-height: 1.4;
+  color: ${({ theme }) => theme.v2.colors.white[500]};
+  word-break: break-word;
+`;
+
+const SegmentTrack = styled(FlexRow)`
+  width: 100%;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 0;
+  row-gap: 8px;
+`;
+
+const SegmentCell = styled(FlexColumn)`
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  max-width: 100%;
+`;
+
+const SegmentSlash = styled.span`
+  flex-shrink: 0;
+  align-self: flex-start;
+  padding: 0 2px;
+  font-family: ${({ theme }) => theme.font_family.primary};
+  font-size: 12px;
+  line-height: 1.4;
+  color: ${({ theme }) => theme.v2.colors.white[500]};
+`;
+
+const RuleGroupRow = styled(FlexColumn)<{ $active?: boolean }>`
+  width: 100%;
+  gap: 6px;
+  padding: 8px 6px;
+  margin: 0 -6px;
+  border-radius: 6px;
+  cursor: pointer;
+  border: 1px solid
+    ${({ theme, $active }) => ($active ? theme.v2.colors.silver[600] : 'transparent')};
+  background: ${({ theme, $active }) => ($active ? theme.v2.colors.silver[900] : 'transparent')};
+  transition: background 0.12s ease;
+
+  &:hover {
+    background: ${({ theme }) => theme.v2.colors.silver[800]};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.v2.colors.blue[400]};
+    outline-offset: 2px;
+  }
+`;
+
+const RuleGroupList = styled(FlexColumn)`
+  width: 100%;
+  gap: 4px;
+`;
+
+const GroupTemplateRow = styled(FlexRow)`
+  width: 100%;
+  align-items: center;
+  padding: 6px 6px;
+  margin: 0 -6px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.12s ease;
+
+  &:hover {
+    background: ${({ theme }) => theme.v2.colors.silver[800]};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.v2.colors.blue[400]};
+    outline-offset: 2px;
+  }
+`;
+
+const GroupTemplateList = styled(FlexColumn)`
+  width: 100%;
+  gap: 2px;
+`;
+
+const CollapseHeader = styled(FlexRow)`
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 4px 0;
+  cursor: pointer;
+  user-select: none;
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.v2.colors.blue[400]};
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+`;
+
+const CollapseChevron = styled.span<{ $open: boolean }>`
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  transform: rotate(${({ $open }) => ($open ? '90deg' : '0deg')});
+  transition: transform 0.15s ease;
+  color: ${({ theme }) => theme.v2.colors.grey[400]};
+`;
+
+const CollapseBody = styled(FlexColumn)`
+  width: 100%;
+  gap: 14px;
+  padding-top: 8px;
+`;
+
+const segmentKindLabel: Record<string, string> = {
+  static: 'Exact',
+  variable: 'Variable',
+  wildcard: 'Any',
+};
+
+type TemplateDetailDrawerProps = {
+  detail: UrlTemplateDetail | null;
+  action: Action | null;
+  actionRuleGroups: CrTemplateGroupRef[];
+  onSelectTemplate: (detail: UrlTemplateDetail) => void;
+  onEditGroupTemplates?: (group: CrTemplateGroupRef) => void;
+  onDeleted?: () => void;
+  onClose: () => void;
+};
+
+function DetailField({
+  label,
+  labelTooltip,
+  children,
+}: {
+  label: string;
+  labelTooltip?: string;
+  children: React.ReactNode;
+}) {
+  const labelNode = (
+    <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+      {label}
+    </Typography>
+  );
+
+  return (
+    <Field $gap={2}>
+      {labelTooltip ? (
+        <Tooltip text={labelTooltip} inline>
+          {labelNode}
+        </Tooltip>
+      ) : (
+        labelNode
+      )}
+      {children}
+    </Field>
+  );
+}
+
+function actionDisplayNameForDrawer(detail: UrlTemplateDetail): string | null {
+  const name = detail.actionDisplayName?.trim();
+  if (!name || name === detail.actionId) {
+    return null;
+  }
+  return name;
+}
+
+function DrawerCollapseSection({
+  title,
+  summary,
+  defaultOpen = false,
+  titleAction,
+  children,
+}: {
+  title: string;
+  summary?: string;
+  defaultOpen?: boolean;
+  titleAction?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <DetailBlock $gap={0}>
+      <CollapseHeader
+        $gap={12}
+        role="button"
+        tabIndex={0}
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            setOpen((value) => !value);
+          }
+        }}
+      >
+        <FlexColumn $gap={2} style={{ flex: 1, minWidth: 0 }}>
+          <FlexRow $gap={8} $alignItems="center">
+            <Typography size={TypographySize.XXS} color={TypographyColor.Secondary}>
+              {title}
+            </Typography>
+            {titleAction}
+          </FlexRow>
+          {!open && summary ? (
+            <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+              {summary}
+            </Typography>
+          ) : null}
+        </FlexColumn>
+        <CollapseChevron $open={open}>
+          <ChevronRightIcon size={14} />
+        </CollapseChevron>
+      </CollapseHeader>
+      {open ? <CollapseBody $gap={14}>{children}</CollapseBody> : null}
+    </DetailBlock>
+  );
+}
+
+export function TemplateDetailDrawer({
+  detail,
+  action,
+  actionRuleGroups,
+  onSelectTemplate,
+  onEditGroupTemplates,
+  onDeleted,
+  onClose,
+}: TemplateDetailDrawerProps) {
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const [updateAction, { loading: deleting }] = useApiMutation('UPDATE_ACTION', {
+    refetchQueries: ['GetActions'],
+    awaitRefetchQueries: true,
+  });
+
+  useEffect(() => {
+    setConfirmDeleteOpen(false);
+    setDeleteError(null);
+  }, [detail]);
+
+  const segments = useMemo(
+    () => (detail?.template.trim() ? parseTemplatePath(detail.template) : []),
+    [detail],
+  );
+
+  const sortedRuleGroups = useMemo(
+    () => [...actionRuleGroups].sort((a, b) => a.groupIndex - b.groupIndex),
+    [actionRuleGroups],
+  );
+
+  const activeRuleGroup = useMemo(() => {
+    if (!detail) {
+      return undefined;
+    }
+    const byIndex = sortedRuleGroups.find((group) => isActiveRuleGroup(detail, group));
+    if (byIndex) {
+      return byIndex;
+    }
+    if (!detail.template.trim()) {
+      return undefined;
+    }
+    return sortedRuleGroups.find(
+      (group) =>
+        group.actionId === detail.actionId &&
+        group.templates.includes(detail.template) &&
+        scopeTokensSortKey(group.scopeTokens) === scopeTokensSortKey(detail.scopeTokens),
+    );
+  }, [sortedRuleGroups, detail]);
+
+  const otherGroupTemplates = useMemo(() => {
+    if (!activeRuleGroup) {
+      return [];
+    }
+    if (!detail?.template.trim()) {
+      return sortUrlTemplates(activeRuleGroup.templates);
+    }
+    return sortUrlTemplates(activeRuleGroup.templates.filter((template) => template !== detail.template));
+  }, [activeRuleGroup, detail?.template]);
+
+  const siblingTemplatesSummary = useMemo(() => {
+    const count = otherGroupTemplates.length;
+    if (count === 0) {
+      return undefined;
+    }
+    return `${count} ${count === 1 ? 'template' : 'templates'}`;
+  }, [otherGroupTemplates.length]);
+
+  const headerBadges = useMemo(() => {
+    if (!detail) {
+      return undefined;
+    }
+    const badges = [actionOriginTitleBadge(detail.actionUiGenerated)];
+    if (detail.actionDisabled) {
+      badges.push({ label: 'Disabled' });
+    }
+    if (detail.count > 1) {
+      badges.push({ label: `×${detail.count}` });
+    }
+    return badges;
+  }, [detail]);
+
+  const drawerDisplayName = detail ? actionDisplayNameForDrawer(detail) : null;
+
+  const groupCollapseSummary = useMemo(() => {
+    if (!detail || sortedRuleGroups.length <= 1) {
+      return undefined;
+    }
+    const activeIndex = activeRuleGroup?.groupIndex;
+    if (activeIndex === undefined) {
+      return undefined;
+    }
+    return `This template is in group ${activeIndex + 1}`;
+  }, [detail, sortedRuleGroups.length, activeRuleGroup?.groupIndex]);
+
+  const showGroupSection = sortedRuleGroups.length > 1;
+
+  const canDeleteTemplate = !!action && !!activeRuleGroup && !!detail?.template.trim() && !!onDeleted;
+
+  const handleDeleteTemplate = async () => {
+    if (!detail || !action || !activeRuleGroup || !onDeleted) {
+      return;
+    }
+    setDeleteError(null);
+    try {
+      const remaining = activeRuleGroup.templates.filter((template) => template !== detail.template);
+      const variables = buildUpdateActionWithGroupTemplates(action, activeRuleGroup.groupIndex, remaining);
+      const { error } = await updateAction(variables);
+      if (error) {
+        setDeleteError(error.message || 'Failed to delete template');
+        return;
+      }
+      setConfirmDeleteOpen(false);
+      onDeleted();
+      onClose();
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : 'Failed to delete template');
+    }
+  };
+
+  return (
+    <>
+    <Drawer
+      isOpen={!!detail}
+      width="min(720px, 96vw)"
+      header={
+        detail
+          ? {
+              icon: ActionIcon,
+              title: 'URL template',
+              subTitle: detail.actionLabel,
+              titleBadges: headerBadges,
+              actions: canDeleteTemplate
+                ? [
+                    {
+                      id: 'delete-template',
+                      label: 'Delete template',
+                      icon: TrashIcon,
+                      onClick: () => {
+                        setDeleteError(null);
+                        setConfirmDeleteOpen(true);
+                      },
+                    },
+                  ]
+                : undefined,
+              onClose,
+            }
+          : undefined
+      }
+    >
+      {detail ? (
+        <DrawerBody $gap={16}>
+          <DetailBlock $gap={8}>
+            <Typography size={TypographySize.XXS} color={TypographyColor.Secondary}>
+              Template
+            </Typography>
+            {detail.template.trim() ? (
+              <TemplatePath template={detail.template} disabled={detail.actionDisabled} fontSize={14} />
+            ) : (
+              <Typography size={TypographySize.XS} color={TypographyColor.Secondary}>
+                No templates in this rule group
+              </Typography>
+            )}
+          </DetailBlock>
+
+          <Divider />
+
+          <DetailBlock $gap={8}>
+            <Typography size={TypographySize.XXS} color={TypographyColor.Secondary}>
+              Action
+            </Typography>
+            <FieldList $gap={10}>
+              {drawerDisplayName ? (
+                <DetailField label="Display name">
+                  <Typography size={TypographySize.XS}>{drawerDisplayName}</Typography>
+                </DetailField>
+              ) : null}
+              <DetailField label="Resource name" labelTooltip="Action CR metadata.name">
+                <ResourceName>{detail.actionId}</ResourceName>
+              </DetailField>
+              <DetailField label="Origin">
+                <ActionOriginBadge uiGenerated={detail.actionUiGenerated} />
+              </DetailField>
+            </FieldList>
+          </DetailBlock>
+
+          {segments.length ? (
+            <>
+              <Divider />
+              <DetailBlock $gap={8}>
+                <Typography size={TypographySize.XXS} color={TypographyColor.Secondary}>
+                  Path segments
+                </Typography>
+                <SegmentTrack $gap={0}>
+                  {detail.template.trimStart().startsWith('/') ? <SegmentSlash>/</SegmentSlash> : null}
+                  {segments.map((segment, index) => (
+                    <React.Fragment key={`${index}-${segment.text}`}>
+                      {index > 0 ? <SegmentSlash>/</SegmentSlash> : null}
+                      <SegmentCell $gap={4}>
+                        <TemplatePathSegmentLabel kind={segment.kind} text={segment.text} fontSize={12} />
+                        <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+                          {segmentKindLabel[segment.kind] ?? segment.kind}
+                        </Typography>
+                      </SegmentCell>
+                    </React.Fragment>
+                  ))}
+                </SegmentTrack>
+                <TemplatePathSimulator template={detail.template} actionDisabled={detail.actionDisabled} />
+              </DetailBlock>
+            </>
+          ) : null}
+
+          {showGroupSection ? (
+            <>
+              <Divider />
+              <DrawerCollapseSection
+                title="Switch rule group"
+                summary={groupCollapseSummary}
+                defaultOpen={false}
+              >
+                <RuleGroupList $gap={4}>
+                  {sortedRuleGroups.map((group) => {
+                    const active = isActiveRuleGroup(detail, group);
+                    const openGroup = () => onSelectTemplate(detailFromCrGroup(group, detail.template));
+                    const groupKey = `${group.actionId}:${group.groupIndex}:${scopeTokensSortKey(group.scopeTokens)}`;
+
+                    return (
+                      <RuleGroupRow
+                        key={groupKey}
+                        $gap={6}
+                        $active={active}
+                        title="View this rule group"
+                        {...templateRowActivationProps(openGroup)}
+                      >
+                        <FlexRow $gap={8} $alignItems="center" style={{ flexWrap: 'wrap' }}>
+                          <Typography size={TypographySize.XS}>Group {group.groupIndex + 1}</Typography>
+                          <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+                            {group.templates.length}{' '}
+                            {group.templates.length === 1 ? 'template' : 'templates'}
+                          </Typography>
+                        </FlexRow>
+                        <ScopeTokens tokens={group.scopeTokens} />
+                        {group.groupNotes?.trim() ? (
+                          <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+                            {group.groupNotes.trim()}
+                          </Typography>
+                        ) : null}
+                      </RuleGroupRow>
+                    );
+                  })}
+                </RuleGroupList>
+              </DrawerCollapseSection>
+            </>
+          ) : null}
+
+          {otherGroupTemplates.length > 0 || (activeRuleGroup && onEditGroupTemplates) ? (
+            <>
+              <Divider />
+              <DrawerCollapseSection
+                title="Other templates in this group"
+                summary={siblingTemplatesSummary}
+                defaultOpen
+                titleAction={
+                  onEditGroupTemplates && activeRuleGroup ? (
+                    <IconButton
+                      data-id="url-templating-detail-edit-group"
+                      icon={EditIcon}
+                      size={IconButtonSize.XS}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onEditGroupTemplates(activeRuleGroup);
+                      }}
+                    />
+                  ) : undefined
+                }
+              >
+                <GroupTemplateList $gap={2}>
+                  {otherGroupTemplates.map((template) => {
+                    const openTemplate = () => {
+                      if (!activeRuleGroup) {
+                        return;
+                      }
+                      onSelectTemplate(detailFromCrTemplate(activeRuleGroup, template));
+                    };
+                    return (
+                      <GroupTemplateRow
+                        key={template}
+                        $gap={8}
+                        title="View template"
+                        {...templateRowActivationProps(openTemplate)}
+                      >
+                        <TemplatePath template={template} disabled={detail.actionDisabled} />
+                      </GroupTemplateRow>
+                    );
+                  })}
+                  {otherGroupTemplates.length === 0 ? (
+                    <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+                      No other templates in this group
+                    </Typography>
+                  ) : null}
+                </GroupTemplateList>
+              </DrawerCollapseSection>
+            </>
+          ) : null}
+        </DrawerBody>
+      ) : null}
+    </Drawer>
+    <WarningModal
+      isOpen={confirmDeleteOpen}
+      title="Delete this template?"
+      description="This template will be removed from the rule group and take effect in the cluster immediately."
+      onClose={() => {
+        if (!deleting) {
+          setConfirmDeleteOpen(false);
+          setDeleteError(null);
+        }
+      }}
+      denyButton={{
+        label: 'Go Back',
+        onClick: () => {
+          setConfirmDeleteOpen(false);
+          setDeleteError(null);
+        },
+        disabled: deleting,
+      }}
+      approveButton={{
+        label: 'Delete One Template',
+        onClick: () => {
+          void handleDeleteTemplate();
+        },
+        loading: deleting,
+        disabled: deleting,
+      }}
+    >
+      {deleteError ? <Note status={StatusType.Error} message={deleteError} fullWidth /> : null}
+    </WarningModal>
+    </>
+  );
+}

--- a/frontend/webapp/app/(v2)/url-templating/template-detail-types.ts
+++ b/frontend/webapp/app/(v2)/url-templating/template-detail-types.ts
@@ -1,0 +1,87 @@
+import type { ScopeToken } from './scope-token-types';
+import { scopeTokensSortKey } from './scope-token-types';
+
+export type CrTemplateGroupRef = {
+  actionId: string;
+  actionDisplayName?: string | null;
+  actionLabel: string;
+  actionDisabled: boolean;
+  actionUiGenerated: boolean;
+  groupIndex: number;
+  scopeTokens: ScopeToken[];
+  groupNotes?: string | null;
+  templates: string[];
+};
+
+export type UrlTemplateDetail = {
+  template: string;
+  scopeTokens: ScopeToken[];
+  actionId: string;
+  actionDisplayName?: string | null;
+  actionLabel: string;
+  actionDisabled: boolean;
+  actionUiGenerated: boolean;
+  count: number;
+  groupIndex?: number;
+  groupNotes?: string | null;
+};
+
+export function urlTemplateDetailKey(detail: UrlTemplateDetail): string {
+  return `${detail.actionId}|${detail.template}|${detail.scopeTokens.map((t) => t.type).join(',')}|${detail.groupIndex ?? ''}`;
+}
+
+export function detailFromAggregatedTemplate(item: {
+  template: string;
+  scopeTokens: ScopeToken[];
+  actionId: string;
+  actionDisplayName?: string | null;
+  actionLabels: string[];
+  actionDisabled: boolean;
+  actionUiGenerated: boolean;
+  count: number;
+}): UrlTemplateDetail {
+  return {
+    template: item.template,
+    scopeTokens: item.scopeTokens,
+    actionId: item.actionId,
+    actionDisplayName: item.actionDisplayName,
+    actionLabel: item.actionLabels[0] ?? item.actionId,
+    actionDisabled: item.actionDisabled,
+    actionUiGenerated: item.actionUiGenerated,
+    count: item.count,
+  };
+}
+
+export function detailFromCrTemplate(
+  group: CrTemplateGroupRef,
+  template: string,
+): UrlTemplateDetail {
+  return {
+    template,
+    scopeTokens: group.scopeTokens,
+    actionId: group.actionId,
+    actionDisplayName: group.actionDisplayName,
+    actionLabel: group.actionLabel,
+    actionDisabled: group.actionDisabled,
+    actionUiGenerated: group.actionUiGenerated,
+    count: 1,
+    groupIndex: group.groupIndex,
+    groupNotes: group.groupNotes,
+  };
+}
+
+export function detailFromCrGroup(group: CrTemplateGroupRef, preferredTemplate?: string): UrlTemplateDetail {
+  const template =
+    preferredTemplate && group.templates.includes(preferredTemplate)
+      ? preferredTemplate
+      : (group.templates[0] ?? '');
+  return detailFromCrTemplate(group, template);
+}
+
+export function isActiveRuleGroup(detail: UrlTemplateDetail, group: CrTemplateGroupRef): boolean {
+  return (
+    detail.actionId === group.actionId &&
+    detail.groupIndex === group.groupIndex &&
+    scopeTokensSortKey(detail.scopeTokens) === scopeTokensSortKey(group.scopeTokens)
+  );
+}

--- a/frontend/webapp/app/(v2)/url-templating/template-path-simulator.tsx
+++ b/frontend/webapp/app/(v2)/url-templating/template-path-simulator.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import styled from 'styled-components';
+import { Input, FlexColumn, Typography, TypographyColor, TypographySize } from '@odigos/ui-kit/components';
+import { TemplatePath } from './template-path';
+import { simulateCustomTemplate } from './template-simulator';
+
+const SimulatorBlock = styled(FlexColumn)<{ $embedded?: boolean }>`
+  width: 100%;
+  gap: 8px;
+  padding-top: ${({ $embedded }) => ($embedded ? 0 : '12px')};
+  margin-top: ${({ $embedded }) => ($embedded ? 0 : '4px')};
+  border-top: ${({ theme, $embedded }) => ($embedded ? 'none' : `1px solid ${theme.v2.colors.silver[700]}`)};
+`;
+
+type TemplatePathSimulatorProps = {
+  template: string;
+  actionDisabled?: boolean;
+  embedded?: boolean;
+};
+
+export function TemplatePathSimulator({ template, actionDisabled, embedded }: TemplatePathSimulatorProps) {
+  const [urlInput, setUrlInput] = useState('');
+
+  const result = useMemo(
+    () => simulateCustomTemplate(template, urlInput),
+    [template, urlInput],
+  );
+
+  if (!template.trim()) {
+    return null;
+  }
+
+  return (
+    <SimulatorBlock $gap={8} $embedded={embedded}>
+      <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+        Try a URL
+      </Typography>
+      <Input
+        data-id="url-template-path-simulator-input"
+        value={urlInput}
+        onChange={(event) => setUrlInput(event.target.value)}
+        placeholder="Paste a URL or path, e.g. https://api.example.com/users/42"
+        width="100%"
+      />
+      {result.status === 'matched' ? (
+        <FlexColumn $gap={4}>
+          <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+            Templated path
+          </Typography>
+          <TemplatePath template={result.outputPath} disabled={actionDisabled} fontSize={12} />
+        </FlexColumn>
+      ) : null}
+      {result.status === 'no_match' && urlInput.trim() ? (
+        <Typography size={TypographySize.XXXS} color={TypographyColor.Secondary}>
+          {result.message}
+        </Typography>
+      ) : null}
+    </SimulatorBlock>
+  );
+}

--- a/frontend/webapp/app/(v2)/url-templating/template-path.test.ts
+++ b/frontend/webapp/app/(v2)/url-templating/template-path.test.ts
@@ -1,0 +1,18 @@
+import { parseTemplatePath } from './template-path';
+
+describe('parseTemplatePath', () => {
+  it('classifies static, variable, and wildcard segments', () => {
+    expect(parseTemplatePath('/users/{id}/orders/{orderId}/items/*')).toEqual([
+      { kind: 'static', text: 'users' },
+      { kind: 'variable', text: '{id}' },
+      { kind: 'static', text: 'orders' },
+      { kind: 'variable', text: '{orderId}' },
+      { kind: 'static', text: 'items' },
+      { kind: 'wildcard', text: '*' },
+    ]);
+  });
+
+  it('handles templates without a leading slash', () => {
+    expect(parseTemplatePath('health')).toEqual([{ kind: 'static', text: 'health' }]);
+  });
+});

--- a/frontend/webapp/app/(v2)/url-templating/template-path.tsx
+++ b/frontend/webapp/app/(v2)/url-templating/template-path.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import styled, { type DefaultTheme, useTheme } from 'styled-components';
+
+export type TemplateSegmentKind = 'static' | 'wildcard' | 'variable';
+
+export type TemplatePathSegment = {
+  kind: TemplateSegmentKind;
+  text: string;
+};
+
+const VARIABLE_SEGMENT = /^\{[^{}]+\}$/;
+
+export function parseTemplatePath(template: string): TemplatePathSegment[] {
+  const trimmed = template.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  const segments: TemplatePathSegment[] = [];
+  for (const part of trimmed.split('/')) {
+    if (part === '') {
+      continue;
+    }
+    if (part === '*') {
+      segments.push({ kind: 'wildcard', text: part });
+    } else if (VARIABLE_SEGMENT.test(part)) {
+      segments.push({ kind: 'variable', text: part });
+    } else {
+      segments.push({ kind: 'static', text: part });
+    }
+  }
+  return segments;
+}
+
+const segmentColor: Record<TemplateSegmentKind, (theme: DefaultTheme) => string> = {
+  static: (theme) => theme.v2.colors.white[500],
+  wildcard: (theme) => theme.v2.colors.orange[600],
+  variable: (theme) => theme.v2.colors.blue[200],
+};
+
+const PathRoot = styled.span<{ $fontSize: number; $disabled?: boolean }>`
+  display: inline;
+  font-family: ${({ theme }) => theme.font_family.primary};
+  font-size: ${({ $fontSize }) => $fontSize}px;
+  line-height: 1.4;
+  opacity: ${({ $disabled }) => ($disabled ? 0.45 : 1)};
+  text-decoration: ${({ $disabled }) => ($disabled ? 'line-through' : 'none')};
+  text-decoration-color: ${({ theme, $disabled }) => ($disabled ? theme.v2.colors.grey[500] : 'currentColor')};
+`;
+
+const Slash = styled.span`
+  color: ${({ theme }) => theme.v2.colors.white[500]};
+  font-weight: 400;
+`;
+
+const Segment = styled.span<{ $kind: TemplateSegmentKind }>`
+  color: ${({ theme, $kind }) => segmentColor[$kind](theme)};
+  font-weight: ${({ $kind }) => ($kind === 'wildcard' ? 700 : $kind === 'variable' ? 500 : 400)};
+  font-style: ${({ $kind }) => ($kind === 'wildcard' ? 'italic' : 'normal')};
+`;
+
+export function templatePathFromSegments(segments: TemplatePathSegment[]): string {
+  if (!segments.length) {
+    return '';
+  }
+  return `/${segments.map((segment) => segment.text).join('/')}`;
+}
+
+export function TemplatePathSegmentLabel({
+  kind,
+  text,
+  fontSize,
+}: {
+  kind: TemplateSegmentKind;
+  text: string;
+  fontSize?: number;
+}) {
+  const theme = useTheme();
+  const size = fontSize ?? theme.v2.text.size.xs;
+  return (
+    <PathRoot $fontSize={size}>
+      <Segment $kind={kind}>{text}</Segment>
+    </PathRoot>
+  );
+}
+
+type TemplatePathProps = {
+  template: string;
+  fontSize?: number;
+  disabled?: boolean;
+};
+
+export function TemplatePath({ template, fontSize, disabled }: TemplatePathProps) {
+  const theme = useTheme();
+  const segments = useMemo(() => parseTemplatePath(template), [template]);
+  const size = fontSize ?? theme.v2.text.size.xs;
+
+  if (!segments.length) {
+    return (
+      <PathRoot $fontSize={size} $disabled={disabled} title={template}>
+        {template}
+      </PathRoot>
+    );
+  }
+
+  const hasLeadingSlash = template.trimStart().startsWith('/');
+
+  return (
+    <PathRoot $fontSize={size} $disabled={disabled} title={template}>
+      {hasLeadingSlash ? <Slash>/</Slash> : null}
+      {segments.map((segment, index) => (
+        <React.Fragment key={`${index}-${segment.text}`}>
+          {index > 0 ? <Slash>/</Slash> : null}
+          <Segment $kind={segment.kind}>{segment.text}</Segment>
+        </React.Fragment>
+      ))}
+    </PathRoot>
+  );
+}

--- a/frontend/webapp/app/(v2)/url-templating/template-row-activation.ts
+++ b/frontend/webapp/app/(v2)/url-templating/template-row-activation.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import React, { type KeyboardEvent, type MouseEvent } from 'react';
+
+export function templateRowActivationProps(onActivate: () => void): {
+  role: 'button';
+  tabIndex: 0;
+  onClick: () => void;
+  onKeyDown: (event: KeyboardEvent<HTMLElement>) => void;
+} {
+  return {
+    role: 'button',
+    tabIndex: 0,
+    onClick: onActivate,
+    onKeyDown: (event: KeyboardEvent<HTMLElement>) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        onActivate();
+      }
+    },
+  };
+}
+
+export function stopRowActivation(event: { stopPropagation: () => void }): void {
+  event.stopPropagation();
+}

--- a/frontend/webapp/app/(v2)/url-templating/template-simulator.test.ts
+++ b/frontend/webapp/app/(v2)/url-templating/template-simulator.test.ts
@@ -1,0 +1,68 @@
+import { extractUrlPath, simulateCustomTemplate } from './template-simulator';
+
+describe('extractUrlPath', () => {
+  it('extracts pathname from http URLs with query strings', () => {
+    expect(extractUrlPath('http://foo.bar/bla/xxx/yyy/1234?adsfds=fsadfds')).toEqual({
+      segments: ['bla', 'xxx', 'yyy', '1234'],
+      hadLeadingSlash: true,
+    });
+  });
+
+  it('extracts pathname from https URLs with hash fragments', () => {
+    expect(extractUrlPath('https://api.example.com/users/42#section')).toEqual({
+      segments: ['users', '42'],
+      hadLeadingSlash: true,
+    });
+  });
+
+  it('handles bare paths with query strings', () => {
+    expect(extractUrlPath('/users/42?tab=1')).toEqual({
+      segments: ['users', '42'],
+      hadLeadingSlash: true,
+    });
+  });
+});
+
+describe('simulateCustomTemplate', () => {
+  it('templates variable segments when static parts match', () => {
+    expect(simulateCustomTemplate('/users/{id}', '/users/42')).toEqual({
+      status: 'matched',
+      outputPath: '/users/{id}',
+    });
+  });
+
+  it('accepts full http URLs with query strings', () => {
+    expect(
+      simulateCustomTemplate('/bla/xxx/yyy/{id}', 'http://foo.bar/bla/xxx/yyy/1234?adsfds=fsadfds'),
+    ).toEqual({
+      status: 'matched',
+      outputPath: '/bla/xxx/yyy/{id}',
+    });
+  });
+
+  it('accepts full URLs and uses pathname only', () => {
+    expect(simulateCustomTemplate('/users/{id}', 'https://api.example.com/users/42?q=1')).toEqual({
+      status: 'matched',
+      outputPath: '/users/{id}',
+    });
+  });
+
+  it('rejects segment count mismatch', () => {
+    const result = simulateCustomTemplate('/users/{id}', '/users/42/orders/9');
+    expect(result.status).toBe('no_match');
+    if (result.status === 'no_match') {
+      expect(result.message).toContain('expects 2');
+    }
+  });
+
+  it('rejects static segment mismatch', () => {
+    expect(simulateCustomTemplate('/users/{id}', '/customers/42').status).toBe('no_match');
+  });
+
+  it('preserves wildcard segment values in output', () => {
+    expect(simulateCustomTemplate('/items/*', '/items/sale')).toEqual({
+      status: 'matched',
+      outputPath: '/items/sale',
+    });
+  });
+});

--- a/frontend/webapp/app/(v2)/url-templating/template-simulator.ts
+++ b/frontend/webapp/app/(v2)/url-templating/template-simulator.ts
@@ -1,0 +1,177 @@
+type RulePathSegment = {
+  wildcard: boolean;
+  staticString: string;
+  templateName: string;
+};
+
+export type TemplateSimulationResult =
+  | { status: 'matched'; outputPath: string }
+  | { status: 'no_match'; message: string }
+  | { status: 'empty_input' };
+
+function parseRuleTemplateName(raw: string): string {
+  const name = raw.trim();
+  return name || 'id';
+}
+
+export function parseUserInputRuleString(userInputRule: string): RulePathSegment[] {
+  let segments = userInputRule.split('/');
+  if (userInputRule.startsWith('/')) {
+    segments = segments.slice(1);
+  }
+
+  return segments.map((segment) => {
+    if (segment === '*') {
+      return { wildcard: true, staticString: '', templateName: '' };
+    }
+    if (segment.startsWith('{') && segment.endsWith('}')) {
+      return {
+        wildcard: false,
+        staticString: '',
+        templateName: parseRuleTemplateName(segment.slice(1, -1)),
+      };
+    }
+    return { wildcard: false, staticString: segment, templateName: '' };
+  });
+}
+
+function attemptTemplateWithRule(pathSegments: string[], ruleSegments: RulePathSegment[]): string | null {
+  for (let i = 0; i < pathSegments.length; i += 1) {
+    const pathSegment = pathSegments[i]!;
+    const ruleSegment = ruleSegments[i]!;
+
+    if (ruleSegment.wildcard) {
+      continue;
+    }
+
+    if (ruleSegment.staticString && ruleSegment.staticString !== pathSegment) {
+      return null;
+    }
+  }
+
+  const result: string[] = [];
+  for (let i = 0; i < ruleSegments.length; i += 1) {
+    const segment = ruleSegments[i]!;
+    const pathSegment = pathSegments[i]!;
+    if (segment.templateName) {
+      result.push(`{${segment.templateName}}`);
+    } else if (segment.wildcard) {
+      result.push(pathSegment);
+    } else {
+      result.push(segment.staticString);
+    }
+  }
+
+  return result.join('/');
+}
+
+function decodePathSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
+function stripQueryAndHash(raw: string): string {
+  let path = raw;
+  const queryIndex = path.indexOf('?');
+  if (queryIndex >= 0) {
+    path = path.slice(0, queryIndex);
+  }
+  const hashIndex = path.indexOf('#');
+  if (hashIndex >= 0) {
+    path = path.slice(0, hashIndex);
+  }
+  return path;
+}
+
+function parseAbsoluteUrl(input: string): URL | null {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const attempts = [
+    trimmed,
+    /^https?:\/\//i.test(trimmed) ? null : trimmed.startsWith('//') ? `https:${trimmed}` : null,
+    /^https?:\/\//i.test(trimmed) || trimmed.startsWith('//') || trimmed.startsWith('/')
+      ? null
+      : `https://${trimmed}`,
+  ].filter((value): value is string => !!value);
+
+  for (const candidate of attempts) {
+    try {
+      return new URL(candidate);
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+function splitPathToSegments(path: string): { segments: string[]; hadLeadingSlash: boolean } {
+  if (path.trim() === '' || path.replace(/\//g, '') === '') {
+    return { segments: [], hadLeadingSlash: true };
+  }
+
+  const hadLeadingSlash = path.startsWith('/');
+  const normalized = hadLeadingSlash ? path : `/${path}`;
+  let segments = normalized.split('/').slice(1).map(decodePathSegment);
+  if (segments.at(-1) === '') {
+    segments = segments.slice(0, -1);
+  }
+
+  if (!segments.length) {
+    return { segments: [], hadLeadingSlash: true };
+  }
+
+  return { segments, hadLeadingSlash: true };
+}
+
+export function extractUrlPath(input: string): { segments: string[]; hadLeadingSlash: boolean } {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return { segments: [], hadLeadingSlash: true };
+  }
+
+  const parsedUrl = parseAbsoluteUrl(trimmed);
+  if (parsedUrl) {
+    return splitPathToSegments(parsedUrl.pathname);
+  }
+
+  const pathOnly = stripQueryAndHash(trimmed);
+  return splitPathToSegments(pathOnly);
+}
+
+export function simulateCustomTemplate(template: string, urlInput: string): TemplateSimulationResult {
+  if (!urlInput.trim()) {
+    return { status: 'empty_input' };
+  }
+
+  const ruleSegments = parseUserInputRuleString(template.trim());
+  if (!ruleSegments.length) {
+    return { status: 'no_match', message: 'Template has no path segments.' };
+  }
+
+  const { segments: pathSegments, hadLeadingSlash } = extractUrlPath(urlInput);
+
+  if (pathSegments.length !== ruleSegments.length) {
+    return {
+      status: 'no_match',
+      message: `Path has ${pathSegments.length} segment${pathSegments.length === 1 ? '' : 's'}; this template expects ${ruleSegments.length}.`,
+    };
+  }
+
+  const joined = attemptTemplateWithRule(pathSegments, ruleSegments);
+  if (!joined) {
+    return {
+      status: 'no_match',
+      message: 'Path does not match this template (static segments must match exactly).',
+    };
+  }
+
+  const outputPath = hadLeadingSlash ? `/${joined}` : joined;
+  return { status: 'matched', outputPath };
+}

--- a/frontend/webapp/app/(v2)/url-templating/template-sort.test.ts
+++ b/frontend/webapp/app/(v2)/url-templating/template-sort.test.ts
@@ -1,0 +1,9 @@
+import { sortUrlTemplates } from './template-sort';
+
+describe('sortUrlTemplates', () => {
+  it('orders paths lexicographically with numeric segments', () => {
+    expect(
+      sortUrlTemplates(['/users/{id}/orders', '/api/v2/items', '/api/v10/items', '/accounts']),
+    ).toEqual(['/accounts', '/api/v10/items', '/api/v2/items', '/users/{id}/orders']);
+  });
+});

--- a/frontend/webapp/app/(v2)/url-templating/template-sort.ts
+++ b/frontend/webapp/app/(v2)/url-templating/template-sort.ts
@@ -1,0 +1,13 @@
+/** Sort key for URL template paths (stable, path-friendly lexicographic order). */
+export function compareUrlTemplates(a: string, b: string): number {
+  const left = a.trim();
+  const right = b.trim();
+  if (left === right) {
+    return 0;
+  }
+  return left.localeCompare(right, undefined, { sensitivity: 'base', numeric: true });
+}
+
+export function sortUrlTemplates(templates: readonly string[]): string[] {
+  return [...templates].sort(compareUrlTemplates);
+}

--- a/frontend/webapp/app/(v2)/url-templating/ui-template-rules.ts
+++ b/frontend/webapp/app/(v2)/url-templating/ui-template-rules.ts
@@ -1,0 +1,57 @@
+import type { Action } from '@odigos/ui-kit/types';
+import type { ScopeToken } from './scope-token-types';
+import type { CustomTemplateCrGroup } from './url-templatization-aggregate';
+
+/** Default Action name for rules created from the URL Templating UI. */
+export const UI_TEMPLATE_RULES_ACTION_NAME = 'UI template rules';
+
+export function findUiTemplateRulesAction(actions: Action[]): Action | undefined {
+  const target = UI_TEMPLATE_RULES_ACTION_NAME.toLowerCase();
+  return actions.find((action) => action.name?.trim().toLowerCase() === target);
+}
+
+export function isEntireClusterScopeTokens(tokens: ScopeToken[]): boolean {
+  return tokens.length === 1 && tokens[0]?.type === 'entire_cluster';
+}
+
+export function isEntireClusterGroup(group: CustomTemplateCrGroup): boolean {
+  return isEntireClusterScopeTokens(group.scopeTokens);
+}
+
+export function findEntireClusterGroupForAction(
+  groups: CustomTemplateCrGroup[],
+  actionId: string,
+): CustomTemplateCrGroup | undefined {
+  return groups.find((group) => group.actionId === actionId && isEntireClusterGroup(group));
+}
+
+function scopeTokenSearchParts(token: ScopeToken): string[] {
+  switch (token.type) {
+    case 'entire_cluster':
+      return ['entire cluster', 'cluster', 'all'];
+    case 'namespace':
+      return ['namespace', ...token.values];
+    case 'language':
+      return ['language', ...token.values];
+    case 'workload':
+      return [
+        'workload',
+        ...token.groups.flatMap((group) => [group.kind, ...group.namespaceNames]),
+      ];
+    default:
+      return [];
+  }
+}
+
+export function customTemplateGroupSearchText(group: CustomTemplateCrGroup): string {
+  return [
+    group.actionLabel,
+    group.actionDisplayName,
+    ...group.scopeTokens.flatMap(scopeTokenSearchParts),
+    ...group.templates,
+    `${group.templates.length} templates`,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+}

--- a/frontend/webapp/app/(v2)/url-templating/url-templatization-aggregate.test.ts
+++ b/frontend/webapp/app/(v2)/url-templating/url-templatization-aggregate.test.ts
@@ -1,0 +1,126 @@
+import { ActionType, type Action } from '@odigos/ui-kit/types';
+import {
+  aggregateUrlTemplatization,
+  deriveUrlTemplatizationPageSummary,
+  type ClusterDefaultTemplatizationEffect,
+} from './url-templatization-aggregate';
+
+function makeAction(partial: {
+  id: string;
+  name?: string;
+  disabled?: boolean;
+  fields?: Action['fields'];
+}): Action {
+  return {
+    id: partial.id,
+    type: ActionType.URLTemplatization,
+    name: partial.name ?? partial.id,
+    disabled: partial.disabled ?? false,
+    signals: [],
+    fields: partial.fields ?? {},
+  } as Action;
+}
+
+const enabledClusterWide: ClusterDefaultTemplatizationEffect = {
+  mode: 'cluster_wide',
+  disabledClusterWide: false,
+  title: '',
+  description: '',
+  sectionSummary: '',
+};
+
+const disabledClusterWide: ClusterDefaultTemplatizationEffect = {
+  mode: 'cluster_wide',
+  disabledClusterWide: true,
+  title: '',
+  description: '',
+  sectionSummary: '',
+};
+
+const scoped: ClusterDefaultTemplatizationEffect = {
+  mode: 'scoped',
+  disabledClusterWide: false,
+  title: '',
+  description: '',
+  sectionSummary: '',
+};
+
+const none: ClusterDefaultTemplatizationEffect = {
+  mode: 'none',
+  disabledClusterWide: false,
+  title: '',
+  description: '',
+  sectionSummary: '',
+};
+
+describe('deriveUrlTemplatizationPageSummary', () => {
+  it('reports OFF when there are no enabled actions', () => {
+    expect(deriveUrlTemplatizationPageSummary(enabledClusterWide, 0, 0)).toBe('URL templating is OFF');
+  });
+
+  it('reports OFF when default is disabled cluster-wide with no custom rules', () => {
+    expect(deriveUrlTemplatizationPageSummary(disabledClusterWide, 0, 1)).toBe('URL templating is OFF');
+  });
+
+  it('reports default OFF with custom rules when cluster-wide default is disabled', () => {
+    expect(deriveUrlTemplatizationPageSummary(disabledClusterWide, 3, 1)).toBe(
+      'Default templating is OFF · 3 custom rules',
+    );
+  });
+
+  it('reports entire-cluster default when explicitly enabled', () => {
+    expect(deriveUrlTemplatizationPageSummary(enabledClusterWide, 0, 1)).toBe(
+      'Applying default templating to the entire cluster',
+    );
+  });
+
+  it('reports default OFF when no default rules are configured', () => {
+    expect(deriveUrlTemplatizationPageSummary(none, 0, 1)).toBe('URL templating is OFF');
+    expect(deriveUrlTemplatizationPageSummary(none, 2, 1)).toBe(
+      'Default templating is OFF · 2 custom rules',
+    );
+  });
+
+  it('reports scoped default with optional custom rules', () => {
+    expect(deriveUrlTemplatizationPageSummary(scoped, 0, 1)).toBe(
+      'Applying default templating to specific scopes',
+    );
+    expect(deriveUrlTemplatizationPageSummary(scoped, 1, 1)).toBe(
+      'Applying default templating to specific scopes · 1 custom rule',
+    );
+  });
+});
+
+describe('aggregateUrlTemplatization pageSummary', () => {
+  it('ignores disabled actions when computing the page summary', () => {
+    const aggregation = aggregateUrlTemplatization([
+      makeAction({
+        id: 'disabled',
+        disabled: true,
+        fields: {
+          urlTemplatizationRulesGroups: [{ templatizationRules: [{ template: '/users/{id}' }] }],
+        },
+      }),
+    ]);
+    expect(aggregation.enabledActionCount).toBe(0);
+    expect(aggregation.enabledCustomRuleInstances).toBe(0);
+    expect(aggregation.pageSummary).toBe('URL templating is OFF');
+  });
+
+  it('summarizes cluster-wide default with custom rules', () => {
+    const aggregation = aggregateUrlTemplatization([
+      makeAction({
+        id: 'global',
+        fields: {
+          urlTemplatizationDefaultGroups: [{}],
+          urlTemplatizationRulesGroups: [
+            { templatizationRules: [{ template: '/users/{id}' }, { template: '/orders/{id}' }] },
+          ],
+        },
+      }),
+    ]);
+    expect(aggregation.pageSummary).toBe(
+      'Applying default templating to the entire cluster · 2 custom rules',
+    );
+  });
+});

--- a/frontend/webapp/app/(v2)/url-templating/url-templatization-aggregate.ts
+++ b/frontend/webapp/app/(v2)/url-templating/url-templatization-aggregate.ts
@@ -1,0 +1,581 @@
+import { ActionType, type Action } from '@odigos/ui-kit/types';
+import { sortUrlTemplates } from './template-sort';
+import { type ScopeToken, scopeTokensSortKey } from './scope-token-types';
+
+export type { ScopeToken } from './scope-token-types';
+export { scopeTokensSortKey } from './scope-token-types';
+
+export type UrlTemplatizationDefaultGroup = {
+  disabled?: boolean | null;
+  scopes?: {
+    namespaces?: string[] | null;
+    languages?: string[] | null;
+    sources?: { namespace?: string | null; kind?: string | null; name?: string | null }[] | null;
+  } | null;
+  skipPolicy?: {
+    skipForNonSuccessCodes?: boolean | null;
+    skipHttpStatusCodes?: number[] | null;
+  } | null;
+};
+
+export type UrlTemplatizationRulesGroup = {
+  filterK8sNamespace?: string | null;
+  filterK8sWorkloadKind?: string | null;
+  filterK8sWorkloadName?: string | null;
+  filterProgrammingLanguage?: string | null;
+  workloadFilters?: { kind?: string | null; name?: string | null }[] | null;
+  templatizationRules?: { template?: string | null }[] | null;
+  notes?: string | null;
+};
+
+export type UrlTemplatizationActionFields = {
+  urlTemplatizationRulesGroups?: UrlTemplatizationRulesGroup[] | null;
+  urlTemplatizationDefaultGroups?: UrlTemplatizationDefaultGroup[] | null;
+};
+
+export type AggregatedCustomTemplate = {
+  template: string;
+  scopeTokens: ScopeToken[];
+  count: number;
+  actionId: string;
+  actionDisplayName?: string | null;
+  actionLabels: string[];
+  actionDisabled: boolean;
+  actionUiGenerated: boolean;
+};
+
+export type CustomTemplateCrGroup = {
+  actionId: string;
+  actionDisplayName?: string | null;
+  actionLabel: string;
+  actionDisabled: boolean;
+  actionUiGenerated: boolean;
+  groupIndex: number;
+  scopeTokens: ScopeToken[];
+  groupNotes?: string | null;
+  templates: string[];
+};
+
+export type AggregatedDefaultGroup = {
+  scopeTokens: ScopeToken[];
+  configLabel: string;
+  count: number;
+  actionLabels: string[];
+  actionDisabled: boolean;
+};
+
+export type DefaultTemplatizationCrGroup = {
+  actionId: string;
+  actionLabel: string;
+  actionDisabled: boolean;
+  actionUiGenerated: boolean;
+  groupIndex: number;
+  scopeTokens: ScopeToken[];
+  disabled: boolean;
+  skipForNonSuccessCodes: boolean;
+  skipHttpStatusCodes: number[];
+  configLabel: string;
+};
+
+export type UrlTemplatizationAggregation = {
+  customTemplates: AggregatedCustomTemplate[];
+  defaultGroups: AggregatedDefaultGroup[];
+  totalCustomRuleInstances: number;
+  totalDefaultGroupInstances: number;
+  actionCount: number;
+  clusterDefaultEffect: ClusterDefaultTemplatizationEffect;
+};
+
+export type ClusterDefaultTemplatizationMode = 'none' | 'cluster_wide' | 'scoped';
+
+export type ClusterDefaultTemplatizationEffect = {
+  mode: ClusterDefaultTemplatizationMode;
+  title: string;
+  description: string;
+  sectionSummary: string;
+};
+
+export function isUrlTemplatizationAction(action: Action): boolean {
+  if (action.type === ActionType.URLTemplatization) {
+    return true;
+  }
+  const fields = action.fields as UrlTemplatizationActionFields | undefined;
+  const customGroups = fields?.urlTemplatizationRulesGroups;
+  const defaultGroups = fields?.urlTemplatizationDefaultGroups;
+  return (Array.isArray(customGroups) && customGroups.length > 0) || (Array.isArray(defaultGroups) && defaultGroups.length > 0);
+}
+
+function actionLabel(action: Action): string {
+  return action.name?.trim() || action.id;
+}
+
+function actionDisplayName(action: Action): string | null {
+  const name = action.name?.trim();
+  return name || null;
+}
+
+function actionUiGenerated(action: Action): boolean {
+  return !!(action as Action & { uiGenerated?: boolean | null }).uiGenerated;
+}
+
+export function isGlobalDefaultScope(scopes: UrlTemplatizationDefaultGroup['scopes']): boolean {
+  if (!scopes) {
+    return true;
+  }
+  const hasNamespaces = (scopes.namespaces?.length ?? 0) > 0;
+  const hasSources = (scopes.sources?.length ?? 0) > 0;
+  const hasLanguages = (scopes.languages?.length ?? 0) > 0;
+  return !hasNamespaces && !hasSources && !hasLanguages;
+}
+
+function collectEnabledDefaultGroups(actions: Action[]): UrlTemplatizationDefaultGroup[] {
+  const groups: UrlTemplatizationDefaultGroup[] = [];
+  for (const action of actions) {
+    if (action.disabled) {
+      continue;
+    }
+    const fields = action.fields as UrlTemplatizationActionFields | undefined;
+    for (const group of fields?.urlTemplatizationDefaultGroups ?? []) {
+      groups.push(group);
+    }
+  }
+  return groups;
+}
+
+export function deriveClusterDefaultTemplatizationEffect(actions: Action[]): ClusterDefaultTemplatizationEffect {
+  const defaultGroups = collectEnabledDefaultGroups(actions);
+
+  if (defaultGroups.length === 0) {
+    return {
+      mode: 'none',
+      title: 'No default templatization rules',
+      sectionSummary: 'No explicit default templating rules configured',
+      description:
+        'No enabled URL templatization action defines default templatization. Odigos still applies built-in heuristic default templatization for instrumented workloads covered by these actions.',
+    };
+  }
+
+  const globalGroups = defaultGroups.filter((group) => isGlobalDefaultScope(group.scopes));
+  if (globalGroups.length > 0) {
+    const allGlobalDisabled = globalGroups.every((group) => group.disabled);
+    if (allGlobalDisabled) {
+      return {
+        mode: 'cluster_wide',
+        title: 'Default templatization disabled cluster-wide',
+        sectionSummary: 'Default templating is disabled in the entire cluster',
+        description:
+          'At least one enabled action disables default templatization for all sources. Scoped default rules may still apply where configured.',
+      };
+    }
+
+    const skipDescriptions = globalGroups
+      .filter((group) => !group.disabled)
+      .map((group) => formatDefaultConfig(group))
+      .filter((label) => label !== 'Default heuristic templatization enabled');
+
+    const skipDetail =
+      skipDescriptions.length > 0
+        ? ` ${[...new Set(skipDescriptions)].join('; ')}.`
+        : ' Default heuristic templatization applies when no custom template matches.';
+
+    return {
+      mode: 'cluster_wide',
+      title: 'Default templatization for the entire cluster',
+      sectionSummary: 'Default templating is enabled in the entire cluster',
+      description: `An enabled action configures default templatization for all sources.${skipDetail}`,
+    };
+  }
+
+  return {
+    mode: 'scoped',
+    title: 'Default templatization for specific scopes only',
+    sectionSummary: 'Default templatization for specific scopes only',
+    description:
+      'Enabled actions define default templatization only for selected namespaces, workloads, or languages—not cluster-wide. Workloads outside those scopes rely on built-in default behavior unless another rule applies.',
+  };
+}
+
+export function customTemplatesSectionSummary(ruleCount: number): string {
+  if (ruleCount === 0) {
+    return 'No custom rules';
+  }
+  if (ruleCount === 1) {
+    return '1 custom rule';
+  }
+  return `${ruleCount} custom rules`;
+}
+
+function formatLanguageToken(language: string): string {
+  return language.trim().toLowerCase();
+}
+
+type WorkloadRef = {
+  namespace?: string | null;
+  kind?: string | null;
+  name?: string | null;
+};
+
+function formatWorkloadKindLabel(kind: string | null | undefined): string {
+  const trimmed = kind?.trim();
+  return trimmed || 'Workload';
+}
+
+function formatWorkloadNamespaceName(namespace: string | null | undefined, name: string | null | undefined): string {
+  const workloadName = name?.trim();
+  if (!workloadName) {
+    return '';
+  }
+  const ns = namespace?.trim();
+  return ns ? `${ns}/${workloadName}` : workloadName;
+}
+
+function buildWorkloadScopeToken(workloads: WorkloadRef[], fallbackNamespace?: string): ScopeToken | null {
+  const byKind = new Map<string, string[]>();
+
+  for (const workload of workloads) {
+    const kind = formatWorkloadKindLabel(workload.kind);
+    const nsName = formatWorkloadNamespaceName(workload.namespace?.trim() || fallbackNamespace, workload.name);
+    if (!nsName) {
+      continue;
+    }
+    const list = byKind.get(kind) ?? [];
+    list.push(nsName);
+    byKind.set(kind, list);
+  }
+
+  if (byKind.size === 0) {
+    return null;
+  }
+
+  const groups = [...byKind.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([kind, namespaceNames]) => ({ kind, namespaceNames }));
+
+  return { type: 'workload', groups };
+}
+
+export function scopeTokensFromSourcesScopes(scopes: UrlTemplatizationDefaultGroup['scopes']): ScopeToken[] {
+  if (isGlobalDefaultScope(scopes)) {
+    return [{ type: 'entire_cluster' }];
+  }
+
+  const tokens: ScopeToken[] = [];
+
+  if (scopes?.namespaces?.length) {
+    tokens.push({ type: 'namespace', values: [...scopes.namespaces] });
+  }
+
+  if (scopes?.sources?.length) {
+    const fallbackNamespace = scopes.namespaces?.length === 1 ? scopes.namespaces[0]?.trim() : undefined;
+    const workloadToken = buildWorkloadScopeToken(
+      scopes.sources.map((source) => ({
+        namespace: source.namespace,
+        kind: source.kind,
+        name: source.name,
+      })),
+      fallbackNamespace,
+    );
+    if (workloadToken) {
+      tokens.push(workloadToken);
+    }
+  }
+
+  if (scopes?.languages?.length) {
+    tokens.push({ type: 'language', values: scopes.languages.map(formatLanguageToken) });
+  }
+
+  return tokens.length ? tokens : [{ type: 'entire_cluster' }];
+}
+
+export function scopeTokensFromCustomRulesGroup(group: UrlTemplatizationRulesGroup): ScopeToken[] {
+  const namespace = group.filterK8sNamespace?.trim();
+  const language = group.filterProgrammingLanguage?.trim();
+  const workloadFilters = group.workloadFilters?.filter((filter) => filter?.kind || filter?.name) ?? [];
+
+  const hasLegacyWorkload = group.filterK8sWorkloadKind || group.filterK8sWorkloadName;
+  if (!namespace && !language && workloadFilters.length === 0 && !hasLegacyWorkload) {
+    return [{ type: 'entire_cluster' }];
+  }
+
+  const tokens: ScopeToken[] = [];
+
+  if (namespace) {
+    tokens.push({ type: 'namespace', values: [namespace] });
+  }
+
+  if (workloadFilters.length) {
+    const workloadToken = buildWorkloadScopeToken(
+      workloadFilters.map((filter) => ({
+        namespace,
+        kind: filter.kind,
+        name: filter.name,
+      })),
+    );
+    if (workloadToken) {
+      tokens.push(workloadToken);
+    }
+  } else if (hasLegacyWorkload) {
+    const workloadToken = buildWorkloadScopeToken([
+      {
+        namespace,
+        kind: group.filterK8sWorkloadKind,
+        name: group.filterK8sWorkloadName,
+      },
+    ]);
+    if (workloadToken) {
+      tokens.push(workloadToken);
+    }
+  }
+
+  if (language) {
+    tokens.push({ type: 'language', values: [formatLanguageToken(language)] });
+  }
+
+  return tokens;
+}
+
+function formatDefaultConfig(group: UrlTemplatizationDefaultGroup): string {
+  if (group.disabled) {
+    return 'Default templatization disabled';
+  }
+  const skip = group.skipPolicy;
+  if (!skip) {
+    return 'Default heuristic templatization enabled';
+  }
+  if (skip.skipForNonSuccessCodes) {
+    return 'Skip default templatization for non-2xx responses';
+  }
+  if (skip.skipHttpStatusCodes?.length) {
+    return `Skip default templatization for HTTP ${skip.skipHttpStatusCodes.join(', ')}`;
+  }
+  return 'Default templatization skip policy configured';
+}
+
+function defaultGroupKey(group: UrlTemplatizationDefaultGroup): string {
+  const scopeTokens = scopeTokensFromSourcesScopes(group.scopes);
+  return JSON.stringify({
+    scopeTokens,
+    config: formatDefaultConfig(group),
+    disabled: !!group.disabled,
+    skipForNonSuccess: !!group.skipPolicy?.skipForNonSuccessCodes,
+    skipCodes: group.skipPolicy?.skipHttpStatusCodes ?? [],
+  });
+}
+
+function customRuleKey(template: string, scopeTokens: ScopeToken[], actionId: string): string {
+  return JSON.stringify({ template, scopeTokens, actionId });
+}
+
+export function collectCustomTemplateCrGroups(actions: Action[]): CustomTemplateCrGroup[] {
+  const groups: CustomTemplateCrGroup[] = [];
+
+  for (const action of actions) {
+    if (!isUrlTemplatizationAction(action)) {
+      continue;
+    }
+    const label = actionLabel(action);
+    const fields = action.fields as UrlTemplatizationActionFields | undefined;
+
+    for (const [groupIndex, group] of (fields?.urlTemplatizationRulesGroups ?? []).entries()) {
+      const templates = sortUrlTemplates(
+        (group.templatizationRules ?? [])
+          .map((rule) => rule.template?.trim())
+          .filter((template): template is string => !!template),
+      );
+      groups.push({
+        actionId: action.id,
+        actionDisplayName: actionDisplayName(action),
+        actionLabel: label,
+        actionDisabled: !!action.disabled,
+        actionUiGenerated: actionUiGenerated(action),
+        groupIndex,
+        scopeTokens: scopeTokensFromCustomRulesGroup(group),
+        groupNotes: group.notes,
+        templates,
+      });
+    }
+  }
+
+  return groups;
+}
+
+export function collectDefaultTemplatizationCrGroups(actions: Action[]): DefaultTemplatizationCrGroup[] {
+  const groups: DefaultTemplatizationCrGroup[] = [];
+
+  for (const action of actions) {
+    if (!isUrlTemplatizationAction(action)) {
+      continue;
+    }
+    const label = actionLabel(action);
+    const fields = action.fields as UrlTemplatizationActionFields | undefined;
+
+    for (const [groupIndex, group] of (fields?.urlTemplatizationDefaultGroups ?? []).entries()) {
+      groups.push({
+        actionId: action.id,
+        actionLabel: label,
+        actionDisabled: !!action.disabled,
+        actionUiGenerated: actionUiGenerated(action),
+        groupIndex,
+        scopeTokens: scopeTokensFromSourcesScopes(group.scopes),
+        disabled: !!group.disabled,
+        skipForNonSuccessCodes: !!group.skipPolicy?.skipForNonSuccessCodes,
+        skipHttpStatusCodes: group.skipPolicy?.skipHttpStatusCodes ?? [],
+        configLabel: formatDefaultConfig(group),
+      });
+    }
+  }
+
+  return groups;
+}
+
+export function aggregateUrlTemplatization(actions: Action[]): UrlTemplatizationAggregation {
+  const customMap = new Map<
+    string,
+    {
+      template: string;
+      scopeTokens: ScopeToken[];
+      count: number;
+      actionLabels: Set<string>;
+      actionId: string;
+      actionDisplayName: string | null;
+      actionDisabled: boolean;
+      actionUiGenerated: boolean;
+    }
+  >();
+  const defaultMap = new Map<
+    string,
+    {
+      scopeTokens: ScopeToken[];
+      configLabel: string;
+      count: number;
+      actionLabels: Set<string>;
+      disabledActionLabels: Set<string>;
+    }
+  >();
+
+  let totalCustomRuleInstances = 0;
+  let totalDefaultGroupInstances = 0;
+
+  for (const action of actions) {
+    const label = actionLabel(action);
+    const fields = action.fields as UrlTemplatizationActionFields | undefined;
+
+    for (const group of fields?.urlTemplatizationRulesGroups ?? []) {
+      const scopeTokens = scopeTokensFromCustomRulesGroup(group);
+      for (const rule of group.templatizationRules ?? []) {
+        const template = rule.template?.trim();
+        if (!template) {
+          continue;
+        }
+        totalCustomRuleInstances += 1;
+        const key = customRuleKey(template, scopeTokens, action.id);
+        const entry =
+          customMap.get(key) ??
+          ({
+            template,
+            scopeTokens,
+            count: 0,
+            actionLabels: new Set<string>(),
+            actionId: action.id,
+            actionDisplayName: actionDisplayName(action),
+            actionDisabled: !!action.disabled,
+            actionUiGenerated: actionUiGenerated(action),
+          } as {
+            template: string;
+            scopeTokens: ScopeToken[];
+            count: number;
+            actionLabels: Set<string>;
+            actionId: string;
+            actionDisplayName: string | null;
+            actionDisabled: boolean;
+            actionUiGenerated: boolean;
+          });
+        entry.count += 1;
+        entry.actionLabels.add(label);
+        customMap.set(key, entry);
+      }
+    }
+
+    for (const group of fields?.urlTemplatizationDefaultGroups ?? []) {
+      totalDefaultGroupInstances += 1;
+      const scopeTokens = scopeTokensFromSourcesScopes(group.scopes);
+      const key = defaultGroupKey(group);
+      const configLabel = formatDefaultConfig(group);
+      const entry =
+        defaultMap.get(key) ??
+        ({
+          scopeTokens,
+          configLabel,
+          count: 0,
+          actionLabels: new Set<string>(),
+          disabledActionLabels: new Set<string>(),
+        } as {
+          scopeTokens: ScopeToken[];
+          configLabel: string;
+          count: number;
+          actionLabels: Set<string>;
+          disabledActionLabels: Set<string>;
+        });
+      entry.count += 1;
+      entry.actionLabels.add(label);
+      if (action.disabled) {
+        entry.disabledActionLabels.add(label);
+      }
+      defaultMap.set(key, entry);
+    }
+  }
+
+  const customTemplates = [...customMap.values()]
+    .map(
+      ({
+        template,
+        scopeTokens,
+        count,
+        actionLabels,
+        actionId,
+        actionDisplayName,
+        actionDisabled,
+        actionUiGenerated,
+      }) => ({
+        template,
+        scopeTokens,
+        count,
+        actionId,
+        actionDisplayName,
+        actionLabels: [...actionLabels].sort((a, b) => a.localeCompare(b)),
+        actionDisabled,
+        actionUiGenerated,
+      }),
+    )
+    .sort(
+      (a, b) =>
+        a.template.localeCompare(b.template) ||
+        scopeTokensSortKey(a.scopeTokens).localeCompare(scopeTokensSortKey(b.scopeTokens)) ||
+        a.actionLabels.join(',').localeCompare(b.actionLabels.join(',')),
+    );
+
+  const defaultGroups = [...defaultMap.values()]
+    .map(({ scopeTokens, configLabel, count, actionLabels, disabledActionLabels }) => ({
+      scopeTokens,
+      configLabel,
+      count,
+      actionLabels: [...actionLabels].sort((a, b) => a.localeCompare(b)),
+      actionDisabled:
+        actionLabels.size > 0 && disabledActionLabels.size === actionLabels.size,
+    }))
+    .sort(
+      (a, b) =>
+        b.count - a.count ||
+        scopeTokensSortKey(a.scopeTokens).localeCompare(scopeTokensSortKey(b.scopeTokens)) ||
+        a.configLabel.localeCompare(b.configLabel),
+    );
+
+  return {
+    customTemplates,
+    defaultGroups,
+    totalCustomRuleInstances,
+    totalDefaultGroupInstances,
+    actionCount: actions.length,
+    clusterDefaultEffect: deriveClusterDefaultTemplatizationEffect(actions),
+  };
+}

--- a/frontend/webapp/app/(v2)/url-templating/url-templatization-aggregate.ts
+++ b/frontend/webapp/app/(v2)/url-templating/url-templatization-aggregate.ts
@@ -70,6 +70,7 @@ export type DefaultTemplatizationCrGroup = {
   actionDisabled: boolean;
   actionUiGenerated: boolean;
   groupIndex: number;
+  scopes: UrlTemplatizationDefaultGroup['scopes'];
   scopeTokens: ScopeToken[];
   disabled: boolean;
   skipForNonSuccessCodes: boolean;
@@ -82,14 +83,18 @@ export type UrlTemplatizationAggregation = {
   defaultGroups: AggregatedDefaultGroup[];
   totalCustomRuleInstances: number;
   totalDefaultGroupInstances: number;
+  enabledCustomRuleInstances: number;
   actionCount: number;
+  enabledActionCount: number;
   clusterDefaultEffect: ClusterDefaultTemplatizationEffect;
+  pageSummary: string;
 };
 
 export type ClusterDefaultTemplatizationMode = 'none' | 'cluster_wide' | 'scoped';
 
 export type ClusterDefaultTemplatizationEffect = {
   mode: ClusterDefaultTemplatizationMode;
+  disabledClusterWide: boolean;
   title: string;
   description: string;
   sectionSummary: string;
@@ -148,10 +153,10 @@ export function deriveClusterDefaultTemplatizationEffect(actions: Action[]): Clu
   if (defaultGroups.length === 0) {
     return {
       mode: 'none',
+      disabledClusterWide: false,
       title: 'No default templatization rules',
-      sectionSummary: 'No explicit default templating rules configured',
-      description:
-        'No enabled URL templatization action defines default templatization. Odigos still applies built-in heuristic default templatization for instrumented workloads covered by these actions.',
+      sectionSummary: 'No default templating rules configured',
+      description: 'No default rules configured. Only custom templates apply.',
     };
   }
 
@@ -161,10 +166,10 @@ export function deriveClusterDefaultTemplatizationEffect(actions: Action[]): Clu
     if (allGlobalDisabled) {
       return {
         mode: 'cluster_wide',
+        disabledClusterWide: true,
         title: 'Default templatization disabled cluster-wide',
         sectionSummary: 'Default templating is disabled in the entire cluster',
-        description:
-          'At least one enabled action disables default templatization for all sources. Scoped default rules may still apply where configured.',
+        description: 'Custom rules apply when they match; otherwise no default templating is used.',
       };
     }
 
@@ -173,25 +178,27 @@ export function deriveClusterDefaultTemplatizationEffect(actions: Action[]): Clu
       .map((group) => formatDefaultConfig(group))
       .filter((label) => label !== 'Default heuristic templatization enabled');
 
-    const skipDetail =
+    const description =
       skipDescriptions.length > 0
-        ? ` ${[...new Set(skipDescriptions)].join('; ')}.`
-        : ' Default heuristic templatization applies when no custom template matches.';
+        ? `Custom templates first, then default templating cluster-wide. ${[...new Set(skipDescriptions)].join('; ')}.`
+        : 'Will try custom templates first; otherwise, apply heuristic default templating.';
 
     return {
       mode: 'cluster_wide',
+      disabledClusterWide: false,
       title: 'Default templatization for the entire cluster',
       sectionSummary: 'Default templating is enabled in the entire cluster',
-      description: `An enabled action configures default templatization for all sources.${skipDetail}`,
+      description,
     };
   }
 
   return {
     mode: 'scoped',
+    disabledClusterWide: false,
     title: 'Default templatization for specific scopes only',
     sectionSummary: 'Default templatization for specific scopes only',
     description:
-      'Enabled actions define default templatization only for selected namespaces, workloads, or languages—not cluster-wide. Workloads outside those scopes rely on built-in default behavior unless another rule applies.',
+      'Spans try custom templates first; if none match, heuristic default templating is applied for the selected scopes.',
   };
 }
 
@@ -203,6 +210,43 @@ export function customTemplatesSectionSummary(ruleCount: number): string {
     return '1 custom rule';
   }
   return `${ruleCount} custom rules`;
+}
+
+function customRulesSuffix(ruleCount: number): string {
+  if (ruleCount === 0) {
+    return '';
+  }
+  if (ruleCount === 1) {
+    return ' · 1 custom rule';
+  }
+  return ` · ${ruleCount} custom rules`;
+}
+
+/** Page-level status line for default templatization + custom rules. */
+export function deriveUrlTemplatizationPageSummary(
+  effect: ClusterDefaultTemplatizationEffect,
+  enabledCustomRuleCount: number,
+  enabledActionCount: number,
+): string {
+  if (enabledActionCount === 0) {
+    return 'URL templating is OFF';
+  }
+
+  const customSuffix = customRulesSuffix(enabledCustomRuleCount);
+  const defaultIsOff = effect.disabledClusterWide || effect.mode === 'none';
+
+  if (defaultIsOff) {
+    if (enabledCustomRuleCount === 0) {
+      return 'URL templating is OFF';
+    }
+    return `Default templating is OFF${customSuffix}`;
+  }
+
+  if (effect.mode === 'scoped') {
+    return `Applying default templating to specific scopes${customSuffix}`;
+  }
+
+  return `Applying default templating to the entire cluster${customSuffix}`;
 }
 
 function formatLanguageToken(language: string): string {
@@ -288,50 +332,76 @@ export function scopeTokensFromSourcesScopes(scopes: UrlTemplatizationDefaultGro
 }
 
 export function scopeTokensFromCustomRulesGroup(group: UrlTemplatizationRulesGroup): ScopeToken[] {
-  const namespace = group.filterK8sNamespace?.trim();
-  const language = group.filterProgrammingLanguage?.trim();
+  const namespaceField = group.filterK8sNamespace?.trim() ?? '';
+  const languageField = group.filterProgrammingLanguage?.trim() ?? '';
   const workloadFilters = group.workloadFilters?.filter((filter) => filter?.kind || filter?.name) ?? [];
+  const hasLegacyWorkload = !!(group.filterK8sWorkloadKind || group.filterK8sWorkloadName);
 
-  const hasLegacyWorkload = group.filterK8sWorkloadKind || group.filterK8sWorkloadName;
-  if (!namespace && !language && workloadFilters.length === 0 && !hasLegacyWorkload) {
+  if (!namespaceField && !languageField && workloadFilters.length === 0 && !hasLegacyWorkload) {
     return [{ type: 'entire_cluster' }];
   }
 
+  const separatorIndex = namespaceField.indexOf('||');
+  const hasExplicitScopeNamespaces = separatorIndex >= 0;
+  const sourceNsPart = hasExplicitScopeNamespaces ? namespaceField.slice(0, separatorIndex) : namespaceField;
+  const extraNsPart = hasExplicitScopeNamespaces ? namespaceField.slice(separatorIndex + 2) : '';
+
+  const sourceNamespaces = sourceNsPart.split(',').map((value) => value.trim());
+  const languages = languageField
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+
   const tokens: ScopeToken[] = [];
 
-  if (namespace) {
-    tokens.push({ type: 'namespace', values: [namespace] });
-  }
-
-  if (workloadFilters.length) {
-    const workloadToken = buildWorkloadScopeToken(
-      workloadFilters.map((filter) => ({
-        namespace,
-        kind: filter.kind,
-        name: filter.name,
-      })),
-    );
-    if (workloadToken) {
-      tokens.push(workloadToken);
+  if (workloadFilters.length > 0 || hasLegacyWorkload) {
+    if (hasExplicitScopeNamespaces) {
+      const scopeNamespaces = extraNsPart
+        .split(',')
+        .map((value) => value.trim())
+        .filter(Boolean);
+      if (scopeNamespaces.length) {
+        tokens.push({ type: 'namespace', values: scopeNamespaces });
+      }
     }
-  } else if (hasLegacyWorkload) {
-    const workloadToken = buildWorkloadScopeToken([
-      {
-        namespace,
-        kind: group.filterK8sWorkloadKind,
-        name: group.filterK8sWorkloadName,
-      },
-    ]);
-    if (workloadToken) {
-      tokens.push(workloadToken);
+
+    if (workloadFilters.length) {
+      const workloadToken = buildWorkloadScopeToken(
+        workloadFilters.map((filter, index) => ({
+          namespace:
+            sourceNamespaces[index] ||
+            (sourceNamespaces.length === 1 ? sourceNamespaces[0] : undefined),
+          kind: filter.kind,
+          name: filter.name,
+        })),
+      );
+      if (workloadToken) {
+        tokens.push(workloadToken);
+      }
+    } else {
+      const workloadToken = buildWorkloadScopeToken([
+        {
+          namespace: sourceNamespaces[0] || undefined,
+          kind: group.filterK8sWorkloadKind,
+          name: group.filterK8sWorkloadName,
+        },
+      ]);
+      if (workloadToken) {
+        tokens.push(workloadToken);
+      }
+    }
+  } else {
+    const scopeNamespaces = sourceNamespaces.filter(Boolean);
+    if (scopeNamespaces.length) {
+      tokens.push({ type: 'namespace', values: scopeNamespaces });
     }
   }
 
-  if (language) {
-    tokens.push({ type: 'language', values: [formatLanguageToken(language)] });
+  if (languages.length) {
+    tokens.push({ type: 'language', values: languages.map(formatLanguageToken) });
   }
 
-  return tokens;
+  return tokens.length ? tokens : [{ type: 'entire_cluster' }];
 }
 
 function formatDefaultConfig(group: UrlTemplatizationDefaultGroup): string {
@@ -416,6 +486,7 @@ export function collectDefaultTemplatizationCrGroups(actions: Action[]): Default
         actionDisabled: !!action.disabled,
         actionUiGenerated: actionUiGenerated(action),
         groupIndex,
+        scopes: group.scopes ?? null,
         scopeTokens: scopeTokensFromSourcesScopes(group.scopes),
         disabled: !!group.disabled,
         skipForNonSuccessCodes: !!group.skipPolicy?.skipForNonSuccessCodes,
@@ -455,10 +526,15 @@ export function aggregateUrlTemplatization(actions: Action[]): UrlTemplatization
 
   let totalCustomRuleInstances = 0;
   let totalDefaultGroupInstances = 0;
+  let enabledCustomRuleInstances = 0;
+  let enabledActionCount = 0;
 
   for (const action of actions) {
     const label = actionLabel(action);
     const fields = action.fields as UrlTemplatizationActionFields | undefined;
+    if (!action.disabled) {
+      enabledActionCount += 1;
+    }
 
     for (const group of fields?.urlTemplatizationRulesGroups ?? []) {
       const scopeTokens = scopeTokensFromCustomRulesGroup(group);
@@ -468,6 +544,9 @@ export function aggregateUrlTemplatization(actions: Action[]): UrlTemplatization
           continue;
         }
         totalCustomRuleInstances += 1;
+        if (!action.disabled) {
+          enabledCustomRuleInstances += 1;
+        }
         const key = customRuleKey(template, scopeTokens, action.id);
         const entry =
           customMap.get(key) ??
@@ -570,12 +649,21 @@ export function aggregateUrlTemplatization(actions: Action[]): UrlTemplatization
         a.configLabel.localeCompare(b.configLabel),
     );
 
+  const clusterDefaultEffect = deriveClusterDefaultTemplatizationEffect(actions);
+
   return {
     customTemplates,
     defaultGroups,
     totalCustomRuleInstances,
     totalDefaultGroupInstances,
+    enabledCustomRuleInstances,
     actionCount: actions.length,
-    clusterDefaultEffect: deriveClusterDefaultTemplatizationEffect(actions),
+    enabledActionCount,
+    clusterDefaultEffect,
+    pageSummary: deriveUrlTemplatizationPageSummary(
+      clusterDefaultEffect,
+      enabledCustomRuleInstances,
+      enabledActionCount,
+    ),
   };
 }

--- a/frontend/webapp/graphql/mutations/action.ts
+++ b/frontend/webapp/graphql/mutations/action.ts
@@ -58,6 +58,22 @@ export const CREATE_ACTION = gql`
             examples
           }
         }
+        urlTemplatizationDefaultGroups {
+          disabled
+          scopes {
+            namespaces
+            languages
+            sources {
+              namespace
+              kind
+              name
+            }
+          }
+          skipPolicy {
+            skipForNonSuccessCodes
+            skipHttpStatusCodes
+          }
+        }
         extractAttribute {
           extractions {
             targetAttributeName
@@ -143,6 +159,22 @@ export const UPDATE_ACTION = gql`
             template
             notes
             examples
+          }
+        }
+        urlTemplatizationDefaultGroups {
+          disabled
+          scopes {
+            namespaces
+            languages
+            sources {
+              namespace
+              kind
+              name
+            }
+          }
+          skipPolicy {
+            skipForNonSuccessCodes
+            skipHttpStatusCodes
           }
         }
         extractAttribute {

--- a/frontend/webapp/graphql/mutations/action.ts
+++ b/frontend/webapp/graphql/mutations/action.ts
@@ -9,6 +9,7 @@ export const CREATE_ACTION = gql`
       notes
       disabled
       signals
+      uiGenerated
       fields {
         collectContainerAttributes
         collectReplicaSetAttributes
@@ -95,6 +96,7 @@ export const UPDATE_ACTION = gql`
       notes
       disabled
       signals
+      uiGenerated
       fields {
         collectContainerAttributes
         collectReplicaSetAttributes

--- a/frontend/webapp/graphql/queries/actions.ts
+++ b/frontend/webapp/graphql/queries/actions.ts
@@ -30,6 +30,7 @@ export const GET_ACTIONS = gql`
         notes
         disabled
         signals
+        uiGenerated
         fields {
           collectContainerAttributes
           collectReplicaSetAttributes
@@ -76,6 +77,22 @@ export const GET_ACTIONS = gql`
               template
               notes
               examples
+            }
+          }
+          urlTemplatizationDefaultGroups {
+            disabled
+            scopes {
+              namespaces
+              languages
+              sources {
+                namespace
+                kind
+                name
+              }
+            }
+            skipPolicy {
+              skipForNonSuccessCodes
+              skipHttpStatusCodes
             }
           }
           extractAttribute {

--- a/frontend/webapp/utils/constants/routes.tsx
+++ b/frontend/webapp/utils/constants/routes.tsx
@@ -6,6 +6,7 @@ export const ROUTES = {
   PIPELINE_COLLECTORS: '/pipeline-collectors',
   SETTINGS: '/settings',
   SAMPLING: '/sampling',
+  URL_TEMPLATING: '/url-templating',
   TRACE_CORRELATIONS: '/trace-correlations',
 
   // legacy routes

--- a/frontend/webapp/utils/functions/navigation.ts
+++ b/frontend/webapp/utils/functions/navigation.ts
@@ -2,7 +2,7 @@ import { ROUTES } from '../constants';
 import { SVG } from '@odigos/ui-kit/types';
 import { NavbarProps } from '@odigos/ui-kit/components';
 import { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
-import { OverviewIcon, PipelineCollectorIcon, SamplingIcon, ServiceMapIcon, SettingsIcon } from '@odigos/ui-kit/icons';
+import { ActionIcon, OverviewIcon, PipelineCollectorIcon, SamplingIcon, ServiceMapIcon, SettingsIcon } from '@odigos/ui-kit/icons';
 
 const getPayloadForIcon = (router: AppRouterInstance, currentPath: string, targetPath: string, label: string, icon: SVG): NavbarProps['icons'][number] => {
   return {
@@ -20,6 +20,7 @@ export const getNavbarIcons = (router: AppRouterInstance, currentPath: string) =
     getPayloadForIcon(router, currentPath, ROUTES.SERVICE_MAP, 'Service Map', ServiceMapIcon),
     getPayloadForIcon(router, currentPath, ROUTES.PIPELINE_COLLECTORS, 'Collectors Pipeline', PipelineCollectorIcon),
     getPayloadForIcon(router, currentPath, ROUTES.SAMPLING, 'Sampling Rules', SamplingIcon),
+    getPayloadForIcon(router, currentPath, ROUTES.URL_TEMPLATING, 'URL Templating', ActionIcon),
     getPayloadForIcon(router, currentPath, ROUTES.SETTINGS, 'Settings', SettingsIcon),
   ];
 

--- a/hack/kind/url-templatization-sample-actions.yaml
+++ b/hack/kind/url-templatization-sample-actions.yaml
@@ -1,0 +1,149 @@
+# Sample URL templatization Actions for kind / UI development.
+# Apply: kubectl apply -f hack/kind/url-templatization-sample-actions.yaml
+---
+apiVersion: odigos.io/v1alpha1
+kind: Action
+metadata:
+  name: action-q2k2j
+  namespace: odigos-system
+spec:
+  actionName: URL templates - global
+  notes: Global REST API templates — user/org trees, wildcards for static segments
+  signals:
+    - TRACES
+  urlTemplatization:
+    rules:
+      - templates:
+          - /users/{id}
+          - /users/{id}/profile
+          - /users/{id}/settings
+          - /users/{id}/orders
+          - /users/{id}/orders/{orderId}
+          - /users/{id}/orders/{orderId}/items/{itemId}
+          - /users/{id}/subroute/{subrouteId}
+          - /users/{id}/subroute/{subrouteId}/attachments/*
+          - /users/{id}/notifications/*
+          - /organizations/{orgId}
+          - /organizations/{orgId}/members/{memberId}
+          - /organizations/{orgId}/billing/invoices/{invoiceId}
+          - /api/v1/products/{productId}
+          - /api/v1/products/{productId}/reviews/{reviewId}
+          - /api/v1/categories/*
+          - /static/*
+          - /health
+          - /ready
+          - /version
+      - scopes:
+          languages:
+            - java
+        templates:
+          - /actuator/*
+          - /api/v2/accounts/{accountId}
+          - /api/v2/accounts/{accountId}/transactions/{transactionId}
+          - /api/v2/accounts/{accountId}/documents/*
+      - scopes:
+          languages:
+            - python
+        templates:
+          - /api/v1/workflows/{workflowId}
+          - /api/v1/workflows/{workflowId}/runs/{runId}
+          - /api/v1/workflows/{workflowId}/runs/{runId}/steps/*
+---
+apiVersion: odigos.io/v1alpha1
+kind: Action
+metadata:
+  name: action-s6php
+  namespace: odigos-system
+spec:
+  actionName: URL templates - java-sql-query
+  notes: sql-query workload — query JDBC admin paths with wildcard result blobs
+  signals:
+    - TRACES
+  urlTemplatization:
+    default:
+      - scopes:
+          namespaces:
+            - java-sql-query
+        skipPolicy:
+          skipForNonSuccessCodes: true
+    rules:
+      - scopes:
+          namespaces:
+            - java-sql-query
+          sources:
+            - kind: Deployment
+              name: sql-query
+              namespace: java-sql-query
+        templates:
+          - /api/queries/{queryId}
+          - /api/queries/{queryId}/execute
+          - /api/queries/{queryId}/explain
+          - /api/queries/{queryId}/results/*
+          - /jdbc/{table}/{id}
+          - /jdbc/{table}/{id}/columns
+          - /jdbc/{table}/{id}/indexes
+          - /admin/datasources/{datasourceId}
+          - /admin/datasources/{datasourceId}/schemas/*
+          - /admin/migrations/*
+          - /health
+---
+apiVersion: odigos.io/v1alpha1
+kind: Action
+metadata:
+  name: action-xqrhn
+  namespace: odigos-system
+spec:
+  actionName: URL templates - disabled
+  disabled: true
+  notes: Disabled action — portal user subtree and legacy admin paths
+  signals:
+    - TRACES
+  urlTemplatization:
+    rules:
+      - templates:
+          - /legacy/{segment}
+          - /legacy/{segment}/details/*
+          - /admin/{resource}/{id}
+          - /admin/{resource}/{id}/audit/*
+          - /admin/{resource}/{id}/permissions/*
+      - scopes:
+          namespaces:
+            - production
+        templates:
+          - /portal/users/{id}
+          - /portal/users/{id}/subroute/{subrouteId}
+          - /portal/users/{id}/subroute/{subrouteId}/files/*
+          - /portal/organizations/{orgId}/settings/*
+---
+apiVersion: odigos.io/v1alpha1
+kind: Action
+metadata:
+  name: action-pyurl
+  namespace: odigos-system
+spec:
+  actionName: URL templates - python checkout
+  notes: Python-only ecommerce API with checkout tree and openapi wildcard
+  signals:
+    - TRACES
+  urlTemplatization:
+    default:
+      - scopes:
+          languages:
+            - python
+        skipPolicy:
+          skipHttpStatusCodes:
+            - 404
+    rules:
+      - scopes:
+          languages:
+            - python
+        templates:
+          - /api/v1/checkout/{cartId}
+          - /api/v1/checkout/{cartId}/items/{itemId}
+          - /api/v1/checkout/{cartId}/payment/*
+          - /api/v1/inventory/{sku}
+          - /api/v1/inventory/{sku}/warehouses/{warehouseId}
+          - /api/v1/customers/{customerId}
+          - /api/v1/customers/{customerId}/addresses/{addressId}
+          - /openapi/*
+          - /docs/*


### PR DESCRIPTION
## Summary
- **WIP** — no Linear ticket yet
- Add URL templatization UI page (default + custom templates, create/edit drawers, path simulator)
- Extend GraphQL/actions service for URL templatization aggregation and mutations
- Include kind sample actions YAML for local testing

## Test plan
- [ ] Open `/url-templating` in the UI and verify default templates load
- [ ] Create, edit, and toggle custom template groups
- [ ] Verify path simulator matches expected templated output
- [ ] Apply sample actions from `hack/kind/url-templatization-sample-actions.yaml` and confirm they appear in the UI


Made with [Cursor](https://cursor.com)