### PR TITLE
CORE-1401 | chore: slim deviceplugin module dependencies

### DIFF
--- a/api/k8sconsts/consts.go
+++ b/api/k8sconsts/consts.go
@@ -12,9 +12,8 @@ const (
 )
 
 const (
-	DefaultPprofEndpointPort      int32 = 6060
-	DevicePluginPprofEndpointPort int32 = 6061
-	CollectorsPprofEndpointPort   int32 = 1777
+	DefaultPprofEndpointPort    int32 = 6060
+	CollectorsPprofEndpointPort int32 = 1777
 )
 
 const (

--- a/deviceplugin/cmd/main.go
+++ b/deviceplugin/cmd/main.go
@@ -5,7 +5,6 @@ import (
 
 	commonlogger "github.com/odigos-io/odigos/common/logger"
 	"github.com/odigos-io/odigos/deviceplugin/pkg"
-	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 	"k8s.io/klog/v2"
 
 	_ "net/http/pprof"
@@ -15,12 +14,6 @@ func main() {
 	commonlogger.Init(os.Getenv("ODIGOS_LOG_LEVEL"), "deviceplugin")
 	klog.SetLogger(commonlogger.ToLogr())
 	logger := commonlogger.LoggerCompat().With("subsystem", "startup")
-
-	// Load env
-	if err := env.Load(); err != nil {
-		logger.Error("Failed to load env", "err", err)
-		os.Exit(1)
-	}
 
 	dp := pkg.New()
 

--- a/deviceplugin/go.mod
+++ b/deviceplugin/go.mod
@@ -2,22 +2,12 @@ module github.com/odigos-io/odigos/deviceplugin
 
 go 1.26.4
 
-replace (
-	github.com/odigos-io/odigos/api => ../api
-	github.com/odigos-io/odigos/common => ../common
-	github.com/odigos-io/odigos/distros => ../distros
-	github.com/odigos-io/odigos/instrumentation => ../instrumentation
-	github.com/odigos-io/odigos/k8sutils => ../k8sutils
-	github.com/odigos-io/odigos/procdiscovery => ../procdiscovery
-)
+replace github.com/odigos-io/odigos/common => ../common
 
 require (
 	github.com/google/uuid v1.6.0
 	github.com/odigos-io/odigos-device-plugin v1.19.8
-	github.com/odigos-io/odigos/api v0.0.0
 	github.com/odigos-io/odigos/common v0.0.0
-	github.com/odigos-io/odigos/k8sutils v0.0.0-00010101000000-000000000000
-	github.com/odigos-io/odigos/procdiscovery v0.0.0-00010101000000-000000000000
 	k8s.io/api v0.35.4
 	k8s.io/apimachinery v0.35.4
 	k8s.io/client-go v0.35.4
@@ -30,7 +20,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
-	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
@@ -56,8 +45,10 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/otel v1.44.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.28.0 // indirect
@@ -76,7 +67,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect
 	sigs.k8s.io/controller-runtime v0.23.3 // indirect

--- a/deviceplugin/go.sum
+++ b/deviceplugin/go.sum
@@ -1,7 +1,5 @@
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
-github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -10,8 +8,6 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emicklei/go-restful/v3 v3.12.2 h1:DhwDP0vY3k8ZzE0RunuJy8GhNpPL6zqLkDf9B/a0/xU=
 github.com/emicklei/go-restful/v3 v3.12.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
-github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
-github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
@@ -100,14 +96,6 @@ github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6u
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
-github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
-github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
-github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
-github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTUGI4=
-github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
-github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEycfc=
-github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
@@ -181,14 +169,10 @@ gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST
 gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.4 h1:P7nFYKl5vo9AGUp1Z+Pmd3p2tA7bX2wbFWCvDeRv988=
 k8s.io/api v0.35.4/go.mod h1:yl4lqySWOgYJJf9RERXKUwE9g2y+CkuwG+xmcOK8wXU=
-k8s.io/apiextensions-apiserver v0.35.0 h1:3xHk2rTOdWXXJM+RDQZJvdx0yEOgC0FgQ1PlJatA5T4=
-k8s.io/apiextensions-apiserver v0.35.0/go.mod h1:E1Ahk9SADaLQ4qtzYFkwUqusXTcaV2uw3l14aqpL2LU=
 k8s.io/apimachinery v0.35.4 h1:xtdom9RG7e+yDp71uoXoJDWEE2eOiHgeO4GdBzwWpds=
 k8s.io/apimachinery v0.35.4/go.mod h1:NNi1taPOpep0jOj+oRha3mBJPqvi0hGdaV8TCqGQ+cc=
 k8s.io/client-go v0.35.4 h1:DN6fyaGuzK64UvnKO5fOA6ymSjvfGAnCAHAR0C66kD8=

--- a/deviceplugin/pkg/instrumentation/lister.go
+++ b/deviceplugin/pkg/instrumentation/lister.go
@@ -4,11 +4,13 @@ import (
 	"context"
 
 	"github.com/odigos-io/odigos-device-plugin/pkg/dpm"
-	"github.com/odigos-io/odigos/api/k8sconsts"
 	"k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 
 	"github.com/odigos-io/odigos/common"
 )
+
+// redefining here to avoid depending on the api package
+var OdigosAgentsDirectory = "/var/odigos"
 
 type lister struct {
 	plugins map[string]dpm.PluginInterface
@@ -47,8 +49,8 @@ func NewLister(ctx context.Context) (dpm.ListerInterface, error) {
 		return &v1beta1.ContainerAllocateResponse{
 			Mounts: []*v1beta1.Mount{
 				{
-					ContainerPath: k8sconsts.OdigosAgentsDirectory,
-					HostPath:      k8sconsts.OdigosAgentsDirectory,
+					ContainerPath: OdigosAgentsDirectory,
+					HostPath:      OdigosAgentsDirectory,
 					ReadOnly:      true,
 				},
 			},

--- a/deviceplugin/pkg/instrumentation/plugin.go
+++ b/deviceplugin/pkg/instrumentation/plugin.go
@@ -4,9 +4,7 @@ import (
 	"context"
 
 	"github.com/odigos-io/odigos-device-plugin/pkg/dpm"
-	"github.com/odigos-io/odigos/procdiscovery/pkg/libc"
 
-	"github.com/odigos-io/odigos/common"
 	commonlogger "github.com/odigos-io/odigos/common/logger"
 	"github.com/odigos-io/odigos/deviceplugin/pkg/instrumentation/devices"
 	"k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
@@ -29,16 +27,6 @@ func NewPlugin(initialSize int64, lsf LangSpecificFunc) dpm.PluginInterface {
 		stopCh:           make(chan struct{}),
 		LangSpecificFunc: lsf,
 	}
-}
-
-func NewMuslPlugin(lang common.ProgrammingLanguage, maxPods int64, lsf LangSpecificFunc) dpm.PluginInterface {
-	wrappedLsf := func(deviceId string) *v1beta1.ContainerAllocateResponse {
-		res := lsf(deviceId)
-		libc.ModifyEnvVarsForMusl(lang, res.Envs)
-		return res
-	}
-
-	return NewPlugin(maxPods, wrappedLsf)
 }
 
 func (p *plugin) GetDevicePluginOptions(ctx context.Context, empty *v1beta1.Empty) (*v1beta1.DevicePluginOptions, error) {

--- a/deviceplugin/pkg/internal.go
+++ b/deviceplugin/pkg/internal.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 
 	"github.com/odigos-io/odigos-device-plugin/pkg/dpm"
-	"github.com/odigos-io/odigos/api/k8sconsts"
 	"github.com/odigos-io/odigos/common"
 	commonlogger "github.com/odigos-io/odigos/common/logger"
 	"github.com/odigos-io/odigos/deviceplugin/pkg/instrumentation"
 )
+
+var DevicePluginPprofEndpointPort = int(6061)
 
 // Start device manager
 // the device manager library doesn't support passing a context,
@@ -28,7 +29,7 @@ func runDeviceManager() error {
 	pprofDone := make(chan struct{})
 	go func() {
 		defer close(pprofDone)
-		err := common.StartPprofServer(ctx, commonlogger.ToLogr(), int(k8sconsts.DevicePluginPprofEndpointPort))
+		err := common.StartPprofServer(ctx, commonlogger.ToLogr(), DevicePluginPprofEndpointPort)
 		if err != nil {
 			logger.Error("Failed to start pprof server", "err", err)
 		} else {

--- a/deviceplugin/pkg/loglevel_watcher.go
+++ b/deviceplugin/pkg/loglevel_watcher.go
@@ -2,6 +2,7 @@ package pkg
 
 import (
 	"context"
+	"os"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -13,7 +14,6 @@ import (
 	"github.com/odigos-io/odigos/common"
 	"github.com/odigos-io/odigos/common/consts"
 	commonlogger "github.com/odigos-io/odigos/common/logger"
-	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 )
 
 func startLogLevelWatcher(ctx context.Context) {
@@ -26,7 +26,10 @@ func startLogLevelWatcher(ctx context.Context) {
 		return
 	}
 
-	ns := env.GetCurrentNamespace()
+	ns := consts.DefaultOdigosNamespace
+	if v, ok := os.LookupEnv(consts.CurrentNamespaceEnvVar); ok {
+		ns = v
+	}
 	var lastLevel string
 	applyLevelFromConfigMap := func(cm *corev1.ConfigMap) {
 		if cm == nil || cm.Data == nil || cm.Data[consts.OdigosConfigurationFileName] == "" {


### PR DESCRIPTION
#### What this PR does / why we need it:
Slims the deviceplugin module by removing unused dependencies and dead code so it no longer pulls in `k8sutils`, `api`, or `procdiscovery` for things it doesn't need.

- Drop unused `env.Load()` at startup (deviceplugin never used `env.Current`)
- Resolve the odigos namespace locally in the log-level watcher
- Inline agents directory / pprof port constants instead of importing `api/k8sconsts`
- Remove unused `NewMuslPlugin` helper and tidy `go.mod` / `go.sum`

Linear: https://linear.app/odigos/issue/CORE-1401/slim-deviceplugin-module-dependencies

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
```release-note
NONE
```

Made with [Cursor](https://cursor.com)