### PR TITLE
CORE-1384 | fix: redact all Cassandra UUIDs in comma-separated IN lists

### DIFF
--- a/collector/processors/odigossqlqueryprocessor/processor.go
+++ b/collector/processors/odigossqlqueryprocessor/processor.go
@@ -20,10 +20,9 @@ import (
 	"github.com/odigos-io/odigos/common/collector"
 )
 
-// uuidRegex matches standalone UUID literals (CQL) so they can be redacted
-// before sqllexer tokenization, which otherwise mangles them.
-// it checks for standalone UUIDs, not part of a longer identifier/literal.
-var uuidRegex = regexp.MustCompile(`(^|[^0-9A-Fa-f])([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12})($|[^0-9A-Fa-f])`)
+// uuidRegex matches UUID literals (CQL) so they can be redacted before
+// sqllexer tokenization, which otherwise mangles them.
+var uuidRegex = regexp.MustCompile(`(^|[^0-9A-Fa-f])([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12})`)
 
 // postgresCastRegex matches PostgreSQL `::type` casts, including optional
 // schema qualification and array brackets (e.g. ::uuid, ::public.my_type, ::int[]).
@@ -148,9 +147,8 @@ func (p *sqlQueryProcessor) processSpan(span ptrace.Span, inferAttributes, redac
 
 	if redactLiterals && isCassandra {
 		// cassandra uses CQL, not SQL
-		// UUIDs are first class citizens in CQL, in they don't get tokenized correctly by sqllexer.
-		// Reject if the UUID is a prefix of a longer identifier/literal
-		query = uuidRegex.ReplaceAllString(query, "${1}?${3}")
+		// UUIDs are first class citizens in CQL, and they don't get tokenized correctly by sqllexer.
+		query = uuidRegex.ReplaceAllString(query, "${1}?")
 		queryModified = true
 	}
 

--- a/collector/processors/odigossqlqueryprocessor/processor_test.go
+++ b/collector/processors/odigossqlqueryprocessor/processor_test.go
@@ -325,6 +325,27 @@ func TestRedactLiterals_UnsupportedDbSystemUsesDefault(t *testing.T) {
 	require.Equal(t, "SELECT * FROM users WHERE id = ? # secret", query.Str())
 }
 
+func TestRedactLiterals_CassandraCommaSeparatedUUIDs(t *testing.T) {
+	proc := newTestProcessor(t, &Config{RedactLiterals: true})
+	// No space after commas: the previous UUID regex consumed each trailing
+	// delimiter, so only every other UUID was redacted.
+	traces := generateTestTrace(map[string]string{
+		string(semconv.DBSystemKey): semconv.DBSystemCassandra.Value.AsString(),
+		string(semconv.DBQueryTextKey): "SELECT * FROM ks.users WHERE id IN (" +
+			"550e8400-e29b-41d4-a716-446655440000," +
+			"6ba7b810-9dad-11d1-80b4-00c04fd430c8," +
+			"6ba7b811-9dad-11d1-80b4-00c04fd430c8)",
+	})
+
+	out, err := proc.processTraces(context.Background(), traces)
+	require.NoError(t, err)
+
+	span := out.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	query, ok := span.Attributes().Get(string(semconv.DBQueryTextKey))
+	require.True(t, ok)
+	require.Equal(t, "SELECT * FROM ks.users WHERE id IN (?,?,?)", query.Str())
+}
+
 func TestInferAttributes_KeepsSpanNameWhenAlreadyPresent(t *testing.T) {
 	proc := newTestProcessor(t, &Config{InferAttributes: true})
 	td := ptrace.NewTraces()


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes Cassandra UUID pre-redaction in `odigossqlqueryprocessor` so tightly comma-separated CQL `IN` lists redact every UUID, not every other one.

The previous regex consumed each UUID's trailing delimiter (`${1}?${3}`), so in queries like `WHERE id IN (uuid1,uuid2)` (no space after commas) the comma after the first UUID was eaten by the match. The next search therefore started mid-list and skipped the following UUID. Unredacted UUIDs were then mangled by sqllexer and still leaked most of their hex into exported `db.query.text`.

The fix stops capturing the trailing delimiter and replaces with `${1}?` only, so consecutive UUIDs are all redacted before sqllexer runs.

Linear: https://linear.app/odigos/issue/CORE-1384/fix-cassandra-uuid-redaction-skipping-every-other-uuid-in-comma

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
```release-note
fix: redact all Cassandra UUID literals in comma-separated CQL IN lists during query templatization
```
