### PR TITLE
RUN-984: bump devcontainer kind to v0.32.0

### DIFF
--- a/.devcontainer/post-install.sh
+++ b/.devcontainer/post-install.sh
@@ -33,7 +33,7 @@ ARCH=$(dpkg --print-architecture) && \
 
 # Install kind (latest stable release)
 log "Installing kind..."
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-$(dpkg --print-architecture) && \
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.32.0/kind-linux-$(dpkg --print-architecture) && \
     install -o root -g root -m 0755 kind /usr/local/bin/kind && \
     rm kind
 


### PR DESCRIPTION
The devcontainer installs kind **v0.23.0**, which cannot run the `kindest/node:v1.32.0` image `e2e.yaml` uses — v0.23.0 predates that node image and only ships support up to k8s 1.30.

CI is unaffected: `e2e.yaml` gets kind from `helm/kind-action@v1.12.0`, not from this script. Only someone bringing up a cluster from a fresh devcontainer hits it.

One line in `.devcontainer/post-install.sh`.

```release-note
NONE
```