### PR TITLE
fix: add missing replace for odigos/actions in operator go.mod

### DIFF
--- a/operator/go.mod
+++ b/operator/go.mod
@@ -192,6 +192,7 @@ require (
 )
 
 replace (
+	github.com/odigos-io/odigos/actions => ../actions
 	github.com/odigos-io/odigos/api => ../api
 	github.com/odigos-io/odigos/cli => ../cli
 	github.com/odigos-io/odigos/common => ../common


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
```release-note
NONE
```