### PR TITLE
PLAT-1383 | feat: wire Insights HTTP client into frontend GraphQL stack

### DIFF
--- a/frontend/graph/resolver.go
+++ b/frontend/graph/resolver.go
@@ -4,6 +4,7 @@ import (
 	"github.com/go-logr/logr"
 	collectormetrics "github.com/odigos-io/odigos/frontend/services/collector_metrics"
 	fecommon "github.com/odigos-io/odigos/frontend/services/common"
+	"github.com/odigos-io/odigos/frontend/services/insights"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -15,6 +16,7 @@ type Resolver struct {
 	MetricsConsumer *collectormetrics.OdigosMetricsConsumer
 	Logger          logr.Logger
 	PromAPI         v1.API
+	InsightsClient  *insights.Client
 	// K8sCacheClient is the controller-runtime client that reads from the informer cache (fast, no API round-trip).
 	// Use this in resolvers for read-only access to cluster state.
 	K8sCacheClient client.Client

--- a/frontend/server/deps.go
+++ b/frontend/server/deps.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/odigos-io/odigos/api/k8sconsts"
 	"github.com/odigos-io/odigos/common/consts"
 	commonlogger "github.com/odigos-io/odigos/common/logger"
 	"github.com/odigos-io/odigos/config"
@@ -18,6 +19,7 @@ import (
 	"github.com/odigos-io/odigos/frontend/kube/watchers"
 	"github.com/odigos-io/odigos/frontend/services"
 	collectormetrics "github.com/odigos-io/odigos/frontend/services/collector_metrics"
+	"github.com/odigos-io/odigos/frontend/services/insights"
 	"github.com/odigos-io/odigos/frontend/services/metrics"
 	"github.com/odigos-io/odigos/frontend/services/otlp"
 	"github.com/odigos-io/odigos/frontend/services/profiles"
@@ -28,13 +30,14 @@ import (
 // like the enterprise MCP server) needs. Constructed once at startup by
 // Bootstrap and threaded through the rest of the lifecycle.
 type Deps struct {
-	Flags         Flags
-	Logger        logr.Logger
+	Flags          Flags
+	Logger         logr.Logger
 	K8sCacheClient client.Client
 	K8sCache       cache.Cache
 
 	OdigosMetrics    *collectormetrics.OdigosMetricsConsumer
 	PromAPI          v1.API
+	InsightsClient   *insights.Client
 	ProfileStore     *profiles.ProfileStore
 	ProfilingGate    *profiles.IngestGate
 	ProfilesConsumer *profiles.OdigosProfilesConsumer
@@ -109,6 +112,11 @@ func Bootstrap(ctx context.Context, flags Flags, logger logr.Logger) (*Deps, err
 		promAPI = api
 	}
 
+	insightsClient, err := insights.NewClient(k8sconsts.InsightsHTTPEndpoint(flags.Namespace))
+	if err != nil {
+		return nil, fmt.Errorf("initializing insights client: %w", err)
+	}
+
 	return &Deps{
 		Flags:            flags,
 		Logger:           logger,
@@ -116,6 +124,7 @@ func Bootstrap(ctx context.Context, flags Flags, logger logr.Logger) (*Deps, err
 		K8sCache:         k8sCache,
 		OdigosMetrics:    odigosMetrics,
 		PromAPI:          promAPI,
+		InsightsClient:   insightsClient,
 		ProfileStore:     profileStore,
 		ProfilingGate:    profilingGate,
 		ProfilesConsumer: profilesConsumer,

--- a/frontend/server/router.go
+++ b/frontend/server/router.go
@@ -78,6 +78,7 @@ func BuildRouter(ctx context.Context, deps *Deps, opts RouterOpts) (*gin.Engine,
 			Logger:          deps.Logger,
 			PromAPI:         deps.PromAPI,
 			K8sCacheClient:  deps.K8sCacheClient,
+			InsightsClient:  deps.InsightsClient,
 			ProfileStore:    deps.ProfileStore,
 		},
 	})


### PR DESCRIPTION
Wire the Insights HTTP client into the frontend GraphQL dependency injection path so resolvers can call the in-cluster Insights service.

#### What this PR does / why we need it:
Constructs `insights.Client` during frontend `Bootstrap` using `k8sconsts.InsightsHTTPEndpoint(namespace)`, stores it on `server.Deps`, and injects it into `graph.Resolver` from `BuildRouter`. This is the prerequisite wiring for implementing Insights GraphQL resolver stubs (PLAT-1382). No hardcoded host/port — the base URL comes from `InsightsHTTPEndpoint`. The existing `K8sCacheClient` on the resolver remains available for feature-gate checks.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
NONE
```

Made with [Cursor](https://cursor.com)