### PR TITLE
CORE-1406: Enable packet flow and interzone network metrics

### DIFF
--- a/docs/snippets/shared/pipeline/rules/networkmetrics.mdx
+++ b/docs/snippets/shared/pipeline/rules/networkmetrics.mdx
@@ -102,6 +102,7 @@ When this rule is enabled, the following metrics are exported for matching workl
 | Name (OpenTelemetry) | Name (Prometheus) | Type | Unit | Description |
 | -------------------- | ----------------- | ---- | ---- | ----------- |
 | `odigos.network.flow.bytes` | `odigos_network_flow_bytes_total` | Counter | bytes | Bytes sent from a source network endpoint to a destination network endpoint |
+| `odigos.network.flow.packets` | `odigos_network_flow_packets_total` | Counter | {packets} | Packets sent from a source network endpoint to a destination network endpoint |
 | `odigos.network.inter.zone.bytes` | `odigos_network_inter_zone_bytes_total` | Counter | bytes | Bytes flowing between cloud availability zones in your cluster (Kubernetes only) |
 | `odigos.stat.tcp.rtt` | `odigos_stat_tcp_rtt_seconds` | Histogram | seconds | TCP round-trip time (RTT) latency observed between network endpoints |
 | `odigos.stat.tcp.failed.connections` | `odigos_stat_tcp_failed_connections_total` | Counter | 1 | Failed TCP connection attempts between endpoints, labeled by failure reason |

--- a/odiglet/pkg/ebpf/sdks/obi/obi.go
+++ b/odiglet/pkg/ebpf/sdks/obi/obi.go
@@ -74,7 +74,7 @@ func obiConfigForOdigos() *obipkg.Config {
 
 	cfg.Traces.Instrumentations = append(cfg.Traces.Instrumentations, instrumentations.InstrumentationDNS)
 
-	cfg.Metrics.Features = export.FeatureNetwork | export.FeatureStats
+	cfg.Metrics.Features = export.FeatureNetwork | export.FeatureNetworkFlowPackets | export.FeatureNetworkInterZone | export.FeatureStats
 
 	return &cfg
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
The inter zone metrics and `flow.packets` network metrics weren't enabled by default in the embedded OBI config we build. This adds them so those metrics show up

cherry-pick:v1.33

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
feat(network metrics): Enable flow packets and inter zone metrics
```
