### PR TITLE
RUN-1055 | fix(security): bump grpc_health_probe to v0.4.54

### DIFF
--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -136,7 +136,7 @@ RUN if [ "$RHEL" = "true" ] ; then \
 
 
 # Download grpc_health_probe this is used by the deviceplugin container to check if the deviceplugin is healthy
-ARG GRPC_HEALTH_PROBE_VERSION=v0.4.52
+ARG GRPC_HEALTH_PROBE_VERSION=v0.4.54
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
         GRPC_ARCH="arm64"; \
     else \


### PR DESCRIPTION
Part of the v1.34.1 vulnerability sweep ([run 31477113031](https://github.com/odigos-io/odigos/actions/runs/31477113031)). Fixes RUN-1055.

## What this actually is

The ticket originally called for rebuilding `odiglet-base` on Go 1.26.5. **That would not have helped.** Checking the published image directly:

```
$ docker run --rm keyval/odiglet-base:v1.19 go version
go version go1.26.5 linux/amd64
```

`odiglet-base` is already on Go 1.26.5 (since RUN-933 / #5351), and odiglet's own binaries are already clean. v1.34.1 was cut when `odiglet/Dockerfile` still pinned `odiglet-base:v1.18`; main has since moved to v1.19 on its own.

Every Go finding in odigos-odiglet comes from one **third-party binary** instead. The only stdlib match in the entire image is at `/root/grpc_health_probe`, pinned at v0.4.52.

## Change

`GRPC_HEALTH_PROBE_VERSION` v0.4.52 → v0.4.54 — one line, clearing 5 HIGH and 2 MEDIUM findings.

## Verification

`go version -m` against both released binaries:

| Component | v0.4.52 (current) | v0.4.54 | Needed | Advisories cleared |
|---|---|---|---|---|
| stdlib | go1.26.4 | **go1.26.5** | 1.26.5 | CVE-2026-39822, GO-2026-4970, CVE-2026-42505, GO-2026-5856 |
| golang.org/x/net | v0.55.0 | **v0.57.0** | 0.56.0 | GO-2026-5942 |
| golang.org/x/text | v0.37.0 | **v0.40.0** | 0.39.0 | GO-2026-5970 |
| google.golang.org/grpc | v1.81.1 | **v1.83.0** | 1.82.1 | GHSA-hrxh-6v49-42gf |

Both `linux/amd64` and `linux/arm64` release assets return HTTP 200.

This is the same class of issue as RUN-625, which bumped this binary for the same reason.

```release-note
Bumped grpc_health_probe to v0.4.54, resolving Go stdlib, grpc, x/net and x/text vulnerabilities in the odiglet image.
```