### PR TITLE
CORE-1385 | docs: add deviceplugin support using nodeOverlay

### DIFF
--- a/docs/snippets/shared/instrumentations/configuration/mount-method.mdx
+++ b/docs/snippets/shared/instrumentations/configuration/mount-method.mdx
@@ -32,7 +32,7 @@ For agents and languages that requires filesystem mounts, odigos webhook will ad
 
 #### Caveats
 
-- Not supported with [Karpenter](../../setup/odigos-with-karpenter). Use [`k8s-init-container`](#3-InitContainer), or [`k8s-host-path`](#2-HostPath) / [`k8s-csi-driver`](#4-CSI-Driver) with the Karpenter integration steps.
+- With [Karpenter](../../setup/odigos-with-karpenter), provisioning can fail because Karpenter does not know about the `instrumentation.odigos.io/generic` extended resource when simulating new nodes. Support depends on your Karpenter version and provider: when [NodeOverlay](https://karpenter.sh/docs/concepts/nodeoverlays/) is available and enabled, apply an overlay that adds this capacity (see the [Karpenter guide](../../setup/odigos-with-karpenter#virtual-device-nodeoverlay)). Otherwise use [`k8s-init-container`](#3-InitContainer), or [`k8s-host-path`](#2-HostPath) / [`k8s-csi-driver`](#4-CSI-Driver) with the Karpenter integration steps.
 - Odiglet daemonset needs to be running on a node for instrumented pods to be scheduled on that node.
 
 ### 2. HostPath

--- a/docs/snippets/shared/setup/odigos-with-karpenter.mdx
+++ b/docs/snippets/shared/setup/odigos-with-karpenter.mdx
@@ -10,15 +10,84 @@ Unlike traditional autoscalers, Karpenter can provision nodes in seconds and mak
 
 Odigos support for Karpenter depends on the configured [mount method](../instrumentations/configuration/mount-method):
 
-- **[`k8s-init-container`](../instrumentations/configuration/mount-method#3-InitContainer)**: Works with Karpenter out of the box. No additional Karpenter configuration is required.
-- **[`k8s-host-path`](../instrumentations/configuration/mount-method#2-HostPath)** and **[`k8s-csi-driver`](../instrumentations/configuration/mount-method#4-CSI-Driver)**: Supported when you follow the Karpenter integration steps in this document.
-- **[`k8s-virtual-device`](../instrumentations/configuration/mount-method#1-VirtualDevice)** (default) and any other mount methods: Not supported with Karpenter.
+| Mount method | Karpenter support | What you need |
+| --- | --- | --- |
+| [`k8s-init-container`](../instrumentations/configuration/mount-method#3-InitContainer) | Works out of the box | No additional Karpenter configuration |
+| [`k8s-host-path`](../instrumentations/configuration/mount-method#2-HostPath) / [`k8s-csi-driver`](../instrumentations/configuration/mount-method#4-CSI-Driver) | Supported with Odigos Karpenter integration | Enable `karpenter.enabled` and configure NodePool `startupTaints` (see [HostPath and CSI](#hostpath-and-csi-startup-taints)) |
+| [`k8s-virtual-device`](../instrumentations/configuration/mount-method#1-VirtualDevice) (default) | Supported only when your Karpenter installation can apply [NodeOverlay](https://karpenter.sh/docs/concepts/nodeoverlays/) capacity | Enable the NodeOverlay feature (when required) and apply a NodeOverlay CR (see [Virtual Device](#virtual-device-nodeoverlay)) |
 
-If you use `k8s-init-container`, you can stop here. The rest of this document applies to `k8s-host-path` and `k8s-csi-driver`.
+Follow the section for your mount method below.
 
 ---
 
-## Why Special Configuration Is Needed with Karpenter
+## Init Container
+
+If you use `k8s-init-container`, no Karpenter-specific configuration is required. You can stop here.
+
+---
+
+## Virtual Device (NodeOverlay)
+
+With `k8s-virtual-device`, instrumented pods request the extended resource `instrumentation.odigos.io/generic`. That capacity is advertised by the Odigos device plugin on nodes where `odiglet` is already running.
+
+Karpenter simulates new nodes from instance-type information. Because that simulation does not include the Odigos device resource by default, Karpenter can fail provisioning with errors such as:
+
+```text
+no instance type has enough resources ... instrumentation.odigos.io/generic: "1"
+```
+
+### Provider and version caveats
+
+Support depends on your **Karpenter version, cloud provider, and how the controller is packaged**:
+
+- [NodeOverlay](https://karpenter.sh/docs/concepts/nodeoverlays/) is an alpha Karpenter feature (available since Karpenter v1.7.x). Exact enablement steps and API readiness vary by release.
+- On many installs (including official AWS Karpenter Helm charts), NodeOverlay is **disabled by default** and must be turned on with a feature gate, for example:
+
+```bash
+helm upgrade karpenter oci://public.ecr.aws/karpenter/karpenter \
+  --namespace <KARPENTER_NAMESPACE> \
+  --reuse-values \
+  --set settings.featureGates.nodeOverlay=true
+```
+
+  Equivalently, set `--feature-gates NodeOverlay=true` / `FEATURE_GATES=...,NodeOverlay=true` on the Karpenter controller.
+- Not every Karpenter distribution applies NodeOverlays during provisioning, even if the CRD and feature gate exist. Validate in your environment that creating the overlay below allows Karpenter to launch nodes for pods that request `instrumentation.odigos.io/generic`.
+
+If NodeOverlay is unavailable or ineffective in your Karpenter install, use [`k8s-init-container`](../instrumentations/configuration/mount-method#3-InitContainer), or [`k8s-host-path`](../instrumentations/configuration/mount-method#2-HostPath) / [`k8s-csi-driver`](../instrumentations/configuration/mount-method#4-CSI-Driver) with the [startup taint integration](#hostpath-and-csi-startup-taints).
+
+### Apply a NodeOverlay
+
+After NodeOverlay support is enabled in your Karpenter controller, apply a [NodeOverlay](https://karpenter.sh/docs/concepts/nodeoverlays/) that adds the Odigos device capacity for the NodePool that should run instrumented workloads.
+
+Replace `default` with your NodePool name if needed:
+
+```bash
+cat <<'EOF' | kubectl apply -f -
+apiVersion: karpenter.sh/v1alpha1
+kind: NodeOverlay
+metadata:
+  name: odigos-instrumentation
+spec:
+  requirements:
+    - key: karpenter.sh/nodepool
+      operator: In
+      values: ["default"]
+  capacity:
+    instrumentation.odigos.io/generic: "1024"
+EOF
+```
+
+Confirm the overlay is ready:
+
+```bash
+kubectl get nodeoverlay odigos-instrumentation
+```
+
+Karpenter should then be able to provision nodes for pods that request `instrumentation.odigos.io/generic`. After the node registers, `odiglet` advertises the real device capacity so pods can schedule.
+
+---
+
+## HostPath and CSI (Startup Taints)
 
 For the [`k8s-host-path`](../instrumentations/configuration/mount-method#2-HostPath) and [`k8s-csi-driver`](../instrumentations/configuration/mount-method#4-CSI-Driver) mount methods, Odigos adds a **node affinity** rule to instrumented pods so they only run on nodes where `odiglet` is installed.
 
@@ -36,13 +105,6 @@ Instead, it relies on a **startup taint mechanism**:
   <Info> The exact method for configuring this taint in Karpenter will be explained in the following section. </Info>
 - The `odiglet` removes this taint after it prepares the node for instrumentation.
 - This allows instrumented pods to schedule only **after** the node is ready — achieving the same safety as affinity, without blocking provisioning.
-
----
-
-## How to Configure Odigos for Karpenter
-
-Use these steps when your [mount method](../instrumentations/configuration/mount-method) is `k8s-host-path` or `k8s-csi-driver`.
-
 
 ### 1. Configure the Karpenter NodePool CRD
 
@@ -68,8 +130,6 @@ kubectl patch nodepool $NODEPOOL_NAME --type merge --patch "$(kubectl get nodepo
 
 Replace `<NODEPOOL_NAME>` with the actual name of your Karpenter NodePool.
 
----
-
 ### 2. Add the Startup Taint to Existing Nodes
 
 To manually add the startup taint to all current nodes:
@@ -79,8 +139,6 @@ kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | x
 ```
 
 This ensures existing nodes behave consistently until they're replaced by Karpenter-managed ones.
-
----
 
 ### 3. Enable the Karpenter Integration in Odigos
 
@@ -104,9 +162,6 @@ helm upgrade --install odigos odigos/odigos \
 ```
 </Tab>
 </Tabs>
-
-
----
 
 ### 4. Restart the Odiglet DaemonSet
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Documented Karpenter compatibility per mount method, including that `k8s-virtual-device` can work when `NodeOverlay` is available and enabled (version/provider-dependent). Added the `NodeOverlay` example for `instrumentation.odigos.io/generic` and **updated the mount-method caveats accordingly**.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
