### PR TITLE
CORE-1324 | test(e2e): make OSS e2e robust to tier-specific env vars and back-to-back rollouts

### DIFF
--- a/tests/common/assert/odigos-installed-no-device-plugin.yaml
+++ b/tests/common/assert/odigos-installed-no-device-plugin.yaml
@@ -82,26 +82,27 @@ spec:
     - name: data-collection
       securityContext:
         privileged: true
-      env:
-        - name: NODE_NAME
-          valueFrom:
+      # Matched by name rather than as a list, so that env vars added only on some tiers
+      # (ODIGOS_ONPREM_TOKEN on enterprise) don't fail the length check.
+      (env[?name == 'NODE_NAME']):
+        - valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        - name: NODE_IP
-          valueFrom:
+      (env[?name == 'NODE_IP']):
+        - valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        - name: POD_NAME
-          valueFrom:
+      (env[?name == 'POD_NAME']):
+        - valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.name
-        - name: GOMEMLIMIT
-          (value != null): true
-        - name: GOMAXPROCS
-          valueFrom:
+      (env[?name == 'GOMEMLIMIT']):
+        - (value != null): true
+      (env[?name == 'GOMAXPROCS']):
+        - valueFrom:
             resourceFieldRef:
               containerName: data-collection
               divisor: "0"

--- a/tests/common/assert/odigos-installed.yaml
+++ b/tests/common/assert/odigos-installed.yaml
@@ -82,26 +82,27 @@ spec:
     - name: data-collection
       securityContext:
         privileged: true
-      env:
-        - name: NODE_NAME
-          valueFrom:
+      # Matched by name rather than as a list, so that env vars added only on some tiers
+      # (ODIGOS_ONPREM_TOKEN on enterprise) don't fail the length check.
+      (env[?name == 'NODE_NAME']):
+        - valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        - name: NODE_IP
-          valueFrom:
+      (env[?name == 'NODE_IP']):
+        - valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        - name: POD_NAME
-          valueFrom:
+      (env[?name == 'POD_NAME']):
+        - valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.name
-        - name: GOMEMLIMIT
-          (value != null): true
-        - name: GOMAXPROCS
-          valueFrom:
+      (env[?name == 'GOMEMLIMIT']):
+        - (value != null): true
+      (env[?name == 'GOMAXPROCS']):
+        - valueFrom:
             resourceFieldRef:
               containerName: data-collection
               divisor: "0"

--- a/tests/common/assert/pipeline-ready.yaml
+++ b/tests/common/assert/pipeline-ready.yaml
@@ -42,21 +42,22 @@ spec:
         odigos.io/collector-role: "CLUSTER_GATEWAY"
     spec:
       containers:
-        - env:
-            - name: ODIGOS_VERSION
-              valueFrom:
+        # Matched by name rather than as a list, so that env vars added only on some tiers
+        # (ODIGOS_ONPREM_TOKEN on enterprise) don't fail the length check.
+        - (env[?name == 'ODIGOS_VERSION']):
+            - valueFrom:
                 configMapKeyRef:
                   key: ODIGOS_VERSION
                   name: odigos-deployment
-            - name: POD_NAME
-              valueFrom:
+          (env[?name == 'POD_NAME']):
+            - valueFrom:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: GOMEMLIMIT
-              (value != null): true
-            - name: GOMAXPROCS
-              valueFrom:
+          (env[?name == 'GOMEMLIMIT']):
+            - (value != null): true
+          (env[?name == 'GOMAXPROCS']):
+            - valueFrom:
                 resourceFieldRef:
                   containerName: gateway
                   divisor: "0"

--- a/tests/e2e/env-injection/chainsaw-test.yaml
+++ b/tests/e2e/env-injection/chainsaw-test.yaml
@@ -124,7 +124,12 @@ spec:
         - script:
             timeout: 1m10s
             content: |
-              kubectl rollout restart deployment
+              # the restart annotation has a resolution of seconds, so a restart triggered by the upgrade
+              # above can still be within the same second as this one. Same guard as the first rollout.
+              sleep 2
+              for i in 1 2 3; do
+                kubectl rollout restart deployment && break || sleep 2
+              done || exit 1 # Exit with error if all attempts fail
 
     - name: 03 - Assert Environment Variables
       try:


### PR DESCRIPTION
#### What this PR does / why we need it:

Chainsaw compares a positional YAML list under `env:` by index **and** length, so an env var present on only some tiers fails the whole assertion.

Enterprise installs inject `ODIGOS_ONPREM_TOKEN` into the collector containers. The odiglet `data-collection` container therefore has 6 env entries where these asserts expect 5:

```
* spec.containers[1].env: Invalid value: [...NODE_NAME, NODE_IP, POD_NAME,
  GOMEMLIMIT, GOMAXPROCS, ODIGOS_ONPREM_TOKEN]: lengths of slices don't match
```

Switched the three affected files to the JMESPath projection already used 80x in `tests/common/assert/simple-demo-instrumented-full.yaml`, which matches by name and is length-independent:

```yaml
(env[?name == 'NODE_NAME']):
  - valueFrom:
      fieldRef:
        apiVersion: v1
        fieldPath: spec.nodeName
```

Each named var is still asserted exactly as before — only the length coupling is dropped.

This is community-tier-neutral: OSS e2e asserts the same values it did previously. It also unblocks `odigos-enterprise` e2e, which fetches these files from this branch at run time.

Also fixed a second, unrelated failure in the same suite. `tests/e2e/env-injection/chainsaw-test.yaml` has two `Rollout instrumented apps` steps. The first wraps `kubectl rollout restart` in a `sleep 2` + retry loop with a comment naming the error it guards against; the second was left bare:

```
error: failed to create patch for python-alpine: if restart has already been triggered
within the past second, please wait before attempting to trigger another
```

The restart annotation has a one-second resolution — `tests/common/wait_for_rollout.sh` documents this exact failure mode — so the restart the preceding `odigos upgrade` triggers can land in the same second as the explicit one. Applied the same guard the first step already uses.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
NONE
```

