### PR TITLE
RUN-1053 | fix(security): bump Go toolchain to 1.26.5

### DIFF
--- a/.github/workflows/build-dev-images.yml
+++ b/.github/workflows/build-dev-images.yml
@@ -77,7 +77,7 @@ jobs:
       - uses: ko-build/setup-ko@v0.9
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
       - name: Build CLI Image
         env:
           COMMIT_HASH: ${{ github.sha }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -149,7 +149,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - name: Build Instrumentor Image
         uses: docker/build-push-action@v6
         with:
@@ -460,7 +460,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - name: Set up Goreleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -473,7 +473,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - name: Test k8sutils module
         working-directory: ./k8sutils
         run: |
@@ -485,7 +485,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - name: Test common module
         working-directory: ./common
         run: |
@@ -497,7 +497,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - name: Test procdiscovery module
         working-directory: ./procdiscovery
         run: |

--- a/.github/workflows/check-operator-manifests.yml
+++ b/.github/workflows/check-operator-manifests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - name: Check operator manifests are up to date
         id: check-manifests

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "~1.26.4"
+          go-version: "~1.26.5"
           check-latest: true
           cache: true
           cache-dependency-path: |
@@ -152,7 +152,7 @@ jobs:
         if: steps.should-run.outputs.skip != 'true' && matrix.test-scenario == 'karpenter-mount-methods'
         uses: actions/setup-go@v6
         with:
-          go-version: "~1.26.4"
+          go-version: "~1.26.5"
           check-latest: true
           cache: true
 

--- a/.github/workflows/full-build.yaml
+++ b/.github/workflows/full-build.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - name: Set up Goreleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/go-mod-tidy.yml
+++ b/.github/workflows/go-mod-tidy.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - name: run make go-mod-tidy
         run: make go-mod-tidy
       - name: Check clean repository
@@ -27,6 +27,6 @@ jobs:
         uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - name: run make verify-go-mod-graph
         run: make verify-go-mod-graph

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - name: Generate Helm Schema
         run: make helm-schema
       - name: Check for schema changes

--- a/.github/workflows/publish-collector-linux-packages.yml
+++ b/.github/workflows/publish-collector-linux-packages.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - name: Set GoReleaser tag
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,7 +167,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/verify-api-crds.yml
+++ b/.github/workflows/verify-api-crds.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - name: install controller-gen
         run: make controller-gen
       - name: Check API CRDs

--- a/.github/workflows/verify-collector-ocb.yml
+++ b/.github/workflows/verify-collector-ocb.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - name: Generate collector with ocb
         working-directory: ./collector
         run: "make genodigoscol generate"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5 AS builder
 ARG SERVICE_NAME
 
 # Copy only go.mod/go.sum for local modules to cache dependency downloads

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -17,7 +17,7 @@ RUN set -e && \
     done && \
     helm package helm/odigos helm/odigos-central -d /workspace/chart-artifacts
 
-FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION

--- a/collector/Dockerfile
+++ b/collector/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.2-trixie AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5-trixie AS builder
 # install the required tooling for calling `setcap` on the compiled binary
 RUN apt-get update && apt-get install -y --no-install-recommends libcap2-bin
 COPY ./collector/ /go/src/collector

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -20,7 +20,7 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY frontend/webapp .
 RUN yarn build
 
-FROM --platform=$BUILDPLATFORM golang:1.26.2 AS backend
+FROM --platform=$BUILDPLATFORM golang:1.26.5 AS backend
 WORKDIR /app
 # Copy only the go.mod/go.sum of the frontend module and its locally-replaced
 # deps first. This lets `go mod download` be cached independently of source

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG ODIGOS_VERSION


### PR DESCRIPTION
Part of the v1.34.1 vulnerability sweep ([run 31477113031](https://github.com/odigos-io/odigos/actions/runs/31477113031)). Fixes RUN-1053.

## Problem

v1.34.1 ships two different Go toolchains, and the older one carries **17 HIGH stdlib findings per image**:

| Image | Built with | Stdlib HIGHs |
|---|---|---|
| odigos-collector | `golang:1.26.2-trixie` | 17 |
| odigos-operator | `golang:1.26.2` | 17 |
| odigos-ui | `golang:1.26.2` | 17 |
| odigos-autoscaler / scheduler / instrumentor | `golang:1.26.4` | 2 |

Every one is fixed in **1.26.5**:

- **from 1.26.2** — CVE-2026-27145, CVE-2026-33811, CVE-2026-33814, CVE-2026-39820, CVE-2026-39836, CVE-2026-42499, CVE-2026-42501, CVE-2026-42504, GO-2026-4918/4971/4977/4981/4986/5037/5038
- **from 1.26.2 and 1.26.4** — CVE-2026-39822 / GO-2026-4970

## Change

All five builder images to `golang:1.26.5`, plus the `setup-go` pins across the workflows.

The `setup-go` pins matter as much as the Dockerfiles: `release.yml` builds release artifacts outside Docker, so leaving it at 1.26.4 would keep embedding the vulnerable stdlib in shipped binaries even after the images are clean.

Verified `golang:1.26.5` and `golang:1.26.5-trixie` both exist on Docker Hub.

## Scope

Only the toolchain version moves — no `go` directives in `go.mod` are touched, so no language-version semantics change.

odiglet builds from `odiglet-base` rather than a `golang:` image and needs that image rebuilt first; tracked separately in RUN-1055.

```release-note
Bumped the Go toolchain to 1.26.5, resolving stdlib vulnerabilities in the collector, operator, UI, autoscaler, scheduler and instrumentor images.
```