### PR TITLE
fix: update cli-install make target for Helm-based CLI flags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,9 +140,13 @@ go run -tags=embed_manifests ./cli
 To run `odigos install` cli command from a local source, use the make command from repo root:
 
 ```bash
-make cli-install
-# Installing Odigos version v0.1.81 in namespace odigos-system ...
+# ODIGOS_CLI_VERSION sets Helm image.tag (use a real published tag; local charts are often 0.0.0)
+make cli-install ODIGOS_CLI_VERSION=v1.32.2
 ```
+
+`make cli-install` uses the local Helm chart (`helm/odigos`) by default. Pass a published
+`ODIGOS_CLI_VERSION` for `image.tag`; do not confuse that with `--chart-version`.
+See comments on the `cli-install` target in `cli.mk` for chart vs image-tag overrides.
 
 If you test changes to the `install` command, you will need to `odigos uninstall` first before you can run install again.
 

--- a/cli.mk
+++ b/cli.mk
@@ -3,9 +3,10 @@
 #   TAG                 - image / version tag (auto-detected from cluster/cli/helm if unset)
 #   ORG                 - registry org (default: registry.odigos.io); STAGING_ORG=true for staging GCR
 #   IMG_SUFFIX          - image name suffix (empty by default; -rhel-certified when RHEL=true)
-#   ODIGOS_CLI_VERSION  - version passed to install/upgrade (default: `odigos version --cli`)
+#   ODIGOS_CLI_VERSION  - sets Helm image.tag for install/upgrade (default: `odigos version --cli`)
 #   CLUSTER_NAME        - cluster name for install (default: local-dev-cluster)
 #   CENTRAL_BACKEND_URL - optional central backend URL for install
+#   CLI_CHART_VERSION   - optional --chart-version for cli-install/upgrade (published chart; not local)
 #   FLAGS               - extra CLI flags appended to cli-install
 
 CLI_IMAGE ?= $(ORG)/odigos-cli$(IMG_SUFFIX):$(TAG)
@@ -28,32 +29,48 @@ cli-docs:
 	done
 
 # Install Odigos from local cli/ source (go run), reflecting local api/cli changes.
-# Defaults: --version=$(ODIGOS_CLI_VERSION) --nowait --cluster-name=$(CLUSTER_NAME).
-# Override: make cli-install ODIGOS_CLI_VERSION=v1.2.3 CLUSTER_NAME=my-cluster FLAGS='--set image.tag=...'
-# Set CENTRAL_BACKEND_URL to pass --central-backend-url for proxy/central setups.
+#
+# Chart vs image tag:
+#   - Default chart is the local path ../helm/odigos (works without a baked/embedded chart).
+#   - ODIGOS_CLI_VERSION maps to --set image.tag=... (a real published tag such as v1.32.2).
+#     Do not pass it as --chart-version: local charts are often version 0.0.0, and that flag
+#     also skips the embedded-chart path used by release builds.
+#   - CLI_CHART_VERSION optionally sets --chart-version and fetches that chart from the Helm
+#     repo instead of using the local chart. Distinct from CHART_VERSION used by build-cli-image.
+#
+# Examples:
+#   make cli-install ODIGOS_CLI_VERSION=v1.32.2
+#   make cli-install ODIGOS_CLI_VERSION=v1.32.2 CLUSTER_NAME=my-cluster
+#   make cli-install CLI_CHART_VERSION=1.32.2 ODIGOS_CLI_VERSION=v1.32.2
+#   make cli-install FLAGS='--set image.tag=v1.32.2'
 .PHONY: cli-install
 cli-install:
-	@echo "Installing odigos from source. version: $(ODIGOS_CLI_VERSION)"
+	@echo "Installing odigos from source. image.tag: $(or $(ODIGOS_CLI_VERSION),<chart appVersion>)"
 	cd ./cli ; go run -tags=embed_manifests . install \
-		--version $(ODIGOS_CLI_VERSION) \
-		--nowait \
-		$(if $(CLUSTER_NAME),--cluster-name $(CLUSTER_NAME)) \
-		$(if $(CENTRAL_BACKEND_URL),--central-backend-url $(CENTRAL_BACKEND_URL)) \
+		$(if $(CLI_CHART_VERSION),--chart-version $(CLI_CHART_VERSION),--chart ../helm/odigos) \
+		$(if $(ODIGOS_CLI_VERSION),--set image.tag=$(ODIGOS_CLI_VERSION)) \
+		$(if $(CLUSTER_NAME),--set clusterName=$(CLUSTER_NAME)) \
+		$(if $(CENTRAL_BACKEND_URL),--set centralProxy.centralBackendURL=$(CENTRAL_BACKEND_URL)) \
 		$(FLAGS)
 
 # Uninstall Odigos from the current cluster using local cli/ source.
 .PHONY: cli-uninstall
 cli-uninstall:
-	@echo "Uninstalling odigos from source. version: $(ODIGOS_CLI_VERSION)"
+	@echo "Uninstalling odigos from source."
 	cd ./cli ; go run -tags=embed_manifests . uninstall
 
-# Upgrade an existing install using local cli/ source.
-# Defaults: --version=$(ODIGOS_CLI_VERSION) --yes.
-# Override: make cli-upgrade ODIGOS_CLI_VERSION=v1.2.3
+# Upgrade an existing install using local cli/ source (same Helm flow as install).
+# See cli-install for chart vs image.tag guidance.
+# Override: make cli-upgrade ODIGOS_CLI_VERSION=v1.32.2
 .PHONY: cli-upgrade
 cli-upgrade:
-	@echo "Upgrading odigos from source. version: $(ODIGOS_CLI_VERSION)"
-	cd ./cli ; go run -tags=embed_manifests . upgrade --version $(ODIGOS_CLI_VERSION) --yes
+	@echo "Upgrading odigos from source. image.tag: $(or $(ODIGOS_CLI_VERSION),<chart appVersion>)"
+	cd ./cli ; go run -tags=embed_manifests . upgrade \
+		$(if $(CLI_CHART_VERSION),--chart-version $(CLI_CHART_VERSION),--chart ../helm/odigos) \
+		$(if $(ODIGOS_CLI_VERSION),--set image.tag=$(ODIGOS_CLI_VERSION)) \
+		$(if $(CLUSTER_NAME),--set clusterName=$(CLUSTER_NAME)) \
+		$(if $(CENTRAL_BACKEND_URL),--set centralProxy.centralBackendURL=$(CENTRAL_BACKEND_URL)) \
+		$(FLAGS)
 
 # Build the cli/odigos binary for local/e2e use, with helm charts embedded.
 # Hardcodes chart/binary version to 0.0.0-e2e-test (not TAG). Output: cli/odigos.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### What this PR does / why we need it:
`make cli-install` was broken after `odigos install` moved to Helm: it still passed removed flags (`--version`, `--cluster-name`, `--central-backend-url`, `--nowait`).

This updates `cli-install` / `cli-upgrade` in `cli.mk` (the target moved out of the root Makefile) to current Helm CLI flags:

- Default chart: local `helm/odigos` (`--chart ../helm/odigos`) so local `go run` works without a baked/embedded chart
- `ODIGOS_CLI_VERSION` → `--set image.tag=...` (not `--chart-version`; local charts are often `0.0.0` and that flag skips the embedded-chart path)
- `CLUSTER_NAME` → `--set clusterName=`
- `CENTRAL_BACKEND_URL` → `--set centralProxy.centralBackendURL=`
- Optional `CLI_CHART_VERSION` → `--chart-version` when you intentionally want a published chart

This supersedes #5199 (which targeted the old Makefile location and mapped `ODIGOS_CLI_VERSION` to `--chart-version`). Please close #5199 in favor of this PR.

Closes #5178
Fixes DEVOPS-64

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
Fix `make cli-install` / `make cli-upgrade` to use current Helm-based Odigos CLI flags.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87f9fdbc-d737-4ecc-96e3-038b6b3bffe0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87f9fdbc-d737-4ecc-96e3-038b6b3bffe0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

