### PR TITLE
fix broken redactprocessor link in odigospiimasking README (CORE-1395)

### DIFF
--- a/collector/processors/odigospiimaskingprocessor/README.md
+++ b/collector/processors/odigospiimaskingprocessor/README.md
@@ -2,7 +2,7 @@
 
 The `odigospiimasking` processor masks personally identifiable information (PII) in span attributes.
 
-It is similar to the [redact processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/redactprocessor) from OpenTelemetry Collector Contrib, but supports additional PII cases and omits features that are not needed for Odigos.
+It is similar to the [redaction processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/redactionprocessor) from OpenTelemetry Collector Contrib, but supports additional PII cases and omits features that are not needed for Odigos.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

Fixes the broken upstream link in `collector/processors/odigospiimaskingprocessor/README.md` that was causing the `check-links` CI job to fail with a 404.

OpenTelemetry Collector Contrib renamed `redactprocessor` → `redactionprocessor`. This PR updates the URL and link text to match.

## Changes

- Update link from `processor/redactprocessor` → `processor/redactionprocessor`
- Update link text from "redact processor" → "redaction processor"

## Related

- Linear: [CORE-1395](https://linear.app/odigos/issue/CORE-1395/fix-broken-redactprocessor-link-in-odigospiimasking-readme)
- Blocks cherry-pick PR #5417 (link check failure)

```release-note
NONE
```

cherry-pick: v1.30 v1.31 v1.32 v1.33