### PR TITLE
RUN-1018 | fix(ci): report PR policy status on merge queue entries

### DIFF
--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -3,18 +3,27 @@ name: PR Policy
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
-    
+  # Required checks have to report on queue entries too, or the merge queue waits
+  # for a status that never arrives.
+  merge_group:
+    types: [checks_requested]
+
 permissions:
   pull-requests: read
   statuses: write
 
 jobs:
+  # Both checks are conditioned on the step rather than the job, so the job still
+  # reports a status on merge_group, where github.event.pull_request is null and
+  # there is no pull request to inspect.
   require-linear:
     runs-on: ubuntu-latest
-    steps: 
-      - uses: odigos-io/ci-core/require-linear@main
+    steps:
+      - if: ${{ github.event_name == 'pull_request' }}
+        uses: odigos-io/ci-core/require-linear@main
 
   release-note:
     runs-on: ubuntu-latest
-    steps: 
-      - uses: odigos-io/ci-core/require-release-note@main
+    steps:
+      - if: ${{ github.event_name == 'pull_request' }}
+        uses: odigos-io/ci-core/require-release-note@main


### PR DESCRIPTION
Closes RUN-1018.

`require-linear` and `release-note` are required checks, but `pr-policy.yml` only triggered on `pull_request`. A merge queue entry fires `merge_group` against a `gh-readonly-queue/*` ref, so the workflow never ran there and neither status was ever posted — the queue waits on checks that never arrive.

This repo already uses merge queues (`build.yaml`, `e2e.yaml`, `go-mod-tidy.yml` all declare `merge_group`), so the same stall seen in `enterprise-go-instrumentation` applies here.

## Change

- Adds the `merge_group` trigger so both jobs report on queue entries.
- Conditions each step on `github.event_name == 'pull_request'`.

The condition matters: both actions read `github.event.pull_request.*`, which is empty under `merge_group`. Without it `require-linear` finds no Linear reference in an empty title/body/branch and `require-release-note` finds no release-note block in an empty body — so simply adding the trigger would turn a stalled queue into one that **rejects every entry**. Conditioning at the step keeps the job reporting while skipping a check that has nothing to inspect.

## Merge order

Safe to merge independently of [ci-core#96](https://github.com/odigos-io/ci-core/pull/96), which fixes the same trap inside both actions. Once that lands these guards are redundant but harmless.

```release-note
- **fix(ci): report PR policy status on merge queue entries**
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)