### PR TITLE
feat: wire security and insights API into UI Kit

### DIFF
--- a/frontend/webapp/app/(v2)/insights/page.tsx
+++ b/frontend/webapp/app/(v2)/insights/page.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import React from 'react';
+import { Insights } from '@odigos/ui-kit/containers';
+
+export default function Page() {
+  return <Insights />;
+}

--- a/frontend/webapp/graphql/mutations/index.ts
+++ b/frontend/webapp/graphql/mutations/index.ts
@@ -6,5 +6,6 @@ export * from './instrumentation-rule';
 export * from './namespace';
 export * from './source';
 export * from './sampling';
+export * from './insights';
 export * from './profiling';
 export * from './token';

--- a/frontend/webapp/graphql/mutations/insights.ts
+++ b/frontend/webapp/graphql/mutations/insights.ts
@@ -1,0 +1,162 @@
+import { gql } from '@apollo/client';
+
+const POLICY_FIELDS = `
+  id
+  name
+  enabled
+  fireAtScore
+  signalWeights
+  enricherLists
+  scope
+  scopeKey
+`;
+
+const LEARNING_POLICY_FIELDS = `
+  class
+  mode
+  conditions {
+    type
+    minObservations
+    minDurationMinutes
+    stableObservations
+    stableMinutes
+  }
+  minMatches
+  scope
+  scopeKey
+`;
+
+const GUARDRAIL_FIELDS = `
+  scope
+  scopeKey
+  rules {
+    key
+    label
+    mode
+    allowlist
+  }
+`;
+
+const SYSTEM_SETTINGS_FIELDS = `
+  sampling {
+    examplesPerTransaction
+    exampleSampleIntervalSeconds
+  }
+  retention {
+    observationRetentionDays
+  }
+  findings {
+    defaultWindowHours
+    maxWindowHours
+  }
+  capacity {
+    maxResidentTransactions
+    maxBaselineSetMembers
+  }
+  writeback {
+    flushIntervalSeconds
+  }
+`;
+
+export const PROMOTE_INSIGHTS_BASELINE_CLASS = gql`
+  mutation PromoteInsightsBaselineClass($transactionId: ID!, $class: InsightsDeviationClass!) {
+    promoteInsightsBaselineClass(transactionId: $transactionId, class: $class) {
+      transactionId
+      class
+      promoted
+    }
+  }
+`;
+
+export const RESET_INSIGHTS_BASELINE_CLASS = gql`
+  mutation ResetInsightsBaselineClass($transactionId: ID!, $class: InsightsDeviationClass!) {
+    resetInsightsBaselineClass(transactionId: $transactionId, class: $class)
+  }
+`;
+
+export const RESET_INSIGHTS_TRANSACTION_BASELINES = gql`
+  mutation ResetInsightsTransactionBaselines($transactionId: ID!) {
+    resetInsightsTransactionBaselines(transactionId: $transactionId)
+  }
+`;
+
+export const UPSERT_INSIGHTS_POLICY = gql`
+  mutation UpsertInsightsPolicy($policy: InsightsPolicyInput!) {
+    upsertInsightsPolicy(policy: $policy) { ${POLICY_FIELDS} }
+  }
+`;
+
+export const DELETE_INSIGHTS_POLICY = gql`
+  mutation DeleteInsightsPolicy($scope: InsightsPolicyScope!, $scopeKey: String!) {
+    deleteInsightsPolicy(scope: $scope, scopeKey: $scopeKey)
+  }
+`;
+
+export const UPSERT_INSIGHTS_LEARNING_POLICY = gql`
+  mutation UpsertInsightsLearningPolicy($policy: InsightsLearningPolicyInput!) {
+    upsertInsightsLearningPolicy(policy: $policy) { ${LEARNING_POLICY_FIELDS} }
+  }
+`;
+
+export const DELETE_INSIGHTS_LEARNING_POLICY = gql`
+  mutation DeleteInsightsLearningPolicy($class: InsightsDeviationClass!, $scope: InsightsPolicyScope!, $scopeKey: String!) {
+    deleteInsightsLearningPolicy(class: $class, scope: $scope, scopeKey: $scopeKey)
+  }
+`;
+
+export const RESOLVE_INSIGHTS_ANOMALY = gql`
+  mutation ResolveInsightsAnomaly($transactionId: ID!, $signature: String!, $resolution: InsightsAnomalyResolution!) {
+    resolveInsightsAnomaly(transactionId: $transactionId, signature: $signature, resolution: $resolution)
+  }
+`;
+
+export const BULK_RESOLVE_INSIGHTS_ANOMALIES = gql`
+  mutation BulkResolveInsightsAnomalies($resolution: InsightsBulkResolution!, $items: [InsightsAnomalyRefInput!]!) {
+    bulkResolveInsightsAnomalies(resolution: $resolution, items: $items) {
+      resolution
+      resolved
+    }
+  }
+`;
+
+export const UPSERT_INSIGHTS_GUARDRAIL = gql`
+  mutation UpsertInsightsGuardrail($guardrail: InsightsGuardrailInput!) {
+    upsertInsightsGuardrail(guardrail: $guardrail) { ${GUARDRAIL_FIELDS} }
+  }
+`;
+
+export const DELETE_INSIGHTS_GUARDRAIL = gql`
+  mutation DeleteInsightsGuardrail($scopeKey: String!) {
+    deleteInsightsGuardrail(scopeKey: $scopeKey)
+  }
+`;
+
+export const SEED_INSIGHTS_GUARDRAIL = gql`
+  mutation SeedInsightsGuardrail($seed: InsightsGuardrailSeedInput!) {
+    seedInsightsGuardrail(seed: $seed)
+  }
+`;
+
+export const ALLOW_INSIGHTS_GUARDRAIL_VIOLATION = gql`
+  mutation AllowInsightsGuardrailViolation($action: InsightsViolationActionInput!) {
+    allowInsightsGuardrailViolation(action: $action)
+  }
+`;
+
+export const DISMISS_INSIGHTS_GUARDRAIL_VIOLATION = gql`
+  mutation DismissInsightsGuardrailViolation($action: InsightsViolationActionInput!) {
+    dismissInsightsGuardrailViolation(action: $action)
+  }
+`;
+
+export const REOPEN_INSIGHTS_GUARDRAIL_VIOLATION = gql`
+  mutation ReopenInsightsGuardrailViolation($action: InsightsViolationActionInput!) {
+    reopenInsightsGuardrailViolation(action: $action)
+  }
+`;
+
+export const UPDATE_INSIGHTS_SYSTEM_SETTINGS = gql`
+  mutation UpdateInsightsSystemSettings($settings: InsightsSystemSettingsInput!) {
+    updateInsightsSystemSettings(settings: $settings) { ${SYSTEM_SETTINGS_FIELDS} }
+  }
+`;

--- a/frontend/webapp/graphql/queries/config.ts
+++ b/frontend/webapp/graphql/queries/config.ts
@@ -11,6 +11,7 @@ export const GET_CONFIG = gql`
       installationStatus
       clusterName
       isCentralProxyRunning
+      insightsEnabled
     }
   }
 `;

--- a/frontend/webapp/graphql/queries/index.ts
+++ b/frontend/webapp/graphql/queries/index.ts
@@ -15,4 +15,5 @@ export * from './trace-correlations';
 export * from './source';
 export * from './tokens';
 export * from './sampling';
+export * from './insights';
 export * from './workload';

--- a/frontend/webapp/graphql/queries/insights.ts
+++ b/frontend/webapp/graphql/queries/insights.ts
@@ -1,0 +1,428 @@
+import { gql } from '@apollo/client';
+
+const SERVICE_STAT_FIELDS = `
+  namespace
+  service
+  transactionCount
+  volume
+  lastSeen
+`;
+
+const TRANSACTION_STAT_FIELDS = `
+  id
+  service
+  namespace
+  operation
+  kind
+  volume
+  lastSeen
+  hasBaseline
+  promoted
+`;
+
+const TRANSACTION_FIELDS = `
+  id
+  service
+  namespace
+  operation
+  kind
+`;
+
+const BASELINE_CLASS_FIELDS = `
+  transactionId
+  class
+  data
+  dataSchemaVersion
+  observationCount
+  promoted
+  learningStartedAt
+  lastChangedAt
+  observationCountAtLastChange
+`;
+
+const OBSERVATION_SUMMARY_FIELDS = `
+  traceId
+  transactionId
+  observedAt
+  durationMs
+  sampleReason
+`;
+
+const FINDING_FIELDS = `
+  kind
+  service
+  namespace
+  title
+  offending
+  score
+  severity
+  occurrences
+  lastSeen
+  status
+  transactionId
+  signature
+  scopeKey
+  ruleKey
+`;
+
+const ANOMALY_SUMMARY_FIELDS = `
+  transactionId
+  signature
+  service
+  namespace
+  operation
+  kind
+  triggeredClasses
+  offending
+  policyId
+  occurrences
+  maxScore
+  severity
+  firstSeen
+  lastSeen
+  lastTraceId
+  status
+`;
+
+const RISK_ASSESSMENT_FIELDS = `
+  score
+  severity
+  correlated
+  correlationBonus
+  fireAtScore
+  categories
+  signals {
+    source
+    category
+    weight
+    confidence
+    contribution
+    rationale
+    mitre
+    owasp
+  }
+`;
+
+const POLICY_FIELDS = `
+  id
+  name
+  enabled
+  fireAtScore
+  signalWeights
+  enricherLists
+  scope
+  scopeKey
+`;
+
+const LEARNING_POLICY_FIELDS = `
+  class
+  mode
+  conditions {
+    type
+    minObservations
+    minDurationMinutes
+    stableObservations
+    stableMinutes
+  }
+  minMatches
+  scope
+  scopeKey
+`;
+
+const GUARDRAIL_FIELDS = `
+  scope
+  scopeKey
+  rules {
+    key
+    label
+    mode
+    allowlist
+  }
+`;
+
+const GUARDRAIL_VIOLATION_FIELDS = `
+  service
+  namespace
+  scopeKey
+  ruleKey
+  ruleLabel
+  offending
+  occurrences
+  maxScore
+  severity
+  lastSeen
+  status
+`;
+
+const CATALOG_FIELDS = `
+  deviationClasses {
+    id
+    label
+    description
+    category
+    categoryLabel
+    weight
+    mitre
+    owasp
+  }
+  enrichers {
+    source
+    parentClass
+    category
+    weight
+    label
+    description
+    list {
+      key
+      label
+      hint
+      default
+    }
+  }
+  categories {
+    id
+    label
+    base
+    mitre
+    owasp
+  }
+  guardrailRules {
+    key
+    label
+    description
+    category
+    weight
+    hint
+  }
+  severityBands {
+    severity
+    minScore
+  }
+  correlationBonus
+  tags
+`;
+
+const SYSTEM_SETTINGS_FIELDS = `
+  sampling {
+    examplesPerTransaction
+    exampleSampleIntervalSeconds
+  }
+  retention {
+    observationRetentionDays
+  }
+  findings {
+    defaultWindowHours
+    maxWindowHours
+  }
+  capacity {
+    maxResidentTransactions
+    maxBaselineSetMembers
+  }
+  writeback {
+    flushIntervalSeconds
+  }
+`;
+
+const STORAGE_HEALTH_FIELDS = `
+  checkedAt
+  status
+  connection {
+    reachable
+    pingLatencyMs
+    version
+    database
+    error
+  }
+  disk {
+    insightsBytes
+    totalBytes
+    usedBytes
+    availableBytes
+    usedPercent
+    status
+  }
+  memory {
+    processRssBytes
+    cgroupUsedBytes
+    cgroupTotalBytes
+    uptimeSeconds
+  }
+  queries {
+    active
+    longestSeconds
+    peakMemoryBytes
+    items {
+      elapsedSeconds
+      user
+      memoryBytes
+      query
+      finishedAt
+    }
+    recentHeaviest {
+      elapsedSeconds
+      user
+      memoryBytes
+      query
+      finishedAt
+    }
+    recentLatest {
+      elapsedSeconds
+      user
+      memoryBytes
+      query
+      finishedAt
+    }
+  }
+  tables {
+    name
+    rows
+    bytesOnDisk
+    activeParts
+  }
+  writePressure {
+    unfinishedMutations
+    activeParts
+  }
+  writeback {
+    flushIntervalSeconds
+    everFlushed
+    lastFlushOk
+    lastFlushAt
+    lastFlushError
+  }
+`;
+
+export const GET_INSIGHTS_SERVICES = gql`
+  query GetInsightsServices {
+    insights {
+      services { ${SERVICE_STAT_FIELDS} }
+    }
+  }
+`;
+
+export const GET_INSIGHTS_TRANSACTIONS = gql`
+  query GetInsightsTransactions($namespace: String, $service: String, $kind: InsightsTransactionKind) {
+    insights {
+      transactions(namespace: $namespace, service: $service, kind: $kind) { ${TRANSACTION_STAT_FIELDS} }
+    }
+  }
+`;
+
+export const GET_INSIGHTS_TRANSACTION = gql`
+  query GetInsightsTransaction($id: ID!) {
+    insights {
+      transaction(id: $id) { ${TRANSACTION_FIELDS} }
+    }
+  }
+`;
+
+export const GET_INSIGHTS_BASELINE = gql`
+  query GetInsightsBaseline($transactionId: ID!) {
+    insights {
+      baseline(transactionId: $transactionId) { ${BASELINE_CLASS_FIELDS} }
+    }
+  }
+`;
+
+export const GET_INSIGHTS_OBSERVATIONS = gql`
+  query GetInsightsObservations($transactionId: ID!, $sampleReason: InsightsSampleReason) {
+    insights {
+      observations(transactionId: $transactionId, sampleReason: $sampleReason) { ${OBSERVATION_SUMMARY_FIELDS} }
+    }
+  }
+`;
+
+export const GET_INSIGHTS_OBSERVATION = gql`
+  query GetInsightsObservation($transactionId: ID!, $traceId: String!) {
+    insights {
+      observation(transactionId: $transactionId, traceId: $traceId) {
+        ${OBSERVATION_SUMMARY_FIELDS}
+        rawOtlp
+      }
+    }
+  }
+`;
+
+export const GET_INSIGHTS_FINDINGS = gql`
+  query GetInsightsFindings($windowHours: Int, $service: String, $namespace: String, $status: String, $kind: InsightsFindingKind) {
+    insights {
+      findings(windowHours: $windowHours, service: $service, namespace: $namespace, status: $status, kind: $kind) { ${FINDING_FIELDS} }
+    }
+  }
+`;
+
+export const GET_INSIGHTS_ANOMALIES = gql`
+  query GetInsightsAnomalies($windowHours: Int, $service: String, $namespace: String, $status: String) {
+    insights {
+      anomalies(windowHours: $windowHours, service: $service, namespace: $namespace, status: $status) { ${ANOMALY_SUMMARY_FIELDS} }
+    }
+  }
+`;
+
+export const GET_INSIGHTS_ANOMALY = gql`
+  query GetInsightsAnomaly($transactionId: ID!, $signature: String!) {
+    insights {
+      anomaly(transactionId: $transactionId, signature: $signature) {
+        ${ANOMALY_SUMMARY_FIELDS}
+        evidence
+        risk { ${RISK_ASSESSMENT_FIELDS} }
+      }
+    }
+  }
+`;
+
+export const GET_INSIGHTS_POLICIES = gql`
+  query GetInsightsPolicies {
+    insights {
+      policies { ${POLICY_FIELDS} }
+    }
+  }
+`;
+
+export const GET_INSIGHTS_LEARNING_POLICIES = gql`
+  query GetInsightsLearningPolicies {
+    insights {
+      learningPolicies { ${LEARNING_POLICY_FIELDS} }
+    }
+  }
+`;
+
+export const GET_INSIGHTS_GUARDRAILS = gql`
+  query GetInsightsGuardrails {
+    insights {
+      guardrails { ${GUARDRAIL_FIELDS} }
+    }
+  }
+`;
+
+export const GET_INSIGHTS_GUARDRAIL_VIOLATIONS = gql`
+  query GetInsightsGuardrailViolations($windowHours: Int, $service: String, $namespace: String, $status: String) {
+    insights {
+      guardrailViolations(windowHours: $windowHours, service: $service, namespace: $namespace, status: $status) { ${GUARDRAIL_VIOLATION_FIELDS} }
+    }
+  }
+`;
+
+export const GET_INSIGHTS_CATALOG = gql`
+  query GetInsightsCatalog {
+    insights {
+      catalog { ${CATALOG_FIELDS} }
+    }
+  }
+`;
+
+export const GET_INSIGHTS_SYSTEM_SETTINGS = gql`
+  query GetInsightsSystemSettings {
+    insights {
+      systemSettings { ${SYSTEM_SETTINGS_FIELDS} }
+    }
+  }
+`;
+
+export const GET_INSIGHTS_STORAGE_HEALTH = gql`
+  query GetInsightsStorageHealth {
+    insights {
+      storageHealth { ${STORAGE_HEALTH_FIELDS} }
+    }
+  }
+`;

--- a/frontend/webapp/lib/odigos-api-adapter.tsx
+++ b/frontend/webapp/lib/odigos-api-adapter.tsx
@@ -17,10 +17,10 @@
  */
 
 import React, { type FC, type PropsWithChildren, useCallback, useEffect, useMemo, useState } from 'react';
-import { normalizeActionForWire, parseRenamesString } from './action-form-normalization';
 import { useConfig, useCSRF } from '@/hooks';
-import { API, INITIAL_CONTEXT, IS_LOCAL, toPlatformType } from '@/utils';
 import { CenterThis, Loader } from '@odigos/ui-kit/components';
+import { API, INITIAL_CONTEXT, IS_LOCAL, toPlatformType } from '@/utils';
+import { normalizeActionForWire, parseRenamesString } from './action-form-normalization';
 import {
   OdigosApiProvider,
   type CreateDestinationResult,
@@ -41,6 +41,24 @@ import type {
   ExtendedPodInfo,
   FetchedConfig,
   GatewayInfo,
+  InsightsAnomalyIssue,
+  InsightsAnomalySummary,
+  InsightsBaselineClass,
+  InsightsBulkResolveResult,
+  InsightsCatalog,
+  InsightsFinding,
+  InsightsGuardrail,
+  InsightsGuardrailViolation,
+  InsightsLearningPolicy,
+  InsightsObservation,
+  InsightsObservationSummary,
+  InsightsPolicy,
+  InsightsPromoteResult,
+  InsightsServiceStat,
+  InsightsStorageHealth,
+  InsightsSystemSettings,
+  InsightsTransaction,
+  InsightsTransactionStat,
   Namespace,
   NodeCollectoInfo,
   PodInfo,
@@ -84,6 +102,22 @@ import {
   GET_NODE_COLLECTOR_INFO,
   GET_NODE_COLLECTOR_PODS,
   GET_COLLECTOR_POD_INFO,
+  GET_INSIGHTS_SERVICES,
+  GET_INSIGHTS_TRANSACTIONS,
+  GET_INSIGHTS_TRANSACTION,
+  GET_INSIGHTS_BASELINE,
+  GET_INSIGHTS_OBSERVATIONS,
+  GET_INSIGHTS_OBSERVATION,
+  GET_INSIGHTS_FINDINGS,
+  GET_INSIGHTS_ANOMALIES,
+  GET_INSIGHTS_ANOMALY,
+  GET_INSIGHTS_POLICIES,
+  GET_INSIGHTS_LEARNING_POLICIES,
+  GET_INSIGHTS_GUARDRAILS,
+  GET_INSIGHTS_GUARDRAIL_VIOLATIONS,
+  GET_INSIGHTS_CATALOG,
+  GET_INSIGHTS_SYSTEM_SETTINGS,
+  GET_INSIGHTS_STORAGE_HEALTH,
   DESCRIBE_ODIGOS,
   DESCRIBE_SOURCE,
   DOWNLOAD_DIAGNOSE,
@@ -120,6 +154,22 @@ import {
   UPDATE_LOCAL_UI_CONFIG,
   UPDATE_LOCAL_UI_SAMPLING_CONFIG,
   UPDATE_NOISY_OPERATION_RULE,
+  PROMOTE_INSIGHTS_BASELINE_CLASS,
+  RESET_INSIGHTS_BASELINE_CLASS,
+  RESET_INSIGHTS_TRANSACTION_BASELINES,
+  UPSERT_INSIGHTS_POLICY,
+  DELETE_INSIGHTS_POLICY,
+  UPSERT_INSIGHTS_LEARNING_POLICY,
+  DELETE_INSIGHTS_LEARNING_POLICY,
+  RESOLVE_INSIGHTS_ANOMALY,
+  BULK_RESOLVE_INSIGHTS_ANOMALIES,
+  UPSERT_INSIGHTS_GUARDRAIL,
+  DELETE_INSIGHTS_GUARDRAIL,
+  SEED_INSIGHTS_GUARDRAIL,
+  ALLOW_INSIGHTS_GUARDRAIL_VIOLATION,
+  DISMISS_INSIGHTS_GUARDRAIL_VIOLATION,
+  REOPEN_INSIGHTS_GUARDRAIL_VIOLATION,
+  UPDATE_INSIGHTS_SYSTEM_SETTINGS,
 } from '@/graphql';
 
 // The CREATE_DATA_STREAM op is intentionally absent: the standalone backend
@@ -399,6 +449,137 @@ const operations: OdigosApiOperations = {
   UPDATE_COST_REDUCTION_RULE: { document: UPDATE_COST_REDUCTION_RULE },
   DELETE_COST_REDUCTION_RULE: { document: DELETE_COST_REDUCTION_RULE },
   UPDATE_LOCAL_UI_SAMPLING_CONFIG: { document: UPDATE_LOCAL_UI_SAMPLING_CONFIG },
+
+  // insights (security) — wire nests under `insights { … }`; kit slots are bare.
+  GET_INSIGHTS_SERVICES: {
+    document: GET_INSIGHTS_SERVICES,
+    transformResult: (raw: unknown) => (raw as { insights?: { services?: InsightsServiceStat[] } } | null | undefined)?.insights?.services ?? [],
+  },
+  GET_INSIGHTS_TRANSACTIONS: {
+    document: GET_INSIGHTS_TRANSACTIONS,
+    transformResult: (raw: unknown) => (raw as { insights?: { transactions?: InsightsTransactionStat[] } } | null | undefined)?.insights?.transactions ?? [],
+  },
+  GET_INSIGHTS_TRANSACTION: {
+    document: GET_INSIGHTS_TRANSACTION,
+    transformResult: (raw: unknown) => (raw as { insights?: { transaction?: InsightsTransaction } } | null | undefined)?.insights?.transaction,
+  },
+  GET_INSIGHTS_BASELINE: {
+    document: GET_INSIGHTS_BASELINE,
+    transformResult: (raw: unknown) => (raw as { insights?: { baseline?: InsightsBaselineClass[] } } | null | undefined)?.insights?.baseline ?? [],
+  },
+  GET_INSIGHTS_OBSERVATIONS: {
+    document: GET_INSIGHTS_OBSERVATIONS,
+    transformResult: (raw: unknown) => (raw as { insights?: { observations?: InsightsObservationSummary[] } } | null | undefined)?.insights?.observations ?? [],
+  },
+  GET_INSIGHTS_OBSERVATION: {
+    document: GET_INSIGHTS_OBSERVATION,
+    transformResult: (raw: unknown) => (raw as { insights?: { observation?: InsightsObservation } } | null | undefined)?.insights?.observation,
+  },
+  GET_INSIGHTS_FINDINGS: {
+    document: GET_INSIGHTS_FINDINGS,
+    transformResult: (raw: unknown) => (raw as { insights?: { findings?: InsightsFinding[] } } | null | undefined)?.insights?.findings ?? [],
+  },
+  GET_INSIGHTS_ANOMALIES: {
+    document: GET_INSIGHTS_ANOMALIES,
+    transformResult: (raw: unknown) => (raw as { insights?: { anomalies?: InsightsAnomalySummary[] } } | null | undefined)?.insights?.anomalies ?? [],
+  },
+  GET_INSIGHTS_ANOMALY: {
+    document: GET_INSIGHTS_ANOMALY,
+    transformResult: (raw: unknown) => (raw as { insights?: { anomaly?: InsightsAnomalyIssue } } | null | undefined)?.insights?.anomaly,
+  },
+  GET_INSIGHTS_POLICIES: {
+    document: GET_INSIGHTS_POLICIES,
+    transformResult: (raw: unknown) => (raw as { insights?: { policies?: InsightsPolicy[] } } | null | undefined)?.insights?.policies ?? [],
+  },
+  GET_INSIGHTS_LEARNING_POLICIES: {
+    document: GET_INSIGHTS_LEARNING_POLICIES,
+    transformResult: (raw: unknown) => (raw as { insights?: { learningPolicies?: InsightsLearningPolicy[] } } | null | undefined)?.insights?.learningPolicies ?? [],
+  },
+  GET_INSIGHTS_GUARDRAILS: {
+    document: GET_INSIGHTS_GUARDRAILS,
+    transformResult: (raw: unknown) => (raw as { insights?: { guardrails?: InsightsGuardrail[] } } | null | undefined)?.insights?.guardrails ?? [],
+  },
+  GET_INSIGHTS_GUARDRAIL_VIOLATIONS: {
+    document: GET_INSIGHTS_GUARDRAIL_VIOLATIONS,
+    transformResult: (raw: unknown) => (raw as { insights?: { guardrailViolations?: InsightsGuardrailViolation[] } } | null | undefined)?.insights?.guardrailViolations ?? [],
+  },
+  GET_INSIGHTS_CATALOG: {
+    document: GET_INSIGHTS_CATALOG,
+    transformResult: (raw: unknown) => (raw as { insights?: { catalog?: InsightsCatalog } } | null | undefined)?.insights?.catalog,
+  },
+  GET_INSIGHTS_SYSTEM_SETTINGS: {
+    document: GET_INSIGHTS_SYSTEM_SETTINGS,
+    transformResult: (raw: unknown) => (raw as { insights?: { systemSettings?: InsightsSystemSettings } } | null | undefined)?.insights?.systemSettings,
+  },
+  GET_INSIGHTS_STORAGE_HEALTH: {
+    document: GET_INSIGHTS_STORAGE_HEALTH,
+    transformResult: (raw: unknown) => (raw as { insights?: { storageHealth?: InsightsStorageHealth } } | null | undefined)?.insights?.storageHealth,
+  },
+
+  PROMOTE_INSIGHTS_BASELINE_CLASS: {
+    document: PROMOTE_INSIGHTS_BASELINE_CLASS,
+    transformResult: (raw: unknown) => (raw as { promoteInsightsBaselineClass?: InsightsPromoteResult } | null | undefined)?.promoteInsightsBaselineClass,
+  },
+  RESET_INSIGHTS_BASELINE_CLASS: {
+    document: RESET_INSIGHTS_BASELINE_CLASS,
+    transformResult: (raw: unknown) => (raw as { resetInsightsBaselineClass?: boolean } | null | undefined)?.resetInsightsBaselineClass ?? false,
+  },
+  RESET_INSIGHTS_TRANSACTION_BASELINES: {
+    document: RESET_INSIGHTS_TRANSACTION_BASELINES,
+    transformResult: (raw: unknown) => (raw as { resetInsightsTransactionBaselines?: boolean } | null | undefined)?.resetInsightsTransactionBaselines ?? false,
+  },
+  UPSERT_INSIGHTS_POLICY: {
+    document: UPSERT_INSIGHTS_POLICY,
+    transformResult: (raw: unknown) => (raw as { upsertInsightsPolicy?: InsightsPolicy } | null | undefined)?.upsertInsightsPolicy,
+  },
+  DELETE_INSIGHTS_POLICY: {
+    document: DELETE_INSIGHTS_POLICY,
+    transformResult: (raw: unknown) => (raw as { deleteInsightsPolicy?: boolean } | null | undefined)?.deleteInsightsPolicy ?? false,
+  },
+  UPSERT_INSIGHTS_LEARNING_POLICY: {
+    document: UPSERT_INSIGHTS_LEARNING_POLICY,
+    transformResult: (raw: unknown) => (raw as { upsertInsightsLearningPolicy?: InsightsLearningPolicy } | null | undefined)?.upsertInsightsLearningPolicy,
+  },
+  DELETE_INSIGHTS_LEARNING_POLICY: {
+    document: DELETE_INSIGHTS_LEARNING_POLICY,
+    transformResult: (raw: unknown) => (raw as { deleteInsightsLearningPolicy?: boolean } | null | undefined)?.deleteInsightsLearningPolicy ?? false,
+  },
+  RESOLVE_INSIGHTS_ANOMALY: {
+    document: RESOLVE_INSIGHTS_ANOMALY,
+    transformResult: (raw: unknown) => (raw as { resolveInsightsAnomaly?: boolean } | null | undefined)?.resolveInsightsAnomaly ?? false,
+  },
+  BULK_RESOLVE_INSIGHTS_ANOMALIES: {
+    document: BULK_RESOLVE_INSIGHTS_ANOMALIES,
+    transformResult: (raw: unknown) => (raw as { bulkResolveInsightsAnomalies?: InsightsBulkResolveResult } | null | undefined)?.bulkResolveInsightsAnomalies,
+  },
+  UPSERT_INSIGHTS_GUARDRAIL: {
+    document: UPSERT_INSIGHTS_GUARDRAIL,
+    transformResult: (raw: unknown) => (raw as { upsertInsightsGuardrail?: InsightsGuardrail } | null | undefined)?.upsertInsightsGuardrail,
+  },
+  DELETE_INSIGHTS_GUARDRAIL: {
+    document: DELETE_INSIGHTS_GUARDRAIL,
+    transformResult: (raw: unknown) => (raw as { deleteInsightsGuardrail?: boolean } | null | undefined)?.deleteInsightsGuardrail ?? false,
+  },
+  SEED_INSIGHTS_GUARDRAIL: {
+    document: SEED_INSIGHTS_GUARDRAIL,
+    transformResult: (raw: unknown) => (raw as { seedInsightsGuardrail?: boolean } | null | undefined)?.seedInsightsGuardrail ?? false,
+  },
+  ALLOW_INSIGHTS_GUARDRAIL_VIOLATION: {
+    document: ALLOW_INSIGHTS_GUARDRAIL_VIOLATION,
+    transformResult: (raw: unknown) => (raw as { allowInsightsGuardrailViolation?: boolean } | null | undefined)?.allowInsightsGuardrailViolation ?? false,
+  },
+  DISMISS_INSIGHTS_GUARDRAIL_VIOLATION: {
+    document: DISMISS_INSIGHTS_GUARDRAIL_VIOLATION,
+    transformResult: (raw: unknown) => (raw as { dismissInsightsGuardrailViolation?: boolean } | null | undefined)?.dismissInsightsGuardrailViolation ?? false,
+  },
+  REOPEN_INSIGHTS_GUARDRAIL_VIOLATION: {
+    document: REOPEN_INSIGHTS_GUARDRAIL_VIOLATION,
+    transformResult: (raw: unknown) => (raw as { reopenInsightsGuardrailViolation?: boolean } | null | undefined)?.reopenInsightsGuardrailViolation ?? false,
+  },
+  UPDATE_INSIGHTS_SYSTEM_SETTINGS: {
+    document: UPDATE_INSIGHTS_SYSTEM_SETTINGS,
+    transformResult: (raw: unknown) => (raw as { updateInsightsSystemSettings?: InsightsSystemSettings } | null | undefined)?.updateInsightsSystemSettings,
+  },
 };
 
 type AdapterProps = PropsWithChildren;

--- a/frontend/webapp/utils/constants/routes.tsx
+++ b/frontend/webapp/utils/constants/routes.tsx
@@ -7,7 +7,7 @@ export const ROUTES = {
   SETTINGS: '/settings',
   SAMPLING: '/sampling',
   TRACE_CORRELATIONS: '/trace-correlations',
-  SECURITY: '/security',
+  INSIGHTS: '/insights',
 
   // legacy routes
   CHOOSE_STREAM: '/choose-stream',

--- a/frontend/webapp/utils/constants/routes.tsx
+++ b/frontend/webapp/utils/constants/routes.tsx
@@ -7,6 +7,7 @@ export const ROUTES = {
   SETTINGS: '/settings',
   SAMPLING: '/sampling',
   TRACE_CORRELATIONS: '/trace-correlations',
+  SECURITY: '/security',
 
   // legacy routes
   CHOOSE_STREAM: '/choose-stream',

--- a/frontend/webapp/utils/functions/navigation.ts
+++ b/frontend/webapp/utils/functions/navigation.ts
@@ -21,7 +21,7 @@ export const getNavbarIcons = (router: AppRouterInstance, currentPath: string) =
     getPayloadForIcon(router, currentPath, ROUTES.PIPELINE_COLLECTORS, 'Collectors Pipeline', PipelineCollectorIcon),
     getPayloadForIcon(router, currentPath, ROUTES.SAMPLING, 'Sampling Rules', SamplingIcon),
     getPayloadForIcon(router, currentPath, ROUTES.SETTINGS, 'Settings', SettingsIcon),
-    getPayloadForIcon(router, currentPath, ROUTES.SECURITY, 'Security', SecurityIcon),
+    getPayloadForIcon(router, currentPath, ROUTES.INSIGHTS, 'Insights', SecurityIcon),
   ];
 
   return navIcons;

--- a/frontend/webapp/utils/functions/navigation.ts
+++ b/frontend/webapp/utils/functions/navigation.ts
@@ -2,7 +2,7 @@ import { ROUTES } from '../constants';
 import { SVG } from '@odigos/ui-kit/types';
 import { NavbarProps } from '@odigos/ui-kit/components';
 import { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
-import { OverviewIcon, PipelineCollectorIcon, SamplingIcon, ServiceMapIcon, SettingsIcon } from '@odigos/ui-kit/icons';
+import { OverviewIcon, PipelineCollectorIcon, SamplingIcon, ServiceMapIcon, SecurityIcon, SettingsIcon } from '@odigos/ui-kit/icons';
 
 const getPayloadForIcon = (router: AppRouterInstance, currentPath: string, targetPath: string, label: string, icon: SVG): NavbarProps['icons'][number] => {
   return {
@@ -21,6 +21,7 @@ export const getNavbarIcons = (router: AppRouterInstance, currentPath: string) =
     getPayloadForIcon(router, currentPath, ROUTES.PIPELINE_COLLECTORS, 'Collectors Pipeline', PipelineCollectorIcon),
     getPayloadForIcon(router, currentPath, ROUTES.SAMPLING, 'Sampling Rules', SamplingIcon),
     getPayloadForIcon(router, currentPath, ROUTES.SETTINGS, 'Settings', SettingsIcon),
+    getPayloadForIcon(router, currentPath, ROUTES.SECURITY, 'Security', SecurityIcon),
   ];
 
   return navIcons;


### PR DESCRIPTION
This PR requires a UI Kit release with: https://github.com/odigos-io/ui-kit/pull/1174

This commit introduces new GraphQL queries and mutations for the Insights feature, including operations for managing policies, anomalies, and guardrails. It also updates the GraphQL configuration to include an `insightsEnabled` flag, allowing the UI to conditionally display insights-related features. Additionally, the navigation and routing have been updated to incorporate a new Security section.

- Added insights queries: GET_INSIGHTS_SERVICES, GET_INSIGHTS_TRANSACTIONS, GET_INSIGHTS_POLICIES, etc.
- Added insights mutations: PROMOTE_INSIGHTS_BASELINE_CLASS, UPSERT_INSIGHTS_POLICY, etc.
- Updated GraphQL config to include insightsEnabled.
- Enhanced navigation to include Security route.

```release-note
feat: wire security and insights API into UI Kit
```
