### PR TITLE
PLAT-1347: Add health probes for central-proxy, central-ui, Redis, and Keycloak

### DIFF
--- a/helm/odigos-central/templates/centralui/deployment.yaml
+++ b/helm/odigos-central/templates/centralui/deployment.yaml
@@ -23,6 +23,32 @@ spec:
         - name: central-ui
           {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
           image: {{ template "utils.imageName" (dict "Values" .Values "Component" "central-ui" "Tag" $imageTag) }}
+          ports:
+            - containerPort: 3000
+              name: ui
+          # /healthz is served as soon as the process binds the port (before central-backend is ready).
+          # /readyz returns 200 only after central-backend is reachable and the UI has initialized.
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+            periodSeconds: 10
+            failureThreshold: 60
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 3000
+            periodSeconds: 5
+            failureThreshold: 60
+            timeoutSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+            periodSeconds: 10
+            failureThreshold: 3
+            timeoutSeconds: 3
           env:
             - name: CURRENT_NS
               valueFrom:

--- a/helm/odigos-central/templates/keycloak/deployment.yaml
+++ b/helm/odigos-central/templates/keycloak/deployment.yaml
@@ -94,6 +94,19 @@ spec:
           ports:
             - containerPort: {{ .Values.auth.port }}
               name: {{ .Values.auth.portName }}
+          {{- if .Values.auth.startupProbe.enabled }}
+          # Gates the liveness and readiness probes until Keycloak finishes booting,
+          # so both can use short delays without restarting a slow-starting pod.
+          startupProbe:
+            httpGet:
+              path: /health/live
+              port: {{ .Values.auth.startupProbe.port }}
+            initialDelaySeconds: {{ .Values.auth.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.auth.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.auth.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.auth.startupProbe.failureThreshold }}
+            successThreshold: {{ .Values.auth.startupProbe.successThreshold }}
+          {{- end }}
           {{- if .Values.auth.livenessProbe.enabled }}
           livenessProbe:
             httpGet:

--- a/helm/odigos-central/templates/redis/redis.yaml
+++ b/helm/odigos-central/templates/redis/redis.yaml
@@ -62,6 +62,26 @@ spec:
           ports:
             - containerPort: {{ .Values.redis.port }}
               name: {{ .Values.redis.portName }}
+          {{- if .Values.redis.livenessProbe.enabled }}
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "-p", "{{ .Values.redis.port }}", "ping"]
+            initialDelaySeconds: {{ .Values.redis.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.redis.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.redis.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.redis.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.redis.livenessProbe.successThreshold }}
+          {{- end }}
+          {{- if .Values.redis.readinessProbe.enabled }}
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "-p", "{{ .Values.redis.port }}", "ping"]
+            initialDelaySeconds: {{ .Values.redis.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.redis.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.redis.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.redis.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.redis.readinessProbe.successThreshold }}
+          {{- end }}
           {{- if .Values.redis.resources }}
           resources:
             {{- toYaml .Values.redis.resources | nindent 12 }}

--- a/helm/odigos-central/values.yaml
+++ b/helm/odigos-central/values.yaml
@@ -96,6 +96,28 @@ redis:
   # TCP keepalive interval in seconds. Sends probe packets on idle connections to prevent
   # network infrastructure (NAT/firewall) from closing them due to idle timeouts.
   tcpKeepalive: 30
+
+  # Liveness probe settings
+  # `redis-cli ping` fails when the server is unresponsive (hung process, OOM),
+  # which a TCP check on the port would not catch.
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 15
+    periodSeconds: 20
+    timeoutSeconds: 3
+    failureThreshold: 5
+    # Must be 1 for liveness probes
+    successThreshold: 1
+
+  # Readiness probe settings
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+    successThreshold: 1
+
   resources:
     requests:
       cpu: 100m
@@ -165,11 +187,26 @@ auth:
   # Limits Keycloak's JVM memory to a small, efficient range suitable for medium traffic
   javaOpts: '-Xms128m -Xmx256m'
 
+  # Startup probe settings
+  # Absorbs Keycloak's slow JVM boot (up to failureThreshold * periodSeconds = 300s)
+  # so the liveness and readiness probes below can use short initial delays.
+  startupProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 30
+    # Must be 1 for startup probes
+    successThreshold: 1
+    port: 8080
+
   # Liveness probe settings
   # Keycloak exposes /health/live for liveness checks
+  # initialDelaySeconds is 0 because the startup probe already covers boot time.
+  # Raise it if startupProbe.enabled is set to false.
   livenessProbe:
     enabled: true
-    initialDelaySeconds: 120
+    initialDelaySeconds: 0
     periodSeconds: 30
     timeoutSeconds: 5
     failureThreshold: 3
@@ -180,7 +217,7 @@ auth:
   # Keycloak exposes /health/ready for readiness checks
   readinessProbe:
     enabled: true
-    initialDelaySeconds: 60
+    initialDelaySeconds: 0
     periodSeconds: 10
     timeoutSeconds: 5
     failureThreshold: 3

--- a/helm/odigos/templates/centralproxy/deployment.yaml
+++ b/helm/odigos/templates/centralproxy/deployment.yaml
@@ -49,6 +49,30 @@ spec:
           image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-central-proxy" "Tag" $imageTag) }}
           ports:
             - containerPort: 8080
+              name: http
+          # /healthz is served as soon as the process binds the port (before effective-config is available).
+          # /readyz returns 200 only after effective-config is readable and the proxy has initialized.
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            periodSeconds: 10
+            failureThreshold: 60
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            periodSeconds: 5
+            failureThreshold: 60
+            timeoutSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            periodSeconds: 10
+            failureThreshold: 3
+            timeoutSeconds: 3
           env:
             - name: CURRENT_NS
               valueFrom:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### What this PR does / why we need it:

Adds missing health probes across Central components:

- **central-proxy** — startup/liveness `/healthz`, readiness `/readyz` (gated on `effective-config`)
- **central-ui** — same layout on port 3000; readiness gated on central-backend
- **Redis** — liveness + readiness via `redis-cli ping` (from #5393 / PLAT-639)
- **Keycloak** — startup probe on `/health/live`; drops redundant liveness/readiness initial delays (from #5393 / PLAT-639)

`central-proxy` and `central-ui` probes assume companion `/healthz` + `/readyz` endpoints in the enterprise images (proxy also needs retry on missing `effective-config` instead of exiting).

```release-note
Added health probes for central-proxy, central-ui, Redis, and a Keycloak startup probe.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ca5d19a-a6cc-4272-899e-57c0ac689237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ca5d19a-a6cc-4272-899e-57c0ac689237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

