### PR TITLE
RUN-1056 | fix(security): bump Java agent to v2.20.0

### DIFF
--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -54,7 +54,7 @@ FROM --platform=$BUILDPLATFORM ${ODIGLET_BASE_IMAGE} AS agents-builder
 WORKDIR /instrumentations
 
 # java-community
-ARG JAVA_OTEL_VERSION=v2.10.0
+ARG JAVA_OTEL_VERSION=v2.20.0
 ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/$JAVA_OTEL_VERSION/opentelemetry-javaagent.jar /instrumentations/java/javaagent.jar
 RUN chmod 644 /instrumentations/java/javaagent.jar
 

--- a/odiglet/debug.Dockerfile
+++ b/odiglet/debug.Dockerfile
@@ -75,7 +75,7 @@ RUN go install github.com/go-delve/delve/cmd/dlv@latest
 WORKDIR /instrumentations
 
 # java-community
-ARG JAVA_OTEL_VERSION=v2.10.0
+ARG JAVA_OTEL_VERSION=v2.20.0
 ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/$JAVA_OTEL_VERSION/opentelemetry-javaagent.jar /instrumentations/java/javaagent.jar
 RUN chmod 644 /instrumentations/java/javaagent.jar
 


### PR DESCRIPTION
Bumps `JAVA_OTEL_VERSION` from v2.10.0 to v2.20.0 in `odiglet/Dockerfile` and `odiglet/debug.Dockerfile`, moving jackson-databind and jackson-core from 2.18.1 to 2.20.0.

Resolves GHSA-j3rv-43j4-c7qm, GHSA-rmj7-2vxq-3g9f, GHSA-r7wm-3cxj-wff9, GHSA-72hv-8253-57qq.

#### Stacked on #5549 (RUN-1061)

The bump alone failed all 6 upgrade e2e tests, because the agents sync rewrote the jar in place under running JVMs. #5549 fixes that; merge it first and GitHub retargets this to `main` automatically.

Validated on `6bd4bae1` (fix + bump): all 6 `cli-upgrade`/`helm-upgrade` × k8s 1.21.12 / 1.23 / 1.32 pass. The only other failure was `1.23 tail-sampling-nodejs`, an unrelated flake that passed on 1.21.12 and 1.32.

Note: `E2E Tests` and `build` only run on PRs targeting `main`/`releases/**`, so pushes here won't re-trigger them while this is stacked.

```release-note
Bumped the OpenTelemetry Java agent to v2.20.0, resolving jackson-databind and jackson-core vulnerabilities.
```
