### PR TITLE
fix(release): use legacy image set for v1.28 patches PLAT-1388

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,9 +126,14 @@ jobs:
 
       - name: Verify Components Image Ready
         run: |
-          declare -a REPOS=("odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-enterprise-collector" "odigos-enterprise-odiglet" "odigos-ui" "odigos-enterprise-instrumentor" "odigos-operator" "odigos-enterprise-agents" "odigos-enterprise-central-backend" "odigos-enterprise-central-proxy" "odigos-enterprise-central-ui" "odigos-enterprise-connector-runtime" "odigos-enterprise-connector-aws" "odigos-enterprise-connector-azure" "odigos-enterprise-connector-gcp" "odigos-enterprise-connector-postgres")
-
           TAG_TO_CHECK=${{ env.TAG }}
+
+          declare -a REPOS=("odigos-autoscaler" "odigos-scheduler" "odigos-instrumentor" "odigos-odiglet" "odigos-collector" "odigos-enterprise-odiglet" "odigos-ui" "odigos-enterprise-instrumentor" "odigos-operator" "odigos-enterprise-agents" "odigos-enterprise-central-backend" "odigos-enterprise-central-proxy" "odigos-enterprise-central-ui")
+
+          # These components were added after v1.28 and do not have images for v1.28 patch releases.
+          if [[ "$TAG_TO_CHECK" != v1.28.* ]]; then
+            REPOS+=("odigos-enterprise-collector" "odigos-enterprise-connector-runtime" "odigos-enterprise-connector-aws" "odigos-enterprise-connector-azure" "odigos-enterprise-connector-gcp" "odigos-enterprise-connector-postgres")
+          fi
 
           for REPO in "${REPOS[@]}"; do
             echo "Checking tag $TAG_TO_CHECK in $REPO..."


### PR DESCRIPTION
The CLI release workflow currently validates images for components added after v1.28, preventing patch releases such as v1.28.12 from reaching GoReleaser and Helm publication.

#### What this PR does / why we need it:
Use the historical component image set for `v1.28.*` releases while preserving the current checks for newer releases. This allows the existing v1.28.12 images to pass verification so the CLI assets and Helm charts can be published.

Validation:
- Parsed `.github/workflows/release.yml` successfully.
- Ran `git diff --check`.
- Confirmed all 13 required v1.28.12 image tags return HTTP 200 from Artifact Registry.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
NONE
```