### PR TITLE
PLAT-1380 | feat: add Insights HTTP client

### DIFF
--- a/frontend/services/insights/client.go
+++ b/frontend/services/insights/client.go
@@ -1,0 +1,367 @@
+package insights
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type Client struct {
+	baseURL    *url.URL
+	httpClient *http.Client
+}
+
+func NewClient(baseURL string) (*Client, error) {
+	return NewClientWithHTTPClient(baseURL, http.DefaultClient)
+}
+
+func NewClientWithHTTPClient(baseURL string, httpClient *http.Client) (*Client, error) {
+	if strings.TrimSpace(baseURL) == "" {
+		return nil, fmt.Errorf("insights base URL is empty")
+	}
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse insights base URL: %w", err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return nil, fmt.Errorf("insights base URL must include scheme and host")
+	}
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &Client{baseURL: parsed, httpClient: httpClient}, nil
+}
+
+func (c *Client) ListServices(ctx context.Context) ([]ServiceStat, error) {
+	return doList[ServiceStat](ctx, c, http.MethodGet, c.apiEndpoint("services"), nil)
+}
+
+func (c *Client) ListTransactions(ctx context.Context, params ListTransactionsParams) ([]TransactionStat, error) {
+	endpoint := c.apiEndpoint("transactions")
+	query := endpoint.Query()
+	addOptionalString(query, "namespace", params.Namespace)
+	addOptionalString(query, "service", params.Service)
+	if params.Kind != nil {
+		query.Set("kind", string(*params.Kind))
+	}
+	endpoint.RawQuery = query.Encode()
+	return doList[TransactionStat](ctx, c, http.MethodGet, endpoint, nil)
+}
+
+func (c *Client) GetTransaction(ctx context.Context, transactionID int64) (*Transaction, error) {
+	var result Transaction
+	if err := c.do(ctx, http.MethodGet, c.transactionEndpoint(transactionID), nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *Client) GetTransactionBaseline(ctx context.Context, transactionID int64) ([]BaselineClass, error) {
+	return doList[BaselineClass](ctx, c, http.MethodGet, c.transactionEndpoint(transactionID, "baseline"), nil)
+}
+
+func (c *Client) PromoteBaselineClass(ctx context.Context, transactionID int64, class DeviationClass) (*PromoteResult, error) {
+	var result PromoteResult
+	if err := c.do(ctx, http.MethodPost, c.transactionEndpoint(transactionID, "baseline", string(class), "promote"), nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *Client) ResetBaselineClass(ctx context.Context, transactionID int64, class DeviationClass) error {
+	return c.do(ctx, http.MethodPost, c.transactionEndpoint(transactionID, "baseline", string(class), "reset"), nil, nil)
+}
+
+func (c *Client) ResetTransactionBaselines(ctx context.Context, transactionID int64) error {
+	return c.do(ctx, http.MethodPost, c.transactionEndpoint(transactionID, "baselines", "reset"), nil, nil)
+}
+
+func (c *Client) ListObservations(ctx context.Context, transactionID int64, params ListObservationsParams) ([]ObservationSummary, error) {
+	endpoint := c.transactionEndpoint(transactionID, "observations")
+	query := endpoint.Query()
+	if params.SampleReason != nil {
+		query.Set("sample_reason", string(*params.SampleReason))
+	}
+	endpoint.RawQuery = query.Encode()
+	return doList[ObservationSummary](ctx, c, http.MethodGet, endpoint, nil)
+}
+
+func (c *Client) GetObservation(ctx context.Context, transactionID int64, traceID string) (*Observation, error) {
+	var result Observation
+	if err := c.do(ctx, http.MethodGet, c.transactionEndpoint(transactionID, "observations", traceID), nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *Client) ListPolicies(ctx context.Context) ([]Policy, error) {
+	return doList[Policy](ctx, c, http.MethodGet, c.apiEndpoint("policies"), nil)
+}
+
+func (c *Client) UpsertPolicy(ctx context.Context, policy Policy) error {
+	return c.do(ctx, http.MethodPut, c.apiEndpoint("policies"), policy, nil)
+}
+
+func (c *Client) DeletePolicy(ctx context.Context, scope PolicyScope, scopeKey string) error {
+	endpoint := c.apiEndpoint("policies")
+	query := endpoint.Query()
+	query.Set("scope", string(scope))
+	query.Set("scope_key", scopeKey)
+	endpoint.RawQuery = query.Encode()
+	return c.do(ctx, http.MethodDelete, endpoint, nil, nil)
+}
+
+func (c *Client) ListLearningPolicies(ctx context.Context) ([]LearningPolicy, error) {
+	return doList[LearningPolicy](ctx, c, http.MethodGet, c.apiEndpoint("learning-policies"), nil)
+}
+
+func (c *Client) UpsertLearningPolicy(ctx context.Context, policy LearningPolicy) error {
+	return c.do(ctx, http.MethodPut, c.apiEndpoint("learning-policies"), policy, nil)
+}
+
+func (c *Client) DeleteLearningPolicy(ctx context.Context, class DeviationClass, scope PolicyScope, scopeKey string) error {
+	endpoint := c.apiEndpoint("learning-policies")
+	query := endpoint.Query()
+	query.Set("class", string(class))
+	query.Set("scope", string(scope))
+	query.Set("scope_key", scopeKey)
+	endpoint.RawQuery = query.Encode()
+	return c.do(ctx, http.MethodDelete, endpoint, nil, nil)
+}
+
+func (c *Client) ListFindings(ctx context.Context, params ListFindingsParams) ([]Finding, error) {
+	endpoint := c.apiEndpoint("findings")
+	addFindingFilters(endpoint, params.WindowHours, params.Service, params.Namespace, params.Status)
+	query := endpoint.Query()
+	if params.Kind != nil {
+		query.Set("kind", string(*params.Kind))
+	}
+	endpoint.RawQuery = query.Encode()
+	return doList[Finding](ctx, c, http.MethodGet, endpoint, nil)
+}
+
+func (c *Client) ListAnomalies(ctx context.Context, params ListAnomaliesParams) ([]AnomalySummary, error) {
+	endpoint := c.apiEndpoint("anomalies")
+	addFindingFilters(endpoint, params.WindowHours, params.Service, params.Namespace, params.Status)
+	return doList[AnomalySummary](ctx, c, http.MethodGet, endpoint, nil)
+}
+
+func (c *Client) GetAnomaly(ctx context.Context, transactionID int64, signature string) (*AnomalyIssue, error) {
+	var result AnomalyIssue
+	if err := c.do(ctx, http.MethodGet, c.apiEndpoint("anomalies", strconv.FormatInt(transactionID, 10), signature), nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *Client) ResolveAnomaly(ctx context.Context, transactionID int64, signature string, resolution AnomalyResolution) error {
+	body := struct {
+		Resolution AnomalyResolution `json:"resolution"`
+	}{Resolution: resolution}
+	return c.do(ctx, http.MethodPost, c.apiEndpoint("anomalies", strconv.FormatInt(transactionID, 10), signature), body, nil)
+}
+
+func (c *Client) BulkResolveAnomalies(ctx context.Context, request BulkAnomalyRequest) (*BulkResolveResult, error) {
+	var result BulkResolveResult
+	if err := c.do(ctx, http.MethodPost, c.apiEndpoint("anomalies"), request, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *Client) ListGuardrails(ctx context.Context) ([]Guardrail, error) {
+	return doList[Guardrail](ctx, c, http.MethodGet, c.apiEndpoint("guardrails"), nil)
+}
+
+func (c *Client) UpsertGuardrail(ctx context.Context, guardrail Guardrail) error {
+	return c.do(ctx, http.MethodPut, c.apiEndpoint("guardrails"), guardrail, nil)
+}
+
+func (c *Client) DeleteGuardrail(ctx context.Context, scopeKey string) error {
+	endpoint := c.apiEndpoint("guardrails")
+	query := endpoint.Query()
+	query.Set("scope_key", scopeKey)
+	endpoint.RawQuery = query.Encode()
+	return c.do(ctx, http.MethodDelete, endpoint, nil, nil)
+}
+
+func (c *Client) SeedGuardrail(ctx context.Context, request GuardrailSeedRequest) error {
+	return c.do(ctx, http.MethodPost, c.apiEndpoint("guardrails", "seed"), request, nil)
+}
+
+func (c *Client) ListGuardrailViolations(ctx context.Context, params ListGuardrailViolationsParams) ([]GuardrailViolation, error) {
+	endpoint := c.apiEndpoint("guardrails", "violations")
+	addFindingFilters(endpoint, params.WindowHours, params.Service, params.Namespace, params.Status)
+	return doList[GuardrailViolation](ctx, c, http.MethodGet, endpoint, nil)
+}
+
+func (c *Client) AllowGuardrailViolation(ctx context.Context, request ViolationActionRequest) error {
+	return c.do(ctx, http.MethodPost, c.apiEndpoint("guardrails", "violations", "allow"), request, nil)
+}
+
+func (c *Client) DismissGuardrailViolation(ctx context.Context, request ViolationActionRequest) error {
+	return c.do(ctx, http.MethodPost, c.apiEndpoint("guardrails", "violations", "dismiss"), request, nil)
+}
+
+func (c *Client) ReopenGuardrailViolation(ctx context.Context, request ViolationActionRequest) error {
+	return c.do(ctx, http.MethodPost, c.apiEndpoint("guardrails", "violations", "reopen"), request, nil)
+}
+
+func (c *Client) GetCatalog(ctx context.Context) (*Catalog, error) {
+	var result Catalog
+	if err := c.do(ctx, http.MethodGet, c.apiEndpoint("catalog"), nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *Client) GetSystemSettings(ctx context.Context) (*SystemSettings, error) {
+	var result SystemSettings
+	if err := c.do(ctx, http.MethodGet, c.apiEndpoint("system-settings"), nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *Client) UpdateSystemSettings(ctx context.Context, settings SystemSettings) error {
+	return c.do(ctx, http.MethodPut, c.apiEndpoint("system-settings"), settings, nil)
+}
+
+func (c *Client) GetStorageHealth(ctx context.Context) (*StorageHealth, error) {
+	var result StorageHealth
+	if err := c.do(ctx, http.MethodGet, c.apiEndpoint("storage-health"), nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *Client) do(ctx context.Context, method string, endpoint *url.URL, body any, result any) error {
+	var requestBody io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("encode insights request: %w", err)
+		}
+		requestBody = bytes.NewReader(encoded)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, method, endpoint.String(), requestBody)
+	if err != nil {
+		return fmt.Errorf("create insights request: %w", err)
+	}
+	request.Header.Set("Accept", "application/json")
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return fmt.Errorf("send insights request: %w", err)
+	}
+	defer response.Body.Close()
+
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return fmt.Errorf("read insights response: %w", err)
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return decodeAPIError(response.StatusCode, responseBody)
+	}
+	if result == nil || response.StatusCode == http.StatusNoContent {
+		return nil
+	}
+	if err := json.Unmarshal(responseBody, result); err != nil {
+		return fmt.Errorf("decode insights response: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) endpoint(segments ...string) *url.URL {
+	endpoint := *c.baseURL
+	path := strings.TrimRight(endpoint.Path, "/")
+	rawPath := strings.TrimRight(endpoint.EscapedPath(), "/")
+	for _, segment := range segments {
+		path += "/" + segment
+		rawPath += "/" + url.PathEscape(segment)
+	}
+	endpoint.Path = path
+	endpoint.RawPath = rawPath
+	return &endpoint
+}
+
+func (c *Client) apiEndpoint(segments ...string) *url.URL {
+	apiSegments := make([]string, 0, len(segments)+2)
+	apiSegments = append(apiSegments, "api", "v1")
+	apiSegments = append(apiSegments, segments...)
+	return c.endpoint(apiSegments...)
+}
+
+func (c *Client) transactionEndpoint(transactionID int64, segments ...string) *url.URL {
+	allSegments := []string{"transactions", strconv.FormatInt(transactionID, 10)}
+	allSegments = append(allSegments, segments...)
+	return c.apiEndpoint(allSegments...)
+}
+
+func doList[T any](ctx context.Context, client *Client, method string, endpoint *url.URL, body any) ([]T, error) {
+	var envelope struct {
+		Items []T `json:"items"`
+	}
+	if err := client.do(ctx, method, endpoint, body, &envelope); err != nil {
+		return nil, err
+	}
+	return envelope.Items, nil
+}
+
+func decodeAPIError(statusCode int, body []byte) error {
+	var envelope struct {
+		Error struct {
+			Code    ErrorCode       `json:"code"`
+			Message string          `json:"message"`
+			Details json.RawMessage `json:"details"`
+		} `json:"error"`
+	}
+	decodeErr := json.Unmarshal(body, &envelope)
+	message := strings.TrimSpace(envelope.Error.Message)
+	if message == "" {
+		message = strings.TrimSpace(string(body))
+	}
+	if message == "" {
+		message = http.StatusText(statusCode)
+	}
+	apiErr := &APIError{
+		StatusCode: statusCode,
+		Code:       envelope.Error.Code,
+		Message:    message,
+		Details:    envelope.Error.Details,
+	}
+	if decodeErr != nil {
+		apiErr.Message = fmt.Sprintf("%s (invalid error response: %v)", message, decodeErr)
+	}
+	if isEngineStarting(statusCode, body, apiErr) {
+		return &EngineStartingError{APIError: apiErr}
+	}
+	return apiErr
+}
+
+func addOptionalString(query url.Values, key string, value *string) {
+	if value != nil {
+		query.Set(key, *value)
+	}
+}
+
+func addFindingFilters(endpoint *url.URL, windowHours *int, service, namespace, status *string) {
+	query := endpoint.Query()
+	if windowHours != nil {
+		query.Set("window_hours", strconv.Itoa(*windowHours))
+	}
+	addOptionalString(query, "service", service)
+	addOptionalString(query, "namespace", namespace)
+	addOptionalString(query, "status", status)
+	endpoint.RawQuery = query.Encode()
+}

--- a/frontend/services/insights/client_test.go
+++ b/frontend/services/insights/client_test.go
@@ -1,0 +1,206 @@
+package insights
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientEscapesPathAndQueryParameters(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/prefix/api/v1/anomalies/42/sig/with spaces", r.URL.Path)
+		assert.Equal(t, "/prefix/api/v1/anomalies/42/sig%2Fwith%20spaces", r.URL.EscapedPath())
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"transaction_id": 42,
+			"signature": "sig/with spaces",
+			"service": "checkout",
+			"namespace": "prod",
+			"triggered_classes": [],
+			"evidence": {},
+			"occurrences": 1,
+			"max_score": 10,
+			"severity": "low",
+			"status": "open"
+		}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL + "/prefix")
+	require.NoError(t, err)
+
+	result, err := client.GetAnomaly(context.Background(), 42, "sig/with spaces")
+	require.NoError(t, err)
+	assert.Equal(t, "sig/with spaces", result.Signature)
+}
+
+func TestClientEncodesQueryParameters(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "team/a + b", r.URL.Query().Get("namespace"))
+		assert.Equal(t, "checkout/api", r.URL.Query().Get("service"))
+		assert.Equal(t, "HTTP", r.URL.Query().Get("kind"))
+		_, _ = w.Write([]byte(`{"count":0,"items":[]}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	require.NoError(t, err)
+	namespace := "team/a + b"
+	service := "checkout/api"
+	kind := TransactionKind("HTTP")
+
+	items, err := client.ListTransactions(context.Background(), ListTransactionsParams{
+		Namespace: &namespace,
+		Service:   &service,
+		Kind:      &kind,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, items)
+}
+
+func TestClientDecodesCollectionEnvelope(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/services", r.URL.Path)
+		_, _ = w.Write([]byte(`{
+			"count": 1,
+			"items": [{
+				"namespace": "prod",
+				"service": "checkout",
+				"transaction_count": 3,
+				"volume": 12,
+				"last_seen": "2026-08-05T06:00:00Z"
+			}]
+		}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	require.NoError(t, err)
+
+	items, err := client.ListServices(context.Background())
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, int64(12), items[0].Volume)
+}
+
+func TestClientMapsTypedAPIErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		code       ErrorCode
+		target     error
+	}{
+		{name: "bad request", statusCode: http.StatusBadRequest, code: ErrorCodeBadRequest, target: ErrBadRequest},
+		{name: "not found", statusCode: http.StatusNotFound, code: ErrorCodeNotFound, target: ErrNotFound},
+		{name: "conflict", statusCode: http.StatusConflict, code: ErrorCodeConflict, target: ErrConflict},
+		{name: "validation", statusCode: http.StatusUnprocessableEntity, code: ErrorCodeUnprocessableEntity, target: ErrUnprocessableEntity},
+		{name: "unavailable", statusCode: http.StatusServiceUnavailable, code: ErrorCodeUnavailable, target: ErrUnavailable},
+		{name: "internal", statusCode: http.StatusInternalServerError, code: ErrorCodeInternal, target: ErrInternal},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"error": map[string]any{
+						"code":    tt.code,
+						"message": "request failed",
+						"details": map[string]any{"field": "scope_key"},
+					},
+				})
+			}))
+			defer server.Close()
+
+			client, err := NewClient(server.URL)
+			require.NoError(t, err)
+			_, err = client.GetTransaction(context.Background(), 1)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, tt.target)
+
+			var apiErr *APIError
+			require.ErrorAs(t, err, &apiErr)
+			assert.Equal(t, tt.statusCode, apiErr.StatusCode)
+			assert.Equal(t, tt.code, apiErr.Code)
+			assert.JSONEq(t, `{"field":"scope_key"}`, string(apiErr.Details))
+		})
+	}
+}
+
+func TestClientMapsEngineStarting(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "error envelope",
+			body: `{"error":{"code":"unavailable","message":"engine starting; retry shortly"}}`,
+		},
+		{
+			name: "plain body",
+			body: "Insights engine is starting",
+		},
+		{
+			name: "server warm-up message",
+			body: `{"error":{"code":"unavailable","message":"engine not ready; try again shortly"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			client, err := NewClient(server.URL)
+			require.NoError(t, err)
+			err = client.ResetTransactionBaselines(context.Background(), 42)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrEngineStarting)
+			assert.ErrorIs(t, err, ErrUnavailable)
+
+			var startingErr *EngineStartingError
+			require.ErrorAs(t, err, &startingErr)
+			assert.Equal(t, http.StatusServiceUnavailable, startingErr.StatusCode)
+		})
+	}
+}
+
+func TestClientSendsJSONAndAcceptsNoContent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		var request ViolationActionRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+		assert.Equal(t, "prod/checkout", request.ScopeKey)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	require.NoError(t, err)
+	err = client.AllowGuardrailViolation(context.Background(), ViolationActionRequest{
+		ScopeKey:  "prod/checkout",
+		RuleKey:   "allowed_egress",
+		Offending: "db:5432",
+	})
+	require.NoError(t, err)
+}
+
+func TestNewClientValidatesBaseURL(t *testing.T) {
+	for _, baseURL := range []string{"", "insights:8080", "://bad"} {
+		t.Run(fmt.Sprintf("%q", baseURL), func(t *testing.T) {
+			_, err := NewClient(baseURL)
+			require.Error(t, err)
+		})
+	}
+}

--- a/frontend/services/insights/errors.go
+++ b/frontend/services/insights/errors.go
@@ -1,0 +1,110 @@
+package insights
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+var (
+	ErrBadRequest          = errors.New("insights request is invalid")
+	ErrNotFound            = errors.New("insights resource was not found")
+	ErrConflict            = errors.New("insights request conflicts with the current state")
+	ErrUnprocessableEntity = errors.New("insights request failed validation")
+	ErrValidation          = ErrUnprocessableEntity
+	ErrUnavailable         = errors.New("insights service is unavailable")
+	ErrInternal            = errors.New("insights service encountered an internal error")
+	ErrEngineStarting      = errors.New("insights engine is starting")
+)
+
+type ErrorCode string
+
+const (
+	ErrorCodeBadRequest          ErrorCode = "bad_request"
+	ErrorCodeNotFound            ErrorCode = "not_found"
+	ErrorCodeConflict            ErrorCode = "conflict"
+	ErrorCodeUnprocessableEntity ErrorCode = "unprocessable_entity"
+	ErrorCodeUnavailable         ErrorCode = "unavailable"
+	ErrorCodeInternal            ErrorCode = "internal_error"
+)
+
+// APIError is the error envelope returned by the Insights REST API.
+type APIError struct {
+	StatusCode int
+	Code       ErrorCode
+	Message    string
+	Details    json.RawMessage
+}
+
+func (e *APIError) Error() string {
+	if e.Code == "" {
+		return fmt.Sprintf("insights API returned status %d: %s", e.StatusCode, e.Message)
+	}
+	return fmt.Sprintf("insights API returned %s (status %d): %s", e.Code, e.StatusCode, e.Message)
+}
+
+func (e *APIError) Is(target error) bool {
+	var category error
+	switch e.Code {
+	case ErrorCodeBadRequest:
+		category = ErrBadRequest
+	case ErrorCodeNotFound:
+		category = ErrNotFound
+	case ErrorCodeConflict:
+		category = ErrConflict
+	case ErrorCodeUnprocessableEntity:
+		category = ErrUnprocessableEntity
+	case ErrorCodeUnavailable:
+		category = ErrUnavailable
+	case ErrorCodeInternal:
+		category = ErrInternal
+	}
+	if category == nil {
+		switch e.StatusCode {
+		case http.StatusBadRequest:
+			category = ErrBadRequest
+		case http.StatusNotFound:
+			category = ErrNotFound
+		case http.StatusConflict:
+			category = ErrConflict
+		case http.StatusUnprocessableEntity:
+			category = ErrUnprocessableEntity
+		case http.StatusServiceUnavailable:
+			category = ErrUnavailable
+		default:
+			if e.StatusCode >= http.StatusInternalServerError {
+				category = ErrInternal
+			}
+		}
+	}
+	return target == category
+}
+
+// EngineStartingError distinguishes the retryable engine warm-up state from
+// other service-unavailable responses while preserving the API error details.
+type EngineStartingError struct {
+	*APIError
+}
+
+func (e *EngineStartingError) Unwrap() error {
+	return ErrEngineStarting
+}
+
+func isEngineStarting(statusCode int, body []byte, apiErr *APIError) bool {
+	if statusCode != http.StatusServiceUnavailable {
+		return false
+	}
+	if apiErr != nil && containsEngineStarting(apiErr.Message) {
+		return true
+	}
+	return containsEngineStarting(string(body))
+}
+
+func containsEngineStarting(value string) bool {
+	value = strings.ToLower(value)
+	return strings.Contains(value, "engine starting") ||
+		strings.Contains(value, "engine is starting") ||
+		strings.Contains(value, "engine not ready")
+}

--- a/frontend/services/insights/types.go
+++ b/frontend/services/insights/types.go
@@ -1,0 +1,438 @@
+package insights
+
+import "encoding/json"
+
+type TransactionKind string
+type DeviationClass string
+type SampleReason string
+type PolicyScope string
+type Severity string
+type FindingKind string
+type AnomalyStatus string
+type ViolationStatus string
+type RuleMode string
+type AnomalyResolution string
+type BulkResolution string
+type LearningMode string
+type LearningConditionType string
+type StorageHealthStatus string
+type StorageDiskStatus string
+
+type ListTransactionsParams struct {
+	Namespace *string
+	Service   *string
+	Kind      *TransactionKind
+}
+
+type ListObservationsParams struct {
+	SampleReason *SampleReason
+}
+
+type ListFindingsParams struct {
+	WindowHours *int
+	Service     *string
+	Namespace   *string
+	Status      *string
+	Kind        *FindingKind
+}
+
+type ListAnomaliesParams struct {
+	WindowHours *int
+	Service     *string
+	Namespace   *string
+	Status      *string
+}
+
+type ListGuardrailViolationsParams struct {
+	WindowHours *int
+	Service     *string
+	Namespace   *string
+	Status      *string
+}
+
+type ServiceStat struct {
+	Namespace        string `json:"namespace"`
+	Service          string `json:"service"`
+	TransactionCount int64  `json:"transaction_count"`
+	Volume           int64  `json:"volume"`
+	LastSeen         string `json:"last_seen"`
+}
+
+type TransactionStat struct {
+	ID          int64           `json:"id"`
+	Service     string          `json:"service"`
+	Namespace   string          `json:"namespace"`
+	Operation   string          `json:"operation"`
+	Kind        TransactionKind `json:"kind"`
+	Volume      int64           `json:"volume"`
+	LastSeen    string          `json:"last_seen"`
+	HasBaseline *bool           `json:"has_baseline,omitempty"`
+	Promoted    *bool           `json:"promoted,omitempty"`
+}
+
+type Transaction struct {
+	ID        int64           `json:"id"`
+	Service   string          `json:"service"`
+	Namespace string          `json:"namespace"`
+	Operation string          `json:"operation"`
+	Kind      TransactionKind `json:"kind"`
+}
+
+type BaselineClass struct {
+	TransactionID                int64           `json:"transaction_id"`
+	Class                        DeviationClass  `json:"class"`
+	Data                         json.RawMessage `json:"data,omitempty"`
+	DataSchemaVersion            *int            `json:"data_schema_version,omitempty"`
+	ObservationCount             int64           `json:"observation_count"`
+	Promoted                     bool            `json:"promoted"`
+	LearningStartedAt            *string         `json:"learning_started_at,omitempty"`
+	LastChangedAt                *string         `json:"last_changed_at,omitempty"`
+	ObservationCountAtLastChange *int64          `json:"observation_count_at_last_change,omitempty"`
+}
+
+type PromoteResult struct {
+	TransactionID int64          `json:"transaction_id"`
+	Class         DeviationClass `json:"class"`
+	Promoted      bool           `json:"promoted"`
+}
+
+type ObservationSummary struct {
+	TraceID       string       `json:"trace_id"`
+	TransactionID int64        `json:"transaction_id"`
+	ObservedAt    string       `json:"observed_at"`
+	DurationMs    int64        `json:"duration_ms"`
+	SampleReason  SampleReason `json:"sample_reason"`
+}
+
+type Observation struct {
+	TraceID       string       `json:"trace_id"`
+	TransactionID int64        `json:"transaction_id"`
+	ObservedAt    string       `json:"observed_at"`
+	DurationMs    int64        `json:"duration_ms"`
+	SampleReason  SampleReason `json:"sample_reason"`
+	RawOTLP       string       `json:"raw_otlp"`
+}
+
+type Policy struct {
+	ID            int64               `json:"id"`
+	Name          string              `json:"name"`
+	Enabled       bool                `json:"enabled"`
+	FireAtScore   int                 `json:"fire_at_score"`
+	SignalWeights map[string]int      `json:"signal_weights,omitempty"`
+	EnricherLists map[string][]string `json:"enricher_lists,omitempty"`
+	Scope         PolicyScope         `json:"scope"`
+	ScopeKey      string              `json:"scope_key"`
+}
+
+type LearningCondition struct {
+	Type               LearningConditionType `json:"type"`
+	MinObservations    *int64                `json:"minObservations,omitempty"`
+	MinDurationMinutes *int64                `json:"minDurationMinutes,omitempty"`
+	StableObservations *int64                `json:"stableObservations,omitempty"`
+	StableMinutes      *int64                `json:"stableMinutes,omitempty"`
+}
+
+type LearningPolicy struct {
+	Class      DeviationClass      `json:"class"`
+	Mode       LearningMode        `json:"mode"`
+	Conditions []LearningCondition `json:"conditions,omitempty"`
+	MinMatches *int                `json:"min_matches,omitempty"`
+	Scope      PolicyScope         `json:"scope"`
+	ScopeKey   string              `json:"scope_key"`
+}
+
+type Finding struct {
+	Kind          FindingKind `json:"kind"`
+	Service       string      `json:"service"`
+	Namespace     string      `json:"namespace"`
+	Title         string      `json:"title"`
+	Offending     *string     `json:"offending,omitempty"`
+	Score         int         `json:"score"`
+	Severity      Severity    `json:"severity"`
+	Occurrences   int64       `json:"occurrences"`
+	LastSeen      string      `json:"last_seen"`
+	Status        string      `json:"status"`
+	TransactionID *int64      `json:"transaction_id,omitempty"`
+	Signature     *string     `json:"signature,omitempty"`
+	ScopeKey      *string     `json:"scope_key,omitempty"`
+	RuleKey       *string     `json:"rule_key,omitempty"`
+}
+
+type RiskSignal struct {
+	Source       string  `json:"source"`
+	Category     string  `json:"category"`
+	Weight       int     `json:"weight"`
+	Confidence   float64 `json:"confidence"`
+	Contribution int     `json:"contribution"`
+	Rationale    *string `json:"rationale,omitempty"`
+	Mitre        *string `json:"mitre,omitempty"`
+	Owasp        *string `json:"owasp,omitempty"`
+}
+
+type RiskAssessment struct {
+	Score            int          `json:"score"`
+	Severity         Severity     `json:"severity"`
+	Correlated       bool         `json:"correlated"`
+	CorrelationBonus int          `json:"correlation_bonus"`
+	FireAtScore      int          `json:"fire_at_score"`
+	Categories       []string     `json:"categories,omitempty"`
+	Signals          []RiskSignal `json:"signals"`
+}
+
+type AnomalySummary struct {
+	TransactionID    int64            `json:"transaction_id"`
+	Signature        string           `json:"signature"`
+	Service          string           `json:"service"`
+	Namespace        string           `json:"namespace"`
+	Operation        *string          `json:"operation,omitempty"`
+	Kind             *TransactionKind `json:"kind,omitempty"`
+	TriggeredClasses []DeviationClass `json:"triggered_classes"`
+	Offending        *string          `json:"offending,omitempty"`
+	PolicyID         *int64           `json:"policy_id,omitempty"`
+	Occurrences      int64            `json:"occurrences"`
+	MaxScore         int              `json:"max_score"`
+	Severity         Severity         `json:"severity"`
+	FirstSeen        *string          `json:"first_seen,omitempty"`
+	LastSeen         *string          `json:"last_seen,omitempty"`
+	LastTraceID      *string          `json:"last_trace_id,omitempty"`
+	Status           AnomalyStatus    `json:"status"`
+}
+
+type AnomalyIssue struct {
+	TransactionID    int64            `json:"transaction_id"`
+	Signature        string           `json:"signature"`
+	Service          string           `json:"service"`
+	Namespace        string           `json:"namespace"`
+	Operation        *string          `json:"operation,omitempty"`
+	Kind             *TransactionKind `json:"kind,omitempty"`
+	TriggeredClasses []DeviationClass `json:"triggered_classes"`
+	Offending        *string          `json:"offending,omitempty"`
+	Evidence         json.RawMessage  `json:"evidence"`
+	PolicyID         *int64           `json:"policy_id,omitempty"`
+	Occurrences      int64            `json:"occurrences"`
+	MaxScore         int              `json:"max_score"`
+	Severity         Severity         `json:"severity"`
+	FirstSeen        *string          `json:"first_seen,omitempty"`
+	LastSeen         *string          `json:"last_seen,omitempty"`
+	LastTraceID      *string          `json:"last_trace_id,omitempty"`
+	Status           AnomalyStatus    `json:"status"`
+	Risk             *RiskAssessment  `json:"risk,omitempty"`
+}
+
+type AnomalyRef struct {
+	TransactionID int64  `json:"transaction_id"`
+	Signature     string `json:"signature"`
+}
+
+type BulkAnomalyRequest struct {
+	Resolution BulkResolution `json:"resolution"`
+	Items      []AnomalyRef   `json:"items"`
+}
+
+type BulkResolveResult struct {
+	Resolution string `json:"resolution"`
+	Resolved   int    `json:"resolved"`
+}
+
+type GuardrailRule struct {
+	Key       string   `json:"key"`
+	Label     string   `json:"label"`
+	Mode      RuleMode `json:"mode"`
+	Allowlist []string `json:"allowlist,omitempty"`
+}
+
+type Guardrail struct {
+	Scope    PolicyScope     `json:"scope"`
+	ScopeKey string          `json:"scope_key"`
+	Rules    []GuardrailRule `json:"rules"`
+}
+
+type GuardrailViolation struct {
+	Service     string          `json:"service"`
+	Namespace   string          `json:"namespace"`
+	ScopeKey    string          `json:"scope_key"`
+	RuleKey     string          `json:"rule_key"`
+	RuleLabel   string          `json:"rule_label"`
+	Offending   *string         `json:"offending,omitempty"`
+	Occurrences int64           `json:"occurrences"`
+	MaxScore    int             `json:"max_score"`
+	Severity    Severity        `json:"severity"`
+	LastSeen    *string         `json:"last_seen,omitempty"`
+	Status      ViolationStatus `json:"status"`
+}
+
+type ViolationActionRequest struct {
+	ScopeKey  string `json:"scope_key"`
+	RuleKey   string `json:"rule_key"`
+	Offending string `json:"offending"`
+}
+
+type GuardrailSeedRequest struct {
+	ScopeKey string              `json:"scope_key"`
+	Mode     *RuleMode           `json:"mode,omitempty"`
+	Items    map[string][]string `json:"items"`
+}
+
+type CatalogClass struct {
+	ID            string  `json:"id"`
+	Label         string  `json:"label"`
+	Description   *string `json:"description,omitempty"`
+	Category      string  `json:"category"`
+	CategoryLabel *string `json:"category_label,omitempty"`
+	Weight        int     `json:"weight"`
+	Mitre         *string `json:"mitre,omitempty"`
+	Owasp         *string `json:"owasp,omitempty"`
+}
+
+type EnricherList struct {
+	Key     string   `json:"key"`
+	Label   string   `json:"label"`
+	Hint    *string  `json:"hint,omitempty"`
+	Default []string `json:"default,omitempty"`
+}
+
+type CatalogEnricher struct {
+	Source      string        `json:"source"`
+	ParentClass string        `json:"parent_class"`
+	Category    string        `json:"category"`
+	Weight      int           `json:"weight"`
+	Label       string        `json:"label"`
+	Description *string       `json:"description,omitempty"`
+	List        *EnricherList `json:"list,omitempty"`
+}
+
+type CatalogCategory struct {
+	ID    string  `json:"id"`
+	Label string  `json:"label"`
+	Base  int     `json:"base"`
+	Mitre *string `json:"mitre,omitempty"`
+	Owasp *string `json:"owasp,omitempty"`
+}
+
+type CatalogGuardrailRule struct {
+	Key         string  `json:"key"`
+	Label       string  `json:"label"`
+	Description *string `json:"description,omitempty"`
+	Category    string  `json:"category"`
+	Weight      int     `json:"weight"`
+	Hint        *string `json:"hint,omitempty"`
+}
+
+type SeverityBand struct {
+	Severity Severity `json:"severity"`
+	MinScore int      `json:"min_score"`
+}
+
+type Catalog struct {
+	DeviationClasses []CatalogClass         `json:"deviation_classes"`
+	Enrichers        []CatalogEnricher      `json:"enrichers"`
+	Categories       []CatalogCategory      `json:"categories"`
+	GuardrailRules   []CatalogGuardrailRule `json:"guardrail_rules"`
+	SeverityBands    []SeverityBand         `json:"severity_bands"`
+	CorrelationBonus int                    `json:"correlation_bonus"`
+	Tags             map[string]string      `json:"tags"`
+}
+
+type SystemSamplingSettings struct {
+	ExamplesPerTransaction       int `json:"examples_per_transaction"`
+	ExampleSampleIntervalSeconds int `json:"example_sample_interval_seconds"`
+}
+
+type SystemRetentionSettings struct {
+	ObservationRetentionDays int `json:"observation_retention_days"`
+}
+
+type SystemFindingsSettings struct {
+	DefaultWindowHours int `json:"default_window_hours"`
+	MaxWindowHours     int `json:"max_window_hours"`
+}
+
+type SystemCapacitySettings struct {
+	MaxResidentTransactions int `json:"max_resident_transactions"`
+	MaxBaselineSetMembers   int `json:"max_baseline_set_members"`
+}
+
+type SystemWritebackSettings struct {
+	FlushIntervalSeconds int `json:"flush_interval_seconds"`
+}
+
+type SystemSettings struct {
+	Sampling  SystemSamplingSettings  `json:"sampling"`
+	Retention SystemRetentionSettings `json:"retention"`
+	Findings  SystemFindingsSettings  `json:"findings"`
+	Capacity  SystemCapacitySettings  `json:"capacity"`
+	Writeback SystemWritebackSettings `json:"writeback"`
+}
+
+type StorageConnection struct {
+	Reachable     bool    `json:"reachable"`
+	PingLatencyMs int64   `json:"ping_latency_ms"`
+	Version       string  `json:"version"`
+	Database      string  `json:"database"`
+	Error         *string `json:"error,omitempty"`
+}
+
+type StorageDisk struct {
+	InsightsBytes  int64             `json:"insights_bytes"`
+	TotalBytes     int64             `json:"total_bytes"`
+	UsedBytes      int64             `json:"used_bytes"`
+	AvailableBytes int64             `json:"available_bytes"`
+	UsedPercent    float64           `json:"used_percent"`
+	Status         StorageDiskStatus `json:"status"`
+}
+
+type StorageMemory struct {
+	ProcessRSSBytes  int64   `json:"process_rss_bytes"`
+	CgroupUsedBytes  int64   `json:"cgroup_used_bytes"`
+	CgroupTotalBytes int64   `json:"cgroup_total_bytes"`
+	UptimeSeconds    float64 `json:"uptime_seconds"`
+}
+
+type StorageQuery struct {
+	ElapsedSeconds float64 `json:"elapsed_seconds"`
+	User           string  `json:"user"`
+	MemoryBytes    int64   `json:"memory_bytes"`
+	Query          string  `json:"query"`
+	FinishedAt     *string `json:"finished_at,omitempty"`
+}
+
+type StorageQueries struct {
+	Active          int            `json:"active"`
+	LongestSeconds  float64        `json:"longest_seconds"`
+	PeakMemoryBytes int64          `json:"peak_memory_bytes"`
+	Items           []StorageQuery `json:"items"`
+	RecentHeaviest  []StorageQuery `json:"recent_heaviest"`
+	RecentLatest    []StorageQuery `json:"recent_latest"`
+}
+
+type StorageTable struct {
+	Name        string `json:"name"`
+	Rows        int64  `json:"rows"`
+	BytesOnDisk int64  `json:"bytes_on_disk"`
+	ActiveParts int64  `json:"active_parts"`
+}
+
+type StorageWritePressure struct {
+	UnfinishedMutations int64 `json:"unfinished_mutations"`
+	ActiveParts         int64 `json:"active_parts"`
+}
+
+type StorageWriteback struct {
+	FlushIntervalSeconds int     `json:"flush_interval_seconds"`
+	EverFlushed          bool    `json:"ever_flushed"`
+	LastFlushOK          bool    `json:"last_flush_ok"`
+	LastFlushAt          *string `json:"last_flush_at,omitempty"`
+	LastFlushError       *string `json:"last_flush_error,omitempty"`
+}
+
+type StorageHealth struct {
+	CheckedAt     string               `json:"checked_at"`
+	Status        StorageHealthStatus  `json:"status"`
+	Connection    StorageConnection    `json:"connection"`
+	Disk          StorageDisk          `json:"disk"`
+	Memory        StorageMemory        `json:"memory"`
+	Queries       StorageQueries       `json:"queries"`
+	Tables        []StorageTable       `json:"tables"`
+	WritePressure StorageWritePressure `json:"write_pressure"`
+	Writeback     StorageWriteback     `json:"writeback"`
+}


### PR DESCRIPTION
Adds the frontend transport layer required to expose the Insights REST API through GraphQL while preserving the service contract and retryable engine warm-up state.

#### What this PR does / why we need it:
Introduces a thin HTTP client covering the Insights query and mutation surface, with dedicated wire types, collection-envelope decoding, URL-escaped path parameters, and typed API errors. A distinct engine-starting error allows resolvers and the UI to identify retryable 503 responses without relying on error strings.

Unit tests cover endpoint escaping, query encoding, response decoding, request payloads, typed error mapping, and engine warm-up responses.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
NONE
```