### PR TITLE
harden: apply PSS Baseline securityContext to non-odiglet pods

### DIFF
--- a/helm/odigos-central/templates/_helpers.tpl
+++ b/helm/odigos-central/templates/_helpers.tpl
@@ -98,6 +98,48 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 
+{{/*
+  Renders a `securityContext:` block by layering three maps, later ones winning per key:
+  the chart-wide defaults, a template-supplied "Base" carrying securityContext keys the
+  template already set on its own, and the per-component override from values.
+  A key whose value is null is dropped, which is how a component opts out of a default.
+*/}}
+{{- define "odigos.renderSecurityContext" -}}
+{{- $ctx := deepCopy (.Defaults | default dict) -}}
+{{- range $layer := list (.Base | default dict) (.Override | default dict) -}}
+{{- range $key, $value := $layer -}}
+{{- if kindIs "invalid" $value -}}
+{{- $_ := unset $ctx $key -}}
+{{- else -}}
+{{- $_ := set $ctx $key $value -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if $ctx -}}
+securityContext:
+{{ toYaml $ctx | indent 2 -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+  Pod-level securityContext, defaulting to the Kubernetes Pod Security Standards
+  "Baseline" profile.
+  Usage: {{- include "odigos.podSecurityContext" (dict "Values" .Values "Component" "redis") | nindent 6 }}
+*/}}
+{{- define "odigos.podSecurityContext" -}}
+{{- $components := .Values.securityContext.components | default dict -}}
+{{- include "odigos.renderSecurityContext" (dict "Defaults" .Values.securityContext.pod "Base" .Base "Override" (dig .Component "pod" dict $components)) -}}
+{{- end -}}
+
+{{/*
+  Container-level securityContext counterpart of "odigos.podSecurityContext".
+  Usage: {{- include "odigos.containerSecurityContext" (dict "Values" .Values "Component" "redis") | nindent 10 }}
+*/}}
+{{- define "odigos.containerSecurityContext" -}}
+{{- $components := .Values.securityContext.components | default dict -}}
+{{- include "odigos.renderSecurityContext" (dict "Defaults" .Values.securityContext.container "Base" .Base "Override" (dig .Component "container" dict $components)) -}}
+{{- end -}}
+
 {{/* Cloud connectors are installed only when the install secret exists AND the feature is enabled. */}}
 {{- define "connectors.enabled" -}}
   {{- if and (include "odigos.secretExists" .) .Values.cloudConnectors.enabled -}}

--- a/helm/odigos-central/templates/centralbackend/deployment.yaml
+++ b/helm/odigos-central/templates/centralbackend/deployment.yaml
@@ -88,6 +88,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 3
             timeoutSeconds: 3
+          {{- include "odigos.containerSecurityContext" (dict "Values" .Values "Component" "centralBackend") | nindent 10 }}
           resources:
             requests:
               cpu: {{ .Values.centralBackend.resources.requests.cpu }}
@@ -95,6 +96,7 @@ spec:
             limits:
               cpu: {{ .Values.centralBackend.resources.limits.cpu }}
               memory: {{ .Values.centralBackend.resources.limits.memory }}
+      {{- include "odigos.podSecurityContext" (dict "Values" .Values "Component" "centralBackend") | nindent 6 }}
       {{- with .Values.centralBackend.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/helm/odigos-central/templates/centralui/deployment.yaml
+++ b/helm/odigos-central/templates/centralui/deployment.yaml
@@ -56,6 +56,7 @@ spec:
                   fieldPath: metadata.namespace
             - name: CENTRAL_BACKEND_URL
               value: {{ .Values.centralUI.centralBackendURL | default (printf "http://central-backend.%s:8081" .Release.Namespace) | quote }}
+          {{- include "odigos.containerSecurityContext" (dict "Values" .Values "Component" "centralUI") | nindent 10 }}
           resources:
             requests:
               cpu: {{ .Values.centralUI.resources.requests.cpu }}
@@ -63,6 +64,7 @@ spec:
             limits:
               cpu: {{ .Values.centralUI.resources.limits.cpu }}
               memory: {{ .Values.centralUI.resources.limits.memory }}
+      {{- include "odigos.podSecurityContext" (dict "Values" .Values "Component" "centralUI") | nindent 6 }}
       {{- with .Values.centralUI.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/helm/odigos-central/templates/connectors/connector-runtime-deployment.yaml
+++ b/helm/odigos-central/templates/connectors/connector-runtime-deployment.yaml
@@ -76,8 +76,10 @@ spec:
               port: 8081
             initialDelaySeconds: 15
             periodSeconds: 20
+          {{- include "odigos.containerSecurityContext" (dict "Values" .Values "Component" "connectorRuntime") | nindent 10 }}
           {{- with .Values.cloudConnectors.connectorRuntime.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- include "odigos.podSecurityContext" (dict "Values" .Values "Component" "connectorRuntime") | nindent 6 }}
 {{- end }}

--- a/helm/odigos-central/templates/connectors/migration-job.yaml
+++ b/helm/odigos-central/templates/connectors/migration-job.yaml
@@ -32,4 +32,6 @@ spec:
                 secretKeyRef:
                   name: odigos-connector-postgres
                   key: dsn
+          {{- include "odigos.containerSecurityContext" (dict "Values" .Values "Component" "connectorMigrations") | nindent 10 }}
+      {{- include "odigos.podSecurityContext" (dict "Values" .Values "Component" "connectorMigrations") | nindent 6 }}
 {{- end }}

--- a/helm/odigos-central/templates/connectors/postgres.yaml
+++ b/helm/odigos-central/templates/connectors/postgres.yaml
@@ -53,10 +53,12 @@ spec:
               command: ["pg_isready", "-U", "{{ .Values.cloudConnectors.postgres.username }}", "-d", "{{ .Values.cloudConnectors.postgres.database }}"]
             initialDelaySeconds: 5
             periodSeconds: 10
+          {{- include "odigos.containerSecurityContext" (dict "Values" .Values "Component" "postgres") | nindent 10 }}
           {{- with .Values.cloudConnectors.postgres.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- include "odigos.podSecurityContext" (dict "Values" .Values "Component" "postgres") | nindent 6 }}
       volumes:
         - name: data
         {{- if .Values.cloudConnectors.postgres.persistence.enabled }}

--- a/helm/odigos-central/templates/keycloak/deployment.yaml
+++ b/helm/odigos-central/templates/keycloak/deployment.yaml
@@ -40,19 +40,21 @@ spec:
       affinity:
         {{- toYaml .Values.auth.affinity | nindent 8 }}
       {{- end }}
+      {{- $keycloakPodBase := dict }}
       {{- if and .Values.auth.persistence.enabled .Values.auth.podSecurityContext.enabled }}
-      securityContext:
-        fsGroup: {{ .Values.auth.podSecurityContext.fsGroup }}
+        {{- $_ := set $keycloakPodBase "fsGroup" .Values.auth.podSecurityContext.fsGroup }}
       {{- end }}
+      {{- include "odigos.podSecurityContext" (dict "Values" .Values "Component" "keycloak" "Base" $keycloakPodBase) | nindent 6 }}
       containers:
         - name: keycloak
           image: {{ .Values.auth.image | quote }}
           args: ["start", "--optimized", "--http-enabled=true"]
+          {{- $keycloakContainerBase := dict }}
           {{- if and .Values.auth.persistence.enabled .Values.auth.securityContext.enabled }}
-          securityContext:
-            runAsNonRoot: {{ .Values.auth.securityContext.runAsNonRoot }}
-            allowPrivilegeEscalation: {{ .Values.auth.securityContext.allowPrivilegeEscalation }}
+            {{- $_ := set $keycloakContainerBase "runAsNonRoot" .Values.auth.securityContext.runAsNonRoot }}
+            {{- $_ := set $keycloakContainerBase "allowPrivilegeEscalation" .Values.auth.securityContext.allowPrivilegeEscalation }}
           {{- end }}
+          {{- include "odigos.containerSecurityContext" (dict "Values" .Values "Component" "keycloak" "Base" $keycloakContainerBase) | nindent 10 }}
           env:
             - name: JAVA_OPTS
               value: "{{ .Values.auth.javaOpts }}"

--- a/helm/odigos-central/templates/redis/redis.yaml
+++ b/helm/odigos-central/templates/redis/redis.yaml
@@ -62,6 +62,7 @@ spec:
           ports:
             - containerPort: {{ .Values.redis.port }}
               name: {{ .Values.redis.portName }}
+          {{- include "odigos.containerSecurityContext" (dict "Values" .Values "Component" "redis") | nindent 10 }}
           {{- if .Values.redis.livenessProbe.enabled }}
           livenessProbe:
             exec:
@@ -86,4 +87,5 @@ spec:
           resources:
             {{- toYaml .Values.redis.resources | nindent 12 }}
           {{- end }}
+      {{- include "odigos.podSecurityContext" (dict "Values" .Values "Component" "redis") | nindent 6 }}
 {{- end }}

--- a/helm/odigos-central/values.yaml
+++ b/helm/odigos-central/values.yaml
@@ -295,6 +295,45 @@ cloudConnectors:
     tolerations: []
     affinity: {}
 
+# Pod Security Standards "Baseline" settings applied to every pod in this chart.
+# `pod` is rendered as the pod-level securityContext, `container` as the container-level
+# securityContext of every container in those pods. These controls do not constrain which
+# user a container runs as: each image keeps its own default user.
+securityContext:
+  pod:
+    seccompProfile:
+      type: RuntimeDefault
+  container:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+  # Per-component overrides, keyed by component name: centralBackend, centralUI, redis,
+  # keycloak, connectorRuntime, connectorMigrations, postgres. Each key set under a
+  # component replaces that key in the defaults above, for that component only, and
+  # setting a key to null drops it.
+  #
+  # The three components below are exempted from the capability drop. Each runs a
+  # third-party image as root, and root without CAP_DAC_OVERRIDE/CAP_CHOWN/CAP_SETUID
+  # cannot complete the startup work these images do.
+  components:
+    # redis-server runs as root (the image sets no USER) with its working directory /data
+    # owned by uid 999 mode 0755, so writing the RDB snapshot needs CAP_DAC_OVERRIDE.
+    # Without it Redis fails BGSAVE and, with stop-writes-on-bgsave-error, rejects writes.
+    redis:
+      container:
+        capabilities: null
+    # The postgres entrypoint runs as root and chowns/chmods PGDATA before dropping to the
+    # postgres user via gosu: that needs CAP_CHOWN, CAP_FOWNER, CAP_SETUID and CAP_SETGID.
+    postgres:
+      container:
+        capabilities: null
+    # Same image as postgres, entered through run-migrations.sh. The script is built
+    # out-of-tree and could not be inspected, so it keeps the postgres exemption.
+    connectorMigrations:
+      container:
+        capabilities: null
+
 # OpenShift-specific toggles (RBAC/SELinux/images)
 openshift:
   enabled: false

--- a/helm/odigos/templates/_helpers.tpl
+++ b/helm/odigos/templates/_helpers.tpl
@@ -248,6 +248,49 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 
+{{/*
+  Renders a `securityContext:` block by layering three maps, later ones winning per key:
+  the chart-wide defaults, a template-supplied "Base" carrying securityContext keys the
+  template already set on its own, and the per-component override from values.
+  A key whose value is null is dropped, which is how a component opts out of a default.
+*/}}
+{{- define "odigos.renderSecurityContext" -}}
+{{- $ctx := deepCopy (.Defaults | default dict) -}}
+{{- range $layer := list (.Base | default dict) (.Override | default dict) -}}
+{{- range $key, $value := $layer -}}
+{{- if kindIs "invalid" $value -}}
+{{- $_ := unset $ctx $key -}}
+{{- else -}}
+{{- $_ := set $ctx $key $value -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if $ctx -}}
+securityContext:
+{{ toYaml $ctx | indent 2 -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+  Pod-level securityContext for the non-privileged Odigos components, defaulting to the
+  Kubernetes Pod Security Standards "Baseline" profile. The odiglet does not use this
+  helper: it is a privileged eBPF node agent that requires host namespaces and capabilities.
+  Usage: {{- include "odigos.podSecurityContext" (dict "Values" .Values "Component" "ui") | nindent 6 }}
+*/}}
+{{- define "odigos.podSecurityContext" -}}
+{{- $components := .Values.securityContext.components | default dict -}}
+{{- include "odigos.renderSecurityContext" (dict "Defaults" .Values.securityContext.pod "Base" .Base "Override" (dig .Component "pod" dict $components)) -}}
+{{- end -}}
+
+{{/*
+  Container-level securityContext counterpart of "odigos.podSecurityContext".
+  Usage: {{- include "odigos.containerSecurityContext" (dict "Values" .Values "Component" "ui") | nindent 8 }}
+*/}}
+{{- define "odigos.containerSecurityContext" -}}
+{{- $components := .Values.securityContext.components | default dict -}}
+{{- include "odigos.renderSecurityContext" (dict "Defaults" .Values.securityContext.container "Base" .Base "Override" (dig .Component "container" dict $components)) -}}
+{{- end -}}
+
 {{/* Returns true when trace correlations service I/O metrics are enabled. */}}
 {{- define "traceCorrelations.serviceIO.enabled" -}}
 {{- and .Values.traceCorrelations .Values.traceCorrelations.serviceIO .Values.traceCorrelations.serviceIO.enabled -}}

--- a/helm/odigos/templates/autoscaler/deployment.yaml
+++ b/helm/odigos/templates/autoscaler/deployment.yaml
@@ -96,10 +96,8 @@ spec:
             readOnly: true
         resources:
 {{ toYaml .Values.autoscaler.resources | indent 10 }}
-        securityContext:
-          allowPrivilegeEscalation: false
-      securityContext:
-        runAsNonRoot: true
+        {{- include "odigos.containerSecurityContext" (dict "Values" .Values "Component" "autoscaler") | nindent 8 }}
+      {{- include "odigos.podSecurityContext" (dict "Values" .Values "Component" "autoscaler" "Base" (dict "runAsNonRoot" true)) | nindent 6 }}
       serviceAccountName: odigos-autoscaler
       volumes:
         - name: autoscaler-webhooks-cert

--- a/helm/odigos/templates/centralproxy/deployment.yaml
+++ b/helm/odigos/templates/centralproxy/deployment.yaml
@@ -115,6 +115,7 @@ spec:
               readOnly: true
             {{- end }}
           {{- end }}
+          {{- include "odigos.containerSecurityContext" (dict "Values" .Values "Component" "centralProxy") | nindent 10 }}
           resources:
             requests:
               cpu: {{ .Values.centralProxy.resources.requests.cpu }}
@@ -143,6 +144,7 @@ spec:
             defaultMode: 420
         {{- end }}
       {{- end }}
+      {{- include "odigos.podSecurityContext" (dict "Values" .Values "Component" "centralProxy") | nindent 6 }}
 
 
 {{- end }}

--- a/helm/odigos/templates/cleanup/cleanup-job.yaml
+++ b/helm/odigos/templates/cleanup/cleanup-job.yaml
@@ -20,5 +20,7 @@ spec:
       - name: cleanup
         image: {{ template "utils.imageName" (dict "Values" .Values "Component" "cli" "Tag" $imageTag) }}
         args: ["cleanup", "--yes", "--instrumentation-only", "--namespace", "{{ .Release.Namespace }}"]
+        {{- include "odigos.containerSecurityContext" (dict "Values" .Values "Component" "cleanup") | nindent 8 }}
+      {{- include "odigos.podSecurityContext" (dict "Values" .Values "Component" "cleanup") | nindent 6 }}
       restartPolicy: Never
       {{ include "odigos.renderPullSecrets" . | nindent 6 }}

--- a/helm/odigos/templates/instrumentor/deployment.yaml
+++ b/helm/odigos/templates/instrumentor/deployment.yaml
@@ -134,10 +134,8 @@ spec:
         name: manager
         resources:
 {{ toYaml .Values.instrumentor.resources | indent 10 }}
-        securityContext:
-          allowPrivilegeEscalation: false
-      securityContext:
-        runAsNonRoot: true
+        {{- include "odigos.containerSecurityContext" (dict "Values" .Values "Component" "instrumentor") | nindent 8 }}
+      {{- include "odigos.podSecurityContext" (dict "Values" .Values "Component" "instrumentor" "Base" (dict "runAsNonRoot" true)) | nindent 6 }}
       serviceAccountName: odigos-instrumentor
       volumes:
         - name: instrumentor-webhooks-cert

--- a/helm/odigos/templates/metricsstore/deployment.yaml
+++ b/helm/odigos/templates/metricsstore/deployment.yaml
@@ -29,6 +29,7 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /vm-data
+        {{- include "odigos.containerSecurityContext" (dict "Values" .Values "Component" "metricsStore") | nindent 8 }}
         livenessProbe:
           httpGet:
             path: /health
@@ -48,6 +49,7 @@ spec:
           limits:
             cpu: 500m
             memory: 2Gi
+      {{- include "odigos.podSecurityContext" (dict "Values" .Values "Component" "metricsStore") | nindent 6 }}
       volumes:
       - name: data
         emptyDir: {}

--- a/helm/odigos/templates/scheduler/deployment.yaml
+++ b/helm/odigos/templates/scheduler/deployment.yaml
@@ -95,10 +95,8 @@ spec:
         name: manager
         resources:
 {{ toYaml .Values.scheduler.resources | indent 10 }}
-        securityContext:
-          allowPrivilegeEscalation: false
-      securityContext:
-        runAsNonRoot: true
+        {{- include "odigos.containerSecurityContext" (dict "Values" .Values "Component" "scheduler") | nindent 8 }}
+      {{- include "odigos.podSecurityContext" (dict "Values" .Values "Component" "scheduler" "Base" (dict "runAsNonRoot" true)) | nindent 6 }}
       serviceAccountName: odigos-scheduler
       terminationGracePeriodSeconds: 10
       {{ include "odigos.renderPullSecrets" . | nindent 6 }}

--- a/helm/odigos/templates/tracecorrelationsmetricsstore/deployment.yaml
+++ b/helm/odigos/templates/tracecorrelationsmetricsstore/deployment.yaml
@@ -29,6 +29,7 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /vm-data
+        {{- include "odigos.containerSecurityContext" (dict "Values" .Values "Component" "traceCorrelationsMetricsStore") | nindent 8 }}
         livenessProbe:
           httpGet:
             path: /health
@@ -48,6 +49,7 @@ spec:
           limits:
             cpu: 500m
             memory: 2Gi
+      {{- include "odigos.podSecurityContext" (dict "Values" .Values "Component" "traceCorrelationsMetricsStore") | nindent 6 }}
       volumes:
       - name: data
         emptyDir: {}

--- a/helm/odigos/templates/ui/deployment.yaml
+++ b/helm/odigos/templates/ui/deployment.yaml
@@ -95,13 +95,11 @@ spec:
           timeoutSeconds: 5
         resources:
 {{ toYaml .Values.ui.resources | indent 10 }}
-        securityContext:
-          allowPrivilegeEscalation: false
+        {{- include "odigos.containerSecurityContext" (dict "Values" .Values "Component" "ui") | nindent 8 }}
         volumeMounts:
           - name: ui-db-storage
             mountPath: /data
-      securityContext:
-        runAsNonRoot: true
+      {{- include "odigos.podSecurityContext" (dict "Values" .Values "Component" "ui" "Base" (dict "runAsNonRoot" true)) | nindent 6 }}
       serviceAccountName: odigos-ui
       terminationGracePeriodSeconds: 10
       volumes:

--- a/helm/odigos/values.schema.json
+++ b/helm/odigos/values.schema.json
@@ -2092,6 +2092,74 @@
       "required": [],
       "title": "scheduler"
     },
+    "securityContext": {
+      "additionalProperties": false,
+      "description": "Pod Security Standards \"Baseline\" settings applied to every Odigos pod except the\nodiglet, which is a privileged eBPF node agent and is intentionally excluded.\n`pod` is rendered as the pod-level securityContext, `container` as the container-level\nsecurityContext of every container in those pods. These controls do not constrain which\nuser a container runs as: each image keeps its own default user.",
+      "properties": {
+        "components": {
+          "additionalProperties": true,
+          "description": "Per-component overrides, keyed by component name: autoscaler, scheduler, instrumentor,\nui, centralProxy, cleanup, metricsStore, traceCorrelationsMetricsStore.\nEach key set under a component replaces that key in the defaults above, for that\ncomponent only, and setting a key to null drops it. Use the latter to exempt a\ncontainer whose entrypoint needs capabilities at startup, e.g.\n  components:\n    metricsStore:\n      container:\n        capabilities: null",
+          "required": [],
+          "title": "components"
+        },
+        "container": {
+          "additionalProperties": true,
+          "description": "Container-level securityContext applied to every container in those pods.",
+          "properties": {
+            "allowPrivilegeEscalation": {
+              "default": false,
+              "title": "allowPrivilegeEscalation",
+              "type": "boolean"
+            },
+            "capabilities": {
+              "additionalProperties": false,
+              "properties": {
+                "drop": {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "required": []
+                  },
+                  "title": "drop",
+                  "type": "array"
+                }
+              },
+              "required": [],
+              "title": "capabilities",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "container"
+        },
+        "pod": {
+          "additionalProperties": true,
+          "description": "Pod-level securityContext.",
+          "properties": {
+            "seccompProfile": {
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "default": "RuntimeDefault",
+                  "title": "type",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "seccompProfile",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "pod"
+        }
+      },
+      "required": [],
+      "title": "securityContext"
+    },
     "signals": {
       "description": "User should be specifying the signals they want to collect.",
       "items": {

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -1199,6 +1199,48 @@ psp:
   enabled: false
 
 # @schema
+# description: |-
+#   Pod Security Standards "Baseline" settings applied to every Odigos pod except the
+#   odiglet, which is a privileged eBPF node agent and is intentionally excluded.
+#   `pod` is rendered as the pod-level securityContext, `container` as the container-level
+#   securityContext of every container in those pods. These controls do not constrain which
+#   user a container runs as: each image keeps its own default user.
+# @schema
+securityContext:
+  # @schema
+  # description: Pod-level securityContext.
+  # additionalProperties: true
+  # @schema
+  pod:
+    seccompProfile:
+      type: RuntimeDefault
+
+  # @schema
+  # description: Container-level securityContext applied to every container in those pods.
+  # additionalProperties: true
+  # @schema
+  container:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+
+  # @schema
+  # description: |-
+  #   Per-component overrides, keyed by component name: autoscaler, scheduler, instrumentor,
+  #   ui, centralProxy, cleanup, metricsStore, traceCorrelationsMetricsStore.
+  #   Each key set under a component replaces that key in the defaults above, for that
+  #   component only, and setting a key to null drops it. Use the latter to exempt a
+  #   container whose entrypoint needs capabilities at startup, e.g.
+  #     components:
+  #       metricsStore:
+  #         container:
+  #           capabilities: null
+  # additionalProperties: true
+  # @schema
+  components: {}
+
+# @schema
 # description: Telemetry configuration for Odigos.
 # @schema
 telemetry:


### PR DESCRIPTION
## Summary

Every pod-producing workload in `helm/odigos` and `helm/odigos-central` **except the odiglet** now renders a `securityContext` defaulting to the Kubernetes [Pod Security Standards **Baseline**](https://kubernetes.io/docs/concepts/security/pod-security-standards/#baseline) profile, plus two safe extras:

- **Pod-level:** `seccompProfile: { type: RuntimeDefault }`
- **Container-level:** `allowPrivilegeEscalation: false` and `capabilities: { drop: ["ALL"] }`

Which user a container runs as is deliberately left to the image — this PR sets no `runAsUser`/`runAsGroup`/`fsGroup`, does not add `runAsNonRoot` anywhere it was not already set, and does not touch the root filesystem mode.

Before this change, the cleanup Job, central-proxy, both VictoriaMetrics stores, and everything in `odigos-central` except Keycloak had **no `securityContext` at all**, so they ran with the full default capability set and privilege escalation permitted.

### How it is wired

Each chart gets one `securityContext` values block plus two helpers in `_helpers.tpl`:

```yaml
securityContext:
  pod:
    seccompProfile: { type: RuntimeDefault }
  container:
    allowPrivilegeEscalation: false
    capabilities: { drop: ["ALL"] }
  components: {}   # per-component overrides
```

The helper layers three maps, later winning per key: **chart defaults → template base → per-component override**. Two properties matter for review:

- **Merging, not replacing.** Templates that already set `securityContext` keys pass them in as the base layer, so nothing pre-existing is dropped and no template ends up with two `securityContext:` keys. The autoscaler, scheduler, instrumentor and UI keep their pod-level `runAsNonRoot: true`, and Keycloak keeps its persistence-gated `fsGroup` / `runAsNonRoot` / `allowPrivilegeEscalation` exactly as `values.yaml` drives them today.
- **Null drops a key.** `capabilities: null` under a component is how a container opts out of the capability drop. The merge is key-presence based rather than `mergeOverwrite`, so a `false` override also takes effect (sprig's mergo-based merge treats `false` as empty and would silently discard it).

## Per-component matrix

Every row gets pod-level `seccompProfile: RuntimeDefault` and container-level `allowPrivilegeEscalation: false`. The last column is the only axis that varies.

### chart: `helm/odigos`

| Component | capabilities drop ALL | Pre-existing keys preserved |
|---|---|---|
| autoscaler | yes | pod `runAsNonRoot: true` |
| scheduler | yes | pod `runAsNonRoot: true` |
| instrumentor | yes | pod `runAsNonRoot: true` |
| ui | yes | pod `runAsNonRoot: true` |
| central-proxy | yes | — (had no securityContext) |
| cleanup Job | yes | — (had no securityContext) |
| metricsstore (VictoriaMetrics) | yes | — (had no securityContext) |
| tracecorrelations metricsstore | yes | — (had no securityContext) |
| **odiglet** | **excluded entirely** | unchanged |

### chart: `helm/odigos-central`

| Component | capabilities drop ALL | Pre-existing keys preserved |
|---|---|---|
| central-backend | yes | — |
| central-ui | yes | — |
| connector-runtime | yes | — |
| keycloak | yes | pod `fsGroup: 1000`, container `runAsNonRoot` + `allowPrivilegeEscalation`, all still gated on `auth.persistence.enabled` |
| **redis** | **exempt** | — |
| **connector postgres** | **exempt** | — |
| **connector migrations Job** | **exempt** | — |

## Capability-drop exemptions

Dropping all capabilities is only free for a process that needs none. Three containers run a third-party image whose startup work is capability-gated, and each keeps `seccompProfile: RuntimeDefault` and `allowPrivilegeEscalation: false`.

**redis** — The chart sets `command: ["redis-server"]` (`templates/redis/redis.yaml:46`), which **overrides the image ENTRYPOINT**, so `docker-entrypoint.sh` never runs and Redis is never dropped to the `redis` user by `gosu`. It therefore runs as **uid 0**, while `WORKDIR /data` is owned by `redis:redis` (999:999) at mode 0755 from the upstream image's `mkdir /data && chown redis:redis /data`. Root without `CAP_DAC_OVERRIDE` is subject to ordinary DAC checks and falls to the "other" bits (`r-x`), so the RDB write is denied. Started without a config file, `redis-server` still uses its built-in save points, so it attempts BGSAVE, and with the default `stop-writes-on-bgsave-error yes` a failed snapshot makes Redis **reject all writes**. This one is a live regression, not a theoretical one: today the container has no `securityContext`, so root keeps `CAP_DAC_OVERRIDE` and the write succeeds.

**connector postgres** — The template sets no `command`, so the image ENTRYPOINT runs. The standard PostgreSQL entrypoint starts as root, `chown`s and `chmod`s `PGDATA`, then `exec gosu postgres`. That sequence needs `CAP_CHOWN`, `CAP_FOWNER`, `CAP_SETUID` and `CAP_SETGID`; dropping them breaks startup outright.

**connector migrations Job** — Same image as postgres, entered through `command: ["run-migrations.sh"]`. The script is built out-of-tree and could not be inspected here, so it conservatively inherits the postgres exemption. This is the one exemption I would happily remove once someone can read the script; it is very likely safe to drop capabilities.

**Keycloak is deliberately not exempt.** It only sets `args`, so the image ENTRYPOINT (`kc.sh`) runs as the image's `USER 1000` — non-root, with no capability-gated startup work, and its HTTP port is 8080. Verified it renders correctly both with and without `auth.persistence.enabled`.

VictoriaMetrics also runs as root but needs no capabilities: its only writable target is the pre-existing `/vm-data` emptyDir, which kubelet creates world-writable.

## Odiglet and other privileged components

`helm/odigos/templates/odiglet/daemonset.yaml` is **not touched by this PR**. It is the privileged eBPF node agent needing `hostPID`, hostPath mounts and `privileged: true`. Its pod also carries the `data-collection` node collector and the `deviceplugin` container, so those are covered by the same exclusion. Rendered output confirms it is byte-identical to `main`:

```
### DaemonSet/odiglet
  pod.securityContext: null
  [init]:            {"privileged": true}
  [odiglet]:         {"privileged": true}
  [data-collection]: {"privileged": true}
  [deviceplugin]:    null
```

No other Helm-managed component needs node privileges — the GKE Autopilot integration is an `AllowlistSynchronizer` CR with no pod. Out of scope but worth a follow-up: the cluster gateway collector is built by the autoscaler in Go (`autoscaler/controllers/clustercollector/deployment.go`), not by Helm.

## Validation

```
$ helm lint helm/odigos helm/odigos-central
==> Linting helm/odigos

==> Linting helm/odigos-central

2 chart(s) linted, 0 chart(s) failed
```

Schema regenerated with `make helm-schema` and confirmed idempotent, so the `generate-schema` CI job passes.

Both charts rendered with every optional component enabled and validated against the Kubernetes API schemas:

```
$ kubeconform -summary -skip CustomResourceDefinition,AllowlistSynchronizer -ignore-missing-schemas \
    /tmp/r2-odigos.yaml /tmp/r2-central.yaml
Summary: 112 resources found in 2 files - Valid: 98, Invalid: 0, Errors: 0, Skipped: 14
```

Also renders cleanly with `openshift.enabled=true`, `gke.autopilot=true`, `psp.enabled=true`, and with connectors/persistence both on and off.

Rendered `securityContext`, `helm/odigos`:

```
odigos-autoscaler    pod {"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}
                     [manager] {"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}
odigos-scheduler     (same)
odigos-instrumentor  (same)
odigos-ui            (same)
central-proxy        pod {"seccompProfile":{"type":"RuntimeDefault"}}
                     [central-proxy] {"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}
odigos-victoriametrics       (same shape as central-proxy)
odigos-correlations-metrics  (same shape as central-proxy)
cleanup-job                  (same shape as central-proxy)
```

`helm/odigos-central` (with `auth.persistence.enabled=true` to exercise Keycloak's pre-existing keys):

```
central-backend     pod {"seccompProfile":{"type":"RuntimeDefault"}}
                    [central-backend] {"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}
central-ui          (same)
connector-runtime   (same)
keycloak            pod {"fsGroup":1000,"seccompProfile":{"type":"RuntimeDefault"}}
                    [keycloak] {"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true}
redis               [redis]      {"allowPrivilegeEscalation":false}     <-- cap-drop exempt
postgres            [postgres]   {"allowPrivilegeEscalation":false}     <-- cap-drop exempt
migrations Job      [migrations] {"allowPrivilegeEscalation":false}     <-- cap-drop exempt
```

With `auth.persistence.enabled` at its default of `false`, Keycloak renders `pod {"seccompProfile":...}` and `[keycloak] {"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}` — i.e. the pre-existing keys correctly stay gated.

## Not validated

Rendered and schema-validated, but **not installed against a live cluster**, and Docker was unavailable in this environment so the capability analysis rests on the upstream image definitions rather than an observed container run. The claims most worth confirming before this leaves draft are the three cap-drop exemptions (especially that Redis genuinely needs `CAP_DAC_OVERRIDE` given the overridden entrypoint) and that no enterprise image's entrypoint does capability-gated startup work of the same kind.
