### PR TITLE
CORE-1390 | Wire GCP and Azure connector images in odigos-central Helm chart

### DIFF
--- a/helm/odigos-central/templates/connectors/connector-runtime-deployment.yaml
+++ b/helm/odigos-central/templates/connectors/connector-runtime-deployment.yaml
@@ -55,6 +55,10 @@ spec:
               value: "http://central-backend:8081"
             - name: CONNECTOR_AWS_IMAGE
               value: {{ .Values.cloudConnectors.aws.image | default (include "utils.imageName" (dict "Values" .Values "Component" "connector-aws" "Tag" $imageTag)) | quote }}
+            - name: CONNECTOR_GCP_IMAGE
+              value: {{ .Values.cloudConnectors.gcp.image | default (include "utils.imageName" (dict "Values" .Values "Component" "connector-gcp" "Tag" $imageTag)) | quote }}
+            - name: CONNECTOR_AZURE_IMAGE
+              value: {{ .Values.cloudConnectors.azure.image | default (include "utils.imageName" (dict "Values" .Values "Component" "connector-azure" "Tag" $imageTag)) | quote }}
           ports:
             - containerPort: 8081
               name: health

--- a/helm/odigos-central/values.yaml
+++ b/helm/odigos-central/values.yaml
@@ -251,9 +251,15 @@ cloudConnectors:
     tolerations: []
     affinity: {}
 
-  # The AWS provider connector runtime image the controller stamps onto per-account connector Deployments.
+  # Provider connector runtime images the controller stamps onto per-account connector Deployments.
   aws:
     # -- Override the AWS connector image (empty = built-in odigos-enterprise-connector-aws).
+    image: ''
+  gcp:
+    # -- Override the GCP connector image (empty = built-in odigos-enterprise-connector-gcp).
+    image: ''
+  azure:
+    # -- Override the Azure connector image (empty = built-in odigos-enterprise-connector-azure).
     image: ''
 
   # Bundled PostgreSQL (durable store for connector state) + Atlas migrations.


### PR DESCRIPTION
## Summary
- Add `CONNECTOR_GCP_IMAGE` and `CONNECTOR_AZURE_IMAGE` env vars to the `connector-runtime` Deployment (matching existing `CONNECTOR_AWS_IMAGE` wiring)
- Add `cloudConnectors.gcp.image` and `cloudConnectors.azure.image` values (default to `odigos-enterprise-connector-{gcp,azure}` at the release tag)

Fixes GCP/Azure `OdigosCloudConnector` CRs failing with `ImageUnresolved` when `spec.runtime.image` is omitted.

Linear: https://linear.app/odigos/issue/CORE-1390

## Test plan
- [ ] `helm template` with `cloudConnectors.enabled=true` renders all three `CONNECTOR_*_IMAGE` env vars
- [ ] Fresh Central install with `cloudConnectors.enabled=true` — create Azure/GCP connector without `spec.runtime.image` — connector Deployment comes up
- [ ] AWS connector behavior unchanged

```release-note
Wire GCP and Azure connector images in odigos-central Helm chart
```