### PR TITLE
RUN-967 | Remove AWS ECR login step for odiglet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,9 +256,6 @@ restart-collector:
 	-kubectl -n odigos-system patch daemonset odiglet -p "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"kubectl.kubernetes.io/restartedAt\":\"$(date +%Y-%m-%dT%H:%M:%S%z)\"}}}}}"
 
 deploy-%:
-	@if [ "$*" = "odiglet" ]; then \
-		aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws; \
-	fi
 	$(MAKE) build-$* ORG=$(ORG) TAG=$(TAG) DOCKERFILE=$(DOCKERFILE) IMG_SUFFIX=$(IMG_SUFFIX)
 	$(MAKE) load-to-kind-$* ORG=$(ORG) TAG=$(TAG) IMG_SUFFIX=$(IMG_SUFFIX)
 	@if [ "$*" != "agents" ]; then \


### PR DESCRIPTION


#### What this PR does / why we need it:
Removed AWS ECR login command for 'odiglet' deployment.

```release-note
NONE
```
