### PR TITLE
CORE-1228: (OBI) Support custom service name and resource attributes

### DIFF
--- a/odiglet/pkg/ebpf/sdks/obi/go.mod
+++ b/odiglet/pkg/ebpf/sdks/obi/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/odigos-io/odigos/common v0.0.0
 	github.com/odigos-io/odigos/instrumentation v0.0.0
 	go.opentelemetry.io/obi v0.10.1-0.20260706144415-c76a93c8775c
+	go.opentelemetry.io/otel v1.44.0
 )
 
 require (
@@ -174,7 +175,6 @@ require (
 	go.opentelemetry.io/contrib/detectors/gcp v1.44.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.68.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0 // indirect
-	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect

--- a/odiglet/pkg/ebpf/sdks/obi/obi.go
+++ b/odiglet/pkg/ebpf/sdks/obi/obi.go
@@ -16,6 +16,8 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 	"go.opentelemetry.io/obi/pkg/instrumenter"
 	obipkg "go.opentelemetry.io/obi/pkg/obi"
+	"go.opentelemetry.io/obi/pkg/selection"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // DistroName is the Odigos Otel distribution name for OBI trace instrumentation.
@@ -107,20 +109,26 @@ type tracesFactory struct {
 	manager *Manager
 }
 
-func (f *tracesFactory) CreateInstrumentation(_ context.Context, pid int, _ instrumentation.Settings) (instrumentation.Instrumentation, error) {
-	return &tracesInstrumentation{manager: f.manager, pid: pid, done: make(chan struct{})}, nil
+func (f *tracesFactory) CreateInstrumentation(_ context.Context, pid int, settings instrumentation.Settings) (instrumentation.Instrumentation, error) {
+	return &tracesInstrumentation{
+		manager: f.manager,
+		pid:     pid,
+		opts:    dynamicPIDOptions(settings),
+		done:    make(chan struct{}),
+	}, nil
 }
 
 type tracesInstrumentation struct {
 	manager   *Manager
 	pid       int
+	opts      selection.DynamicPIDOptions
 	done      chan struct{}
 	closeOnce sync.Once
 }
 
 func (t *tracesInstrumentation) Load(context.Context) (instrumentation.Status, error) {
 	t.manager.ensureInstrumenterRunning()
-	t.manager.selector.Traces().AddPIDs(uint32(t.pid))
+	t.manager.selector.Traces().AddPID(uint32(t.pid), t.opts)
 	return instrumentation.Status{}, nil
 }
 
@@ -156,6 +164,7 @@ func (f *metricsFactory) CreateInstrumentation(_ context.Context, pid int, setti
 	return &metricsInstrumentation{
 		manager: f.manager,
 		pid:     pid,
+		opts:    dynamicPIDOptions(settings),
 		enabled: networkMetricsEnabled(settings.InitialConfig),
 		done:    make(chan struct{}),
 	}, nil
@@ -164,6 +173,7 @@ func (f *metricsFactory) CreateInstrumentation(_ context.Context, pid int, setti
 type metricsInstrumentation struct {
 	manager   *Manager
 	pid       int
+	opts      selection.DynamicPIDOptions
 	enabled   bool
 	done      chan struct{}
 	closeOnce sync.Once
@@ -171,9 +181,7 @@ type metricsInstrumentation struct {
 
 func (mi *metricsInstrumentation) Load(context.Context) (instrumentation.Status, error) {
 	if mi.enabled {
-		mi.manager.ensureInstrumenterRunning()
-		mi.manager.selector.NetworkMetrics().AddPIDs(uint32(mi.pid))
-		mi.manager.selector.StatsMetrics().AddPIDs(uint32(mi.pid))
+		mi.manager.setNetworkMetrics(mi.pid, true, mi.opts)
 	}
 	// OBI network metrics apply to any process (enabled per-workload via the networkMetrics
 	// InstrumentationRule) and do not own the process's InstrumentationInstance. As a generic
@@ -200,7 +208,7 @@ func (mi *metricsInstrumentation) Close(context.Context) error {
 
 func (mi *metricsInstrumentation) ApplyConfig(_ context.Context, config instrumentation.Config) error {
 	mi.enabled = networkMetricsEnabled(config)
-	mi.manager.setNetworkMetrics(mi.pid, mi.enabled)
+	mi.manager.setNetworkMetrics(mi.pid, mi.enabled, mi.opts)
 	mi.manager.maybeStopInstrumenter()
 	return nil
 }
@@ -215,7 +223,41 @@ func networkMetricsEnabled(config instrumentation.Config) bool {
 	return cc.Metrics.NetworkMetrics != nil
 }
 
-func (m *Manager) setNetworkMetrics(pid int, enabled bool) {
+// dynamicPIDOptions maps instrumentation.Settings (from InstrumentationConfig service name +
+// odiglet-built resource attributes) to OBI's per-PID DynamicPIDOptions. Service name and
+// resource attributes are shared across all signals for the same PID.
+func dynamicPIDOptions(settings instrumentation.Settings) selection.DynamicPIDOptions {
+	return selection.DynamicPIDOptions{
+		ServiceName:        settings.ServiceName,
+		ResourceAttributes: resourceAttributesMap(settings.ResourceAttributes),
+	}
+}
+
+// resourceAttributesMap converts OTel resource attributes to the string map OBI's
+// DynamicPIDOptions expects for per-PID resource decoration.
+func resourceAttributesMap(attrs []attribute.KeyValue) map[string]string {
+	if len(attrs) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(attrs))
+	for _, kv := range attrs {
+		key := string(kv.Key)
+		if key == "" {
+			continue
+		}
+		val := kv.Value.Emit()
+		if val == "" {
+			continue
+		}
+		out[key] = val
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func (m *Manager) setNetworkMetrics(pid int, enabled bool, opts selection.DynamicPIDOptions) {
 	if pid <= 0 {
 		return
 	}
@@ -224,7 +266,8 @@ func (m *Manager) setNetworkMetrics(pid int, enabled bool) {
 		return
 	}
 	m.ensureInstrumenterRunning()
-	m.selector.NetworkMetrics().AddPIDs(uint32(pid))
+	// Set identity on the first signal view; subsequent AddPIDs preserves shared attrs.
+	m.selector.NetworkMetrics().AddPID(uint32(pid), opts)
 	m.selector.StatsMetrics().AddPIDs(uint32(pid))
 }
 

--- a/tests/e2e/source/wait-for-shipping-trace.yaml
+++ b/tests/e2e/source/wait-for-shipping-trace.yaml
@@ -5,10 +5,10 @@ description: |
   spans once it is instrumented via the OBI container override
   (opentelemetry-ebpf-instrumentation). The frontend's /buy traffic fans out
   to shipping (via SHIPPING_SERVICE_HOST), so OBI should produce server spans
-  reported under the configured service name.
+  reported under the Source's otelServiceName override (shipping-reported).
 query: |
   length([?(
-    span.serviceName == 'shipping' &&
+    span.serviceName == 'shipping-reported' &&
     span.kind == 'server'
   )]) > `0`
 expected:


### PR DESCRIPTION
#### What this PR does / why we need it:
This updates the OBI distro + network metrics implementations to support custom service name and resource attributes at instrumentation time. These attributes are shared across signals via the obi internals (so for example you can't have a different service name for traces and metrics, which wouldn't be useful anyway).

These only apply at CreateInstrumentation, so these attributes can't be changed without uninstrumenting and reinstrumenting (ie, disable, edit service name, reenable). From what I could tell the other distros don't support mid-instrumentation changes either so this is consistent. (The OBI dynamic sdk does support changing these, but our pipeline doesn't have a clear way to do that)

cherry-pick:v1.33

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
feat: support service.name and resource attributes for OBI traces and network metrics.
```
