### PR TITLE
CORE-1399 | fix: resolve unresolvable Go module graph across 12 packages

### DIFF
--- a/autoscaler/go.mod
+++ b/autoscaler/go.mod
@@ -104,5 +104,9 @@ replace (
 	github.com/odigos-io/odigos/api => ../api
 	github.com/odigos-io/odigos/common => ../common
 	github.com/odigos-io/odigos/k8sutils => ../k8sutils
+	// k8sutils requires this via its own local-only replace, which doesn't propagate to us.
+	github.com/odigos-io/odigos/odigosauth => ../odigosauth
 	github.com/odigos-io/odigos/status => ../status
+	// argo-rollouts@v1.9.1 requires this via its own internal-only replace, which doesn't propagate to us.
+	k8s.io/kubelet => k8s.io/kubelet v0.34.1
 )

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -163,10 +163,14 @@ require (
 )
 
 replace (
+	// k8sutils requires this via its own local-only replace, which doesn't propagate to us.
+	github.com/odigos-io/odigos/actions => ../actions
 	github.com/odigos-io/odigos/api => ../api
 	github.com/odigos-io/odigos/autoscaler => ../autoscaler
 	github.com/odigos-io/odigos/common => ../common
 	github.com/odigos-io/odigos/k8sutils => ../k8sutils
 	github.com/odigos-io/odigos/odigosauth => ../odigosauth
 	github.com/odigos-io/odigos/profiles => ../profiles
+	// argo-rollouts@v1.9.1 requires this via its own internal-only replace, which doesn't propagate to us.
+	k8s.io/kubelet => k8s.io/kubelet v0.34.1
 )

--- a/collector/builder-config.yaml
+++ b/collector/builder-config.yaml
@@ -157,3 +157,5 @@ replaces:
   - github.com/odigos-io/odigos/collector/extension/odigosconfigk8sextension => ../extension/odigosconfigk8sextension
   - github.com/apache/thrift => github.com/apache/thrift v0.23.0
   - github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.311.4-0.20260507094802-91c184a899b8
+  # datadogexporter transitively requires this at an unresolvable DataDog-internal placeholder version.
+  - github.com/DataDog/datadog-agent/comp/core/delegatedauth => github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.79.0-devel

--- a/collector/odigosotelcol/go.mod
+++ b/collector/odigosotelcol/go.mod
@@ -821,4 +821,6 @@ replace github.com/apache/thrift => github.com/apache/thrift v0.23.0
 
 replace github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.311.4-0.20260507094802-91c184a899b8
 
+replace github.com/DataDog/datadog-agent/comp/core/delegatedauth => github.com/DataDog/datadog-agent/comp/core/delegatedauth v0.79.0-devel
+
 exclude github.com/knadh/koanf v1.5.0

--- a/frontend/go.mod
+++ b/frontend/go.mod
@@ -402,4 +402,6 @@ replace (
 	// Pyroscope (and Mimir) expect KnownFields YAML decoding; upstream v3.0.1 lacks DecodeWithOptions.
 	// Matches github.com/grafana/pyroscope go.mod.
 	gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720105220-255a8d16d094
+	// argo-rollouts@v1.9.1 requires this via its own internal-only replace, which doesn't propagate to us.
+	k8s.io/kubelet => k8s.io/kubelet v0.34.1
 )

--- a/instrumentor/go.mod
+++ b/instrumentor/go.mod
@@ -107,5 +107,9 @@ replace (
 	github.com/odigos-io/odigos/common => ../common
 	github.com/odigos-io/odigos/distros => ../distros
 	github.com/odigos-io/odigos/k8sutils => ../k8sutils
+	// k8sutils requires this via its own local-only replace, which doesn't propagate to us.
+	github.com/odigos-io/odigos/odigosauth => ../odigosauth
 	github.com/odigos-io/odigos/status => ../status
+	// argo-rollouts@v1.9.1 requires this via its own internal-only replace, which doesn't propagate to us.
+	k8s.io/kubelet => k8s.io/kubelet v0.34.1
 )

--- a/k8sutils/go.mod
+++ b/k8sutils/go.mod
@@ -102,4 +102,6 @@ replace (
 	github.com/odigos-io/odigos/api => ../api
 	github.com/odigos-io/odigos/common => ../common
 	github.com/odigos-io/odigos/odigosauth => ../odigosauth
+	// argo-rollouts@v1.9.1 requires this via its own internal-only replace, which doesn't propagate to us.
+	k8s.io/kubelet => k8s.io/kubelet v0.34.1
 )

--- a/odiglet/go.mod
+++ b/odiglet/go.mod
@@ -257,12 +257,16 @@ require (
 )
 
 replace (
+	// k8sutils requires this via its own local-only replace, which doesn't propagate to us.
+	github.com/odigos-io/odigos/actions => ../actions
 	github.com/odigos-io/odigos/api => ../api
 	github.com/odigos-io/odigos/common => ../common
 	github.com/odigos-io/odigos/distros => ../distros
 	github.com/odigos-io/odigos/instrumentation => ../instrumentation
 	github.com/odigos-io/odigos/k8sutils => ../k8sutils
 	github.com/odigos-io/odigos/odiglet/pkg/ebpf/sdks/obi => ./pkg/ebpf/sdks/obi
+	// Same as actions above, required transitively via k8sutils.
+	github.com/odigos-io/odigos/odigosauth => ../odigosauth
 	github.com/odigos-io/odigos/opampserver => ../opampserver
 	github.com/odigos-io/odigos/procdiscovery => ../procdiscovery
 )

--- a/opampserver/go.mod
+++ b/opampserver/go.mod
@@ -93,7 +93,13 @@ require (
 )
 
 replace (
+	// k8sutils requires this via its own local-only replace, which doesn't propagate to us.
+	github.com/odigos-io/odigos/actions => ../actions
 	github.com/odigos-io/odigos/api => ../api
 	github.com/odigos-io/odigos/common => ../common
 	github.com/odigos-io/odigos/k8sutils => ../k8sutils
+	// Same as actions above, required transitively via k8sutils.
+	github.com/odigos-io/odigos/odigosauth => ../odigosauth
+	// argo-rollouts@v1.9.1 requires this via its own internal-only replace, which doesn't propagate to us.
+	k8s.io/kubelet => k8s.io/kubelet v0.34.1
 )

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -192,6 +192,8 @@ require (
 )
 
 replace (
+	// k8sutils requires this via its own local-only replace, which doesn't propagate to us.
+	github.com/odigos-io/odigos/actions => ../actions
 	github.com/odigos-io/odigos/api => ../api
 	github.com/odigos-io/odigos/cli => ../cli
 	github.com/odigos-io/odigos/common => ../common

--- a/scheduler/go.mod
+++ b/scheduler/go.mod
@@ -96,9 +96,15 @@ require (
 )
 
 replace (
+	// k8sutils requires this via its own local-only replace, which doesn't propagate to us.
+	github.com/odigos-io/odigos/actions => ../actions
 	github.com/odigos-io/odigos/api => ../api
 	github.com/odigos-io/odigos/common => ../common
 	github.com/odigos-io/odigos/destinations => ../destinations
 	github.com/odigos-io/odigos/k8sutils => ../k8sutils
+	// Same as actions above, required transitively via k8sutils.
+	github.com/odigos-io/odigos/odigosauth => ../odigosauth
 	github.com/odigos-io/odigos/profiles => ../profiles
+	// argo-rollouts@v1.9.1 requires this via its own internal-only replace, which doesn't propagate to us.
+	k8s.io/kubelet => k8s.io/kubelet v0.34.1
 )

--- a/scripts/cli-docgen/go.mod
+++ b/scripts/cli-docgen/go.mod
@@ -166,6 +166,8 @@ require (
 )
 
 replace (
+	// k8sutils requires this via its own local-only replace, which doesn't propagate to us.
+	github.com/odigos-io/odigos/actions => ../../actions
 	github.com/odigos-io/odigos/api => ../../api
 	github.com/odigos-io/odigos/cli => ../../cli
 	github.com/odigos-io/odigos/cli/cmd => ../../cli/cmd
@@ -173,4 +175,6 @@ replace (
 	github.com/odigos-io/odigos/k8sutils => ../../k8sutils
 	github.com/odigos-io/odigos/odigosauth => ../../odigosauth
 	github.com/odigos-io/odigos/profiles => ../../profiles
+	// argo-rollouts@v1.9.1 requires this via its own internal-only replace, which doesn't propagate to us.
+	k8s.io/kubelet => k8s.io/kubelet v0.34.1
 )


### PR DESCRIPTION
#### What this PR does / why we need it:
`go list -m all` fails on 12 modules because several dependencies declare `replace` directives in their own go.mod that Go does not propagate to consumers.

A module with an unresolvable transitive dependency breaks any tooling that loads its full dependency graph

Adds the missing `replace` to each affected module, pointing to the real resolvable version or local path the upstream module already intends.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
```release-note
NONE
```