### PR TITLE
CORE-1385 | Refresh Karpenter documentation

### DIFF
--- a/docs/snippets/shared/instrumentations/configuration/mount-method.mdx
+++ b/docs/snippets/shared/instrumentations/configuration/mount-method.mdx
@@ -75,18 +75,8 @@ For agents and languages that requires filesystem mounts, odigos webhook will ad
 
 #### Caveats
 
-The "HostPath" option should be enabled in the cluster. Some policy tools may block this, like:
-
-- [Open Policy Agent](https://www.openpolicyagent.org/)
-- [Kyverno](https://kyverno.io/)
-
-If your cluster enforces such policies, you have the following options:
-
-- Use the VirtualDevice method.
-- Request the cluster administrator to whitelist the Odigos agent host path in the policy tool.
-
-When using [Karpenter](../../setup/odigos-with-karpenter), follow the Karpenter integration steps. HostPath requires the `karpenter.enabled` configuration and startup taint workflow.
-
+- The "HostPath" option should be enabled in the cluster. Some policy tools may block this, like [Open Policy Agent](https://www.openpolicyagent.org/) or [Kyverno](https://kyverno.io/). If blocked, use the VirtualDevice method, or ask the cluster administrator to whitelist the Odigos agent host path.
+- With [Karpenter](../../setup/odigos-with-karpenter), additional configuration is required. By default Odigos adds node affinity for the odiglet-installed label, which blocks Karpenter from provisioning nodes. Enable `karpenter.enabled` and configure the NodePool `startupTaints` as described in the [Karpenter guide](../../setup/odigos-with-karpenter).
 
 ### 3. InitContainer
 
@@ -162,4 +152,4 @@ For agents and languages that requires filesystem mounts, odigos webhook will ad
 
 - Requires CSI support in the cluster (available in Kubernetes 1.13+).
 - Like VirtualDevice, requires odiglet daemonset to be running on nodes for instrumented pods to be scheduled.
-- When using [Karpenter](../../setup/odigos-with-karpenter), follow the Karpenter integration steps. CSI Driver requires the `karpenter.enabled` configuration and startup taint workflow.
+- With [Karpenter](../../setup/odigos-with-karpenter), additional configuration is required. By default Odigos adds node affinity for the odiglet-installed label, which blocks Karpenter from provisioning nodes. Enable `karpenter.enabled` and configure the NodePool `startupTaints` as described in the [Karpenter guide](../../setup/odigos-with-karpenter).

--- a/docs/snippets/shared/instrumentations/configuration/mount-method.mdx
+++ b/docs/snippets/shared/instrumentations/configuration/mount-method.mdx
@@ -32,7 +32,7 @@ For agents and languages that requires filesystem mounts, odigos webhook will ad
 
 #### Caveats
 
-- May sometimes not integrate well with node auto-scaling tools like [Karpenter](https://karpenter.sh/).
+- Not supported with [Karpenter](../../setup/odigos-with-karpenter). Use [`k8s-init-container`](#3-InitContainer), or [`k8s-host-path`](#2-HostPath) / [`k8s-csi-driver`](#4-CSI-Driver) with the Karpenter integration steps.
 - Odiglet daemonset needs to be running on a node for instrumented pods to be scheduled on that node.
 
 ### 2. HostPath
@@ -85,6 +85,8 @@ If your cluster enforces such policies, you have the following options:
 - Use the VirtualDevice method.
 - Request the cluster administrator to whitelist the Odigos agent host path in the policy tool.
 
+When using [Karpenter](../../setup/odigos-with-karpenter), follow the Karpenter integration steps. HostPath requires the `karpenter.enabled` configuration and startup taint workflow.
+
 
 ### 3. InitContainer
 
@@ -114,6 +116,8 @@ Odigos will add an InitContainer that copies the necessary files for instrumenta
 
 The InitContainer method must be enabled in the cluster and introduces a slight delay during pod initialization.
 This approach is ideal for users who prioritize avoiding hostPath or virtual device usage over startup speed.
+
+Works with [Karpenter](../../setup/odigos-with-karpenter) out of the box. No additional Karpenter configuration is required.
 
 ### 4. CSI Driver
 
@@ -158,3 +162,4 @@ For agents and languages that requires filesystem mounts, odigos webhook will ad
 
 - Requires CSI support in the cluster (available in Kubernetes 1.13+).
 - Like VirtualDevice, requires odiglet daemonset to be running on nodes for instrumented pods to be scheduled.
+- When using [Karpenter](../../setup/odigos-with-karpenter), follow the Karpenter integration steps. CSI Driver requires the `karpenter.enabled` configuration and startup taint workflow.

--- a/docs/snippets/shared/setup/odigos-with-karpenter.mdx
+++ b/docs/snippets/shared/setup/odigos-with-karpenter.mdx
@@ -6,9 +6,21 @@ Unlike traditional autoscalers, Karpenter can provision nodes in seconds and mak
 
 ---
 
+## Mount Method Compatibility
+
+Odigos support for Karpenter depends on the configured [mount method](../instrumentations/configuration/mount-method):
+
+- **[`k8s-init-container`](../instrumentations/configuration/mount-method#3-InitContainer)**: Works with Karpenter out of the box. No additional Karpenter configuration is required.
+- **[`k8s-host-path`](../instrumentations/configuration/mount-method#2-HostPath)** and **[`k8s-csi-driver`](../instrumentations/configuration/mount-method#4-CSI-Driver)**: Supported when you follow the Karpenter integration steps in this document.
+- **[`k8s-virtual-device`](../instrumentations/configuration/mount-method#1-VirtualDevice)** (default) and any other mount methods: Not supported with Karpenter.
+
+If you use `k8s-init-container`, you can stop here. The rest of this document applies to `k8s-host-path` and `k8s-csi-driver`.
+
+---
+
 ## Why Special Configuration Is Needed with Karpenter
 
-By default, Odigos adds a **node affinity** rule to all instrumented pods to ensure they only run on nodes where `odiglet` is installed.
+For the [`k8s-host-path`](../instrumentations/configuration/mount-method#2-HostPath) and [`k8s-csi-driver`](../instrumentations/configuration/mount-method#4-CSI-Driver) mount methods, Odigos adds a **node affinity** rule to instrumented pods so they only run on nodes where `odiglet` is installed.
 
 This works fine in static clusters — but in Karpenter-managed clusters, this causes a problem:
 
@@ -29,7 +41,7 @@ Instead, it relies on a **startup taint mechanism**:
 
 ## How to Configure Odigos for Karpenter
 
-To enable seamless integration between Odigos and Karpenter, follow these four steps:
+Use these steps when your [mount method](../instrumentations/configuration/mount-method) is `k8s-host-path` or `k8s-csi-driver`.
 
 
 ### 1. Configure the Karpenter NodePool CRD

--- a/helm/odigos/values.schema.json
+++ b/helm/odigos/values.schema.json
@@ -706,7 +706,7 @@
         },
         "mountMethod": {
           "default": "",
-          "description": "which mount method to use for odigos agent directory\nk8s-virtual-device: default method using a virtual device\nk8s-host-path: alternative which uses hostPath volume (recommended if supported, requires hostPath volume to be enabled in the cluster)\nk8s-init-container: alternative which uses an init container to copy the agent files to the shared volume",
+          "description": "which mount method to use for odigos agent directory\nk8s-virtual-device: default method using a virtual device\nk8s-host-path: alternative which uses hostPath volume (recommended if supported, requires hostPath volume to be enabled in the cluster)\nk8s-init-container: alternative which uses an init container to copy the agent files to the shared volume\nk8s-csi-driver: alternative which uses a CSI driver to mount the agent directory",
           "required": [],
           "title": "mountMethod"
         },

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -747,6 +747,7 @@ instrumentor:
   #   k8s-virtual-device: default method using a virtual device
   #   k8s-host-path: alternative which uses hostPath volume (recommended if supported, requires hostPath volume to be enabled in the cluster)
   #   k8s-init-container: alternative which uses an init container to copy the agent files to the shared volume
+  #   k8s-csi-driver: alternative which uses a CSI driver to mount the agent directory
   # @schema
   mountMethod: ''
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Documents which mount methods work with Karpenter: init-container works out of the box, hostPath and CSI require the Karpenter integration, and the default virtual-device method is not supported. Also clarifies the Karpenter setup steps and cross-links them from the mount method docs so users can pick a compatible configuration.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
