### PR TITLE
DEVOPS-60: fix full-build failing on multi-arch docker export

### DIFF
--- a/.github/workflows/full-build.yaml
+++ b/.github/workflows/full-build.yaml
@@ -28,7 +28,6 @@ jobs:
         env:
           IMAGE_TAG: v0.0.0-pr${{ github.event.number || github.run_number }}
           PLATFORM: linux/amd64,linux/arm64
-          OUTPUT_DIR: /tmp
 
   build-all-services:
     name: build-all-services


### PR DESCRIPTION
#### What this PR does / why we need it:
The `full odigos build` workflow fails when building multi-platform images (`linux/amd64,linux/arm64`) because `OUTPUT_DIR: /tmp` makes `depot.mk` use `--output type=docker`, and the docker exporter does not support exporting manifest lists.

Remove `OUTPUT_DIR` so the job only verifies that images can be built, without downloading tarballs locally.

Fixes [DEVOPS-60](https://linear.app/odigos/issue/DEVOPS-60/fix-full-build-workflow-docker-exporter-fails-on-multi-arch-manifest)

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
```release-note
NONE
```

cherry-pick: v1.33