### PR TITLE
PLAT-1384 | feat: expose insightsEnabled on GraphQL Config

### DIFF
--- a/frontend/graph/configs.graphqls
+++ b/frontend/graph/configs.graphqls
@@ -9,6 +9,7 @@ type Config {
   installationStatus: InstallationStatus!
   clusterName: String
   isCentralProxyRunning: Boolean
+  insightsEnabled: Boolean!
 }
 
 # Effective configuration, reflects the actual values applied to the cluster

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -226,6 +226,7 @@ type ComplexityRoot struct {
 
 	Config struct {
 		ClusterName           func(childComplexity int) int
+		InsightsEnabled       func(childComplexity int) int
 		InstallationMethod    func(childComplexity int) int
 		InstallationStatus    func(childComplexity int) int
 		IsCentralProxyRunning func(childComplexity int) int
@@ -2805,6 +2806,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Config.ClusterName(childComplexity), true
+
+	case "Config.insightsEnabled":
+		if e.complexity.Config.InsightsEnabled == nil {
+			break
+		}
+
+		return e.complexity.Config.InsightsEnabled(childComplexity), true
 
 	case "Config.installationMethod":
 		if e.complexity.Config.InstallationMethod == nil {
@@ -19312,6 +19320,50 @@ func (ec *executionContext) _Config_isCentralProxyRunning(ctx context.Context, f
 }
 
 func (ec *executionContext) fieldContext_Config_isCentralProxyRunning(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Config",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Config_insightsEnabled(ctx context.Context, field graphql.CollectedField, obj *model.Config) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Config_insightsEnabled(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.InsightsEnabled, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Config_insightsEnabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Config",
 		Field:      field,
@@ -60069,6 +60121,8 @@ func (ec *executionContext) fieldContext_Query_config(_ context.Context, field g
 				return ec.fieldContext_Config_clusterName(ctx, field)
 			case "isCentralProxyRunning":
 				return ec.fieldContext_Config_isCentralProxyRunning(ctx, field)
+			case "insightsEnabled":
+				return ec.fieldContext_Config_insightsEnabled(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Config", field.Name)
 		},
@@ -72421,6 +72475,11 @@ func (ec *executionContext) _Config(ctx context.Context, sel ast.SelectionSet, o
 			out.Values[i] = ec._Config_clusterName(ctx, field, obj)
 		case "isCentralProxyRunning":
 			out.Values[i] = ec._Config_isCentralProxyRunning(ctx, field, obj)
+		case "insightsEnabled":
+			out.Values[i] = ec._Config_insightsEnabled(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -223,6 +223,7 @@ type Config struct {
 	InstallationStatus    InstallationStatus  `json:"installationStatus"`
 	ClusterName           *string             `json:"clusterName,omitempty"`
 	IsCentralProxyRunning *bool               `json:"isCentralProxyRunning,omitempty"`
+	InsightsEnabled       bool                `json:"insightsEnabled"`
 }
 
 type ConfigYaml struct {

--- a/frontend/services/deployment_config.go
+++ b/frontend/services/deployment_config.go
@@ -66,6 +66,7 @@ func buildConfigResponse(ctx context.Context, deploymentData map[string]string) 
 	response.OdigosVersion = deploymentData[k8sconsts.OdigosDeploymentConfigMapVersionKey]
 	response.InstallationMethod = string(deploymentData[k8sconsts.OdigosDeploymentConfigMapInstallationMethodKey])
 	response.ClusterName = &config.ClusterName
+	response.InsightsEnabled = config.InsightsEnabled()
 	isConnected, err := isCentralProxyRunning(ctx)
 	if err != nil {
 		log.Printf("Error checking if central proxy connected: %v\n", err)

--- a/frontend/services/deployment_config_test.go
+++ b/frontend/services/deployment_config_test.go
@@ -1,0 +1,67 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/odigos-io/odigos/api/k8sconsts"
+	"github.com/odigos-io/odigos/common/consts"
+	"github.com/odigos-io/odigos/frontend/kube"
+	"github.com/odigos-io/odigos/k8sutils/pkg/env"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestBuildConfigResponseInsightsEnabled(t *testing.T) {
+	tests := []struct {
+		name       string
+		configYAML string
+		want       bool
+	}{
+		{
+			name:       "enabled",
+			configYAML: "insights:\n  enabled: true\n",
+			want:       true,
+		},
+		{
+			name:       "disabled",
+			configYAML: "insights:\n  enabled: false\n",
+			want:       false,
+		},
+		{
+			name:       "unset",
+			configYAML: "configVersion: 1\n",
+			want:       false,
+		},
+	}
+
+	originalClient := kube.DefaultClient
+	t.Cleanup(func() {
+		kube.SetDefaultClient(originalClient)
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			effectiveConfig := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      consts.OdigosEffectiveConfigName,
+					Namespace: env.GetCurrentNamespace(),
+				},
+				Data: map[string]string{
+					consts.OdigosConfigurationFileName: tt.configYAML,
+				},
+			}
+			kube.SetDefaultClient(&kube.Client{
+				Interface: fake.NewSimpleClientset(effectiveConfig),
+			})
+
+			config := buildConfigResponse(context.Background(), map[string]string{
+				k8sconsts.OdigosDeploymentConfigMapInstallationStatusKey: string(Finished),
+			})
+
+			assert.Equal(t, tt.want, config.InsightsEnabled)
+		})
+	}
+}


### PR DESCRIPTION
The UI needs a cheap flag before calling nested `insights { ... }` queries, so it can hide the feature without probing APIs that return `ErrNotEnabled`.

#### What this PR does / why we need it:

Adds `insightsEnabled: Boolean!` to the GraphQL `Config` type and populates it in `buildConfigResponse` from the effective config via `config.InsightsEnabled()` — the same source of truth as `services/insights.IsEnabled`.

- Schema field on `Config` + gqlgen regeneration
- Value is `true` only when effective config has insights explicitly enabled; otherwise `false`
- Unit tests cover enabled / disabled / unset

Stacked on #5469 — review that one first; this branch contains its commits.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
NONE
```