### PR TITLE
Cherry-pick: CORE-1390 | Wire GCP and Azure connector images in odigos-central Helm chart

### DIFF
--- a/helm/odigos-central/templates/connectors/connector-runtime-deployment.yaml
+++ b/helm/odigos-central/templates/connectors/connector-runtime-deployment.yaml
@@ -55,6 +55,10 @@ spec:
               value: "http://central-backend:8081"
             - name: CONNECTOR_AWS_IMAGE
               value: {{ .Values.cloudConnectors.aws.image | default (include "utils.imageName" (dict "Values" .Values "Component" "connector-aws" "Tag" $imageTag)) | quote }}
+            - name: CONNECTOR_GCP_IMAGE
+              value: {{ .Values.cloudConnectors.gcp.image | default (include "utils.imageName" (dict "Values" .Values "Component" "connector-gcp" "Tag" $imageTag)) | quote }}
+            - name: CONNECTOR_AZURE_IMAGE
+              value: {{ .Values.cloudConnectors.azure.image | default (include "utils.imageName" (dict "Values" .Values "Component" "connector-azure" "Tag" $imageTag)) | quote }}
           ports:
             - containerPort: 8081
               name: health

--- a/helm/odigos-central/values.yaml
+++ b/helm/odigos-central/values.yaml
@@ -251,9 +251,15 @@ cloudConnectors:
     tolerations: []
     affinity: {}
 
-  # The AWS provider connector runtime image the controller stamps onto per-account connector Deployments.
+  # Provider connector runtime images the controller stamps onto per-account connector Deployments.
   aws:
     # -- Override the AWS connector image (empty = built-in odigos-enterprise-connector-aws).
+    image: ''
+  gcp:
+    # -- Override the GCP connector image (empty = built-in odigos-enterprise-connector-gcp).
+    image: ''
+  azure:
+    # -- Override the Azure connector image (empty = built-in odigos-enterprise-connector-azure).
     image: ''
 
   # Bundled PostgreSQL (durable store for connector state) + Atlas migrations.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Cherry-pick of `6056ef7f285c8e42d206b9376841784991ffef5a` onto `releases/v1.33.0`.

- Add `CONNECTOR_GCP_IMAGE` and `CONNECTOR_AZURE_IMAGE` env vars to the `connector-runtime` Deployment (matching existing `CONNECTOR_AWS_IMAGE` wiring)
- Add `cloudConnectors.gcp.image` and `cloudConnectors.azure.image` values (default to `odigos-enterprise-connector-{gcp,azure}` at the release tag)

Fixes GCP/Azure `OdigosCloudConnector` CRs failing with `ImageUnresolved` when `spec.runtime.image` is omitted.

Linear: https://linear.app/odigos/issue/CORE-1390

Original PR: https://github.com/odigos-io/odigos/pull/5409

## Test plan
- [ ] `helm template` with `cloudConnectors.enabled=true` renders all three `CONNECTOR_*_IMAGE` env vars
- [ ] Fresh Central install with `cloudConnectors.enabled=true` — create Azure/GCP connector without `spec.runtime.image` — connector Deployment comes up
- [ ] AWS connector behavior unchanged

```release-note
Wire GCP and Azure connector images in odigos-central Helm chart
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f83d7636-171a-435f-91c0-7b30339016b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f83d7636-171a-435f-91c0-7b30339016b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

