### PR TITLE
PLAT-1382 | feat: fill Insights GraphQL resolver stubs

### DIFF
--- a/frontend/graph/insights.resolvers.go
+++ b/frontend/graph/insights.resolvers.go
@@ -6,174 +6,533 @@ package graph
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"github.com/odigos-io/odigos/frontend/graph/model"
+	"github.com/odigos-io/odigos/frontend/services/insights"
 )
 
 // Services is the resolver for the services field.
 func (r *insightsResolver) Services(ctx context.Context, obj *model.Insights) ([]*model.InsightsServiceStat, error) {
-	panic(fmt.Errorf("not implemented: Services - services"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	stats, err := client.ListServices(ctx)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	return insights.ServiceStatsToModel(stats), nil
 }
 
 // Transactions is the resolver for the transactions field.
 func (r *insightsResolver) Transactions(ctx context.Context, obj *model.Insights, namespace *string, service *string, kind *model.InsightsTransactionKind) ([]*model.InsightsTransactionStat, error) {
-	panic(fmt.Errorf("not implemented: Transactions - transactions"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	stats, err := client.ListTransactions(ctx, insights.ListTransactionsParams{
+		Namespace: namespace,
+		Service:   service,
+		Kind:      insights.TransactionKindPtrFromModel(kind),
+	})
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	return insights.TransactionStatsToModel(stats), nil
 }
 
 // Transaction is the resolver for the transaction field.
 func (r *insightsResolver) Transaction(ctx context.Context, obj *model.Insights, id string) (*model.InsightsTransaction, error) {
-	panic(fmt.Errorf("not implemented: Transaction - transaction"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	transactionID, err := insights.ParseID(id)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	transaction, err := client.GetTransaction(ctx, transactionID)
+	if err != nil {
+		// The field is nullable, so an unknown transaction is null rather than
+		// an error — same for the other single-entity lookups below.
+		if errors.Is(err, insights.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	return insights.TransactionToModel(*transaction), nil
 }
 
 // Baseline is the resolver for the baseline field.
 func (r *insightsResolver) Baseline(ctx context.Context, obj *model.Insights, transactionID string) ([]*model.InsightsBaselineClass, error) {
-	panic(fmt.Errorf("not implemented: Baseline - baseline"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	id, err := insights.ParseID(transactionID)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	baseline, err := client.GetTransactionBaseline(ctx, id)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	converted, err := insights.BaselineClassesToModel(baseline)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	return converted, nil
 }
 
 // Observations is the resolver for the observations field.
 func (r *insightsResolver) Observations(ctx context.Context, obj *model.Insights, transactionID string, sampleReason *model.InsightsSampleReason) ([]*model.InsightsObservationSummary, error) {
-	panic(fmt.Errorf("not implemented: Observations - observations"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	id, err := insights.ParseID(transactionID)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	observations, err := client.ListObservations(ctx, id, insights.ListObservationsParams{
+		SampleReason: insights.SampleReasonPtrFromModel(sampleReason),
+	})
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	return insights.ObservationSummariesToModel(observations), nil
 }
 
 // Observation is the resolver for the observation field.
 func (r *insightsResolver) Observation(ctx context.Context, obj *model.Insights, transactionID string, traceID string) (*model.InsightsObservation, error) {
-	panic(fmt.Errorf("not implemented: Observation - observation"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	id, err := insights.ParseID(transactionID)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	observation, err := client.GetObservation(ctx, id, traceID)
+	if err != nil {
+		if errors.Is(err, insights.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	return insights.ObservationToModel(*observation), nil
 }
 
 // Findings is the resolver for the findings field.
 func (r *insightsResolver) Findings(ctx context.Context, obj *model.Insights, windowHours *int, service *string, namespace *string, status *string, kind *model.InsightsFindingKind) ([]*model.InsightsFinding, error) {
-	panic(fmt.Errorf("not implemented: Findings - findings"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	findings, err := client.ListFindings(ctx, insights.ListFindingsParams{
+		WindowHours: windowHours,
+		Service:     service,
+		Namespace:   namespace,
+		Status:      status,
+		Kind:        insights.FindingKindPtrFromModel(kind),
+	})
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	return insights.FindingsToModel(findings), nil
 }
 
 // Anomalies is the resolver for the anomalies field.
 func (r *insightsResolver) Anomalies(ctx context.Context, obj *model.Insights, windowHours *int, service *string, namespace *string, status *string) ([]*model.InsightsAnomalySummary, error) {
-	panic(fmt.Errorf("not implemented: Anomalies - anomalies"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	anomalies, err := client.ListAnomalies(ctx, insights.ListAnomaliesParams{
+		WindowHours: windowHours,
+		Service:     service,
+		Namespace:   namespace,
+		Status:      status,
+	})
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	return insights.AnomalySummariesToModel(anomalies), nil
 }
 
 // Anomaly is the resolver for the anomaly field.
 func (r *insightsResolver) Anomaly(ctx context.Context, obj *model.Insights, transactionID string, signature string) (*model.InsightsAnomalyIssue, error) {
-	panic(fmt.Errorf("not implemented: Anomaly - anomaly"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	id, err := insights.ParseID(transactionID)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	anomaly, err := client.GetAnomaly(ctx, id, signature)
+	if err != nil {
+		if errors.Is(err, insights.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	converted, err := insights.AnomalyIssueToModel(*anomaly)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	return converted, nil
 }
 
 // Policies is the resolver for the policies field.
 func (r *insightsResolver) Policies(ctx context.Context, obj *model.Insights) ([]*model.InsightsPolicy, error) {
-	panic(fmt.Errorf("not implemented: Policies - policies"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	policies, err := client.ListPolicies(ctx)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	converted, err := insights.PoliciesToModel(policies)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	return converted, nil
 }
 
 // LearningPolicies is the resolver for the learningPolicies field.
 func (r *insightsResolver) LearningPolicies(ctx context.Context, obj *model.Insights) ([]*model.InsightsLearningPolicy, error) {
-	panic(fmt.Errorf("not implemented: LearningPolicies - learningPolicies"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	policies, err := client.ListLearningPolicies(ctx)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	return insights.LearningPoliciesToModel(policies), nil
 }
 
 // Guardrails is the resolver for the guardrails field.
 func (r *insightsResolver) Guardrails(ctx context.Context, obj *model.Insights) ([]*model.InsightsGuardrail, error) {
-	panic(fmt.Errorf("not implemented: Guardrails - guardrails"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	guardrails, err := client.ListGuardrails(ctx)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	return insights.GuardrailsToModel(guardrails), nil
 }
 
 // GuardrailViolations is the resolver for the guardrailViolations field.
 func (r *insightsResolver) GuardrailViolations(ctx context.Context, obj *model.Insights, windowHours *int, service *string, namespace *string, status *string) ([]*model.InsightsGuardrailViolation, error) {
-	panic(fmt.Errorf("not implemented: GuardrailViolations - guardrailViolations"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	violations, err := client.ListGuardrailViolations(ctx, insights.ListGuardrailViolationsParams{
+		WindowHours: windowHours,
+		Service:     service,
+		Namespace:   namespace,
+		Status:      status,
+	})
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	return insights.GuardrailViolationsToModel(violations), nil
 }
 
 // Catalog is the resolver for the catalog field.
 func (r *insightsResolver) Catalog(ctx context.Context, obj *model.Insights) (*model.InsightsCatalog, error) {
-	panic(fmt.Errorf("not implemented: Catalog - catalog"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	catalog, err := client.GetCatalog(ctx)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	converted, err := insights.CatalogToModel(*catalog)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	return converted, nil
 }
 
 // SystemSettings is the resolver for the systemSettings field.
 func (r *insightsResolver) SystemSettings(ctx context.Context, obj *model.Insights) (*model.InsightsSystemSettings, error) {
-	panic(fmt.Errorf("not implemented: SystemSettings - systemSettings"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	settings, err := client.GetSystemSettings(ctx)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	return insights.SystemSettingsToModel(*settings), nil
 }
 
 // StorageHealth is the resolver for the storageHealth field.
 func (r *insightsResolver) StorageHealth(ctx context.Context, obj *model.Insights) (*model.InsightsStorageHealth, error) {
-	panic(fmt.Errorf("not implemented: StorageHealth - storageHealth"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	health, err := client.GetStorageHealth(ctx)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	return insights.StorageHealthToModel(*health), nil
 }
 
 // PromoteInsightsBaselineClass is the resolver for the promoteInsightsBaselineClass field.
 func (r *mutationResolver) PromoteInsightsBaselineClass(ctx context.Context, transactionID string, class model.InsightsDeviationClass) (*model.InsightsPromoteResult, error) {
-	panic(fmt.Errorf("not implemented: PromoteInsightsBaselineClass - promoteInsightsBaselineClass"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	id, err := insights.ParseID(transactionID)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	result, err := client.PromoteBaselineClass(ctx, id, insights.DeviationClassFromModel(class))
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	return insights.PromoteResultToModel(*result), nil
 }
 
 // ResetInsightsBaselineClass is the resolver for the resetInsightsBaselineClass field.
 func (r *mutationResolver) ResetInsightsBaselineClass(ctx context.Context, transactionID string, class model.InsightsDeviationClass) (bool, error) {
-	panic(fmt.Errorf("not implemented: ResetInsightsBaselineClass - resetInsightsBaselineClass"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return false, err
+	}
+	id, err := insights.ParseID(transactionID)
+	if err != nil {
+		return false, insights.GraphQLError(ctx, err)
+	}
+	if err := client.ResetBaselineClass(ctx, id, insights.DeviationClassFromModel(class)); err != nil {
+		return false, insights.GraphQLError(ctx, err)
+	}
+	return true, nil
 }
 
 // ResetInsightsTransactionBaselines is the resolver for the resetInsightsTransactionBaselines field.
 func (r *mutationResolver) ResetInsightsTransactionBaselines(ctx context.Context, transactionID string) (bool, error) {
-	panic(fmt.Errorf("not implemented: ResetInsightsTransactionBaselines - resetInsightsTransactionBaselines"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return false, err
+	}
+	id, err := insights.ParseID(transactionID)
+	if err != nil {
+		return false, insights.GraphQLError(ctx, err)
+	}
+	if err := client.ResetTransactionBaselines(ctx, id); err != nil {
+		return false, insights.GraphQLError(ctx, err)
+	}
+	return true, nil
 }
 
 // UpsertInsightsPolicy is the resolver for the upsertInsightsPolicy field.
 func (r *mutationResolver) UpsertInsightsPolicy(ctx context.Context, policy model.InsightsPolicyInput) (*model.InsightsPolicy, error) {
-	panic(fmt.Errorf("not implemented: UpsertInsightsPolicy - upsertInsightsPolicy"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	request, err := insights.PolicyFromInput(policy)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	stored, err := client.UpsertPolicyAndRead(ctx, request)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	converted, err := insights.PolicyToModel(stored)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	return converted, nil
 }
 
 // DeleteInsightsPolicy is the resolver for the deleteInsightsPolicy field.
 func (r *mutationResolver) DeleteInsightsPolicy(ctx context.Context, scope model.InsightsPolicyScope, scopeKey string) (bool, error) {
-	panic(fmt.Errorf("not implemented: DeleteInsightsPolicy - deleteInsightsPolicy"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return false, err
+	}
+	if err := client.DeletePolicy(ctx, insights.PolicyScopeFromModel(scope), scopeKey); err != nil {
+		return false, insights.GraphQLError(ctx, err)
+	}
+	return true, nil
 }
 
 // UpsertInsightsLearningPolicy is the resolver for the upsertInsightsLearningPolicy field.
 func (r *mutationResolver) UpsertInsightsLearningPolicy(ctx context.Context, policy model.InsightsLearningPolicyInput) (*model.InsightsLearningPolicy, error) {
-	panic(fmt.Errorf("not implemented: UpsertInsightsLearningPolicy - upsertInsightsLearningPolicy"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	stored, err := client.UpsertLearningPolicyAndRead(ctx, insights.LearningPolicyFromInput(policy))
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	return insights.LearningPolicyToModel(stored), nil
 }
 
 // DeleteInsightsLearningPolicy is the resolver for the deleteInsightsLearningPolicy field.
 func (r *mutationResolver) DeleteInsightsLearningPolicy(ctx context.Context, class model.InsightsDeviationClass, scope model.InsightsPolicyScope, scopeKey string) (bool, error) {
-	panic(fmt.Errorf("not implemented: DeleteInsightsLearningPolicy - deleteInsightsLearningPolicy"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return false, err
+	}
+	err = client.DeleteLearningPolicy(ctx, insights.DeviationClassFromModel(class), insights.PolicyScopeFromModel(scope), scopeKey)
+	if err != nil {
+		return false, insights.GraphQLError(ctx, err)
+	}
+	return true, nil
 }
 
 // ResolveInsightsAnomaly is the resolver for the resolveInsightsAnomaly field.
 func (r *mutationResolver) ResolveInsightsAnomaly(ctx context.Context, transactionID string, signature string, resolution model.InsightsAnomalyResolution) (bool, error) {
-	panic(fmt.Errorf("not implemented: ResolveInsightsAnomaly - resolveInsightsAnomaly"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return false, err
+	}
+	id, err := insights.ParseID(transactionID)
+	if err != nil {
+		return false, insights.GraphQLError(ctx, err)
+	}
+	if err := client.ResolveAnomaly(ctx, id, signature, insights.AnomalyResolutionFromModel(resolution)); err != nil {
+		return false, insights.GraphQLError(ctx, err)
+	}
+	return true, nil
 }
 
 // BulkResolveInsightsAnomalies is the resolver for the bulkResolveInsightsAnomalies field.
 func (r *mutationResolver) BulkResolveInsightsAnomalies(ctx context.Context, resolution model.InsightsBulkResolution, items []*model.InsightsAnomalyRefInput) (*model.InsightsBulkResolveResult, error) {
-	panic(fmt.Errorf("not implemented: BulkResolveInsightsAnomalies - bulkResolveInsightsAnomalies"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	request, err := insights.BulkAnomalyRequestFromInput(resolution, items)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	result, err := client.BulkResolveAnomalies(ctx, request)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	return insights.BulkResolveResultToModel(*result), nil
 }
 
 // UpsertInsightsGuardrail is the resolver for the upsertInsightsGuardrail field.
 func (r *mutationResolver) UpsertInsightsGuardrail(ctx context.Context, guardrail model.InsightsGuardrailInput) (*model.InsightsGuardrail, error) {
-	panic(fmt.Errorf("not implemented: UpsertInsightsGuardrail - upsertInsightsGuardrail"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	stored, err := client.UpsertGuardrailAndRead(ctx, insights.GuardrailFromInput(guardrail))
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	return insights.GuardrailToModel(stored), nil
 }
 
 // DeleteInsightsGuardrail is the resolver for the deleteInsightsGuardrail field.
 func (r *mutationResolver) DeleteInsightsGuardrail(ctx context.Context, scopeKey string) (bool, error) {
-	panic(fmt.Errorf("not implemented: DeleteInsightsGuardrail - deleteInsightsGuardrail"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return false, err
+	}
+	if err := client.DeleteGuardrail(ctx, scopeKey); err != nil {
+		return false, insights.GraphQLError(ctx, err)
+	}
+	return true, nil
 }
 
 // SeedInsightsGuardrail is the resolver for the seedInsightsGuardrail field.
 func (r *mutationResolver) SeedInsightsGuardrail(ctx context.Context, seed model.InsightsGuardrailSeedInput) (bool, error) {
-	panic(fmt.Errorf("not implemented: SeedInsightsGuardrail - seedInsightsGuardrail"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return false, err
+	}
+	request, err := insights.GuardrailSeedFromInput(seed)
+	if err != nil {
+		return false, insights.GraphQLError(ctx, err)
+	}
+	if err := client.SeedGuardrail(ctx, request); err != nil {
+		return false, insights.GraphQLError(ctx, err)
+	}
+	return true, nil
 }
 
 // AllowInsightsGuardrailViolation is the resolver for the allowInsightsGuardrailViolation field.
 func (r *mutationResolver) AllowInsightsGuardrailViolation(ctx context.Context, action model.InsightsViolationActionInput) (bool, error) {
-	panic(fmt.Errorf("not implemented: AllowInsightsGuardrailViolation - allowInsightsGuardrailViolation"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return false, err
+	}
+	if err := client.AllowGuardrailViolation(ctx, insights.ViolationActionFromInput(action)); err != nil {
+		return false, insights.GraphQLError(ctx, err)
+	}
+	return true, nil
 }
 
 // DismissInsightsGuardrailViolation is the resolver for the dismissInsightsGuardrailViolation field.
 func (r *mutationResolver) DismissInsightsGuardrailViolation(ctx context.Context, action model.InsightsViolationActionInput) (bool, error) {
-	panic(fmt.Errorf("not implemented: DismissInsightsGuardrailViolation - dismissInsightsGuardrailViolation"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return false, err
+	}
+	if err := client.DismissGuardrailViolation(ctx, insights.ViolationActionFromInput(action)); err != nil {
+		return false, insights.GraphQLError(ctx, err)
+	}
+	return true, nil
 }
 
 // ReopenInsightsGuardrailViolation is the resolver for the reopenInsightsGuardrailViolation field.
 func (r *mutationResolver) ReopenInsightsGuardrailViolation(ctx context.Context, action model.InsightsViolationActionInput) (bool, error) {
-	panic(fmt.Errorf("not implemented: ReopenInsightsGuardrailViolation - reopenInsightsGuardrailViolation"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return false, err
+	}
+	if err := client.ReopenGuardrailViolation(ctx, insights.ViolationActionFromInput(action)); err != nil {
+		return false, insights.GraphQLError(ctx, err)
+	}
+	return true, nil
 }
 
 // UpdateInsightsSystemSettings is the resolver for the updateInsightsSystemSettings field.
 func (r *mutationResolver) UpdateInsightsSystemSettings(ctx context.Context, settings model.InsightsSystemSettingsInput) (*model.InsightsSystemSettings, error) {
-	panic(fmt.Errorf("not implemented: UpdateInsightsSystemSettings - updateInsightsSystemSettings"))
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	request, err := insights.SystemSettingsFromInput(settings)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	stored, err := client.UpdateSystemSettingsAndRead(ctx, request)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	return insights.SystemSettingsToModel(stored), nil
 }
 
 // Insights is the resolver for the insights field.
 func (r *queryResolver) Insights(ctx context.Context) (*model.Insights, error) {
-	panic(fmt.Errorf("not implemented: Insights - insights"))
+	// Gate here so a disabled feature fails once on the root field instead of
+	// once per selected child field; the children resolve lazily against the
+	// same gate.
+	if _, err := r.insightsClient(ctx); err != nil {
+		return nil, err
+	}
+	return &model.Insights{}, nil
 }
 
 // Insights returns InsightsResolver implementation.

--- a/frontend/graph/insights_helpers.go
+++ b/frontend/graph/insights_helpers.go
@@ -1,0 +1,26 @@
+package graph
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/odigos-io/odigos/frontend/services/insights"
+)
+
+// insightsClient is the gate every insights resolver goes through: insights is
+// an optional feature, and the odigos-insights service it talks to only runs in
+// the cluster when the effective configuration enables it. Returns an error that
+// is ready to hand back from a resolver.
+func (r *Resolver) insightsClient(ctx context.Context) (*insights.Client, error) {
+	enabled, err := insights.IsEnabled(ctx, r.K8sCacheClient)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, fmt.Errorf("reading effective config for insights: %w", err))
+	}
+	if !enabled {
+		return nil, insights.GraphQLError(ctx, insights.ErrNotEnabled)
+	}
+	if r.InsightsClient == nil {
+		return nil, insights.GraphQLError(ctx, fmt.Errorf("%w: insights client was not initialized", insights.ErrInternal))
+	}
+	return r.InsightsClient, nil
+}

--- a/frontend/services/insights/conversions.go
+++ b/frontend/services/insights/conversions.go
@@ -49,6 +49,10 @@ func (c *LearningCondition) UnmarshalJSON(data []byte) error {
 }
 
 // ID helpers — GraphQL exposes transaction / policy ids as ID (string); REST uses int64.
+//
+// These and the input converters further down report failures as ErrBadRequest:
+// they only ever fail on caller-supplied GraphQL arguments, so resolvers surface
+// them as invalid requests rather than as service errors.
 
 func FormatID(id int64) string {
 	return strconv.FormatInt(id, 10)
@@ -57,7 +61,7 @@ func FormatID(id int64) string {
 func ParseID(id string) (int64, error) {
 	parsed, err := strconv.ParseInt(id, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("invalid insights id %q: %w", id, err)
+		return 0, fmt.Errorf("%w: id %q is not a number", ErrBadRequest, id)
 	}
 	return parsed, nil
 }
@@ -120,7 +124,7 @@ func encodeOptionalJSONString(value any) (*string, error) {
 func decodeJSONString[T any](encoded string) (T, error) {
 	var value T
 	if err := json.Unmarshal([]byte(encoded), &value); err != nil {
-		return value, fmt.Errorf("decode insights json field: %w", err)
+		return value, fmt.Errorf("%w: field is not valid JSON: %v", ErrBadRequest, err)
 	}
 	return value, nil
 }
@@ -905,7 +909,7 @@ func AnomalyRefFromInput(input model.InsightsAnomalyRefInput) (AnomalyRef, error
 func BulkAnomalyRequestFromInput(resolution model.InsightsBulkResolution, items []*model.InsightsAnomalyRefInput) (BulkAnomalyRequest, error) {
 	refs, err := mapSliceErr(items, func(item *model.InsightsAnomalyRefInput) (AnomalyRef, error) {
 		if item == nil {
-			return AnomalyRef{}, fmt.Errorf("anomaly ref item is nil")
+			return AnomalyRef{}, fmt.Errorf("%w: anomaly ref item is nil", ErrBadRequest)
 		}
 		return AnomalyRefFromInput(*item)
 	})
@@ -920,7 +924,7 @@ func BulkAnomalyRequestFromInput(resolution model.InsightsBulkResolution, items 
 
 func SystemSettingsFromInput(input model.InsightsSystemSettingsInput) (SystemSettings, error) {
 	if input.Sampling == nil || input.Retention == nil || input.Findings == nil || input.Capacity == nil || input.Writeback == nil {
-		return SystemSettings{}, fmt.Errorf("system settings input is incomplete")
+		return SystemSettings{}, fmt.Errorf("%w: system settings input is incomplete", ErrBadRequest)
 	}
 	return SystemSettings{
 		Sampling: SystemSamplingSettings{

--- a/frontend/services/insights/errors.go
+++ b/frontend/services/insights/errors.go
@@ -1,11 +1,15 @@
 package insights
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"strings"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 var (
@@ -107,4 +111,55 @@ func containsEngineStarting(value string) bool {
 	return strings.Contains(value, "engine starting") ||
 		strings.Contains(value, "engine is starting") ||
 		strings.Contains(value, "engine not ready")
+}
+
+// Codes carried in the GraphQL error extensions, so the UI can tell "feature is
+// off" from "engine still warming up" from a real failure without matching
+// message text.
+const (
+	CodeNotEnabled     = "INSIGHTS_NOT_ENABLED"
+	CodeEngineStarting = "INSIGHTS_ENGINE_STARTING"
+	CodeBadRequest     = "INSIGHTS_BAD_REQUEST"
+	CodeNotFound       = "INSIGHTS_NOT_FOUND"
+	CodeConflict       = "INSIGHTS_CONFLICT"
+	CodeValidation     = "INSIGHTS_VALIDATION_FAILED"
+	CodeUnavailable    = "INSIGHTS_UNAVAILABLE"
+	CodeInternal       = "INSIGHTS_INTERNAL_ERROR"
+)
+
+// GraphQLError wraps an insights error for return from a resolver, tagging it
+// with the matching extensions code.
+func GraphQLError(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &gqlerror.Error{
+		Err:        err,
+		Message:    err.Error(),
+		Path:       graphql.GetPath(ctx),
+		Extensions: map[string]any{"code": errorCode(err)},
+	}
+}
+
+func errorCode(err error) string {
+	switch {
+	case errors.Is(err, ErrNotEnabled):
+		return CodeNotEnabled
+	// Engine warm-up is a service-unavailable response too, so it has to be
+	// matched before ErrUnavailable.
+	case errors.Is(err, ErrEngineStarting):
+		return CodeEngineStarting
+	case errors.Is(err, ErrBadRequest):
+		return CodeBadRequest
+	case errors.Is(err, ErrNotFound):
+		return CodeNotFound
+	case errors.Is(err, ErrConflict):
+		return CodeConflict
+	case errors.Is(err, ErrUnprocessableEntity):
+		return CodeValidation
+	case errors.Is(err, ErrUnavailable):
+		return CodeUnavailable
+	default:
+		return CodeInternal
+	}
 }

--- a/frontend/services/insights/errors_test.go
+++ b/frontend/services/insights/errors_test.go
@@ -1,0 +1,52 @@
+package insights
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+)
+
+func TestGraphQLErrorCarriesCode(t *testing.T) {
+	_, invalidID := ParseID("not-a-number")
+	require.Error(t, invalidID)
+
+	tests := []struct {
+		name string
+		err  error
+		code string
+	}{
+		{name: "not enabled", err: ErrNotEnabled, code: CodeNotEnabled},
+		{name: "wrapped not enabled", err: fmt.Errorf("listing findings: %w", ErrNotEnabled), code: CodeNotEnabled},
+		{name: "bad request", err: ErrBadRequest, code: CodeBadRequest},
+		{name: "invalid id argument", err: invalidID, code: CodeBadRequest},
+		{name: "not found", err: ErrNotFound, code: CodeNotFound},
+		{name: "conflict", err: ErrConflict, code: CodeConflict},
+		{name: "validation", err: ErrValidation, code: CodeValidation},
+		{name: "unavailable", err: ErrUnavailable, code: CodeUnavailable},
+		{name: "internal", err: ErrInternal, code: CodeInternal},
+		{name: "unclassified", err: fmt.Errorf("connection refused"), code: CodeInternal},
+		// Engine warm-up arrives as a 503, so it must win over unavailable.
+		{name: "engine starting", err: decodeAPIError(http.StatusServiceUnavailable, []byte("engine starting")), code: CodeEngineStarting},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := GraphQLError(context.Background(), tt.err)
+
+			var gqlErr *gqlerror.Error
+			require.ErrorAs(t, err, &gqlErr)
+			assert.Equal(t, tt.code, gqlErr.Extensions["code"])
+			assert.Equal(t, tt.err.Error(), gqlErr.Message)
+			assert.ErrorIs(t, err, tt.err)
+		})
+	}
+}
+
+func TestGraphQLErrorPassesThroughNil(t *testing.T) {
+	assert.NoError(t, GraphQLError(context.Background(), nil))
+}

--- a/frontend/services/insights/upsert.go
+++ b/frontend/services/insights/upsert.go
@@ -1,0 +1,77 @@
+package insights
+
+import (
+	"context"
+	"fmt"
+)
+
+// Read-after-write wrappers for the upsert endpoints. The REST API answers an
+// upsert with 204 No Content while the GraphQL schema returns the stored entity,
+// so each wrapper re-reads what the engine actually persisted — it derives
+// policy ids, normalizes scopes and fills missing fields with defaults, none of
+// which the request body reflects.
+
+func (c *Client) UpsertPolicyAndRead(ctx context.Context, policy Policy) (Policy, error) {
+	if err := c.UpsertPolicy(ctx, policy); err != nil {
+		return Policy{}, err
+	}
+	stored, err := c.ListPolicies(ctx)
+	if err != nil {
+		return Policy{}, err
+	}
+	for _, candidate := range stored {
+		if candidate.Scope == policy.Scope && candidate.ScopeKey == policy.ScopeKey {
+			return candidate, nil
+		}
+	}
+	// ListPolicies returns enabled policies only, so a policy that was just
+	// disabled is legitimately absent from the read-back; echo the accepted
+	// request in that case.
+	if !policy.Enabled {
+		return policy, nil
+	}
+	return Policy{}, fmt.Errorf("%w: policy %s/%q is missing after upsert", ErrInternal, policy.Scope, policy.ScopeKey)
+}
+
+func (c *Client) UpsertLearningPolicyAndRead(ctx context.Context, policy LearningPolicy) (LearningPolicy, error) {
+	if err := c.UpsertLearningPolicy(ctx, policy); err != nil {
+		return LearningPolicy{}, err
+	}
+	stored, err := c.ListLearningPolicies(ctx)
+	if err != nil {
+		return LearningPolicy{}, err
+	}
+	for _, candidate := range stored {
+		if candidate.Class == policy.Class && candidate.Scope == policy.Scope && candidate.ScopeKey == policy.ScopeKey {
+			return candidate, nil
+		}
+	}
+	return LearningPolicy{}, fmt.Errorf("%w: learning policy %s %s/%q is missing after upsert", ErrInternal, policy.Class, policy.Scope, policy.ScopeKey)
+}
+
+func (c *Client) UpsertGuardrailAndRead(ctx context.Context, guardrail Guardrail) (Guardrail, error) {
+	if err := c.UpsertGuardrail(ctx, guardrail); err != nil {
+		return Guardrail{}, err
+	}
+	stored, err := c.ListGuardrails(ctx)
+	if err != nil {
+		return Guardrail{}, err
+	}
+	for _, candidate := range stored {
+		if candidate.ScopeKey == guardrail.ScopeKey {
+			return candidate, nil
+		}
+	}
+	return Guardrail{}, fmt.Errorf("%w: guardrail %q is missing after upsert", ErrInternal, guardrail.ScopeKey)
+}
+
+func (c *Client) UpdateSystemSettingsAndRead(ctx context.Context, settings SystemSettings) (SystemSettings, error) {
+	if err := c.UpdateSystemSettings(ctx, settings); err != nil {
+		return SystemSettings{}, err
+	}
+	stored, err := c.GetSystemSettings(ctx)
+	if err != nil {
+		return SystemSettings{}, err
+	}
+	return *stored, nil
+}

--- a/frontend/services/insights/upsert_test.go
+++ b/frontend/services/insights/upsert_test.go
@@ -1,0 +1,183 @@
+package insights
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpsertPolicyAndReadReturnsPersistedPolicy(t *testing.T) {
+	var upserted Policy
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&upserted))
+			w.WriteHeader(http.StatusNoContent)
+		case http.MethodGet:
+			// The engine assigns the id and defaults fire_at_score.
+			_, _ = w.Write([]byte(`{"count":1,"items":[{
+				"id": 991,
+				"name": "checkout",
+				"enabled": true,
+				"fire_at_score": 60,
+				"scope": "service",
+				"scope_key": "prod/checkout"
+			}]}`))
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	require.NoError(t, err)
+
+	stored, err := client.UpsertPolicyAndRead(context.Background(), Policy{
+		Name:     "checkout",
+		Enabled:  true,
+		Scope:    "service",
+		ScopeKey: "prod/checkout",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "checkout", upserted.Name)
+	assert.Equal(t, int64(991), stored.ID)
+	assert.Equal(t, 60, stored.FireAtScore)
+}
+
+func TestUpsertPolicyAndReadWhenAbsentFromReadBack(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		_, _ = w.Write([]byte(`{"count":0,"items":[]}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	require.NoError(t, err)
+
+	// Listing skips disabled policies, so their absence is expected and the
+	// accepted request is echoed back.
+	disabled := Policy{Name: "checkout", Scope: "service", ScopeKey: "prod/checkout"}
+	stored, err := client.UpsertPolicyAndRead(context.Background(), disabled)
+	require.NoError(t, err)
+	assert.Equal(t, disabled, stored)
+
+	// An enabled policy that is missing after the write is a real failure.
+	enabled := disabled
+	enabled.Enabled = true
+	_, err = client.UpsertPolicyAndRead(context.Background(), enabled)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInternal)
+}
+
+func TestUpsertLearningPolicyAndReadMatchesOnClassAndScope(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		_, _ = w.Write([]byte(`{"count":2,"items":[
+			{"class":"D2_egress","mode":"all","scope":"global","scope_key":""},
+			{"class":"D3_latency","mode":"any","min_matches":2,"scope":"service","scope_key":"prod/checkout"}
+		]}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	require.NoError(t, err)
+
+	stored, err := client.UpsertLearningPolicyAndRead(context.Background(), LearningPolicy{
+		Class:    "D3_latency",
+		Mode:     "any",
+		Scope:    "service",
+		ScopeKey: "prod/checkout",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, stored.MinMatches)
+	assert.Equal(t, 2, *stored.MinMatches)
+
+	_, err = client.UpsertLearningPolicyAndRead(context.Background(), LearningPolicy{
+		Class:    "D8_payload_size",
+		Mode:     "all",
+		Scope:    "global",
+		ScopeKey: "",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInternal)
+}
+
+func TestUpsertGuardrailAndReadReturnsPersistedRules(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		_, _ = w.Write([]byte(`{"count":1,"items":[{
+			"scope": "service",
+			"scope_key": "prod/checkout",
+			"rules": [{"key":"allowed_egress","label":"Allowed egress","mode":"enforce","allowlist":["db:5432"]}]
+		}]}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	require.NoError(t, err)
+
+	stored, err := client.UpsertGuardrailAndRead(context.Background(), Guardrail{
+		Scope:    "service",
+		ScopeKey: "prod/checkout",
+		Rules:    []GuardrailRule{{Key: "allowed_egress", Mode: "enforce"}},
+	})
+	require.NoError(t, err)
+	require.Len(t, stored.Rules, 1)
+	assert.Equal(t, "Allowed egress", stored.Rules[0].Label)
+	assert.Equal(t, []string{"db:5432"}, stored.Rules[0].Allowlist)
+}
+
+func TestUpdateSystemSettingsAndReadReturnsServerDefaults(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		_, _ = w.Write([]byte(`{
+			"sampling": {"examples_per_transaction": 3, "example_sample_interval_seconds": 60},
+			"retention": {"observation_retention_days": 14},
+			"findings": {"default_window_hours": 24, "max_window_hours": 168},
+			"capacity": {"max_resident_transactions": 1000, "max_baseline_set_members": 500},
+			"writeback": {"flush_interval_seconds": 30}
+		}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	require.NoError(t, err)
+
+	stored, err := client.UpdateSystemSettingsAndRead(context.Background(), SystemSettings{
+		Sampling: SystemSamplingSettings{ExamplesPerTransaction: 3},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 168, stored.Findings.MaxWindowHours)
+	assert.Equal(t, 30, stored.Writeback.FlushIntervalSeconds)
+}
+
+func TestUpsertPolicyAndReadPropagatesWriteError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method, "read-back must not run after a failed write")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":{"code":"unavailable","message":"engine starting"}}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	require.NoError(t, err)
+
+	_, err = client.UpsertPolicyAndRead(context.Background(), Policy{Scope: "global"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEngineStarting)
+}


### PR DESCRIPTION
The Insights resolvers were gqlgen stubs that panicked, so the schema introduced in PLAT-1376 could not serve requests.

#### What this PR does / why we need it:
Implements all 26 Insights GraphQL resolvers as thin delegations to `frontend/services/insights`, including conversion and error handling tests.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
NONE
```