### PR TITLE
CORE-1324 | test(e2e): match collector env vars by name for tier-specific extras

### DIFF
--- a/tests/common/assert/odigos-installed-no-device-plugin.yaml
+++ b/tests/common/assert/odigos-installed-no-device-plugin.yaml
@@ -82,26 +82,27 @@ spec:
     - name: data-collection
       securityContext:
         privileged: true
-      env:
-        - name: NODE_NAME
-          valueFrom:
+      # Matched by name rather than as a list, so that env vars added only on some tiers
+      # (ODIGOS_ONPREM_TOKEN on enterprise) don't fail the length check.
+      (env[?name == 'NODE_NAME']):
+        - valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        - name: NODE_IP
-          valueFrom:
+      (env[?name == 'NODE_IP']):
+        - valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        - name: POD_NAME
-          valueFrom:
+      (env[?name == 'POD_NAME']):
+        - valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.name
-        - name: GOMEMLIMIT
-          (value != null): true
-        - name: GOMAXPROCS
-          valueFrom:
+      (env[?name == 'GOMEMLIMIT']):
+        - (value != null): true
+      (env[?name == 'GOMAXPROCS']):
+        - valueFrom:
             resourceFieldRef:
               containerName: data-collection
               divisor: "0"

--- a/tests/common/assert/odigos-installed.yaml
+++ b/tests/common/assert/odigos-installed.yaml
@@ -82,26 +82,27 @@ spec:
     - name: data-collection
       securityContext:
         privileged: true
-      env:
-        - name: NODE_NAME
-          valueFrom:
+      # Matched by name rather than as a list, so that env vars added only on some tiers
+      # (ODIGOS_ONPREM_TOKEN on enterprise) don't fail the length check.
+      (env[?name == 'NODE_NAME']):
+        - valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        - name: NODE_IP
-          valueFrom:
+      (env[?name == 'NODE_IP']):
+        - valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        - name: POD_NAME
-          valueFrom:
+      (env[?name == 'POD_NAME']):
+        - valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.name
-        - name: GOMEMLIMIT
-          (value != null): true
-        - name: GOMAXPROCS
-          valueFrom:
+      (env[?name == 'GOMEMLIMIT']):
+        - (value != null): true
+      (env[?name == 'GOMAXPROCS']):
+        - valueFrom:
             resourceFieldRef:
               containerName: data-collection
               divisor: "0"

--- a/tests/common/assert/pipeline-ready.yaml
+++ b/tests/common/assert/pipeline-ready.yaml
@@ -42,21 +42,22 @@ spec:
         odigos.io/collector-role: "CLUSTER_GATEWAY"
     spec:
       containers:
-        - env:
-            - name: ODIGOS_VERSION
-              valueFrom:
+        # Matched by name rather than as a list, so that env vars added only on some tiers
+        # (ODIGOS_ONPREM_TOKEN on enterprise) don't fail the length check.
+        - (env[?name == 'ODIGOS_VERSION']):
+            - valueFrom:
                 configMapKeyRef:
                   key: ODIGOS_VERSION
                   name: odigos-deployment
-            - name: POD_NAME
-              valueFrom:
+          (env[?name == 'POD_NAME']):
+            - valueFrom:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: GOMEMLIMIT
-              (value != null): true
-            - name: GOMAXPROCS
-              valueFrom:
+          (env[?name == 'GOMEMLIMIT']):
+            - (value != null): true
+          (env[?name == 'GOMAXPROCS']):
+            - valueFrom:
                 resourceFieldRef:
                   containerName: gateway
                   divisor: "0"


### PR DESCRIPTION
## Summary
- Update `odigos-installed.yaml`, `odigos-installed-no-device-plugin.yaml`, and `pipeline-ready.yaml` so collector `env` entries are matched by name (JMESPath) instead of as a positional list.
- Avoids Chainsaw `lengths of slices don't match` when enterprise injects `ODIGOS_ONPREM_TOKEN` into `data-collection` / gateway. OSS installs are unchanged; these asserts still only require the shared env vars.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
NONE
```