### PR TITLE
RUN-1051 | fix(ci): stop losing vulnerability scan results and gate on CRITICAL

### DIFF
--- a/.github/workflows/vulnerability-scan.yaml
+++ b/.github/workflows/vulnerability-scan.yaml
@@ -10,21 +10,39 @@ on:
         type: string
 
 jobs:
+  # The image list lives here rather than inline in the matrix so the report job can
+  # verify every image actually reported back, without a second copy drifting out of sync.
+  setup:
+    name: Resolve image list
+    runs-on: ubuntu-latest
+    outputs:
+      images: ${{ steps.list.outputs.images }}
+      count: ${{ steps.list.outputs.count }}
+    steps:
+      - id: list
+        run: |
+          set -euo pipefail
+          IMAGES='[
+            "odigos-autoscaler",
+            "odigos-scheduler",
+            "odigos-instrumentor",
+            "odigos-odiglet",
+            "odigos-collector",
+            "odigos-ui",
+            "odigos-operator",
+            "odigos-agents"
+          ]'
+          echo "images=$(echo "$IMAGES" | jq -c .)" >> "$GITHUB_OUTPUT"
+          echo "count=$(echo "$IMAGES" | jq 'length')" >> "$GITHUB_OUTPUT"
+
   scan-images:
     name: Scan ${{ matrix.image }}
+    needs: setup
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        image:
-          - odigos-autoscaler
-          - odigos-scheduler
-          - odigos-instrumentor
-          - odigos-odiglet
-          - odigos-collector
-          - odigos-ui
-          - odigos-operator
-          - odigos-agents
+        image: ${{ fromJson(needs.setup.outputs.images) }}
     steps:
       - name: Pull image from registry
         run: |
@@ -40,13 +58,27 @@ jobs:
 
       - name: Save scan JSON results
         if: always()
+        env:
+          RESULTS_FILE: ${{ steps.scan.outputs.results-file }}
+          IMAGE: ${{ matrix.image }}
+          TAG: ${{ inputs.tag }}
         run: |
+          set -euo pipefail
           mkdir -p /tmp/scan-results
-          cat > /tmp/scan-results/${{ matrix.image }}.json << 'EOF'
-          ${{ steps.scan.outputs.results-json }}
-          EOF
-          jq --arg img "${{ matrix.image }}" --arg tag "${{ inputs.tag }}" '. + {imageName: $img, imageTag: $tag}' /tmp/scan-results/${{ matrix.image }}.json > /tmp/scan-results/${{ matrix.image }}_enriched.json
-          mv /tmp/scan-results/${{ matrix.image }}_enriched.json /tmp/scan-results/${{ matrix.image }}.json
+          OUT="/tmp/scan-results/${IMAGE}.json"
+
+          # Read the report from disk rather than through an expression. Reports for the
+          # larger images run to several MB, which exceeds the Actions expression limit
+          # and previously expanded to an empty file without failing the job.
+          if [ -z "${RESULTS_FILE:-}" ] || [ ! -s "$RESULTS_FILE" ]; then
+            echo "::error::No scan results produced for ${IMAGE}. Expected a report at '${RESULTS_FILE:-<unset>}'."
+            exit 1
+          fi
+
+          jq --arg img "$IMAGE" --arg tag "$TAG" \
+            '. + {imageName: $img, imageTag: $tag}' "$RESULTS_FILE" > "$OUT"
+
+          echo "Saved $(wc -c < "$OUT") bytes for ${IMAGE}"
 
       - name: Upload scan results JSON
         if: always()
@@ -58,7 +90,7 @@ jobs:
 
   vulnerability-report:
     name: Generate Vulnerability Report
-    needs: [scan-images]
+    needs: [setup, scan-images]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -85,3 +117,74 @@ jobs:
           name: vulnerability-report
           path: scan-results.zip
           retention-days: 90
+
+      - name: Summarise findings and gate on CRITICAL
+        env:
+          EXPECTED_IMAGES: ${{ needs.setup.outputs.count }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+
+          {
+            echo "## 🔍 Vulnerability scan — ${TAG}"
+            echo ""
+            echo "| Image | Total | Critical | High | Medium | Low |"
+            echo "|---|---|---|---|---|---|"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          total_critical=0
+          found_images=0
+          lost_results=0
+
+          for f in scan-results/*.json; do
+            [ -e "$f" ] || continue
+            found_images=$((found_images + 1))
+
+            # An empty or unparseable report is treated as a failure, not as a clean
+            # image. Silently scoring it zero is what hid odiglet's CRITICALs before.
+            if ! jq -e . "$f" > /dev/null 2>&1; then
+              echo "::error::$f is empty or not valid JSON — scan results were lost."
+              echo "| \`$(basename "$f" .json)\` | ⚠️ results missing | | | | |" >> "$GITHUB_STEP_SUMMARY"
+              lost_results=$((lost_results + 1))
+              continue
+            fi
+
+            read -r name total crit high med low <<< "$(jq -r '
+              (.matches // []) as $m |
+              def c(s): [$m[] | select((.vulnerability.severity // "" | ascii_downcase) == s)] | length;
+              [(.imageName // "unknown"), ($m | length), c("critical"), c("high"), c("medium"), c("low")]
+              | @tsv' "$f")"
+
+            echo "| \`$name\` | $total | $crit | $high | $med | $low |" >> "$GITHUB_STEP_SUMMARY"
+            total_critical=$((total_critical + crit))
+          done
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          # Guard against a scan job dying before it uploaded anything: a missing file
+          # produces no row at all, so counting rows is the only way to notice.
+          if [ "$found_images" -ne "$EXPECTED_IMAGES" ]; then
+            echo "::error::Expected $EXPECTED_IMAGES scan results, got $found_images. Some scans did not report."
+            echo "> ❌ Expected $EXPECTED_IMAGES scan results, got $found_images." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          failed=0
+
+          if [ "$lost_results" -gt 0 ]; then
+            echo "::error::$lost_results image(s) produced no usable scan results."
+            echo "> ❌ **$lost_results image(s) produced no usable scan results.**" >> "$GITHUB_STEP_SUMMARY"
+            failed=1
+          fi
+
+          if [ "$total_critical" -gt 0 ]; then
+            echo "::error::$total_critical CRITICAL finding(s) across scanned images."
+            echo "> ❌ **$total_critical CRITICAL finding(s).**" >> "$GITHUB_STEP_SUMMARY"
+            failed=1
+          fi
+
+          if [ "$failed" -ne 0 ]; then
+            exit 1
+          fi
+
+          echo "> ✅ No CRITICAL findings, all $found_images images reported." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Depends on odigos-io/ci-core#97 — both reference `@main`, so that must merge first.

## Problem

[Run 31477113031](https://github.com/odigos-io/odigos/actions/runs/31477113031) scanned v1.34.1 and reported **all 9 jobs green**. `odigos-odiglet.json` in the report artifact was **0 bytes**, and odiglet is the only image of the eight with CRITICAL findings — 2, both in `libssl3`. The one image that mattered reported nothing, and nothing failed.

Two independent faults:

**1. The results were too big to survive an expression.** Line 46 expanded `${{ steps.scan.outputs.results-json }}` inside a heredoc. Odiglet's Grype report is 4.1 MB, past the Actions expression limit, so the step failed with `System.InvalidOperationException: Maximum object size exceeded` and the heredoc expanded to nothing. Verified odiglet was the only job to hit this.

**2. Nothing checked the results.** The scan step is `continue-on-error: true`, so tripping the CRITICAL cutoff (exit 1) still reported success. The report job only downloaded and zipped the artifacts — it never opened them. Verified odiglet was the only job to exit 1.

Together: green run, empty report, two CRITICALs shipped.

## Change

- Read the report from `results-file` (new in ci-core#97) rather than through an expression, and **fail if it is missing or empty**.
- Add a **summary table** and **gate the run**: fail on any CRITICAL, on results that came back empty/unparseable, or when fewer images reported than expected.
- Move the image list into a `setup` job that outputs it. The matrix and the completeness check now read one list instead of two that can drift.

`continue-on-error` on the scan step is deliberately kept so one bad image doesn't abort the others — the gate in the report job is what enforces the policy now.

## Testing

Replayed the real v1.34.1 artifacts through the new gate:

| Scenario | Before | Now |
|---|---|---|
| v1.34.1 exactly as it ran (odiglet empty) | ✅ green | ❌ `1 image(s) produced no usable scan results` |
| odiglet results restored (2 real CRITICALs) | ✅ green | ❌ `2 CRITICAL finding(s)` |
| CRITICALs cleared | ✅ green | ✅ green, with summary table |
| an image missing entirely | ✅ green | ❌ `Expected 8 scan results, got 7` |

Sample summary on a clean run:

| Image | Total | Critical | High | Medium | Low |
|---|---|---|---|---|---|
| `odigos-agents` | 132 | 0 | 38 | 94 | 0 |
| `odigos-odiglet` | 161 | 0 | 60 | 99 | 1 |
| `odigos-collector` | 32 | 0 | 17 | 14 | 0 |

## Follow-up

`.github/workflows/build.yaml` consumes `results-json` the same way at 9 call sites, as does odigos-enterprise at 3. Those have the same latent truncation and are left for a separate change to keep this reviewable.

```release-note
Fixed the vulnerability scan workflow silently discarding results for large images, and made it fail the run when CRITICAL vulnerabilities are found.
```