### PR TITLE
RUN-1052 | fix(security): re-pin odiglet distroless base, clearing 2 CRITICALs

### DIFF
--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -214,7 +214,7 @@ USER 65532:65532
 CMD ["/root/odiglet"]
 
 ######### Default Odiglet #########
-FROM gcr.io/distroless/base:3443777deec6bd5c58be682f286aefffd1c871ae
+FROM gcr.io/distroless/base@sha256:f4a335ca209e1d2ee873102c17c389ad0142e3d5b21aee2817e9cc9c01d87d20
 COPY --from=builder /go/src/github.com/odigos-io/odigos/odiglet/odiglet /root/odiglet
 COPY --from=deviceplugin-builder /go/src/github.com/odigos-io/odigos/deviceplugin/deviceplugin /root/deviceplugin
 COPY --from=csi-driver-builder /go/src/github.com/odigos-io/odigos/odiglet/odigos-csi-driver /root/odigos-csi-driver


### PR DESCRIPTION
Part of the v1.34.1 vulnerability sweep ([run 31477113031](https://github.com/odigos-io/odigos/actions/runs/31477113031)). Fixes RUN-1052.

**This is the only change in the sweep that clears a CRITICAL.**

## Problem

The only two CRITICALs across all eight scanned images are both in odiglet's runtime base, which was pinned to `gcr.io/distroless/base:3443777deec6bd5c58be682f286aefffd1c871ae`:

| CVE | Package | Fixed in |
|---|---|---|
| CVE-2026-34182 | `libssl3@3.0.18-1~deb12u2` | 3.0.20-1~deb12u2 |
| CVE-2026-31789 | `libssl3@3.0.18-1~deb12u2` | 3.0.19-1~deb12u2 |

`collector/Dockerfile` uses `gcr.io/distroless/base:latest` and shows no OS-package findings at all — the stale pin is the entire difference, and it's why odiglet was alone in carrying these.

## Change

Re-pin to the current distroless/base, **by digest** rather than by tag. Digest pinning keeps the base reproducible and makes the next re-pin a visible, reviewable change instead of silent drift — which is what let this one go stale.

## Verification

Scanned both bases directly with the same Grype version and flags used in CI:

| Base | Total | Critical | High | Packages flagged |
|---|---|---|---|---|
| `:3443777d…` (current pin) | 21 | **2** | 15 | `libssl3@3.0.18-1~deb12u2`, `libc6@2.36-9+deb12u13` |
| `@sha256:f4a335ca…` (this PR) | **0** | **0** | **0** | — |

Beyond the two CRITICALs this also clears 10 HIGH libssl3 findings (CVE-2026-28387/28388/28389/28390, 31790, 34180, 45445, 45447, 7383, 9076) and 5 HIGH libc6 findings via `libc6 → 2.36-9+deb12u14`.

Odiglet's remaining findings are unrelated to the base — Go stdlib (RUN-1055) and bundled agent libraries (RUN-1056/1057/1058).

```release-note
Updated the odiglet base image, resolving two critical and fifteen high severity vulnerabilities in libssl3 and libc6.
```