### PR TITLE
CORE-1324 | ci: tag the collector modules and release the enterprise collector image

### DIFF
--- a/.github/actions/tag-modules/action.yml
+++ b/.github/actions/tag-modules/action.yml
@@ -14,6 +14,31 @@ runs:
       run: |
         git tag actions/${{ inputs.tag }}
         git tag api/${{ inputs.tag }}
+        # the collector components, pinned by the enterprise distribution's builder-config.yaml
+        git tag collector/config/configgrpc/${{ inputs.tag }}
+        git tag collector/connectors/odigosrouterconnector/${{ inputs.tag }}
+        git tag collector/connectors/servicegraphconnector/${{ inputs.tag }}
+        git tag collector/connectors/serviceioconnector/${{ inputs.tag }}
+        git tag collector/exporters/azureblobstorageexporter/${{ inputs.tag }}
+        git tag collector/exporters/googlecloudstorageexporter/${{ inputs.tag }}
+        git tag collector/exporters/mockdestinationexporter/${{ inputs.tag }}
+        git tag collector/extension/odigosconfigk8sextension/${{ inputs.tag }}
+        git tag collector/processors/odigosconditionalattributes/${{ inputs.tag }}
+        git tag collector/processors/odigosextractattributeprocessor/${{ inputs.tag }}
+        git tag collector/processors/odigoslogsresourceattrsprocessor/${{ inputs.tag }}
+        git tag collector/processors/odigospiimaskingprocessor/${{ inputs.tag }}
+        git tag collector/processors/odigosprofilesprocessor/${{ inputs.tag }}
+        git tag collector/processors/odigossqldboperationprocessor/${{ inputs.tag }}
+        git tag collector/processors/odigossqlqueryprocessor/${{ inputs.tag }}
+        git tag collector/processors/odigossymbolizeprocessor/${{ inputs.tag }}
+        git tag collector/processors/odigostailsamplingprocessor/${{ inputs.tag }}
+        git tag collector/processors/odigostracefilterprocessor/${{ inputs.tag }}
+        git tag collector/processors/odigostracestateprocessor/${{ inputs.tag }}
+        git tag collector/processors/odigostrafficmetrics/${{ inputs.tag }}
+        git tag collector/processors/odigosurltemplateprocessor/${{ inputs.tag }}
+        git tag collector/processors/odigosvmprofileattrsprocessor/${{ inputs.tag }}
+        git tag collector/providers/odigosk8scmprovider/${{ inputs.tag }}
+        git tag collector/receivers/odigosebpfreceiver/${{ inputs.tag }}
         git tag common/${{ inputs.tag }}
         git tag config/${{ inputs.tag }}
         git tag destinations/${{ inputs.tag }}

--- a/.github/workflows/promote-rc-to-stable.yml
+++ b/.github/workflows/promote-rc-to-stable.yml
@@ -117,11 +117,11 @@ jobs:
             # Define which images go to which registries
             # All non-RHEL component images (OSS + enterprise). Each is promoted in components
             # and mirrored to components-private.
-            GCR_IMAGE_NAMES=("odigos-agents" "odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-ui" "odigos-operator" "odigos-cli" "odigos-victoria-metrics" "odigos-enterprise-central-backend" "odigos-enterprise-central-proxy" "odigos-enterprise-central-ui" "odigos-enterprise-ui" "odigos-enterprise-agents" "odigos-enterprise-instrumentor" "odigos-enterprise-odiglet")
+            GCR_IMAGE_NAMES=("odigos-agents" "odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-ui" "odigos-operator" "odigos-cli" "odigos-victoria-metrics" "odigos-enterprise-central-backend" "odigos-enterprise-central-proxy" "odigos-enterprise-central-ui" "odigos-enterprise-ui" "odigos-enterprise-agents" "odigos-enterprise-collector" "odigos-enterprise-instrumentor" "odigos-enterprise-odiglet")
 
             GHCR_IMAGE_NAMES=("odigos-agents" "odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-ui" "odigos-operator")
 
-            DOCKERHUB_IMAGE_NAMES=("odigos-agents" "odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-ui" "odigos-operator" "odigos-enterprise-agents" "odigos-enterprise-instrumentor" "odigos-enterprise-odiglet")
+            DOCKERHUB_IMAGE_NAMES=("odigos-agents" "odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-ui" "odigos-operator" "odigos-enterprise-agents" "odigos-enterprise-collector" "odigos-enterprise-instrumentor" "odigos-enterprise-odiglet")
 
             # Keep this empty for now to support another image SUFFIXES in the future if needed (e.g. rhel-certified)
             IMAGE_SUFFIXES=("")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Verify Components Image Ready
         run: |
-          declare -a REPOS=("odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-enterprise-odiglet" "odigos-ui" "odigos-enterprise-instrumentor" "odigos-operator" "odigos-enterprise-agents" "odigos-enterprise-central-backend" "odigos-enterprise-central-proxy" "odigos-enterprise-central-ui")
+          declare -a REPOS=("odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-enterprise-collector" "odigos-enterprise-odiglet" "odigos-ui" "odigos-enterprise-instrumentor" "odigos-operator" "odigos-enterprise-agents" "odigos-enterprise-central-backend" "odigos-enterprise-central-proxy" "odigos-enterprise-central-ui")
 
           TAG_TO_CHECK=${{ env.TAG }}
 

--- a/docs/snippets/enterprise/setup/docker-registry.mdx
+++ b/docs/snippets/enterprise/setup/docker-registry.mdx
@@ -22,7 +22,7 @@ docker pull registry.odigos.io/odigos-enterprise-instrumentor:$VERSION
 docker pull registry.odigos.io/odigos-ui:$VERSION
 docker pull registry.odigos.io/odigos-autoscaler:$VERSION
 docker pull registry.odigos.io/odigos-enterprise-odiglet:$VERSION
-docker pull registry.odigos.io/odigos-collector:$VERSION
+docker pull registry.odigos.io/odigos-enterprise-collector:$VERSION
 ```
 
 If you are using the [k8s-init-container](/enterprise/instrumentations/configuration/mount-method#3-InitContainer) mount method
@@ -44,7 +44,7 @@ docker pull --platform $PLATFORM registry.odigos.io/odigos-enterprise-instrument
 docker pull --platform $PLATFORM registry.odigos.io/odigos-ui:$VERSION
 docker pull --platform $PLATFORM registry.odigos.io/odigos-autoscaler:$VERSION
 docker pull --platform $PLATFORM registry.odigos.io/odigos-enterprise-odiglet:$VERSION
-docker pull --platform $PLATFORM registry.odigos.io/odigos-collector:$VERSION
+docker pull --platform $PLATFORM registry.odigos.io/odigos-enterprise-collector:$VERSION
 ```
 
 ### Step 3: Tag the Images
@@ -56,11 +56,13 @@ docker tag registry.odigos.io/odigos-enterprise-instrumentor:$VERSION $CUSTOM_DO
 docker tag registry.odigos.io/odigos-ui:$VERSION $CUSTOM_DOCKER_REGISTRY/odigos-ui:$VERSION
 docker tag registry.odigos.io/odigos-autoscaler:$VERSION $CUSTOM_DOCKER_REGISTRY/odigos-autoscaler:$VERSION
 docker tag registry.odigos.io/odigos-enterprise-odiglet:$VERSION $CUSTOM_DOCKER_REGISTRY/odigos-enterprise-odiglet:$VERSION
-docker tag registry.odigos.io/odigos-collector:$VERSION $CUSTOM_DOCKER_REGISTRY/odigos-collector:$VERSION
+docker tag registry.odigos.io/odigos-enterprise-collector:$VERSION $CUSTOM_DOCKER_REGISTRY/odigos-enterprise-collector:$VERSION
 ```
 
 
 > **Note:** Prior to v1.0.155, Odigos images were prefixed with `keyval/` (such as `keyval/odigos-scheduler`) In v1.0.155+, this is no longer the case, and Odigos does not assume this prefix. If you were hosting custom images prior to this version, you may have to re-tag your images to remove the `keyval/` prefix.
+
+> **Note:** Odigos Enterprise now runs a dedicated collector image, `odigos-enterprise-collector`, in place of `odigos-collector`. If you were already mirroring `odigos-collector`, mirror `odigos-enterprise-collector` as well before upgrading, otherwise the gateway and the node collectors will fail to pull.
 
 ### Step 4: Push the Images
 Now, push the tagged images to your custom Docker registry:
@@ -70,7 +72,7 @@ docker push $CUSTOM_DOCKER_REGISTRY/odigos-enterprise-instrumentor:$VERSION
 docker push $CUSTOM_DOCKER_REGISTRY/odigos-ui:$VERSION
 docker push $CUSTOM_DOCKER_REGISTRY/odigos-autoscaler:$VERSION
 docker push $CUSTOM_DOCKER_REGISTRY/odigos-enterprise-odiglet:$VERSION
-docker push $CUSTOM_DOCKER_REGISTRY/odigos-collector:$VERSION
+docker push $CUSTOM_DOCKER_REGISTRY/odigos-enterprise-collector:$VERSION
 ```
 
 ### Step 5: Configure Access for Private Registries


### PR DESCRIPTION
#### What this PR does / why we need it:

Release plumbing for the enterprise collector distribution (odigos-io/odigos-enterprise#3309).

It builds with `ocb` from a manifest that pins each Odigos collector component as a Go module version, so:

- `tag-modules` tags the 24 collector modules that manifest consumes — without them a release can only pin pseudo-versions.
- `odigos-enterprise-collector` added to the release readiness gate and the RC→stable promote lists. Helm already points pro installs at this image, but nothing verified it was built and promotion skipped it. Not added to GHCR, which carries no enterprise images.
- Docs updated to mirror the new image name.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
NONE
```
