### PR TITLE
CORE-1407 | ci: tag deviceplugin module on release

### DIFF
--- a/.github/actions/tag-modules/action.yml
+++ b/.github/actions/tag-modules/action.yml
@@ -17,6 +17,7 @@ runs:
         git tag common/${{ inputs.tag }}
         git tag config/${{ inputs.tag }}
         git tag destinations/${{ inputs.tag }}
+        git tag deviceplugin/${{ inputs.tag }}
         git tag distros/${{ inputs.tag }}
         git tag frontend/${{ inputs.tag }}
         git tag instrumentation/${{ inputs.tag }}


### PR DESCRIPTION
#### What this PR does / why we need it:
The `deviceplugin` Go module was missing from the tag-modules action, so it was never tagged on release and could not be consumed as a versioned dependency by other projects.

Fixes: CORE-1407

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
```release-note
NONE
```

Made with [Cursor](https://cursor.com)