### PR TITLE
RUN-969 | chore: add libcap to odiglet base image

### DIFF
--- a/odiglet/base.Dockerfile
+++ b/odiglet/base.Dockerfile
@@ -33,7 +33,8 @@ RUN apt-get update && apt-get install -y \
     llvm \
     make \
     libbpf-dev \
-    goreleaser
+    goreleaser \
+    libcap2-bin
 
 # Bring in rsync
 COPY --from=rsync-builder /rsync-install/usr/bin/rsync /usr/bin/rsync


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->

To improve the non-prviliged mode of the odiglet, and run as non root UID, we will need to `setcap` on the odiglet binary for the set of capabilities we might need.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
