### PR TITLE
ci: verify Go module graphs resolve in CI

### DIFF
--- a/.github/workflows/go-mod-tidy.yml
+++ b/.github/workflows/go-mod-tidy.yml
@@ -16,3 +16,17 @@ jobs:
         run: make go-mod-tidy
       - name: Check clean repository
         run: make check-clean-work-tree
+
+  # go mod tidy only resolves what's actually compiled, so it can pass even when a module's full
+  # dependency graph is unresolvable (see CORE-1400). This reproduces gopls/GoLand's `go list -m all`
+  # per module so a broken module graph fails CI instead of surfacing as red imports in a contributor's IDE.
+  verify-go-mod-graph:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.4"
+      - name: run make verify-go-mod-graph
+        run: make verify-go-mod-graph

--- a/Makefile
+++ b/Makefile
@@ -285,6 +285,17 @@ go-mod-tidy/%: DIR=$*
 go-mod-tidy/%:
 	@cd $(DIR) && go mod tidy -compat=1.21
 
+# `go build`/`go test`/`go mod tidy` only need to resolve packages actually compiled, so a module whose
+# graph contains an unresolvable dependency (e.g. one only reachable via another module's own internal-only
+# replace directive) can pass all three while still being completely broken for tooling that loads the whole
+# module graph, like gopls/GoLand's `go list -m all`. This target reproduces that exact call per module so
+# CI catches it instead of a contributor's IDE (see CORE-1400).
+.PHONY: verify-go-mod-graph
+verify-go-mod-graph: $(ALL_GO_MOD_DIRS:%=verify-go-mod-graph/%)
+verify-go-mod-graph/%: DIR=$*
+verify-go-mod-graph/%:
+	@cd $(DIR) && go list -mod=mod -m all > /dev/null
+
 .PHONY: update-dep
 update-dep: $(ALL_GO_MOD_DIRS:%=update-dep/%)
 update-dep/%: DIR=$*


### PR DESCRIPTION
#### What this PR does / why we need it:
`go build`, `go test`, and `go mod tidy` only need to resolve packages actually compiled, so they pass even when a module's full dependency graph is unresolvable (see CORE-1399), nothing in CI catches that class of break before it ships.

Adds a `verify-go-mod-graph` job that runs `go list -m all` across every module, the one command that does exercise the full graph, so a broken module graph fails CI directly instead of surfacing later.

Fixes CORE-1400

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
```release-note
NONE
```