### PR TITLE
Cherry-pick: CORE-1390

### DIFF
--- a/helm/odigos-central/templates/connectors/connector-runtime-deployment.yaml
+++ b/helm/odigos-central/templates/connectors/connector-runtime-deployment.yaml
@@ -55,6 +55,10 @@ spec:
               value: "http://central-backend:8081"
             - name: CONNECTOR_AWS_IMAGE
               value: {{ .Values.cloudConnectors.aws.image | default (include "utils.imageName" (dict "Values" .Values "Component" "connector-aws" "Tag" $imageTag)) | quote }}
+            - name: CONNECTOR_GCP_IMAGE
+              value: {{ .Values.cloudConnectors.gcp.image | default (include "utils.imageName" (dict "Values" .Values "Component" "connector-gcp" "Tag" $imageTag)) | quote }}
+            - name: CONNECTOR_AZURE_IMAGE
+              value: {{ .Values.cloudConnectors.azure.image | default (include "utils.imageName" (dict "Values" .Values "Component" "connector-azure" "Tag" $imageTag)) | quote }}
           ports:
             - containerPort: 8081
               name: health

--- a/helm/odigos-central/values.yaml
+++ b/helm/odigos-central/values.yaml
@@ -251,9 +251,15 @@ cloudConnectors:
     tolerations: []
     affinity: {}
 
-  # The AWS provider connector runtime image the controller stamps onto per-account connector Deployments.
+  # Provider connector runtime images the controller stamps onto per-account connector Deployments.
   aws:
     # -- Override the AWS connector image (empty = built-in odigos-enterprise-connector-aws).
+    image: ''
+  gcp:
+    # -- Override the GCP connector image (empty = built-in odigos-enterprise-connector-gcp).
+    image: ''
+  azure:
+    # -- Override the Azure connector image (empty = built-in odigos-enterprise-connector-azure).
     image: ''
 
   # Bundled PostgreSQL (durable store for connector state) + Atlas migrations.


### PR DESCRIPTION
Cherry-pick of `6056ef7f285c8e42d206b9376841784991ffef5a` onto `releases/v1.33.0`.
Original PR: https://github.com/odigos-io/odigos/pull/5409

```release-note
Wire GCP and Azure connector images in odigos-central Helm chart
```

