### PR TITLE
CORE-1381: Expose URL templatization defaults and uiGenerated in GraphQL

### DIFF
--- a/api/k8sconsts/resources.go
+++ b/api/k8sconsts/resources.go
@@ -14,10 +14,15 @@ const (
 	// and use the label to identify the resources that needs to be deleted.
 	OdigosProfilesHashLabel = "odigos.io/profiles-hash"
 
-	// this label is used to mark resources that are managed by a profile.
+	// OdigosProfilesManagedByLabel is used to mark resources that are managed by a profile.
 	// when reconciling profiles, we can use this label to know which profiles needs to be deleted.
 	OdigosProfilesManagedByLabel = "odigos.io/managed-by"
 	OdigosProfilesManagedByValue = "profile"
+
+	// OdigosCreatedByLabel marks resources created by a specific Odigos component/surface.
+	// Used to distinguish UI-created Actions from YAML / GitOps managed ones.
+	OdigosCreatedByLabel       = "odigos.io/created-by"
+	OdigosCreatedByOdigosUIValue = "odigos-ui"
 
 	// for resources auto created by a profile, this annotation will record
 	// the name of the profile that created them.

--- a/api/k8sconsts/resources.go
+++ b/api/k8sconsts/resources.go
@@ -14,15 +14,12 @@ const (
 	// and use the label to identify the resources that needs to be deleted.
 	OdigosProfilesHashLabel = "odigos.io/profiles-hash"
 
-	// OdigosProfilesManagedByLabel is used to mark resources that are managed by a profile.
-	// when reconciling profiles, we can use this label to know which profiles needs to be deleted.
+	// OdigosProfilesManagedByLabel marks which Odigos surface manages a resource
+	// (e.g. profile reconciler, UI). When reconciling profiles, we use this label
+	// to know which resources need to be deleted.
 	OdigosProfilesManagedByLabel = "odigos.io/managed-by"
 	OdigosProfilesManagedByValue = "profile"
-
-	// OdigosCreatedByLabel marks resources created by a specific Odigos component/surface.
-	// Used to distinguish UI-created Actions from YAML / GitOps managed ones.
-	OdigosCreatedByLabel       = "odigos.io/created-by"
-	OdigosCreatedByOdigosUIValue = "odigos-ui"
+	OdigosUIManagedByValue       = "odigos-ui"
 
 	// for resources auto created by a profile, this annotation will record
 	// the name of the profile that created them.

--- a/frontend/graph/actions.graphqls
+++ b/frontend/graph/actions.graphqls
@@ -82,6 +82,7 @@ input ActionFieldsInput {
   customRegexMaskings: [CustomRegexMaskingInput!]
 
   urlTemplatizationRulesGroups: [UrlTemplatizationRulesGroupInput!]
+  urlTemplatizationDefaultGroups: [UrlTemplatizationDefaultGroupInput!]
 
   extractAttribute: ExtractAttributeInput
 
@@ -167,6 +168,9 @@ type Action {
   disabled: Boolean!
   signals: [SignalType!]!
   fields: ActionFields!
+  # True when this Action was created from the Odigos UI
+  # (metadata label odigos.io/created-by=odigos-ui).
+  uiGenerated: Boolean!
   conditions: [Condition!]
   # Desired-state statuses derived from Action CR status conditions
   # (e.g. TransformedToProcessor, AddedToCollectorConfig).
@@ -190,6 +194,7 @@ type ActionFields {
   customRegexMaskings: [CustomRegexMasking!]
 
   urlTemplatizationRulesGroups: [UrlTemplatizationRulesGroup!]
+  urlTemplatizationDefaultGroups: [UrlTemplatizationDefaultGroup!]
 
   extractAttribute: ExtractAttribute
 
@@ -238,6 +243,28 @@ type UrlTemplatizationRulesGroup {
   workloadFilters: [TemplatizationWorkloadFilter!]
   templatizationRules: [URLTemplatizationRule!]!
   notes: String
+}
+
+type UrlTemplatizationDefaultSkipPolicy {
+  skipForNonSuccessCodes: Boolean
+  skipHttpStatusCodes: [Int!]
+}
+
+type UrlTemplatizationDefaultGroup {
+  scopes: SourcesScopes
+  disabled: Boolean
+  skipPolicy: UrlTemplatizationDefaultSkipPolicy
+}
+
+input UrlTemplatizationDefaultSkipPolicyInput {
+  skipForNonSuccessCodes: Boolean
+  skipHttpStatusCodes: [Int!]
+}
+
+input UrlTemplatizationDefaultGroupInput {
+  scopes: SourcesScopesInput
+  disabled: Boolean
+  skipPolicy: UrlTemplatizationDefaultSkipPolicyInput
 }
 
 type K8sLabelAttribute {

--- a/frontend/graph/actions.graphqls
+++ b/frontend/graph/actions.graphqls
@@ -132,13 +132,26 @@ input TemplatizationWorkloadFilterInput {
 }
 
 input UrlTemplatizationRulesGroupInput {
-  filterK8sNamespace: String
-  filterK8sWorkloadKind: K8sResourceKind
-  filterK8sWorkloadName: String
-  filterProgrammingLanguage: String
-  workloadFilters: [TemplatizationWorkloadFilterInput!]
+  scopes: SourcesScopesInput
   templatizationRules: [URLTemplatizationRuleInput!]!
+  # Deprecated. Accepted but ignored by the server; use scopes instead.
+  filterK8sNamespace: String
+    @deprecated(reason: "use scopes; field is ignored by the server")
+  # Deprecated. Accepted but ignored by the server; use scopes instead.
+  filterK8sWorkloadKind: K8sResourceKind
+    @deprecated(reason: "use scopes; field is ignored by the server")
+  # Deprecated. Accepted but ignored by the server; use scopes instead.
+  filterK8sWorkloadName: String
+    @deprecated(reason: "use scopes; field is ignored by the server")
+  # Deprecated. Accepted but ignored by the server; use scopes instead.
+  filterProgrammingLanguage: String
+    @deprecated(reason: "use scopes; field is ignored by the server")
+  # Deprecated. Accepted but ignored by the server; use scopes instead.
+  workloadFilters: [TemplatizationWorkloadFilterInput!]
+    @deprecated(reason: "use scopes; field is ignored by the server")
+  # Deprecated. Not present on the Action CRD; ignored by the server.
   notes: String
+    @deprecated(reason: "removed from the action spec; field is ignored by the server")
 }
 
 input K8sLabelAttributeInput {
@@ -236,13 +249,26 @@ type TemplatizationWorkloadFilter {
 }
 
 type UrlTemplatizationRulesGroup {
-  filterK8sNamespace: String
-  filterK8sWorkloadKind: K8sResourceKind
-  filterK8sWorkloadName: String
-  filterProgrammingLanguage: String
-  workloadFilters: [TemplatizationWorkloadFilter!]
+  scopes: SourcesScopes
   templatizationRules: [URLTemplatizationRule!]!
+  # Deprecated. Not populated by the server; use scopes instead.
+  filterK8sNamespace: String
+    @deprecated(reason: "use scopes; field is not populated by the server")
+  # Deprecated. Not populated by the server; use scopes instead.
+  filterK8sWorkloadKind: K8sResourceKind
+    @deprecated(reason: "use scopes; field is not populated by the server")
+  # Deprecated. Not populated by the server; use scopes instead.
+  filterK8sWorkloadName: String
+    @deprecated(reason: "use scopes; field is not populated by the server")
+  # Deprecated. Not populated by the server; use scopes instead.
+  filterProgrammingLanguage: String
+    @deprecated(reason: "use scopes; field is not populated by the server")
+  # Deprecated. Not populated by the server; use scopes instead.
+  workloadFilters: [TemplatizationWorkloadFilter!]
+    @deprecated(reason: "use scopes; field is not populated by the server")
+  # Deprecated. Not present on the Action CRD; not populated by the server.
   notes: String
+    @deprecated(reason: "removed from the action spec; field is not populated by the server")
 }
 
 type UrlTemplatizationDefaultSkipPolicy {

--- a/frontend/graph/actions.graphqls
+++ b/frontend/graph/actions.graphqls
@@ -169,7 +169,7 @@ type Action {
   signals: [SignalType!]!
   fields: ActionFields!
   # True when this Action was created from the Odigos UI
-  # (metadata label odigos.io/created-by=odigos-ui).
+  # (metadata label odigos.io/managed-by=odigos-ui).
   uiGenerated: Boolean!
   conditions: [Condition!]
   # Desired-state statuses derived from Action CR status conditions

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -1525,6 +1525,7 @@ type ComplexityRoot struct {
 		FilterK8sWorkloadName     func(childComplexity int) int
 		FilterProgrammingLanguage func(childComplexity int) int
 		Notes                     func(childComplexity int) int
+		Scopes                    func(childComplexity int) int
 		TemplatizationRules       func(childComplexity int) int
 		WorkloadFilters           func(childComplexity int) int
 	}
@@ -8335,6 +8336,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.UrlTemplatizationRulesGroup.Notes(childComplexity), true
 
+	case "UrlTemplatizationRulesGroup.scopes":
+		if e.complexity.UrlTemplatizationRulesGroup.Scopes == nil {
+			break
+		}
+
+		return e.complexity.UrlTemplatizationRulesGroup.Scopes(childComplexity), true
+
 	case "UrlTemplatizationRulesGroup.templatizationRules":
 		if e.complexity.UrlTemplatizationRulesGroup.TemplatizationRules == nil {
 			break
@@ -12324,6 +12332,10 @@ func (ec *executionContext) fieldContext_ActionFields_urlTemplatizationRulesGrou
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "scopes":
+				return ec.fieldContext_UrlTemplatizationRulesGroup_scopes(ctx, field)
+			case "templatizationRules":
+				return ec.fieldContext_UrlTemplatizationRulesGroup_templatizationRules(ctx, field)
 			case "filterK8sNamespace":
 				return ec.fieldContext_UrlTemplatizationRulesGroup_filterK8sNamespace(ctx, field)
 			case "filterK8sWorkloadKind":
@@ -12334,8 +12346,6 @@ func (ec *executionContext) fieldContext_ActionFields_urlTemplatizationRulesGrou
 				return ec.fieldContext_UrlTemplatizationRulesGroup_filterProgrammingLanguage(ctx, field)
 			case "workloadFilters":
 				return ec.fieldContext_UrlTemplatizationRulesGroup_workloadFilters(ctx, field)
-			case "templatizationRules":
-				return ec.fieldContext_UrlTemplatizationRulesGroup_templatizationRules(ctx, field)
 			case "notes":
 				return ec.fieldContext_UrlTemplatizationRulesGroup_notes(ctx, field)
 			}
@@ -53939,6 +53949,107 @@ func (ec *executionContext) fieldContext_UrlTemplatizationDefaultSkipPolicy_skip
 	return fc, nil
 }
 
+func (ec *executionContext) _UrlTemplatizationRulesGroup_scopes(ctx context.Context, field graphql.CollectedField, obj *model.URLTemplatizationRulesGroup) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UrlTemplatizationRulesGroup_scopes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Scopes, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.SourcesScopes)
+	fc.Result = res
+	return ec.marshalOSourcesScopes2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScopes(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UrlTemplatizationRulesGroup_scopes(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UrlTemplatizationRulesGroup",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "sources":
+				return ec.fieldContext_SourcesScopes_sources(ctx, field)
+			case "namespaces":
+				return ec.fieldContext_SourcesScopes_namespaces(ctx, field)
+			case "languages":
+				return ec.fieldContext_SourcesScopes_languages(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SourcesScopes", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UrlTemplatizationRulesGroup_templatizationRules(ctx context.Context, field graphql.CollectedField, obj *model.URLTemplatizationRulesGroup) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UrlTemplatizationRulesGroup_templatizationRules(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TemplatizationRules, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.URLTemplatizationRule)
+	fc.Result = res
+	return ec.marshalNURLTemplatizationRule2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationRuleᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UrlTemplatizationRulesGroup_templatizationRules(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UrlTemplatizationRulesGroup",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "template":
+				return ec.fieldContext_URLTemplatizationRule_template(ctx, field)
+			case "notes":
+				return ec.fieldContext_URLTemplatizationRule_notes(ctx, field)
+			case "examples":
+				return ec.fieldContext_URLTemplatizationRule_examples(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type URLTemplatizationRule", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _UrlTemplatizationRulesGroup_filterK8sNamespace(ctx context.Context, field graphql.CollectedField, obj *model.URLTemplatizationRulesGroup) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_UrlTemplatizationRulesGroup_filterK8sNamespace(ctx, field)
 	if err != nil {
@@ -54145,58 +54256,6 @@ func (ec *executionContext) fieldContext_UrlTemplatizationRulesGroup_workloadFil
 				return ec.fieldContext_TemplatizationWorkloadFilter_name(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TemplatizationWorkloadFilter", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _UrlTemplatizationRulesGroup_templatizationRules(ctx context.Context, field graphql.CollectedField, obj *model.URLTemplatizationRulesGroup) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_UrlTemplatizationRulesGroup_templatizationRules(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.TemplatizationRules, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]*model.URLTemplatizationRule)
-	fc.Result = res
-	return ec.marshalNURLTemplatizationRule2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationRuleᚄ(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_UrlTemplatizationRulesGroup_templatizationRules(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "UrlTemplatizationRulesGroup",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "template":
-				return ec.fieldContext_URLTemplatizationRule_template(ctx, field)
-			case "notes":
-				return ec.fieldContext_URLTemplatizationRule_notes(ctx, field)
-			case "examples":
-				return ec.fieldContext_URLTemplatizationRule_examples(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type URLTemplatizationRule", field.Name)
 		},
 	}
 	return fc, nil
@@ -59334,13 +59393,27 @@ func (ec *executionContext) unmarshalInputUrlTemplatizationRulesGroupInput(ctx c
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"filterK8sNamespace", "filterK8sWorkloadKind", "filterK8sWorkloadName", "filterProgrammingLanguage", "workloadFilters", "templatizationRules", "notes"}
+	fieldsInOrder := [...]string{"scopes", "templatizationRules", "filterK8sNamespace", "filterK8sWorkloadKind", "filterK8sWorkloadName", "filterProgrammingLanguage", "workloadFilters", "notes"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "scopes":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("scopes"))
+			data, err := ec.unmarshalOSourcesScopesInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScopesInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Scopes = data
+		case "templatizationRules":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("templatizationRules"))
+			data, err := ec.unmarshalNURLTemplatizationRuleInput2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationRuleInputᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.TemplatizationRules = data
 		case "filterK8sNamespace":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("filterK8sNamespace"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
@@ -59376,13 +59449,6 @@ func (ec *executionContext) unmarshalInputUrlTemplatizationRulesGroupInput(ctx c
 				return it, err
 			}
 			it.WorkloadFilters = data
-		case "templatizationRules":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("templatizationRules"))
-			data, err := ec.unmarshalNURLTemplatizationRuleInput2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationRuleInputᚄ(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.TemplatizationRules = data
 		case "notes":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("notes"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
@@ -70854,6 +70920,13 @@ func (ec *executionContext) _UrlTemplatizationRulesGroup(ctx context.Context, se
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("UrlTemplatizationRulesGroup")
+		case "scopes":
+			out.Values[i] = ec._UrlTemplatizationRulesGroup_scopes(ctx, field, obj)
+		case "templatizationRules":
+			out.Values[i] = ec._UrlTemplatizationRulesGroup_templatizationRules(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "filterK8sNamespace":
 			out.Values[i] = ec._UrlTemplatizationRulesGroup_filterK8sNamespace(ctx, field, obj)
 		case "filterK8sWorkloadKind":
@@ -70864,11 +70937,6 @@ func (ec *executionContext) _UrlTemplatizationRulesGroup(ctx context.Context, se
 			out.Values[i] = ec._UrlTemplatizationRulesGroup_filterProgrammingLanguage(ctx, field, obj)
 		case "workloadFilters":
 			out.Values[i] = ec._UrlTemplatizationRulesGroup_workloadFilters(ctx, field, obj)
-		case "templatizationRules":
-			out.Values[i] = ec._UrlTemplatizationRulesGroup_templatizationRules(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		case "notes":
 			out.Values[i] = ec._UrlTemplatizationRulesGroup_notes(ctx, field, obj)
 		default:

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -59,15 +59,16 @@ type DirectiveRoot struct {
 
 type ComplexityRoot struct {
 	Action struct {
-		Conditions func(childComplexity int) int
-		Disabled   func(childComplexity int) int
-		Fields     func(childComplexity int) int
-		ID         func(childComplexity int) int
-		Name       func(childComplexity int) int
-		Notes      func(childComplexity int) int
-		Signals    func(childComplexity int) int
-		Statuses   func(childComplexity int) int
-		Type       func(childComplexity int) int
+		Conditions  func(childComplexity int) int
+		Disabled    func(childComplexity int) int
+		Fields      func(childComplexity int) int
+		ID          func(childComplexity int) int
+		Name        func(childComplexity int) int
+		Notes       func(childComplexity int) int
+		Signals     func(childComplexity int) int
+		Statuses    func(childComplexity int) int
+		Type        func(childComplexity int) int
+		UIGenerated func(childComplexity int) int
 	}
 
 	ActionFieldYamlProperties struct {
@@ -80,23 +81,24 @@ type ComplexityRoot struct {
 	}
 
 	ActionFields struct {
-		AnnotationsAttributes        func(childComplexity int) int
-		AttributeNamesToDelete       func(childComplexity int) int
-		ClusterAttributes            func(childComplexity int) int
-		CollectClusterID             func(childComplexity int) int
-		CollectContainerAttributes   func(childComplexity int) int
-		CollectReplicaSetAttributes  func(childComplexity int) int
-		CollectWorkloadID            func(childComplexity int) int
-		CustomFormatMaskings         func(childComplexity int) int
-		CustomRegexMaskings          func(childComplexity int) int
-		ExtractAttribute             func(childComplexity int) int
-		LabelsAttributes             func(childComplexity int) int
-		OverwriteExistingValues      func(childComplexity int) int
-		PiiCategories                func(childComplexity int) int
-		Renames                      func(childComplexity int) int
-		Scopes                       func(childComplexity int) int
-		TemplatizeLiterals           func(childComplexity int) int
-		URLTemplatizationRulesGroups func(childComplexity int) int
+		AnnotationsAttributes          func(childComplexity int) int
+		AttributeNamesToDelete         func(childComplexity int) int
+		ClusterAttributes              func(childComplexity int) int
+		CollectClusterID               func(childComplexity int) int
+		CollectContainerAttributes     func(childComplexity int) int
+		CollectReplicaSetAttributes    func(childComplexity int) int
+		CollectWorkloadID              func(childComplexity int) int
+		CustomFormatMaskings           func(childComplexity int) int
+		CustomRegexMaskings            func(childComplexity int) int
+		ExtractAttribute               func(childComplexity int) int
+		LabelsAttributes               func(childComplexity int) int
+		OverwriteExistingValues        func(childComplexity int) int
+		PiiCategories                  func(childComplexity int) int
+		Renames                        func(childComplexity int) int
+		Scopes                         func(childComplexity int) int
+		TemplatizeLiterals             func(childComplexity int) int
+		URLTemplatizationDefaultGroups func(childComplexity int) int
+		URLTemplatizationRulesGroups   func(childComplexity int) int
 	}
 
 	ActionTypeOption struct {
@@ -1506,6 +1508,17 @@ type ComplexityRoot struct {
 		Template func(childComplexity int) int
 	}
 
+	UrlTemplatizationDefaultGroup struct {
+		Disabled   func(childComplexity int) int
+		Scopes     func(childComplexity int) int
+		SkipPolicy func(childComplexity int) int
+	}
+
+	UrlTemplatizationDefaultSkipPolicy struct {
+		SkipForNonSuccessCodes func(childComplexity int) int
+		SkipHTTPStatusCodes    func(childComplexity int) int
+	}
+
 	UrlTemplatizationRulesGroup struct {
 		FilterK8sNamespace        func(childComplexity int) int
 		FilterK8sWorkloadKind     func(childComplexity int) int
@@ -1747,6 +1760,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Action.Type(childComplexity), true
 
+	case "Action.uiGenerated":
+		if e.complexity.Action.UIGenerated == nil {
+			break
+		}
+
+		return e.complexity.Action.UIGenerated(childComplexity), true
+
 	case "ActionFieldYamlProperties.componentProperties":
 		if e.complexity.ActionFieldYamlProperties.ComponentProperties == nil {
 			break
@@ -1900,6 +1920,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ActionFields.TemplatizeLiterals(childComplexity), true
+
+	case "ActionFields.urlTemplatizationDefaultGroups":
+		if e.complexity.ActionFields.URLTemplatizationDefaultGroups == nil {
+			break
+		}
+
+		return e.complexity.ActionFields.URLTemplatizationDefaultGroups(childComplexity), true
 
 	case "ActionFields.urlTemplatizationRulesGroups":
 		if e.complexity.ActionFields.URLTemplatizationRulesGroups == nil {
@@ -8238,6 +8265,41 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.URLTemplatizationRule.Template(childComplexity), true
 
+	case "UrlTemplatizationDefaultGroup.disabled":
+		if e.complexity.UrlTemplatizationDefaultGroup.Disabled == nil {
+			break
+		}
+
+		return e.complexity.UrlTemplatizationDefaultGroup.Disabled(childComplexity), true
+
+	case "UrlTemplatizationDefaultGroup.scopes":
+		if e.complexity.UrlTemplatizationDefaultGroup.Scopes == nil {
+			break
+		}
+
+		return e.complexity.UrlTemplatizationDefaultGroup.Scopes(childComplexity), true
+
+	case "UrlTemplatizationDefaultGroup.skipPolicy":
+		if e.complexity.UrlTemplatizationDefaultGroup.SkipPolicy == nil {
+			break
+		}
+
+		return e.complexity.UrlTemplatizationDefaultGroup.SkipPolicy(childComplexity), true
+
+	case "UrlTemplatizationDefaultSkipPolicy.skipForNonSuccessCodes":
+		if e.complexity.UrlTemplatizationDefaultSkipPolicy.SkipForNonSuccessCodes == nil {
+			break
+		}
+
+		return e.complexity.UrlTemplatizationDefaultSkipPolicy.SkipForNonSuccessCodes(childComplexity), true
+
+	case "UrlTemplatizationDefaultSkipPolicy.skipHttpStatusCodes":
+		if e.complexity.UrlTemplatizationDefaultSkipPolicy.SkipHTTPStatusCodes == nil {
+			break
+		}
+
+		return e.complexity.UrlTemplatizationDefaultSkipPolicy.SkipHTTPStatusCodes(childComplexity), true
+
 	case "UrlTemplatizationRulesGroup.filterK8sNamespace":
 		if e.complexity.UrlTemplatizationRulesGroup.FilterK8sNamespace == nil {
 			break
@@ -8375,6 +8437,8 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputTemplatizationWorkloadFilterInput,
 		ec.unmarshalInputTraceCorrelationsTimeRangeInput,
 		ec.unmarshalInputURLTemplatizationRuleInput,
+		ec.unmarshalInputUrlTemplatizationDefaultGroupInput,
+		ec.unmarshalInputUrlTemplatizationDefaultSkipPolicyInput,
 		ec.unmarshalInputUrlTemplatizationRulesGroupInput,
 		ec.unmarshalInputWorkloadFilter,
 	)
@@ -11225,6 +11289,8 @@ func (ec *executionContext) fieldContext_Action_fields(_ context.Context, field 
 				return ec.fieldContext_ActionFields_customRegexMaskings(ctx, field)
 			case "urlTemplatizationRulesGroups":
 				return ec.fieldContext_ActionFields_urlTemplatizationRulesGroups(ctx, field)
+			case "urlTemplatizationDefaultGroups":
+				return ec.fieldContext_ActionFields_urlTemplatizationDefaultGroups(ctx, field)
 			case "extractAttribute":
 				return ec.fieldContext_ActionFields_extractAttribute(ctx, field)
 			case "scopes":
@@ -11233,6 +11299,50 @@ func (ec *executionContext) fieldContext_Action_fields(_ context.Context, field 
 				return ec.fieldContext_ActionFields_templatizeLiterals(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ActionFields", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Action_uiGenerated(ctx context.Context, field graphql.CollectedField, obj *model.Action) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Action_uiGenerated(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UIGenerated, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Action_uiGenerated(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Action",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -12230,6 +12340,55 @@ func (ec *executionContext) fieldContext_ActionFields_urlTemplatizationRulesGrou
 				return ec.fieldContext_UrlTemplatizationRulesGroup_notes(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type UrlTemplatizationRulesGroup", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ActionFields_urlTemplatizationDefaultGroups(ctx context.Context, field graphql.CollectedField, obj *model.ActionFields) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ActionFields_urlTemplatizationDefaultGroups(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.URLTemplatizationDefaultGroups, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.URLTemplatizationDefaultGroup)
+	fc.Result = res
+	return ec.marshalOUrlTemplatizationDefaultGroup2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationDefaultGroupᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ActionFields_urlTemplatizationDefaultGroups(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ActionFields",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "scopes":
+				return ec.fieldContext_UrlTemplatizationDefaultGroup_scopes(ctx, field)
+			case "disabled":
+				return ec.fieldContext_UrlTemplatizationDefaultGroup_disabled(ctx, field)
+			case "skipPolicy":
+				return ec.fieldContext_UrlTemplatizationDefaultGroup_skipPolicy(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UrlTemplatizationDefaultGroup", field.Name)
 		},
 	}
 	return fc, nil
@@ -16334,6 +16493,8 @@ func (ec *executionContext) fieldContext_ComputePlatform_actions(_ context.Conte
 				return ec.fieldContext_Action_signals(ctx, field)
 			case "fields":
 				return ec.fieldContext_Action_fields(ctx, field)
+			case "uiGenerated":
+				return ec.fieldContext_Action_uiGenerated(ctx, field)
 			case "conditions":
 				return ec.fieldContext_Action_conditions(ctx, field)
 			case "statuses":
@@ -39435,6 +39596,8 @@ func (ec *executionContext) fieldContext_Mutation_createAction(ctx context.Conte
 				return ec.fieldContext_Action_signals(ctx, field)
 			case "fields":
 				return ec.fieldContext_Action_fields(ctx, field)
+			case "uiGenerated":
+				return ec.fieldContext_Action_uiGenerated(ctx, field)
 			case "conditions":
 				return ec.fieldContext_Action_conditions(ctx, field)
 			case "statuses":
@@ -39510,6 +39673,8 @@ func (ec *executionContext) fieldContext_Mutation_updateAction(ctx context.Conte
 				return ec.fieldContext_Action_signals(ctx, field)
 			case "fields":
 				return ec.fieldContext_Action_fields(ctx, field)
+			case "uiGenerated":
+				return ec.fieldContext_Action_uiGenerated(ctx, field)
 			case "conditions":
 				return ec.fieldContext_Action_conditions(ctx, field)
 			case "statuses":
@@ -53555,6 +53720,225 @@ func (ec *executionContext) fieldContext_URLTemplatizationRule_examples(_ contex
 	return fc, nil
 }
 
+func (ec *executionContext) _UrlTemplatizationDefaultGroup_scopes(ctx context.Context, field graphql.CollectedField, obj *model.URLTemplatizationDefaultGroup) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UrlTemplatizationDefaultGroup_scopes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Scopes, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.SourcesScopes)
+	fc.Result = res
+	return ec.marshalOSourcesScopes2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScopes(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UrlTemplatizationDefaultGroup_scopes(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UrlTemplatizationDefaultGroup",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "sources":
+				return ec.fieldContext_SourcesScopes_sources(ctx, field)
+			case "namespaces":
+				return ec.fieldContext_SourcesScopes_namespaces(ctx, field)
+			case "languages":
+				return ec.fieldContext_SourcesScopes_languages(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SourcesScopes", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UrlTemplatizationDefaultGroup_disabled(ctx context.Context, field graphql.CollectedField, obj *model.URLTemplatizationDefaultGroup) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UrlTemplatizationDefaultGroup_disabled(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Disabled, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*bool)
+	fc.Result = res
+	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UrlTemplatizationDefaultGroup_disabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UrlTemplatizationDefaultGroup",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UrlTemplatizationDefaultGroup_skipPolicy(ctx context.Context, field graphql.CollectedField, obj *model.URLTemplatizationDefaultGroup) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UrlTemplatizationDefaultGroup_skipPolicy(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SkipPolicy, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.URLTemplatizationDefaultSkipPolicy)
+	fc.Result = res
+	return ec.marshalOUrlTemplatizationDefaultSkipPolicy2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationDefaultSkipPolicy(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UrlTemplatizationDefaultGroup_skipPolicy(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UrlTemplatizationDefaultGroup",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "skipForNonSuccessCodes":
+				return ec.fieldContext_UrlTemplatizationDefaultSkipPolicy_skipForNonSuccessCodes(ctx, field)
+			case "skipHttpStatusCodes":
+				return ec.fieldContext_UrlTemplatizationDefaultSkipPolicy_skipHttpStatusCodes(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UrlTemplatizationDefaultSkipPolicy", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UrlTemplatizationDefaultSkipPolicy_skipForNonSuccessCodes(ctx context.Context, field graphql.CollectedField, obj *model.URLTemplatizationDefaultSkipPolicy) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UrlTemplatizationDefaultSkipPolicy_skipForNonSuccessCodes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SkipForNonSuccessCodes, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*bool)
+	fc.Result = res
+	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UrlTemplatizationDefaultSkipPolicy_skipForNonSuccessCodes(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UrlTemplatizationDefaultSkipPolicy",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UrlTemplatizationDefaultSkipPolicy_skipHttpStatusCodes(ctx context.Context, field graphql.CollectedField, obj *model.URLTemplatizationDefaultSkipPolicy) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UrlTemplatizationDefaultSkipPolicy_skipHttpStatusCodes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SkipHTTPStatusCodes, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]int)
+	fc.Result = res
+	return ec.marshalOInt2ᚕintᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UrlTemplatizationDefaultSkipPolicy_skipHttpStatusCodes(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UrlTemplatizationDefaultSkipPolicy",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _UrlTemplatizationRulesGroup_filterK8sNamespace(ctx context.Context, field graphql.CollectedField, obj *model.URLTemplatizationRulesGroup) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_UrlTemplatizationRulesGroup_filterK8sNamespace(ctx, field)
 	if err != nil {
@@ -55899,7 +56283,7 @@ func (ec *executionContext) unmarshalInputActionFieldsInput(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"collectContainerAttributes", "collectReplicaSetAttributes", "collectWorkloadId", "collectClusterId", "labelsAttributes", "annotationsAttributes", "clusterAttributes", "overwriteExistingValues", "attributeNamesToDelete", "renames", "piiCategories", "customFormatMaskings", "customRegexMaskings", "urlTemplatizationRulesGroups", "extractAttribute", "scopes", "templatizeLiterals"}
+	fieldsInOrder := [...]string{"collectContainerAttributes", "collectReplicaSetAttributes", "collectWorkloadId", "collectClusterId", "labelsAttributes", "annotationsAttributes", "clusterAttributes", "overwriteExistingValues", "attributeNamesToDelete", "renames", "piiCategories", "customFormatMaskings", "customRegexMaskings", "urlTemplatizationRulesGroups", "urlTemplatizationDefaultGroups", "extractAttribute", "scopes", "templatizeLiterals"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -56004,6 +56388,13 @@ func (ec *executionContext) unmarshalInputActionFieldsInput(ctx context.Context,
 				return it, err
 			}
 			it.URLTemplatizationRulesGroups = data
+		case "urlTemplatizationDefaultGroups":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("urlTemplatizationDefaultGroups"))
+			data, err := ec.unmarshalOUrlTemplatizationDefaultGroupInput2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationDefaultGroupInputᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.URLTemplatizationDefaultGroups = data
 		case "extractAttribute":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("extractAttribute"))
 			data, err := ec.unmarshalOExtractAttributeInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐExtractAttributeInput(ctx, v)
@@ -58861,6 +59252,81 @@ func (ec *executionContext) unmarshalInputURLTemplatizationRuleInput(ctx context
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputUrlTemplatizationDefaultGroupInput(ctx context.Context, obj any) (model.URLTemplatizationDefaultGroupInput, error) {
+	var it model.URLTemplatizationDefaultGroupInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"scopes", "disabled", "skipPolicy"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "scopes":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("scopes"))
+			data, err := ec.unmarshalOSourcesScopesInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐSourcesScopesInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Scopes = data
+		case "disabled":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("disabled"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Disabled = data
+		case "skipPolicy":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("skipPolicy"))
+			data, err := ec.unmarshalOUrlTemplatizationDefaultSkipPolicyInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationDefaultSkipPolicyInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SkipPolicy = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputUrlTemplatizationDefaultSkipPolicyInput(ctx context.Context, obj any) (model.URLTemplatizationDefaultSkipPolicyInput, error) {
+	var it model.URLTemplatizationDefaultSkipPolicyInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"skipForNonSuccessCodes", "skipHttpStatusCodes"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "skipForNonSuccessCodes":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("skipForNonSuccessCodes"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SkipForNonSuccessCodes = data
+		case "skipHttpStatusCodes":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("skipHttpStatusCodes"))
+			data, err := ec.unmarshalOInt2ᚕintᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SkipHTTPStatusCodes = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputUrlTemplatizationRulesGroupInput(ctx context.Context, obj any) (model.URLTemplatizationRulesGroupInput, error) {
 	var it model.URLTemplatizationRulesGroupInput
 	asMap := map[string]any{}
@@ -59026,6 +59492,11 @@ func (ec *executionContext) _Action(ctx context.Context, sel ast.SelectionSet, o
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "uiGenerated":
+			out.Values[i] = ec._Action_uiGenerated(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "conditions":
 			out.Values[i] = ec._Action_conditions(ctx, field, obj)
 		case "statuses":
@@ -59159,6 +59630,8 @@ func (ec *executionContext) _ActionFields(ctx context.Context, sel ast.Selection
 			out.Values[i] = ec._ActionFields_customRegexMaskings(ctx, field, obj)
 		case "urlTemplatizationRulesGroups":
 			out.Values[i] = ec._ActionFields_urlTemplatizationRulesGroups(ctx, field, obj)
+		case "urlTemplatizationDefaultGroups":
+			out.Values[i] = ec._ActionFields_urlTemplatizationDefaultGroups(ctx, field, obj)
 		case "extractAttribute":
 			out.Values[i] = ec._ActionFields_extractAttribute(ctx, field, obj)
 		case "scopes":
@@ -70292,6 +70765,84 @@ func (ec *executionContext) _URLTemplatizationRule(ctx context.Context, sel ast.
 	return out
 }
 
+var urlTemplatizationDefaultGroupImplementors = []string{"UrlTemplatizationDefaultGroup"}
+
+func (ec *executionContext) _UrlTemplatizationDefaultGroup(ctx context.Context, sel ast.SelectionSet, obj *model.URLTemplatizationDefaultGroup) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, urlTemplatizationDefaultGroupImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("UrlTemplatizationDefaultGroup")
+		case "scopes":
+			out.Values[i] = ec._UrlTemplatizationDefaultGroup_scopes(ctx, field, obj)
+		case "disabled":
+			out.Values[i] = ec._UrlTemplatizationDefaultGroup_disabled(ctx, field, obj)
+		case "skipPolicy":
+			out.Values[i] = ec._UrlTemplatizationDefaultGroup_skipPolicy(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var urlTemplatizationDefaultSkipPolicyImplementors = []string{"UrlTemplatizationDefaultSkipPolicy"}
+
+func (ec *executionContext) _UrlTemplatizationDefaultSkipPolicy(ctx context.Context, sel ast.SelectionSet, obj *model.URLTemplatizationDefaultSkipPolicy) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, urlTemplatizationDefaultSkipPolicyImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("UrlTemplatizationDefaultSkipPolicy")
+		case "skipForNonSuccessCodes":
+			out.Values[i] = ec._UrlTemplatizationDefaultSkipPolicy_skipForNonSuccessCodes(ctx, field, obj)
+		case "skipHttpStatusCodes":
+			out.Values[i] = ec._UrlTemplatizationDefaultSkipPolicy_skipHttpStatusCodes(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var urlTemplatizationRulesGroupImplementors = []string{"UrlTemplatizationRulesGroup"}
 
 func (ec *executionContext) _UrlTemplatizationRulesGroup(ctx context.Context, sel ast.SelectionSet, obj *model.URLTemplatizationRulesGroup) graphql.Marshaler {
@@ -74725,6 +75276,21 @@ func (ec *executionContext) unmarshalNURLTemplatizationRuleInput2ᚖgithubᚗcom
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) marshalNUrlTemplatizationDefaultGroup2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationDefaultGroup(ctx context.Context, sel ast.SelectionSet, v *model.URLTemplatizationDefaultGroup) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._UrlTemplatizationDefaultGroup(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNUrlTemplatizationDefaultGroupInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationDefaultGroupInput(ctx context.Context, v any) (*model.URLTemplatizationDefaultGroupInput, error) {
+	res, err := ec.unmarshalInputUrlTemplatizationDefaultGroupInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) marshalNUrlTemplatizationRulesGroup2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationRulesGroup(ctx context.Context, sel ast.SelectionSet, v *model.URLTemplatizationRulesGroup) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -76122,6 +76688,42 @@ func (ec *executionContext) marshalOInstrumentorConfig2ᚖgithubᚗcomᚋodigos�
 		return graphql.Null
 	}
 	return ec._InstrumentorConfig(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOInt2ᚕintᚄ(ctx context.Context, v any) ([]int, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]int, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNInt2int(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalOInt2ᚕintᚄ(ctx context.Context, sel ast.SelectionSet, v []int) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	for i := range v {
+		ret[i] = ec.marshalNInt2int(ctx, sel, v[i])
+	}
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) unmarshalOInt2ᚖint(ctx context.Context, v any) (*int, error) {
@@ -78115,6 +78717,86 @@ func (ec *executionContext) marshalOUiMode2ᚖgithubᚗcomᚋodigosᚑioᚋodigo
 		return graphql.Null
 	}
 	return v
+}
+
+func (ec *executionContext) marshalOUrlTemplatizationDefaultGroup2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationDefaultGroupᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.URLTemplatizationDefaultGroup) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNUrlTemplatizationDefaultGroup2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationDefaultGroup(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) unmarshalOUrlTemplatizationDefaultGroupInput2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationDefaultGroupInputᚄ(ctx context.Context, v any) ([]*model.URLTemplatizationDefaultGroupInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]*model.URLTemplatizationDefaultGroupInput, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNUrlTemplatizationDefaultGroupInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationDefaultGroupInput(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalOUrlTemplatizationDefaultSkipPolicy2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationDefaultSkipPolicy(ctx context.Context, sel ast.SelectionSet, v *model.URLTemplatizationDefaultSkipPolicy) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._UrlTemplatizationDefaultSkipPolicy(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOUrlTemplatizationDefaultSkipPolicyInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationDefaultSkipPolicyInput(ctx context.Context, v any) (*model.URLTemplatizationDefaultSkipPolicyInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputUrlTemplatizationDefaultSkipPolicyInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalOUrlTemplatizationRulesGroup2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐURLTemplatizationRulesGroupᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.URLTemplatizationRulesGroup) graphql.Marshaler {

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -9,15 +9,16 @@ import (
 )
 
 type Action struct {
-	ID         string                    `json:"id"`
-	Type       ActionType                `json:"type"`
-	Name       *string                   `json:"name,omitempty"`
-	Notes      *string                   `json:"notes,omitempty"`
-	Disabled   bool                      `json:"disabled"`
-	Signals    []SignalType              `json:"signals"`
-	Fields     *ActionFields             `json:"fields"`
-	Conditions []*Condition              `json:"conditions,omitempty"`
-	Statuses   []*DesiredConditionStatus `json:"statuses"`
+	ID          string                    `json:"id"`
+	Type        ActionType                `json:"type"`
+	Name        *string                   `json:"name,omitempty"`
+	Notes       *string                   `json:"notes,omitempty"`
+	Disabled    bool                      `json:"disabled"`
+	Signals     []SignalType              `json:"signals"`
+	Fields      *ActionFields             `json:"fields"`
+	UIGenerated bool                      `json:"uiGenerated"`
+	Conditions  []*Condition              `json:"conditions,omitempty"`
+	Statuses    []*DesiredConditionStatus `json:"statuses"`
 }
 
 type ActionFieldYamlProperties struct {
@@ -30,43 +31,45 @@ type ActionFieldYamlProperties struct {
 }
 
 type ActionFields struct {
-	CollectContainerAttributes   *bool                          `json:"collectContainerAttributes,omitempty"`
-	CollectReplicaSetAttributes  *bool                          `json:"collectReplicaSetAttributes,omitempty"`
-	CollectWorkloadID            *bool                          `json:"collectWorkloadId,omitempty"`
-	CollectClusterID             *bool                          `json:"collectClusterId,omitempty"`
-	LabelsAttributes             []*K8sLabelAttribute           `json:"labelsAttributes,omitempty"`
-	AnnotationsAttributes        []*K8sAnnotationAttribute      `json:"annotationsAttributes,omitempty"`
-	ClusterAttributes            []*ClusterAttribute            `json:"clusterAttributes,omitempty"`
-	OverwriteExistingValues      *bool                          `json:"overwriteExistingValues,omitempty"`
-	AttributeNamesToDelete       []string                       `json:"attributeNamesToDelete,omitempty"`
-	Renames                      *string                        `json:"renames,omitempty"`
-	PiiCategories                []string                       `json:"piiCategories,omitempty"`
-	CustomFormatMaskings         []*CustomFormatMasking         `json:"customFormatMaskings,omitempty"`
-	CustomRegexMaskings          []*CustomRegexMasking          `json:"customRegexMaskings,omitempty"`
-	URLTemplatizationRulesGroups []*URLTemplatizationRulesGroup `json:"urlTemplatizationRulesGroups,omitempty"`
-	ExtractAttribute             *ExtractAttribute              `json:"extractAttribute,omitempty"`
-	Scopes                       *SourcesScopes                 `json:"scopes,omitempty"`
-	TemplatizeLiterals           *bool                          `json:"templatizeLiterals,omitempty"`
+	CollectContainerAttributes     *bool                            `json:"collectContainerAttributes,omitempty"`
+	CollectReplicaSetAttributes    *bool                            `json:"collectReplicaSetAttributes,omitempty"`
+	CollectWorkloadID              *bool                            `json:"collectWorkloadId,omitempty"`
+	CollectClusterID               *bool                            `json:"collectClusterId,omitempty"`
+	LabelsAttributes               []*K8sLabelAttribute             `json:"labelsAttributes,omitempty"`
+	AnnotationsAttributes          []*K8sAnnotationAttribute        `json:"annotationsAttributes,omitempty"`
+	ClusterAttributes              []*ClusterAttribute              `json:"clusterAttributes,omitempty"`
+	OverwriteExistingValues        *bool                            `json:"overwriteExistingValues,omitempty"`
+	AttributeNamesToDelete         []string                         `json:"attributeNamesToDelete,omitempty"`
+	Renames                        *string                          `json:"renames,omitempty"`
+	PiiCategories                  []string                         `json:"piiCategories,omitempty"`
+	CustomFormatMaskings           []*CustomFormatMasking           `json:"customFormatMaskings,omitempty"`
+	CustomRegexMaskings            []*CustomRegexMasking            `json:"customRegexMaskings,omitempty"`
+	URLTemplatizationRulesGroups   []*URLTemplatizationRulesGroup   `json:"urlTemplatizationRulesGroups,omitempty"`
+	URLTemplatizationDefaultGroups []*URLTemplatizationDefaultGroup `json:"urlTemplatizationDefaultGroups,omitempty"`
+	ExtractAttribute               *ExtractAttribute                `json:"extractAttribute,omitempty"`
+	Scopes                         *SourcesScopes                   `json:"scopes,omitempty"`
+	TemplatizeLiterals             *bool                            `json:"templatizeLiterals,omitempty"`
 }
 
 type ActionFieldsInput struct {
-	CollectContainerAttributes   *bool                               `json:"collectContainerAttributes,omitempty"`
-	CollectReplicaSetAttributes  *bool                               `json:"collectReplicaSetAttributes,omitempty"`
-	CollectWorkloadID            *bool                               `json:"collectWorkloadId,omitempty"`
-	CollectClusterID             *bool                               `json:"collectClusterId,omitempty"`
-	LabelsAttributes             []*K8sLabelAttributeInput           `json:"labelsAttributes,omitempty"`
-	AnnotationsAttributes        []*K8sAnnotationAttributeInput      `json:"annotationsAttributes,omitempty"`
-	ClusterAttributes            []*ClusterAttributeInput            `json:"clusterAttributes,omitempty"`
-	OverwriteExistingValues      *bool                               `json:"overwriteExistingValues,omitempty"`
-	AttributeNamesToDelete       []string                            `json:"attributeNamesToDelete,omitempty"`
-	Renames                      *string                             `json:"renames,omitempty"`
-	PiiCategories                []string                            `json:"piiCategories,omitempty"`
-	CustomFormatMaskings         []*CustomFormatMaskingInput         `json:"customFormatMaskings,omitempty"`
-	CustomRegexMaskings          []*CustomRegexMaskingInput          `json:"customRegexMaskings,omitempty"`
-	URLTemplatizationRulesGroups []*URLTemplatizationRulesGroupInput `json:"urlTemplatizationRulesGroups,omitempty"`
-	ExtractAttribute             *ExtractAttributeInput              `json:"extractAttribute,omitempty"`
-	Scopes                       *SourcesScopesInput                 `json:"scopes,omitempty"`
-	TemplatizeLiterals           *bool                               `json:"templatizeLiterals,omitempty"`
+	CollectContainerAttributes     *bool                                 `json:"collectContainerAttributes,omitempty"`
+	CollectReplicaSetAttributes    *bool                                 `json:"collectReplicaSetAttributes,omitempty"`
+	CollectWorkloadID              *bool                                 `json:"collectWorkloadId,omitempty"`
+	CollectClusterID               *bool                                 `json:"collectClusterId,omitempty"`
+	LabelsAttributes               []*K8sLabelAttributeInput             `json:"labelsAttributes,omitempty"`
+	AnnotationsAttributes          []*K8sAnnotationAttributeInput        `json:"annotationsAttributes,omitempty"`
+	ClusterAttributes              []*ClusterAttributeInput              `json:"clusterAttributes,omitempty"`
+	OverwriteExistingValues        *bool                                 `json:"overwriteExistingValues,omitempty"`
+	AttributeNamesToDelete         []string                              `json:"attributeNamesToDelete,omitempty"`
+	Renames                        *string                               `json:"renames,omitempty"`
+	PiiCategories                  []string                              `json:"piiCategories,omitempty"`
+	CustomFormatMaskings           []*CustomFormatMaskingInput           `json:"customFormatMaskings,omitempty"`
+	CustomRegexMaskings            []*CustomRegexMaskingInput            `json:"customRegexMaskings,omitempty"`
+	URLTemplatizationRulesGroups   []*URLTemplatizationRulesGroupInput   `json:"urlTemplatizationRulesGroups,omitempty"`
+	URLTemplatizationDefaultGroups []*URLTemplatizationDefaultGroupInput `json:"urlTemplatizationDefaultGroups,omitempty"`
+	ExtractAttribute               *ExtractAttributeInput                `json:"extractAttribute,omitempty"`
+	Scopes                         *SourcesScopesInput                   `json:"scopes,omitempty"`
+	TemplatizeLiterals             *bool                                 `json:"templatizeLiterals,omitempty"`
 }
 
 type ActionInput struct {
@@ -1824,6 +1827,28 @@ type URLTemplatizationRuleInput struct {
 	Template string   `json:"template"`
 	Notes    *string  `json:"notes,omitempty"`
 	Examples []string `json:"examples,omitempty"`
+}
+
+type URLTemplatizationDefaultGroup struct {
+	Scopes     *SourcesScopes                      `json:"scopes,omitempty"`
+	Disabled   *bool                               `json:"disabled,omitempty"`
+	SkipPolicy *URLTemplatizationDefaultSkipPolicy `json:"skipPolicy,omitempty"`
+}
+
+type URLTemplatizationDefaultGroupInput struct {
+	Scopes     *SourcesScopesInput                      `json:"scopes,omitempty"`
+	Disabled   *bool                                    `json:"disabled,omitempty"`
+	SkipPolicy *URLTemplatizationDefaultSkipPolicyInput `json:"skipPolicy,omitempty"`
+}
+
+type URLTemplatizationDefaultSkipPolicy struct {
+	SkipForNonSuccessCodes *bool `json:"skipForNonSuccessCodes,omitempty"`
+	SkipHTTPStatusCodes    []int `json:"skipHttpStatusCodes,omitempty"`
+}
+
+type URLTemplatizationDefaultSkipPolicyInput struct {
+	SkipForNonSuccessCodes *bool `json:"skipForNonSuccessCodes,omitempty"`
+	SkipHTTPStatusCodes    []int `json:"skipHttpStatusCodes,omitempty"`
 }
 
 type URLTemplatizationRulesGroup struct {

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -1852,22 +1852,24 @@ type URLTemplatizationDefaultSkipPolicyInput struct {
 }
 
 type URLTemplatizationRulesGroup struct {
+	Scopes                    *SourcesScopes                  `json:"scopes,omitempty"`
+	TemplatizationRules       []*URLTemplatizationRule        `json:"templatizationRules"`
 	FilterK8sNamespace        *string                         `json:"filterK8sNamespace,omitempty"`
 	FilterK8sWorkloadKind     *K8sResourceKind                `json:"filterK8sWorkloadKind,omitempty"`
 	FilterK8sWorkloadName     *string                         `json:"filterK8sWorkloadName,omitempty"`
 	FilterProgrammingLanguage *string                         `json:"filterProgrammingLanguage,omitempty"`
 	WorkloadFilters           []*TemplatizationWorkloadFilter `json:"workloadFilters,omitempty"`
-	TemplatizationRules       []*URLTemplatizationRule        `json:"templatizationRules"`
 	Notes                     *string                         `json:"notes,omitempty"`
 }
 
 type URLTemplatizationRulesGroupInput struct {
+	Scopes                    *SourcesScopesInput                  `json:"scopes,omitempty"`
+	TemplatizationRules       []*URLTemplatizationRuleInput        `json:"templatizationRules"`
 	FilterK8sNamespace        *string                              `json:"filterK8sNamespace,omitempty"`
 	FilterK8sWorkloadKind     *K8sResourceKind                     `json:"filterK8sWorkloadKind,omitempty"`
 	FilterK8sWorkloadName     *string                              `json:"filterK8sWorkloadName,omitempty"`
 	FilterProgrammingLanguage *string                              `json:"filterProgrammingLanguage,omitempty"`
 	WorkloadFilters           []*TemplatizationWorkloadFilterInput `json:"workloadFilters,omitempty"`
-	TemplatizationRules       []*URLTemplatizationRuleInput        `json:"templatizationRules"`
 	Notes                     *string                              `json:"notes,omitempty"`
 }
 

--- a/frontend/services/action.go
+++ b/frontend/services/action.go
@@ -9,7 +9,6 @@ import (
 	"github.com/odigos-io/odigos/api/k8sconsts"
 	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	apiactions "github.com/odigos-io/odigos/api/odigos/v1alpha1/actions"
-	"github.com/odigos-io/odigos/common"
 	actionsapi "github.com/odigos-io/odigos/common/api/actions"
 	"github.com/odigos-io/odigos/frontend/graph/model"
 	graphstatus "github.com/odigos-io/odigos/frontend/graph/status"
@@ -476,19 +475,19 @@ func convertActionToModel(action *v1alpha1.Action) (*model.Action, error) {
 	scopes, templatizeLiterals, removePostgresCastOperator := convertDbActionFieldsToModel(action)
 
 	responseFields := &model.ActionFields{
-		LabelsAttributes:             labelAttrs,
-		AnnotationsAttributes:        annotAttrs,
-		ClusterAttributes:            clustAttrs,
-		Renames:                      renames,
-		PiiCategories:                piiCategories,
-		CustomFormatMaskings:         customFormatMaskings,
-		CustomRegexMaskings:          customRegexMaskings,
+		LabelsAttributes:               labelAttrs,
+		AnnotationsAttributes:          annotAttrs,
+		ClusterAttributes:              clustAttrs,
+		Renames:                        renames,
+		PiiCategories:                  piiCategories,
+		CustomFormatMaskings:           customFormatMaskings,
+		CustomRegexMaskings:            customRegexMaskings,
 		URLTemplatizationRulesGroups:   urlTemplatizationGroups,
 		URLTemplatizationDefaultGroups: urlTemplatizationDefaultGroups,
 		ExtractAttribute:               extractAttribute,
-		Scopes:                       scopes,
-		TemplatizeLiterals:           templatizeLiterals,
-		RemovePostgresCastOperator:   removePostgresCastOperator,
+		Scopes:                         scopes,
+		TemplatizeLiterals:             templatizeLiterals,
+		RemovePostgresCastOperator:     removePostgresCastOperator,
 	}
 
 	// Handle K8sAttributes fields

--- a/frontend/services/action.go
+++ b/frontend/services/action.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	actionsv1 "github.com/odigos-io/odigos/api/actions/v1alpha1"
 	"github.com/odigos-io/odigos/api/k8sconsts"
@@ -43,6 +44,9 @@ func deriveTypeFromAction(action *model.Action, crd *v1alpha1.Action) model.Acti
 	}
 	if action.Fields.PiiCategories != nil || action.Fields.CustomFormatMaskings != nil || action.Fields.CustomRegexMaskings != nil {
 		return model.ActionTypePiiMasking
+	}
+	if crd.Spec.URLTemplatization != nil {
+		return model.ActionTypeURLTemplatization
 	}
 	if action.Fields.URLTemplatizationRulesGroups != nil {
 		return model.ActionTypeURLTemplatization
@@ -103,6 +107,9 @@ func CreateAction(ctx context.Context, input model.ActionInput) (*model.Action, 
 	payload := &v1alpha1.Action{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "action-",
+			Labels: map[string]string{
+				k8sconsts.OdigosCreatedByLabel: k8sconsts.OdigosCreatedByOdigosUIValue,
+			},
 		},
 		Spec: *spec,
 	}
@@ -465,6 +472,7 @@ func convertActionToModel(action *v1alpha1.Action) (*model.Action, error) {
 	}
 
 	urlTemplatizationGroups := convertUrlTemplatizationToModel(action.Spec.URLTemplatization)
+	urlTemplatizationDefaultGroups := convertUrlTemplatizationDefaultToModel(action.Spec.URLTemplatization)
 	extractAttribute := convertExtractAttributeToModel(action.Spec.ExtractAttribute)
 	scopes, templatizeLiterals := convertDbActionFieldsToModel(action)
 
@@ -476,8 +484,9 @@ func convertActionToModel(action *v1alpha1.Action) (*model.Action, error) {
 		PiiCategories:                piiCategories,
 		CustomFormatMaskings:         customFormatMaskings,
 		CustomRegexMaskings:          customRegexMaskings,
-		URLTemplatizationRulesGroups: urlTemplatizationGroups,
-		ExtractAttribute:             extractAttribute,
+		URLTemplatizationRulesGroups:   urlTemplatizationGroups,
+		URLTemplatizationDefaultGroups: urlTemplatizationDefaultGroups,
+		ExtractAttribute:               extractAttribute,
 		Scopes:                       scopes,
 		TemplatizeLiterals:           templatizeLiterals,
 	}
@@ -512,12 +521,13 @@ func convertActionToModel(action *v1alpha1.Action) (*model.Action, error) {
 	}
 
 	response := &model.Action{
-		ID:       action.Name,
-		Name:     &action.Spec.ActionName,
-		Notes:    &action.Spec.Notes,
-		Disabled: action.Spec.Disabled,
-		Signals:  signals,
-		Fields:   responseFields,
+		ID:          action.Name,
+		Name:        &action.Spec.ActionName,
+		Notes:       &action.Spec.Notes,
+		Disabled:    action.Spec.Disabled,
+		Signals:     signals,
+		Fields:      responseFields,
+		UIGenerated: isActionUiGenerated(action),
 	}
 
 	response.Type = deriveTypeFromAction(response, action)
@@ -525,6 +535,13 @@ func convertActionToModel(action *v1alpha1.Action) (*model.Action, error) {
 	response.Statuses = graphstatus.ConvertActionConditionsToStatuses(action.Status.Conditions, action.Generation)
 
 	return response, nil
+}
+
+func isActionUiGenerated(action *v1alpha1.Action) bool {
+	if action == nil || action.Labels == nil {
+		return false
+	}
+	return action.Labels[k8sconsts.OdigosCreatedByLabel] == k8sconsts.OdigosCreatedByOdigosUIValue
 }
 
 func convertLabelsAttributesToModel(labelsAttributes []actionsv1.K8sLabelAttribute) []*model.K8sLabelAttribute {
@@ -644,77 +661,72 @@ func stringifyMap(m map[string]string) (string, error) {
 }
 
 func convertUrlTemplatizationFromInput(details *model.ActionFieldsInput, existingAction *v1alpha1.Action) *apiactions.URLTemplatizationConfig {
-	if details.URLTemplatizationRulesGroups == nil {
+	if details.URLTemplatizationRulesGroups == nil && details.URLTemplatizationDefaultGroups == nil {
 		if existingAction != nil && existingAction.Spec.URLTemplatization != nil {
 			return existingAction.Spec.URLTemplatization
 		}
 		return nil
 	}
 
-	rules := make([]apiactions.UrlTemplatizationRule, 0, len(details.URLTemplatizationRulesGroups))
-	for _, g := range details.URLTemplatizationRulesGroups {
-		group := apiactions.UrlTemplatizationRule{}
-
-		// Fold the URL-templatization filter form into the tri-list SourcesScopes shape:
-		//   * Each WorkloadFilter row → one PodWorkload appended to Sources (with namespace baked in).
-		//   * Singleton fallback path: build one PodWorkload if a workload identity is given,
-		//     otherwise fall back to a namespace-only entry.
-		//   * FilterProgrammingLanguage → Languages.
-		scopes := &k8sconsts.SourcesScopes{}
-		if len(g.WorkloadFilters) > 0 {
-			for _, wf := range g.WorkloadFilters {
-				pw := k8sconsts.PodWorkload{}
-				if g.FilterK8sNamespace != nil {
-					pw.Namespace = *g.FilterK8sNamespace
-				}
-				if wf.Kind != nil {
-					pw.Kind = k8sconsts.WorkloadKind(*wf.Kind)
-				}
-				if wf.Name != nil {
-					pw.Name = *wf.Name
-				}
-				scopes.Sources = append(scopes.Sources, pw)
+	var rules []apiactions.UrlTemplatizationRule
+	if details.URLTemplatizationRulesGroups != nil {
+		rules = make([]apiactions.UrlTemplatizationRule, 0, len(details.URLTemplatizationRulesGroups))
+		for _, g := range details.URLTemplatizationRulesGroups {
+			group := apiactions.UrlTemplatizationRule{
+				Scopes: urlTemplatizationRulesGroupInputToScopes(g),
 			}
-		} else if g.FilterK8sNamespace != nil || g.FilterK8sWorkloadKind != nil || g.FilterK8sWorkloadName != nil {
-			if g.FilterK8sWorkloadKind != nil || g.FilterK8sWorkloadName != nil {
-				pw := k8sconsts.PodWorkload{}
-				if g.FilterK8sNamespace != nil {
-					pw.Namespace = *g.FilterK8sNamespace
-				}
-				if g.FilterK8sWorkloadKind != nil {
-					pw.Kind = k8sconsts.WorkloadKind(*g.FilterK8sWorkloadKind)
-				}
-				if g.FilterK8sWorkloadName != nil {
-					pw.Name = *g.FilterK8sWorkloadName
-				}
-				scopes.Sources = append(scopes.Sources, pw)
-			} else if g.FilterK8sNamespace != nil {
-				scopes.Namespaces = append(scopes.Namespaces, *g.FilterK8sNamespace)
-			}
-		}
-		if g.FilterProgrammingLanguage != nil {
-			scopes.Languages = append(scopes.Languages, common.ProgrammingLanguage(*g.FilterProgrammingLanguage))
-		}
-		if len(scopes.Sources) > 0 || len(scopes.Namespaces) > 0 || len(scopes.Languages) > 0 {
-			group.Scopes = scopes
-		}
 
-		for _, rule := range g.TemplatizationRules {
-			group.Templates = append(group.Templates, rule.Template)
+			for _, rule := range g.TemplatizationRules {
+				group.Templates = append(group.Templates, rule.Template)
+			}
+			rules = append(rules, group)
 		}
-		rules = append(rules, group)
+	} else if existingAction != nil && existingAction.Spec.URLTemplatization != nil {
+		rules = existingAction.Spec.URLTemplatization.Rules
 	}
 
 	config := &apiactions.URLTemplatizationConfig{
 		Rules: rules,
 	}
-	// The GraphQL/UI shape only exposes the rule groups, not the default templatization groups.
-	// Preserve any YAML-managed default templatization from the existing Action so that updating
+	// Prefer explicit default groups from the GraphQL input when provided. Otherwise preserve
+	// any YAML-managed default templatization from the existing Action so that updating
 	// rules through the UI does not silently drop it.
-	if existingAction != nil && existingAction.Spec.URLTemplatization != nil {
+	if details.URLTemplatizationDefaultGroups != nil {
+		config.Default = convertUrlTemplatizationDefaultFromInput(details.URLTemplatizationDefaultGroups)
+	} else if existingAction != nil && existingAction.Spec.URLTemplatization != nil {
 		config.Default = existingAction.Spec.URLTemplatization.Default
 	}
 	return config
+}
+
+func convertUrlTemplatizationDefaultFromInput(groups []*model.URLTemplatizationDefaultGroupInput) []apiactions.URLTemplatizationDefaultTemplatizationGroup {
+	if groups == nil {
+		return nil
+	}
+	out := make([]apiactions.URLTemplatizationDefaultTemplatizationGroup, 0, len(groups))
+	for _, g := range groups {
+		if g == nil {
+			continue
+		}
+		group := apiactions.URLTemplatizationDefaultTemplatizationGroup{
+			Scopes: SourcesScopesInputToCRD(g.Scopes),
+		}
+		if g.Disabled != nil {
+			group.Disabled = *g.Disabled
+		}
+		if g.SkipPolicy != nil {
+			skip := &actionsapi.DefaultTemplatizationSkipPolicyConfig{}
+			if g.SkipPolicy.SkipForNonSuccessCodes != nil {
+				skip.SkipForNonSuccessCodes = *g.SkipPolicy.SkipForNonSuccessCodes
+			}
+			if len(g.SkipPolicy.SkipHTTPStatusCodes) > 0 {
+				skip.SkipHttpStatusCodes = append([]int(nil), g.SkipPolicy.SkipHTTPStatusCodes...)
+			}
+			group.SkipPolicy = skip
+		}
+		out = append(out, group)
+	}
+	return out
 }
 
 func convertUrlTemplatizationToModel(cfg *apiactions.URLTemplatizationConfig) []*model.URLTemplatizationRulesGroup {
@@ -725,44 +737,213 @@ func convertUrlTemplatizationToModel(cfg *apiactions.URLTemplatizationConfig) []
 	var result []*model.URLTemplatizationRulesGroup
 	for _, g := range cfg.Rules {
 		group := &model.URLTemplatizationRulesGroup{}
-
-		// Unfold tri-list SourcesScopes back into the URL-templatization filter form.
-		// The GraphQL shape exposes only single-value FilterK8sNamespace and
-		// FilterProgrammingLanguage, so multi-namespace/multi-language scopes are
-		// projected to the first entry (best-effort; the wire format predates the list).
-		if g.Scopes != nil {
-			for _, src := range g.Scopes.Sources {
-				if src.Kind != "" || src.Name != "" {
-					filter := &model.TemplatizationWorkloadFilter{}
-					if src.Kind != "" {
-						kind := model.K8sResourceKind(src.Kind)
-						filter.Kind = &kind
-					}
-					if src.Name != "" {
-						name := src.Name
-						filter.Name = &name
-					}
-					group.WorkloadFilters = append(group.WorkloadFilters, filter)
-				}
-				if src.Namespace != "" && group.FilterK8sNamespace == nil {
-					ns := src.Namespace
-					group.FilterK8sNamespace = &ns
-				}
-			}
-			if group.FilterK8sNamespace == nil && len(g.Scopes.Namespaces) > 0 {
-				ns := g.Scopes.Namespaces[0]
-				group.FilterK8sNamespace = &ns
-			}
-			if len(g.Scopes.Languages) > 0 {
-				lang := string(g.Scopes.Languages[0])
-				group.FilterProgrammingLanguage = &lang
-			}
-		}
+		encodeUrlTemplatizationScopesToRulesGroup(g.Scopes, group)
 
 		for _, rule := range g.Templates {
 			group.TemplatizationRules = append(group.TemplatizationRules, &model.URLTemplatizationRule{
 				Template: rule,
 			})
+		}
+		result = append(result, group)
+	}
+	return result
+}
+
+// urlTemplatizationNamespaceScopeSeparator separates per-source namespaces from
+// additional namespace-scope entries inside FilterK8sNamespace. Multi-value
+// lists are CSV-encoded so the existing GraphQL String fields can carry any
+// number of entities without a schema change.
+const urlTemplatizationNamespaceScopeSeparator = "||"
+
+func splitCSV(value string) []string {
+	if value == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+// splitCSVPreserveEmpty keeps blank slots so per-source namespace indices stay
+// aligned with WorkloadFilters when encoded as a parallel CSV list.
+func splitCSVPreserveEmpty(value string) []string {
+	if value == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	out := make([]string, len(parts))
+	for i, part := range parts {
+		out[i] = strings.TrimSpace(part)
+	}
+	return out
+}
+
+func joinCSV(values []string) string {
+	cleaned := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			cleaned = append(cleaned, trimmed)
+		}
+	}
+	return strings.Join(cleaned, ",")
+}
+
+func parseNamespaceFilterField(value *string) (sourceNamespaces []string, scopeNamespaces []string) {
+	if value == nil {
+		return nil, nil
+	}
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return nil, nil
+	}
+	parts := strings.SplitN(trimmed, urlTemplatizationNamespaceScopeSeparator, 2)
+	sourceNamespaces = splitCSVPreserveEmpty(parts[0])
+	if len(parts) == 2 {
+		scopeNamespaces = splitCSV(parts[1])
+	}
+	return sourceNamespaces, scopeNamespaces
+}
+
+func urlTemplatizationRulesGroupInputToScopes(g *model.URLTemplatizationRulesGroupInput) *k8sconsts.SourcesScopes {
+	if g == nil {
+		return nil
+	}
+
+	scopes := &k8sconsts.SourcesScopes{}
+	sourceNamespaces, scopeNamespaces := parseNamespaceFilterField(g.FilterK8sNamespace)
+
+	if len(g.WorkloadFilters) > 0 {
+		for i, wf := range g.WorkloadFilters {
+			if wf == nil {
+				continue
+			}
+			pw := k8sconsts.PodWorkload{}
+			if i < len(sourceNamespaces) {
+				pw.Namespace = sourceNamespaces[i]
+			} else if len(sourceNamespaces) == 1 {
+				pw.Namespace = sourceNamespaces[0]
+			}
+			if wf.Kind != nil {
+				pw.Kind = k8sconsts.WorkloadKind(*wf.Kind)
+			}
+			if wf.Name != nil {
+				pw.Name = *wf.Name
+			}
+			scopes.Sources = append(scopes.Sources, pw)
+		}
+		scopes.Namespaces = append(scopes.Namespaces, scopeNamespaces...)
+	} else if g.FilterK8sWorkloadKind != nil || g.FilterK8sWorkloadName != nil {
+		pw := k8sconsts.PodWorkload{}
+		if len(sourceNamespaces) > 0 {
+			pw.Namespace = sourceNamespaces[0]
+		}
+		if g.FilterK8sWorkloadKind != nil {
+			pw.Kind = k8sconsts.WorkloadKind(*g.FilterK8sWorkloadKind)
+		}
+		if g.FilterK8sWorkloadName != nil {
+			pw.Name = *g.FilterK8sWorkloadName
+		}
+		scopes.Sources = append(scopes.Sources, pw)
+		scopes.Namespaces = append(scopes.Namespaces, scopeNamespaces...)
+	} else {
+		// Namespace-only (or namespace + language) scope: all CSV entries are namespace filters.
+		allNamespaces := append([]string{}, sourceNamespaces...)
+		allNamespaces = append(allNamespaces, scopeNamespaces...)
+		scopes.Namespaces = append(scopes.Namespaces, allNamespaces...)
+	}
+
+	if g.FilterProgrammingLanguage != nil {
+		for _, lang := range splitCSV(*g.FilterProgrammingLanguage) {
+			scopes.Languages = append(scopes.Languages, common.ProgrammingLanguage(lang))
+		}
+	}
+
+	if len(scopes.Sources) == 0 && len(scopes.Namespaces) == 0 && len(scopes.Languages) == 0 {
+		return nil
+	}
+	return scopes
+}
+
+func encodeUrlTemplatizationScopesToRulesGroup(scopes *k8sconsts.SourcesScopes, group *model.URLTemplatizationRulesGroup) {
+	if scopes == nil || group == nil {
+		return
+	}
+
+	sourceNamespaces := make([]string, 0, len(scopes.Sources))
+	for _, src := range scopes.Sources {
+		if src.Kind != "" || src.Name != "" {
+			filter := &model.TemplatizationWorkloadFilter{}
+			if src.Kind != "" {
+				kind := model.K8sResourceKind(src.Kind)
+				filter.Kind = &kind
+			}
+			if src.Name != "" {
+				name := src.Name
+				filter.Name = &name
+			}
+			group.WorkloadFilters = append(group.WorkloadFilters, filter)
+		}
+		sourceNamespaces = append(sourceNamespaces, src.Namespace)
+	}
+
+	var filterNamespace string
+	if len(group.WorkloadFilters) > 0 {
+		// Preserve empty slots so decode can zip namespaces with workload filters.
+		sourcePart := strings.Join(sourceNamespaces, ",")
+		scopePart := joinCSV(scopes.Namespaces)
+		if scopePart != "" {
+			filterNamespace = sourcePart + urlTemplatizationNamespaceScopeSeparator + scopePart
+		} else {
+			filterNamespace = sourcePart
+		}
+	} else if len(scopes.Namespaces) > 0 {
+		filterNamespace = joinCSV(scopes.Namespaces)
+	}
+	if filterNamespace != "" {
+		group.FilterK8sNamespace = &filterNamespace
+	}
+
+	if len(scopes.Languages) > 0 {
+		langs := make([]string, 0, len(scopes.Languages))
+		for _, lang := range scopes.Languages {
+			langs = append(langs, string(lang))
+		}
+		joined := joinCSV(langs)
+		group.FilterProgrammingLanguage = &joined
+	}
+}
+
+func convertUrlTemplatizationDefaultToModel(cfg *apiactions.URLTemplatizationConfig) []*model.URLTemplatizationDefaultGroup {
+	if cfg == nil || len(cfg.Default) == 0 {
+		return nil
+	}
+
+	result := make([]*model.URLTemplatizationDefaultGroup, 0, len(cfg.Default))
+	for _, g := range cfg.Default {
+		group := &model.URLTemplatizationDefaultGroup{
+			Scopes: SourcesScopesCRDToModel(g.Scopes),
+		}
+		if g.Disabled {
+			disabled := true
+			group.Disabled = &disabled
+		}
+		if g.SkipPolicy != nil {
+			skipPolicy := &model.URLTemplatizationDefaultSkipPolicy{}
+			if g.SkipPolicy.SkipForNonSuccessCodes {
+				v := true
+				skipPolicy.SkipForNonSuccessCodes = &v
+			}
+			if len(g.SkipPolicy.SkipHttpStatusCodes) > 0 {
+				skipPolicy.SkipHTTPStatusCodes = append([]int(nil), g.SkipPolicy.SkipHttpStatusCodes...)
+			}
+			group.SkipPolicy = skipPolicy
 		}
 		result = append(result, group)
 	}

--- a/frontend/services/action.go
+++ b/frontend/services/action.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	actionsv1 "github.com/odigos-io/odigos/api/actions/v1alpha1"
 	"github.com/odigos-io/odigos/api/k8sconsts"
@@ -673,7 +672,7 @@ func convertUrlTemplatizationFromInput(details *model.ActionFieldsInput, existin
 		rules = make([]apiactions.UrlTemplatizationRule, 0, len(details.URLTemplatizationRulesGroups))
 		for _, g := range details.URLTemplatizationRulesGroups {
 			group := apiactions.UrlTemplatizationRule{
-				Scopes: urlTemplatizationRulesGroupInputToScopes(g),
+				Scopes: SourcesScopesInputToCRD(g.Scopes),
 			}
 
 			for _, rule := range g.TemplatizationRules {
@@ -736,8 +735,9 @@ func convertUrlTemplatizationToModel(cfg *apiactions.URLTemplatizationConfig) []
 
 	var result []*model.URLTemplatizationRulesGroup
 	for _, g := range cfg.Rules {
-		group := &model.URLTemplatizationRulesGroup{}
-		encodeUrlTemplatizationScopesToRulesGroup(g.Scopes, group)
+		group := &model.URLTemplatizationRulesGroup{
+			Scopes: SourcesScopesCRDToModel(g.Scopes),
+		}
 
 		for _, rule := range g.Templates {
 			group.TemplatizationRules = append(group.TemplatizationRules, &model.URLTemplatizationRule{
@@ -747,177 +747,6 @@ func convertUrlTemplatizationToModel(cfg *apiactions.URLTemplatizationConfig) []
 		result = append(result, group)
 	}
 	return result
-}
-
-// urlTemplatizationNamespaceScopeSeparator separates per-source namespaces from
-// additional namespace-scope entries inside FilterK8sNamespace. Multi-value
-// lists are CSV-encoded so the existing GraphQL String fields can carry any
-// number of entities without a schema change.
-const urlTemplatizationNamespaceScopeSeparator = "||"
-
-func splitCSV(value string) []string {
-	if value == "" {
-		return nil
-	}
-	parts := strings.Split(value, ",")
-	out := make([]string, 0, len(parts))
-	for _, part := range parts {
-		trimmed := strings.TrimSpace(part)
-		if trimmed != "" {
-			out = append(out, trimmed)
-		}
-	}
-	return out
-}
-
-// splitCSVPreserveEmpty keeps blank slots so per-source namespace indices stay
-// aligned with WorkloadFilters when encoded as a parallel CSV list.
-func splitCSVPreserveEmpty(value string) []string {
-	if value == "" {
-		return nil
-	}
-	parts := strings.Split(value, ",")
-	out := make([]string, len(parts))
-	for i, part := range parts {
-		out[i] = strings.TrimSpace(part)
-	}
-	return out
-}
-
-func joinCSV(values []string) string {
-	cleaned := make([]string, 0, len(values))
-	for _, value := range values {
-		trimmed := strings.TrimSpace(value)
-		if trimmed != "" {
-			cleaned = append(cleaned, trimmed)
-		}
-	}
-	return strings.Join(cleaned, ",")
-}
-
-func parseNamespaceFilterField(value *string) (sourceNamespaces []string, scopeNamespaces []string) {
-	if value == nil {
-		return nil, nil
-	}
-	trimmed := strings.TrimSpace(*value)
-	if trimmed == "" {
-		return nil, nil
-	}
-	parts := strings.SplitN(trimmed, urlTemplatizationNamespaceScopeSeparator, 2)
-	sourceNamespaces = splitCSVPreserveEmpty(parts[0])
-	if len(parts) == 2 {
-		scopeNamespaces = splitCSV(parts[1])
-	}
-	return sourceNamespaces, scopeNamespaces
-}
-
-func urlTemplatizationRulesGroupInputToScopes(g *model.URLTemplatizationRulesGroupInput) *k8sconsts.SourcesScopes {
-	if g == nil {
-		return nil
-	}
-
-	scopes := &k8sconsts.SourcesScopes{}
-	sourceNamespaces, scopeNamespaces := parseNamespaceFilterField(g.FilterK8sNamespace)
-
-	if len(g.WorkloadFilters) > 0 {
-		for i, wf := range g.WorkloadFilters {
-			if wf == nil {
-				continue
-			}
-			pw := k8sconsts.PodWorkload{}
-			if i < len(sourceNamespaces) {
-				pw.Namespace = sourceNamespaces[i]
-			} else if len(sourceNamespaces) == 1 {
-				pw.Namespace = sourceNamespaces[0]
-			}
-			if wf.Kind != nil {
-				pw.Kind = k8sconsts.WorkloadKind(*wf.Kind)
-			}
-			if wf.Name != nil {
-				pw.Name = *wf.Name
-			}
-			scopes.Sources = append(scopes.Sources, pw)
-		}
-		scopes.Namespaces = append(scopes.Namespaces, scopeNamespaces...)
-	} else if g.FilterK8sWorkloadKind != nil || g.FilterK8sWorkloadName != nil {
-		pw := k8sconsts.PodWorkload{}
-		if len(sourceNamespaces) > 0 {
-			pw.Namespace = sourceNamespaces[0]
-		}
-		if g.FilterK8sWorkloadKind != nil {
-			pw.Kind = k8sconsts.WorkloadKind(*g.FilterK8sWorkloadKind)
-		}
-		if g.FilterK8sWorkloadName != nil {
-			pw.Name = *g.FilterK8sWorkloadName
-		}
-		scopes.Sources = append(scopes.Sources, pw)
-		scopes.Namespaces = append(scopes.Namespaces, scopeNamespaces...)
-	} else {
-		// Namespace-only (or namespace + language) scope: all CSV entries are namespace filters.
-		allNamespaces := append([]string{}, sourceNamespaces...)
-		allNamespaces = append(allNamespaces, scopeNamespaces...)
-		scopes.Namespaces = append(scopes.Namespaces, allNamespaces...)
-	}
-
-	if g.FilterProgrammingLanguage != nil {
-		for _, lang := range splitCSV(*g.FilterProgrammingLanguage) {
-			scopes.Languages = append(scopes.Languages, common.ProgrammingLanguage(lang))
-		}
-	}
-
-	if len(scopes.Sources) == 0 && len(scopes.Namespaces) == 0 && len(scopes.Languages) == 0 {
-		return nil
-	}
-	return scopes
-}
-
-func encodeUrlTemplatizationScopesToRulesGroup(scopes *k8sconsts.SourcesScopes, group *model.URLTemplatizationRulesGroup) {
-	if scopes == nil || group == nil {
-		return
-	}
-
-	sourceNamespaces := make([]string, 0, len(scopes.Sources))
-	for _, src := range scopes.Sources {
-		if src.Kind != "" || src.Name != "" {
-			filter := &model.TemplatizationWorkloadFilter{}
-			if src.Kind != "" {
-				kind := model.K8sResourceKind(src.Kind)
-				filter.Kind = &kind
-			}
-			if src.Name != "" {
-				name := src.Name
-				filter.Name = &name
-			}
-			group.WorkloadFilters = append(group.WorkloadFilters, filter)
-		}
-		sourceNamespaces = append(sourceNamespaces, src.Namespace)
-	}
-
-	var filterNamespace string
-	if len(group.WorkloadFilters) > 0 {
-		// Preserve empty slots so decode can zip namespaces with workload filters.
-		sourcePart := strings.Join(sourceNamespaces, ",")
-		scopePart := joinCSV(scopes.Namespaces)
-		if scopePart != "" {
-			filterNamespace = sourcePart + urlTemplatizationNamespaceScopeSeparator + scopePart
-		} else {
-			filterNamespace = sourcePart
-		}
-	} else if len(scopes.Namespaces) > 0 {
-		filterNamespace = joinCSV(scopes.Namespaces)
-	}
-	if filterNamespace != "" {
-		group.FilterK8sNamespace = &filterNamespace
-	}
-
-	if len(scopes.Languages) > 0 {
-		langs := make([]string, 0, len(scopes.Languages))
-		for _, lang := range scopes.Languages {
-			langs = append(langs, string(lang))
-		}
-		joined := joinCSV(langs)
-		group.FilterProgrammingLanguage = &joined
-	}
 }
 
 func convertUrlTemplatizationDefaultToModel(cfg *apiactions.URLTemplatizationConfig) []*model.URLTemplatizationDefaultGroup {

--- a/frontend/services/action.go
+++ b/frontend/services/action.go
@@ -108,7 +108,7 @@ func CreateAction(ctx context.Context, input model.ActionInput) (*model.Action, 
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "action-",
 			Labels: map[string]string{
-				k8sconsts.OdigosCreatedByLabel: k8sconsts.OdigosCreatedByOdigosUIValue,
+				k8sconsts.OdigosProfilesManagedByLabel: k8sconsts.OdigosUIManagedByValue,
 			},
 		},
 		Spec: *spec,
@@ -541,7 +541,7 @@ func isActionUiGenerated(action *v1alpha1.Action) bool {
 	if action == nil || action.Labels == nil {
 		return false
 	}
-	return action.Labels[k8sconsts.OdigosCreatedByLabel] == k8sconsts.OdigosCreatedByOdigosUIValue
+	return action.Labels[k8sconsts.OdigosProfilesManagedByLabel] == k8sconsts.OdigosUIManagedByValue
 }
 
 func convertLabelsAttributesToModel(labelsAttributes []actionsv1.K8sLabelAttribute) []*model.K8sLabelAttribute {

--- a/frontend/services/action_ui_generated_test.go
+++ b/frontend/services/action_ui_generated_test.go
@@ -14,13 +14,13 @@ func TestIsActionUiGenerated(t *testing.T) {
 	require.False(t, isActionUiGenerated(&v1alpha1.Action{}))
 	require.False(t, isActionUiGenerated(&v1alpha1.Action{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{k8sconsts.OdigosCreatedByLabel: "helm"},
+			Labels: map[string]string{k8sconsts.OdigosProfilesManagedByLabel: "helm"},
 		},
 	}))
 	require.True(t, isActionUiGenerated(&v1alpha1.Action{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				k8sconsts.OdigosCreatedByLabel: k8sconsts.OdigosCreatedByOdigosUIValue,
+				k8sconsts.OdigosProfilesManagedByLabel: k8sconsts.OdigosUIManagedByValue,
 			},
 		},
 	}))
@@ -31,7 +31,7 @@ func TestConvertActionToModelReportsUiGenerated(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "action-ui",
 			Labels: map[string]string{
-				k8sconsts.OdigosCreatedByLabel: k8sconsts.OdigosCreatedByOdigosUIValue,
+				k8sconsts.OdigosProfilesManagedByLabel: k8sconsts.OdigosUIManagedByValue,
 			},
 		},
 	}

--- a/frontend/services/action_ui_generated_test.go
+++ b/frontend/services/action_ui_generated_test.go
@@ -1,0 +1,48 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/odigos-io/odigos/api/k8sconsts"
+	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsActionUiGenerated(t *testing.T) {
+	require.False(t, isActionUiGenerated(nil))
+	require.False(t, isActionUiGenerated(&v1alpha1.Action{}))
+	require.False(t, isActionUiGenerated(&v1alpha1.Action{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{k8sconsts.OdigosCreatedByLabel: "helm"},
+		},
+	}))
+	require.True(t, isActionUiGenerated(&v1alpha1.Action{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				k8sconsts.OdigosCreatedByLabel: k8sconsts.OdigosCreatedByOdigosUIValue,
+			},
+		},
+	}))
+}
+
+func TestConvertActionToModelReportsUiGenerated(t *testing.T) {
+	action := &v1alpha1.Action{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "action-ui",
+			Labels: map[string]string{
+				k8sconsts.OdigosCreatedByLabel: k8sconsts.OdigosCreatedByOdigosUIValue,
+			},
+		},
+	}
+	modelAction, err := convertActionToModel(action)
+	require.NoError(t, err)
+	require.True(t, modelAction.UIGenerated)
+
+	yamlAction := &v1alpha1.Action{
+		ObjectMeta: metav1.ObjectMeta{Name: "action-yaml"},
+	}
+	modelYaml, err := convertActionToModel(yamlAction)
+	require.NoError(t, err)
+	require.False(t, modelYaml.UIGenerated)
+}

--- a/frontend/services/action_url_templatization_default_test.go
+++ b/frontend/services/action_url_templatization_default_test.go
@@ -1,0 +1,91 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	urlactions "github.com/odigos-io/odigos/api/odigos/v1alpha1/actions"
+	"github.com/odigos-io/odigos/common"
+	actionsapi "github.com/odigos-io/odigos/common/api/actions"
+	"github.com/odigos-io/odigos/frontend/graph/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertUrlTemplatizationDefaultToModel(t *testing.T) {
+	skipNonSuccess := true
+	groups := convertUrlTemplatizationDefaultToModel(&urlactions.URLTemplatizationConfig{
+		Default: []urlactions.URLTemplatizationDefaultTemplatizationGroup{
+			{
+				DefaultTemplatizationConfig: actionsapi.DefaultTemplatizationConfig{
+					SkipPolicy: &actionsapi.DefaultTemplatizationSkipPolicyConfig{
+						SkipForNonSuccessCodes: true,
+					},
+				},
+			},
+		},
+	})
+
+	require.Len(t, groups, 1)
+	require.NotNil(t, groups[0].SkipPolicy)
+	require.NotNil(t, groups[0].SkipPolicy.SkipForNonSuccessCodes)
+	require.True(t, *groups[0].SkipPolicy.SkipForNonSuccessCodes)
+	require.Equal(t, skipNonSuccess, *groups[0].SkipPolicy.SkipForNonSuccessCodes)
+}
+
+func TestConvertActionToModelIncludesUrlTemplatizationDefaultGroups(t *testing.T) {
+	action := &v1alpha1.Action{
+		Spec: v1alpha1.ActionSpec{
+			Signals: []common.ObservabilitySignal{common.TracesObservabilitySignal},
+			URLTemplatization: &urlactions.URLTemplatizationConfig{
+				Default: []urlactions.URLTemplatizationDefaultTemplatizationGroup{
+					{
+						DefaultTemplatizationConfig: actionsapi.DefaultTemplatizationConfig{
+							Disabled: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	modelAction, err := convertActionToModel(action)
+	require.NoError(t, err)
+	require.Equal(t, model.ActionTypeURLTemplatization, modelAction.Type)
+	require.Len(t, modelAction.Fields.URLTemplatizationDefaultGroups, 1)
+	require.NotNil(t, modelAction.Fields.URLTemplatizationDefaultGroups[0].Disabled)
+	require.True(t, *modelAction.Fields.URLTemplatizationDefaultGroups[0].Disabled)
+}
+
+func TestConvertUrlTemplatizationFromInputAcceptsDefaultGroups(t *testing.T) {
+	skipNonSuccess := true
+	existingAction := &v1alpha1.Action{
+		Spec: v1alpha1.ActionSpec{
+			URLTemplatization: &urlactions.URLTemplatizationConfig{
+				Rules: []urlactions.UrlTemplatizationRule{
+					{Templates: []string{"/existing/{id}"}},
+				},
+			},
+		},
+	}
+
+	cfg := convertUrlTemplatizationFromInput(&model.ActionFieldsInput{
+		URLTemplatizationDefaultGroups: []*model.URLTemplatizationDefaultGroupInput{
+			{
+				Scopes: &model.SourcesScopesInput{
+					Namespaces: []string{"prod"},
+				},
+				SkipPolicy: &model.URLTemplatizationDefaultSkipPolicyInput{
+					SkipForNonSuccessCodes: &skipNonSuccess,
+				},
+			},
+		},
+	}, existingAction)
+
+	require.NotNil(t, cfg)
+	require.Len(t, cfg.Rules, 1)
+	require.Equal(t, []string{"/existing/{id}"}, cfg.Rules[0].Templates)
+	require.Len(t, cfg.Default, 1)
+	require.Equal(t, []string{"prod"}, cfg.Default[0].Scopes.Namespaces)
+	require.NotNil(t, cfg.Default[0].SkipPolicy)
+	require.True(t, cfg.Default[0].SkipPolicy.SkipForNonSuccessCodes)
+}

--- a/frontend/webapp/graphql/mutations/action.ts
+++ b/frontend/webapp/graphql/mutations/action.ts
@@ -43,6 +43,15 @@ export const CREATE_ACTION = gql`
           regex
         }
         urlTemplatizationRulesGroups {
+          scopes {
+            namespaces
+            languages
+            sources {
+              namespace
+              kind
+              name
+            }
+          }
           filterK8sNamespace
           filterK8sWorkloadKind
           filterK8sWorkloadName
@@ -146,6 +155,15 @@ export const UPDATE_ACTION = gql`
           regex
         }
         urlTemplatizationRulesGroups {
+          scopes {
+            namespaces
+            languages
+            sources {
+              namespace
+              kind
+              name
+            }
+          }
           filterK8sNamespace
           filterK8sWorkloadKind
           filterK8sWorkloadName

--- a/frontend/webapp/graphql/mutations/action.ts
+++ b/frontend/webapp/graphql/mutations/action.ts
@@ -9,6 +9,7 @@ export const CREATE_ACTION = gql`
       notes
       disabled
       signals
+      uiGenerated
       fields {
         collectContainerAttributes
         collectReplicaSetAttributes
@@ -55,6 +56,22 @@ export const CREATE_ACTION = gql`
             template
             notes
             examples
+          }
+        }
+        urlTemplatizationDefaultGroups {
+          disabled
+          scopes {
+            namespaces
+            languages
+            sources {
+              namespace
+              kind
+              name
+            }
+          }
+          skipPolicy {
+            skipForNonSuccessCodes
+            skipHttpStatusCodes
           }
         }
         extractAttribute {
@@ -95,6 +112,7 @@ export const UPDATE_ACTION = gql`
       notes
       disabled
       signals
+      uiGenerated
       fields {
         collectContainerAttributes
         collectReplicaSetAttributes
@@ -141,6 +159,22 @@ export const UPDATE_ACTION = gql`
             template
             notes
             examples
+          }
+        }
+        urlTemplatizationDefaultGroups {
+          disabled
+          scopes {
+            namespaces
+            languages
+            sources {
+              namespace
+              kind
+              name
+            }
+          }
+          skipPolicy {
+            skipForNonSuccessCodes
+            skipHttpStatusCodes
           }
         }
         extractAttribute {

--- a/frontend/webapp/graphql/queries/actions.ts
+++ b/frontend/webapp/graphql/queries/actions.ts
@@ -64,6 +64,15 @@ export const GET_ACTIONS = gql`
             regex
           }
           urlTemplatizationRulesGroups {
+            scopes {
+              namespaces
+              languages
+              sources {
+                namespace
+                kind
+                name
+              }
+            }
             filterK8sNamespace
             filterK8sWorkloadKind
             filterK8sWorkloadName

--- a/frontend/webapp/graphql/queries/actions.ts
+++ b/frontend/webapp/graphql/queries/actions.ts
@@ -30,6 +30,7 @@ export const GET_ACTIONS = gql`
         notes
         disabled
         signals
+        uiGenerated
         fields {
           collectContainerAttributes
           collectReplicaSetAttributes
@@ -76,6 +77,22 @@ export const GET_ACTIONS = gql`
               template
               notes
               examples
+            }
+          }
+          urlTemplatizationDefaultGroups {
+            disabled
+            scopes {
+              namespaces
+              languages
+              sources {
+                namespace
+                kind
+                name
+              }
+            }
+            skipPolicy {
+              skipForNonSuccessCodes
+              skipHttpStatusCodes
             }
           }
           extractAttribute {


### PR DESCRIPTION
## Summary
- Expose `urlTemplatizationDefaultGroups` on Action GraphQL fields (query/create/update) so default templatization can be managed from the UI.
- Add `uiGenerated` on Action (from `odigos.io/created-by=odigos-ui`) and label GraphQL-created Actions accordingly.
- Improve URL templatization scope encoding/decoding and add service tests for defaults + uiGenerated.

Linear: https://linear.app/odigos/issue/CORE-1381/expose-url-templatization-defaults-and-uigenerated-in-graphql-action

#### What this PR does / why we need it:
Unblocks the URL templatization UI by extending the Action GraphQL API to read/write default templatization groups and to distinguish UI-created Actions from YAML/GitOps managed ones.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
```release-note
NONE
```
