### PR TITLE
CORE-1423 | expose concurrent-agent source actions

### DIFF
--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -866,9 +866,10 @@ type ComplexityRoot struct {
 	}
 
 	K8sWorkloadContainerOverrides struct {
-		ContainerName  func(childComplexity int) int
-		OtelDistroName func(childComplexity int) int
-		RuntimeInfo    func(childComplexity int) int
+		AllowConcurrentAgents func(childComplexity int) int
+		ContainerName         func(childComplexity int) int
+		OtelDistroName        func(childComplexity int) int
+		RuntimeInfo           func(childComplexity int) int
 	}
 
 	K8sWorkloadId struct {
@@ -5364,6 +5365,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation.RuleID(childComplexity), true
+
+	case "K8sWorkloadContainerOverrides.allowConcurrentAgents":
+		if e.complexity.K8sWorkloadContainerOverrides.AllowConcurrentAgents == nil {
+			break
+		}
+
+		return e.complexity.K8sWorkloadContainerOverrides.AllowConcurrentAgents(childComplexity), true
 
 	case "K8sWorkloadContainerOverrides.containerName":
 		if e.complexity.K8sWorkloadContainerOverrides.ContainerName == nil {
@@ -33280,6 +33288,8 @@ func (ec *executionContext) fieldContext_K8sWorkloadContainer_overrides(_ contex
 				return ec.fieldContext_K8sWorkloadContainerOverrides_runtimeInfo(ctx, field)
 			case "otelDistroName":
 				return ec.fieldContext_K8sWorkloadContainerOverrides_otelDistroName(ctx, field)
+			case "allowConcurrentAgents":
+				return ec.fieldContext_K8sWorkloadContainerOverrides_allowConcurrentAgents(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type K8sWorkloadContainerOverrides", field.Name)
 		},
@@ -34976,6 +34986,47 @@ func (ec *executionContext) fieldContext_K8sWorkloadContainerOverrides_otelDistr
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _K8sWorkloadContainerOverrides_allowConcurrentAgents(ctx context.Context, field graphql.CollectedField, obj *model.K8sWorkloadContainerOverrides) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_K8sWorkloadContainerOverrides_allowConcurrentAgents(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AllowConcurrentAgents, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*bool)
+	fc.Result = res
+	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_K8sWorkloadContainerOverrides_allowConcurrentAgents(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "K8sWorkloadContainerOverrides",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -58822,7 +58873,7 @@ func (ec *executionContext) unmarshalInputPatchSourceRequestInput(ctx context.Co
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"currentStreamName", "otelServiceName", "containerName", "language", "version", "otelDistroName"}
+	fieldsInOrder := [...]string{"currentStreamName", "otelServiceName", "containerName", "language", "version", "otelDistroName", "allowConcurrentAgents"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -58871,6 +58922,13 @@ func (ec *executionContext) unmarshalInputPatchSourceRequestInput(ctx context.Co
 				return it, err
 			}
 			it.OtelDistroName = data
+		case "allowConcurrentAgents":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("allowConcurrentAgents"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AllowConcurrentAgents = data
 		}
 	}
 
@@ -65694,6 +65752,8 @@ func (ec *executionContext) _K8sWorkloadContainerOverrides(ctx context.Context, 
 			out.Values[i] = ec._K8sWorkloadContainerOverrides_runtimeInfo(ctx, field, obj)
 		case "otelDistroName":
 			out.Values[i] = ec._K8sWorkloadContainerOverrides_otelDistroName(ctx, field, obj)
+		case "allowConcurrentAgents":
+			out.Values[i] = ec._K8sWorkloadContainerOverrides_allowConcurrentAgents(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -1060,9 +1060,10 @@ type K8sWorkloadContainerCollectorConfigTailSamplingNoisyOperation struct {
 }
 
 type K8sWorkloadContainerOverrides struct {
-	ContainerName  string                           `json:"containerName"`
-	RuntimeInfo    *K8sWorkloadRuntimeInfoContainer `json:"runtimeInfo,omitempty"`
-	OtelDistroName *string                          `json:"otelDistroName,omitempty"`
+	ContainerName         string                           `json:"containerName"`
+	RuntimeInfo           *K8sWorkloadRuntimeInfoContainer `json:"runtimeInfo,omitempty"`
+	OtelDistroName        *string                          `json:"otelDistroName,omitempty"`
+	AllowConcurrentAgents *bool                            `json:"allowConcurrentAgents,omitempty"`
 }
 
 type K8sWorkloadID struct {
@@ -1425,12 +1426,13 @@ type OverviewMetricsResponse struct {
 }
 
 type PatchSourceRequestInput struct {
-	CurrentStreamName string  `json:"currentStreamName"`
-	OtelServiceName   *string `json:"otelServiceName,omitempty"`
-	ContainerName     *string `json:"containerName,omitempty"`
-	Language          *string `json:"language,omitempty"`
-	Version           *string `json:"version,omitempty"`
-	OtelDistroName    *string `json:"otelDistroName,omitempty"`
+	CurrentStreamName     string  `json:"currentStreamName"`
+	OtelServiceName       *string `json:"otelServiceName,omitempty"`
+	ContainerName         *string `json:"containerName,omitempty"`
+	Language              *string `json:"language,omitempty"`
+	Version               *string `json:"version,omitempty"`
+	OtelDistroName        *string `json:"otelDistroName,omitempty"`
+	AllowConcurrentAgents *bool   `json:"allowConcurrentAgents,omitempty"`
 }
 
 type PayloadCollection struct {

--- a/frontend/graph/source_overrides.go
+++ b/frontend/graph/source_overrides.go
@@ -1,0 +1,59 @@
+package graph
+
+import (
+	"fmt"
+
+	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	"github.com/odigos-io/odigos/common"
+	"github.com/odigos-io/odigos/frontend/graph/model"
+)
+
+func mergeContainerOverride(existing []v1alpha1.ContainerOverride, containerName string, patch model.PatchSourceRequestInput) ([]v1alpha1.ContainerOverride, error) {
+	containerOverrides := make([]v1alpha1.ContainerOverride, 0, len(existing)+1)
+	containerOverride := v1alpha1.ContainerOverride{ContainerName: containerName}
+
+	for _, override := range existing {
+		if override.ContainerName == containerName {
+			containerOverride = override
+			continue
+		}
+		containerOverrides = append(containerOverrides, override)
+	}
+
+	if patch.Language != nil {
+		if *patch.Language == "" {
+			containerOverride.RuntimeInfo = nil
+		} else {
+			runtimeVersion := ""
+			if patch.Version != nil {
+				runtimeVersion = *patch.Version
+			} else if containerOverride.RuntimeInfo != nil {
+				runtimeVersion = containerOverride.RuntimeInfo.RuntimeVersion
+			}
+			if runtimeVersion != "" && common.GetVersion(runtimeVersion) == nil {
+				return nil, fmt.Errorf("invalid runtime version: %s", runtimeVersion)
+			}
+			containerOverride.RuntimeInfo = &v1alpha1.RuntimeDetailsByContainer{
+				ContainerName:  containerName,
+				Language:       common.ProgrammingLanguage(*patch.Language),
+				RuntimeVersion: runtimeVersion,
+			}
+		}
+	} else if patch.Version != nil && containerOverride.RuntimeInfo != nil {
+		if *patch.Version != "" && common.GetVersion(*patch.Version) == nil {
+			return nil, fmt.Errorf("invalid runtime version: %s", *patch.Version)
+		}
+		runtimeInfo := *containerOverride.RuntimeInfo
+		runtimeInfo.RuntimeVersion = *patch.Version
+		containerOverride.RuntimeInfo = &runtimeInfo
+	}
+
+	if patch.OtelDistroName != nil {
+		containerOverride.OtelDistroName = patch.OtelDistroName
+	}
+	if patch.AllowConcurrentAgents != nil {
+		containerOverride.AllowConcurrentAgents = patch.AllowConcurrentAgents
+	}
+
+	return append(containerOverrides, containerOverride), nil
+}

--- a/frontend/graph/source_overrides_test.go
+++ b/frontend/graph/source_overrides_test.go
@@ -1,0 +1,92 @@
+package graph
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	"github.com/odigos-io/odigos/common"
+	"github.com/odigos-io/odigos/frontend/graph/model"
+)
+
+func TestMergeContainerOverridePreservesOmittedFields(t *testing.T) {
+	distroName := "java-community"
+	allowConcurrentAgents := true
+	existing := []v1alpha1.ContainerOverride{
+		{
+			ContainerName: "sidecar",
+			OtelDistroName: func() *string {
+				value := "python-community"
+				return &value
+			}(),
+		},
+		{
+			ContainerName: "app",
+			RuntimeInfo: &v1alpha1.RuntimeDetailsByContainer{
+				ContainerName:  "app",
+				Language:       common.JavaProgrammingLanguage,
+				RuntimeVersion: "17",
+			},
+			OtelDistroName:        &distroName,
+			AllowConcurrentAgents: &allowConcurrentAgents,
+		},
+	}
+	disallowConcurrentAgents := false
+
+	got, err := mergeContainerOverride(existing, "app", model.PatchSourceRequestInput{
+		AllowConcurrentAgents: &disallowConcurrentAgents,
+	})
+	if err != nil {
+		t.Fatalf("mergeContainerOverride returned an error: %v", err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("expected two overrides, got %d", len(got))
+	}
+	if !reflect.DeepEqual(got[0], existing[0]) {
+		t.Fatalf("unrelated container override changed: got %#v, want %#v", got[0], existing[0])
+	}
+
+	appOverride := got[1]
+	if !reflect.DeepEqual(appOverride.RuntimeInfo, existing[1].RuntimeInfo) {
+		t.Fatalf("runtime override changed: got %#v, want %#v", appOverride.RuntimeInfo, existing[1].RuntimeInfo)
+	}
+	if !reflect.DeepEqual(appOverride.OtelDistroName, existing[1].OtelDistroName) {
+		t.Fatalf("distro override changed: got %#v, want %#v", appOverride.OtelDistroName, existing[1].OtelDistroName)
+	}
+	if appOverride.AllowConcurrentAgents == nil || *appOverride.AllowConcurrentAgents {
+		t.Fatalf("expected allowConcurrentAgents to be explicitly false, got %#v", appOverride.AllowConcurrentAgents)
+	}
+}
+
+func TestMergeContainerOverridePreservesConcurrentAgentSetting(t *testing.T) {
+	allowConcurrentAgents := true
+	language := string(common.PythonProgrammingLanguage)
+	version := "3.12"
+	distroName := "python-community"
+
+	got, err := mergeContainerOverride([]v1alpha1.ContainerOverride{
+		{
+			ContainerName:         "app",
+			AllowConcurrentAgents: &allowConcurrentAgents,
+		},
+	}, "app", model.PatchSourceRequestInput{
+		Language:       &language,
+		Version:        &version,
+		OtelDistroName: &distroName,
+	})
+	if err != nil {
+		t.Fatalf("mergeContainerOverride returned an error: %v", err)
+	}
+
+	appOverride := got[0]
+	if appOverride.AllowConcurrentAgents == nil || !*appOverride.AllowConcurrentAgents {
+		t.Fatalf("expected allowConcurrentAgents to remain true, got %#v", appOverride.AllowConcurrentAgents)
+	}
+	if appOverride.RuntimeInfo == nil || appOverride.RuntimeInfo.Language != common.PythonProgrammingLanguage || appOverride.RuntimeInfo.RuntimeVersion != version {
+		t.Fatalf("unexpected runtime override: %#v", appOverride.RuntimeInfo)
+	}
+	if appOverride.OtelDistroName == nil || *appOverride.OtelDistroName != distroName {
+		t.Fatalf("unexpected distro override: %#v", appOverride.OtelDistroName)
+	}
+}

--- a/frontend/graph/sources.graphqls
+++ b/frontend/graph/sources.graphqls
@@ -71,11 +71,12 @@ input PersistNamespaceSourceInput {
 input PatchSourceRequestInput {
   currentStreamName: String!
   otelServiceName: String
-  # for runtime override
+  # for container overrides
   containerName: String
   language: String
   version: String
   otelDistroName: String
+  allowConcurrentAgents: Boolean
 }
 
 type SourceConditions {

--- a/frontend/graph/sources.resolvers.go
+++ b/frontend/graph/sources.resolvers.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
-	"github.com/odigos-io/odigos/common"
 	"github.com/odigos-io/odigos/frontend/graph/model"
 	"github.com/odigos-io/odigos/frontend/kube"
 	"github.com/odigos-io/odigos/frontend/services"
@@ -212,41 +211,11 @@ func (r *mutationResolver) UpdateK8sActualSource(ctx context.Context, sourceID m
 	}
 
 	cont := patchSourceRequest.ContainerName
-	lang := patchSourceRequest.Language
-	vers := patchSourceRequest.Version
 	if cont != nil {
-		containerOverrides := make([]v1alpha1.ContainerOverride, 0)
-		// get previous overrides (except the one we are updating)
-		if source.Spec.ContainerOverrides != nil {
-			for _, override := range source.Spec.ContainerOverrides {
-				if override.ContainerName != *cont {
-					containerOverrides = append(containerOverrides, override)
-				}
-			}
+		containerOverrides, err := mergeContainerOverride(source.Spec.ContainerOverrides, *cont, patchSourceRequest)
+		if err != nil {
+			return false, err
 		}
-		// add the new override
-		var overrideRuntimeInfo *v1alpha1.RuntimeDetailsByContainer
-		if lang == nil || *lang == "" {
-			overrideRuntimeInfo = nil
-		} else {
-			runtimeVersion := ""
-			if vers != nil && *vers != "" {
-				if common.GetVersion(*vers) == nil {
-					return false, fmt.Errorf("invalid runtime version: %s", *vers)
-				}
-				runtimeVersion = *vers
-			}
-			overrideRuntimeInfo = &v1alpha1.RuntimeDetailsByContainer{
-				ContainerName:  *cont,
-				Language:       common.ProgrammingLanguage(*lang),
-				RuntimeVersion: runtimeVersion,
-			}
-		}
-		containerOverrides = append(containerOverrides, v1alpha1.ContainerOverride{
-			ContainerName:  *cont,
-			OtelDistroName: patchSourceRequest.OtelDistroName,
-			RuntimeInfo:    overrideRuntimeInfo,
-		})
 		// patch the source with the new container overrides
 		patchBytes, err := json.Marshal([]map[string]interface{}{
 			{

--- a/frontend/graph/status/agentInjectionEnabled_test.go
+++ b/frontend/graph/status/agentInjectionEnabled_test.go
@@ -1,0 +1,51 @@
+package status
+
+import (
+	"testing"
+
+	"github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	"github.com/odigos-io/odigos/frontend/graph/model"
+	agentInjectionEnabledStatus "github.com/odigos-io/odigos/status/instrumentationconfig/generated"
+)
+
+func TestCalculateAgentInjectionEnabledStatusForContainerConcurrentAgentActions(t *testing.T) {
+	tests := []struct {
+		name               string
+		reason             agentInjectionEnabledStatus.AgentEnabledReason
+		expectedActionType model.DesiredConditionActionItemType
+		expectedButtonText string
+	}{
+		{
+			name:               "other agent detected",
+			reason:             agentInjectionEnabledStatus.AgentEnabledReasonOtherAgentDetected,
+			expectedActionType: model.DesiredConditionActionItemTypeAllowConcurrentAgentsForContainer,
+			expectedButtonText: "Run Odigos With Other Agents",
+		},
+		{
+			name:               "enabled with other agents",
+			reason:             agentInjectionEnabledStatus.AgentEnabledReasonEnabledWithOtherAgents,
+			expectedActionType: model.DesiredConditionActionItemTypeDisallowConcurrentAgentsForContainer,
+			expectedButtonText: "Don't Run With Other Agents",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CalculateAgentInjectionEnabledStatusForContainer(&v1alpha1.ContainerAgentConfig{
+				AgentEnabledReason: v1alpha1.AgentEnabledReason(tt.reason),
+			})
+			if got == nil {
+				t.Fatal("expected a status, got nil")
+			}
+			if len(got.ActionItems) != 1 {
+				t.Fatalf("expected one action item, got %d", len(got.ActionItems))
+			}
+			if got.ActionItems[0].Type != tt.expectedActionType {
+				t.Fatalf("expected action type %q, got %q", tt.expectedActionType, got.ActionItems[0].Type)
+			}
+			if got.ActionItems[0].ButtonText != tt.expectedButtonText {
+				t.Fatalf("expected button text %q, got %q", tt.expectedButtonText, got.ActionItems[0].ButtonText)
+			}
+		})
+	}
+}

--- a/frontend/graph/utils.go
+++ b/frontend/graph/utils.go
@@ -101,8 +101,9 @@ func runtimeDetailsContainersToModel(runtimeDetails *v1alpha1.RuntimeDetailsByCo
 
 func containerOverrideToModel(containerOverride *v1alpha1.ContainerOverride) *model.K8sWorkloadContainerOverrides {
 	overrides := &model.K8sWorkloadContainerOverrides{
-		ContainerName:  containerOverride.ContainerName,
-		OtelDistroName: containerOverride.OtelDistroName,
+		ContainerName:         containerOverride.ContainerName,
+		OtelDistroName:        containerOverride.OtelDistroName,
+		AllowConcurrentAgents: containerOverride.AllowConcurrentAgents,
 	}
 	if containerOverride.RuntimeInfo != nil {
 		overrides.RuntimeInfo = runtimeDetailsContainersToModel(containerOverride.RuntimeInfo)

--- a/frontend/graph/workload.graphqls
+++ b/frontend/graph/workload.graphqls
@@ -269,6 +269,10 @@ type K8sWorkloadContainerOverrides {
   # when null (most times), the distro is selected based on the runtime detection values.
   # if not null, this distro is used regardless of any runtime detection values.
   otelDistroName: String
+
+  # Whether Odigos may run alongside other instrumentation agents in this container.
+  # when null, the global configuration is used.
+  allowConcurrentAgents: Boolean
 }
 
 # traces configuration for the instrumentation agent.

--- a/frontend/webapp/graphql/queries/workload.ts
+++ b/frontend/webapp/graphql/queries/workload.ts
@@ -183,12 +183,17 @@ export const GET_WORKLOADS_BY_IDS = gql`
             status
             reasonEnum
             message
+            actionItems {
+              type
+              buttonText
+            }
           }
           otelDistroName
         }
         overrides {
           containerName
           otelDistroName
+          allowConcurrentAgents
           runtimeInfo {
             language
             runtimeVersion

--- a/frontend/webapp/package.json
+++ b/frontend/webapp/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@apollo/client": "^4.2.8",
-    "@odigos/ui-kit": "0.0.282",
+    "@odigos/ui-kit": "0.0.283",
     "graphql": "^16.14.2",
     "next": "15.5.21",
     "react": "19.2.7",

--- a/frontend/webapp/yarn.lock
+++ b/frontend/webapp/yarn.lock
@@ -583,10 +583,10 @@
   resolved "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
-"@odigos/ui-kit@0.0.282":
-  version "0.0.282"
-  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.282.tgz#11e7e0c671769e1300fbc37b24189fe847d5bb10"
-  integrity sha512-gg9YXikHdLLifvszPPSC+ugewg/j3jCb4C0OkUQlBCgAhjudTT+im2N2ZMKGBmuWEAASt2VJD13kpYRvY0wldw==
+"@odigos/ui-kit@0.0.283":
+  version "0.0.283"
+  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.283.tgz#8201aad30b141411bf85ec2ebcf3d02df80841a1"
+  integrity sha512-nwCZ8lRncug0dWvpCDftdIFkzjEnGXScevVcZXHb9IvykeTLUtxnu9SM/T+HSoT9tmvH0EdOLDGzXLIqYFxVRQ==
   dependencies:
     "@xyflow/react" "^12.11.2"
     elkjs "^0.12.0"


### PR DESCRIPTION
Surface backend-provided allow/disallow actions without losing existing container overrides, and require confirmation before enabling concurrent agents.

<img width="2642" height="1676" alt="image" src="https://github.com/user-attachments/assets/d5475f17-9471-492d-aebb-9b3fa6861976" />


```release-note
Add source drawer actions for allowing or disallowing Odigos alongside other instrumentation agents.
```
