### PR TITLE
CORE-1408 | feat: detect Wo11y Java agent

### DIFF
--- a/common/otheragent/knownagents.go
+++ b/common/otheragent/knownagents.go
@@ -8,6 +8,7 @@ const (
 	NewRelicAgentName      = "New Relic Agent"
 	DynatraceAgentName     = "Dynatrace Agent"
 	OpenTelemetryAgentName = "OpenTelemetry Agent"
+	Wo11yAgentName         = "Wo11y Agent"
 	GrafanaOtelAgentName   = "Grafana OpenTelemetry Agent"
 	SplunkOtelAgentName    = "Splunk OpenTelemetry Agent"
 	AWSDistroOtelAgentName = "AWS Distro for OpenTelemetry Agent"
@@ -99,6 +100,9 @@ var KnownAgents = []KnownAgent{
 	{Name: OpenTelemetryAgentName, Language: common.JavascriptProgrammingLanguage, Signal: EnvValueContains,
 		Key: envNodeOptions, Match: "@opentelemetry/auto-instrumentations-node"},
 	{Name: OpenTelemetryAgentName, Language: common.PythonProgrammingLanguage, Signal: CmdlineContains, Match: "opentelemetry-instrument"},
+
+	// Wo11y Agent
+	{Name: Wo11yAgentName, Language: common.JavaProgrammingLanguage, Signal: EnvValueContains, Key: envJavaToolOptions, Match: "wo11y-agent"},
 
 	// Grafana OpenTelemetry
 	{Name: GrafanaOtelAgentName, Language: common.JavaProgrammingLanguage, Signal: CmdlineContains, Match: "grafana-opentelemetry-java"},


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds detection for Wo11y Java agent (`wo11y-agent` in `JAVA_TOOL_OPTIONS`) so Odigos can skip instrumentation when a service is already instrumented with that agent.

Fixes [CORE-1408](https://linear.app/odigos/issue/CORE-1408/add-detection-to-wolly-walmart-java-agent)

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
```release-note
Detect Wo11y agent in java and prevent odigos from instrumenting in this case
```