### PR TITLE
RUN-985: stop old and pre-release builds from taking the :latest image tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,6 +209,43 @@ jobs:
             echo "Release version $RELEASE_VERSION is NOT newer than tap version $CURRENT_TAP_VERSION — skipping Homebrew tap update"
             echo "SKIP_HOMEBREW_UPDATE=true" >> $GITHUB_ENV
           fi
+      - name: Check if the :latest image tag should move
+        run: |
+          # Decide whether this release owns :latest, i.e. whether the tag
+          # being released is the newest version we have. Only then may the
+          # image tag move; every other release still publishes under its own
+          # version tag.
+
+          # A pre-release is never the newest shipped version.
+          if [ "${{ env.IS_PRERELEASE }}" = "true" ]; then
+            echo "Pre-release $TAG — leaving :latest where it is"
+            echo "PUSH_LATEST=false" >> $GITHUB_ENV
+            exit 0
+          fi
+
+          # Highest stable vX.Y.Z tag in the repo. The tag being released is
+          # already among them, so it comes out on top when it really is the
+          # newest — and loses to a higher one when this is a patch cut from an
+          # older release branch.
+          HIGHEST_STABLE=$(git tag -l 'v*' \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | sort -V | tail -1)
+
+          if [ -z "$HIGHEST_STABLE" ]; then
+            echo "No stable tags found — moving :latest"
+            echo "PUSH_LATEST=true" >> $GITHUB_ENV
+            exit 0
+          fi
+
+          echo "Releasing: $TAG   highest stable tag: $HIGHEST_STABLE"
+          if [ "$TAG" = "$HIGHEST_STABLE" ]; then
+            echo "$TAG is the newest stable release — moving :latest"
+            echo "PUSH_LATEST=true" >> $GITHUB_ENV
+          else
+            echo "$TAG is older than $HIGHEST_STABLE — leaving :latest where it is"
+            echo "PUSH_LATEST=false" >> $GITHUB_ENV
+          fi
+
       - name: Decide which homebrew repository to authenticate against
         run: |
           HOMEBREW_REPO="homebrew-odigos-cli-rc"
@@ -265,7 +302,12 @@ jobs:
           SHORT_COMMIT: ${{ steps.vars.outputs.short_commit }}
           DATE: ${{ steps.vars.outputs.date }}
         run: |
-          ko build --bare --tags latest --tags ${{ env.TAG }} --platform=linux/amd64,linux/arm64
+          KO_TAGS="--tags ${{ env.TAG }}"
+          if [ "${{ env.PUSH_LATEST }}" = "true" ]; then
+            KO_TAGS="$KO_TAGS --tags latest"
+          fi
+          echo "ko tags: $KO_TAGS"
+          ko build --bare $KO_TAGS --platform=linux/amd64,linux/arm64
 
       - name: Install crane
         uses: imjasonh/setup-crane@v0.4
@@ -277,9 +319,16 @@ jobs:
           GCR_PRIVATE_DEST_IMAGE: us-central1-docker.pkg.dev/odigos-cloud/components-private/odigos-cli
         run: |
           crane copy ${SOURCE_IMAGE}:${{ env.TAG }} ${DEST_IMAGE}:${{ env.TAG }}
-          crane copy ${SOURCE_IMAGE}:latest ${DEST_IMAGE}:latest
           crane copy ${SOURCE_IMAGE}:${{ env.TAG }} ${GCR_PRIVATE_DEST_IMAGE}:${{ env.TAG }}
-          crane copy ${SOURCE_IMAGE}:latest ${GCR_PRIVATE_DEST_IMAGE}:latest
+
+          # Mirror :latest only when this release owns it, so the mirrors stay
+          # in step with the source registry.
+          if [ "${{ env.PUSH_LATEST }}" = "true" ]; then
+            crane copy ${SOURCE_IMAGE}:latest ${DEST_IMAGE}:latest
+            crane copy ${SOURCE_IMAGE}:latest ${GCR_PRIVATE_DEST_IMAGE}:latest
+          else
+            echo "Skipping :latest mirror for ${{ env.TAG }}"
+          fi
 
       - name: Copy VictoriaMetrics image to Docker Hub and GCR
         env:
@@ -289,11 +338,18 @@ jobs:
           GCR_PRIVATE_DEST_IMAGE: us-central1-docker.pkg.dev/odigos-cloud/components-private/odigos-victoria-metrics
         run: |
           crane copy ${SOURCE_IMAGE} ${DOCKERHUB_DEST_IMAGE}:${{ env.TAG }}
-          crane copy ${SOURCE_IMAGE} ${DOCKERHUB_DEST_IMAGE}:latest
           crane copy ${SOURCE_IMAGE} ${GCR_DEST_IMAGE}:${{ env.TAG }}
-          crane copy ${SOURCE_IMAGE} ${GCR_DEST_IMAGE}:latest
           crane copy ${SOURCE_IMAGE} ${GCR_PRIVATE_DEST_IMAGE}:${{ env.TAG }}
-          crane copy ${SOURCE_IMAGE} ${GCR_PRIVATE_DEST_IMAGE}:latest
+
+          # VICTORIA_METRICS_VERSION is pinned per branch, so :latest here
+          # tracks whichever release owns it rather than the last one to run.
+          if [ "${{ env.PUSH_LATEST }}" = "true" ]; then
+            crane copy ${SOURCE_IMAGE} ${DOCKERHUB_DEST_IMAGE}:latest
+            crane copy ${SOURCE_IMAGE} ${GCR_DEST_IMAGE}:latest
+            crane copy ${SOURCE_IMAGE} ${GCR_PRIVATE_DEST_IMAGE}:latest
+          else
+            echo "Skipping :latest mirror for ${{ env.TAG }}"
+          fi
 
       - name: Set notification messages
         run: |


### PR DESCRIPTION
`release.yml` runs `ko build --bare --tags latest` unconditionally, so any dispatch moves `odigos-cli:latest` regardless of what it releases — and the `crane copy ...:latest` steps push that to Docker Hub and private GCR.

So `:latest` currently reflects whichever release ran last, not the newest version:

- The v1.28.12 backport from `releases/v1.28.0` on 2026-08-04 pointed it at v1.28.12 while v1.33 was current.
- Pre-releases take it too — right now it resolves to `v1.34.0-rc0`.

This also leaked downstream: `offsets-push.yml` builds `FROM registry.odigos.io/odigos-cli:latest` and reads its own version off that base, so it published `odigos-cli-offsets:v1.28.12-b68e781` built on a five-minor-old CLI.

### Change

`:latest` moves only when the released tag is the highest stable tag in the repo. Versioned tags are pushed exactly as before. The VictoriaMetrics mirror gets the same guard, since `VICTORIA_METRICS_VERSION` is pinned per branch.

Verified against the real tag history: `v1.33.0` moves it; `v1.28.12`, `v1.32.2` and `v1.34.0-rc0` do not.

Note this doesn't repair current state — `:latest` stays on `v1.34.0-rc0` until the next stable release from `main`.

```release-note
Fixed the `:latest` tag on published images being moved by patch releases from older release branches and by pre-releases.
```