### PR TITLE
RUN-1050: pin agent images by digest in COPY --from

### DIFF
--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -41,24 +41,24 @@ ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/release
 RUN chmod 644 /instrumentations/java/javaagent.jar
 
 # python-community/python-community3.8
-COPY --from=public.ecr.aws/odigos/agents/python-community:v1.0.73-py3.8 /instrumentations/python3.8 /instrumentations/python3.8
-COPY --from=public.ecr.aws/odigos/agents/python-community:v1.0.90 /instrumentations/python /instrumentations/python
+COPY --from=public.ecr.aws/odigos/agents/python-community:v1.0.73-py3.8@sha256:661308cb08d293f4ff3e1823cc7ebc0537ba53dd1fff72f61b411637d62ec3d4 /instrumentations/python3.8 /instrumentations/python3.8
+COPY --from=public.ecr.aws/odigos/agents/python-community:v1.0.90@sha256:26be5a681e6cde7585f0bff6714fd74dbc90515a239d4759f5b6225591a78185 /instrumentations/python /instrumentations/python
 
 # nodejs-community
-COPY --from=public.ecr.aws/odigos/agents/nodejs-community:v0.13.0 /instrumentations/opentelemetry-node /instrumentations/opentelemetry-node
-COPY --from=public.ecr.aws/odigos/agents/nodejs-community:v0.13.0 /instrumentations/nodejs-community /instrumentations/nodejs-community
+COPY --from=public.ecr.aws/odigos/agents/nodejs-community:v0.13.0@sha256:f908dd3a2ae4d9213d923521685b10f138d6739c902ec1f9a20c0ce5b7b435c8 /instrumentations/opentelemetry-node /instrumentations/opentelemetry-node
+COPY --from=public.ecr.aws/odigos/agents/nodejs-community:v0.13.0@sha256:f908dd3a2ae4d9213d923521685b10f138d6739c902ec1f9a20c0ce5b7b435c8 /instrumentations/nodejs-community /instrumentations/nodejs-community
 # nodejs-community-14
-COPY --from=public.ecr.aws/odigos/agents/nodejs-community-14:v0.0.20 /instrumentations/opentelemetry-node-14 /instrumentations/opentelemetry-node-14
-COPY --from=public.ecr.aws/odigos/agents/nodejs-community-14:v0.0.20 /instrumentations/nodejs-community-14 /instrumentations/nodejs-community-14
+COPY --from=public.ecr.aws/odigos/agents/nodejs-community-14:v0.0.20@sha256:3bd5a2da5b6bf0874660d53c45ac8b549438cdb36e458c5e3340893658456b5c /instrumentations/opentelemetry-node-14 /instrumentations/opentelemetry-node-14
+COPY --from=public.ecr.aws/odigos/agents/nodejs-community-14:v0.0.20@sha256:3bd5a2da5b6bf0874660d53c45ac8b549438cdb36e458c5e3340893658456b5c /instrumentations/nodejs-community-14 /instrumentations/nodejs-community-14
 
 # nodejs-community
 COPY --from=dotnet-builder /dotnet-instrumentation /instrumentations/dotnet
 
 # php-community
-COPY --from=public.ecr.aws/odigos/agents/php-community:v0.5.0 /instrumentations/php /instrumentations/php
+COPY --from=public.ecr.aws/odigos/agents/php-community:v0.5.0@sha256:2742c2e003ddece79010fd47b4da021b54e3ce046dafd850f1b4a772d38aa08b /instrumentations/php /instrumentations/php
 
 # ruby-community
-COPY --from=public.ecr.aws/odigos/agents/ruby-community:v0.0.8 /instrumentations/ruby /instrumentations/ruby
+COPY --from=public.ecr.aws/odigos/agents/ruby-community:v0.0.8@sha256:a9df41f7684f550a3b7e1693456f7c4eb4ce432aba82d4b9e22d2a73687473b1 /instrumentations/ruby /instrumentations/ruby
 
 # loader
 ARG TARGETARCH

--- a/odiglet/agent-deps.mk
+++ b/odiglet/agent-deps.mk
@@ -37,12 +37,13 @@ upgrade-image-agent-version:
 	fi
 	@echo "Updating $(AGENT_DISTRO) agent image tag to $(AGENT_VERSION) in Dockerfile and debug.Dockerfile"
 	@if [ "$(shell uname)" = "Darwin" ]; then \
-		sed -i '' -E 's|$(AGENT_DISTRO):[0-9A-Za-z._-]+|$(AGENT_DISTRO):$(AGENT_VERSION)|g' Dockerfile; \
-		sed -i '' -E 's|$(AGENT_DISTRO):[0-9A-Za-z._-]+|$(AGENT_DISTRO):$(AGENT_VERSION)|g' debug.Dockerfile; \
+		sed -i '' -E 's|$(AGENT_DISTRO):[0-9A-Za-z._-]+(@sha256:[0-9a-f]+)?|$(AGENT_DISTRO):$(AGENT_VERSION)|g' Dockerfile; \
+		sed -i '' -E 's|$(AGENT_DISTRO):[0-9A-Za-z._-]+(@sha256:[0-9a-f]+)?|$(AGENT_DISTRO):$(AGENT_VERSION)|g' debug.Dockerfile; \
 	else \
-		sed -i -E 's|$(AGENT_DISTRO):[0-9A-Za-z._-]+|$(AGENT_DISTRO):$(AGENT_VERSION)|g' Dockerfile; \
-		sed -i -E 's|$(AGENT_DISTRO):[0-9A-Za-z._-]+|$(AGENT_DISTRO):$(AGENT_VERSION)|g' debug.Dockerfile; \
+		sed -i -E 's|$(AGENT_DISTRO):[0-9A-Za-z._-]+(@sha256:[0-9a-f]+)?|$(AGENT_DISTRO):$(AGENT_VERSION)|g' Dockerfile; \
+		sed -i -E 's|$(AGENT_DISTRO):[0-9A-Za-z._-]+(@sha256:[0-9a-f]+)?|$(AGENT_DISTRO):$(AGENT_VERSION)|g' debug.Dockerfile; \
 	fi
+	@$(MAKE) -f $(MK) pin-image-agent-digest AGENT_DISTRO=$(AGENT_DISTRO) AGENT_VERSION=$(AGENT_VERSION) FILES="Dockerfile debug.Dockerfile"
 
 # python-community has two image tags pinned in the dockerfiles, this upgrades the specific agent version that needs to be updated and not python3.8
 .PHONY: upgrade-python-community-version
@@ -53,9 +54,30 @@ upgrade-python-community-version:
 	fi
 	@echo "Updating python-community agent image tag to $(AGENT_VERSION) in Dockerfile and debug.Dockerfile (preserving -py3.8 pin)"
 	@if [ "$(shell uname)" = "Darwin" ]; then \
-		sed -i '' -E 's|python-community:[0-9A-Za-z._-]+( +/instrumentations/python )|python-community:$(AGENT_VERSION)\1|g' Dockerfile; \
-		sed -i '' -E 's|python-community:[0-9A-Za-z._-]+( +/instrumentations/python )|python-community:$(AGENT_VERSION)\1|g' debug.Dockerfile; \
+		sed -i '' -E 's|python-community:[0-9A-Za-z._-]+(@sha256:[0-9a-f]+)?( +/instrumentations/python )|python-community:$(AGENT_VERSION)\2|g' Dockerfile; \
+		sed -i '' -E 's|python-community:[0-9A-Za-z._-]+(@sha256:[0-9a-f]+)?( +/instrumentations/python )|python-community:$(AGENT_VERSION)\2|g' debug.Dockerfile; \
 	else \
-		sed -i -E 's|python-community:[0-9A-Za-z._-]+( +/instrumentations/python )|python-community:$(AGENT_VERSION)\1|g' Dockerfile; \
-		sed -i -E 's|python-community:[0-9A-Za-z._-]+( +/instrumentations/python )|python-community:$(AGENT_VERSION)\1|g' debug.Dockerfile; \
+		sed -i -E 's|python-community:[0-9A-Za-z._-]+(@sha256:[0-9a-f]+)?( +/instrumentations/python )|python-community:$(AGENT_VERSION)\2|g' Dockerfile; \
+		sed -i -E 's|python-community:[0-9A-Za-z._-]+(@sha256:[0-9a-f]+)?( +/instrumentations/python )|python-community:$(AGENT_VERSION)\2|g' debug.Dockerfile; \
 	fi
+	@$(MAKE) -f $(MK) pin-image-agent-digest AGENT_DISTRO=python-community AGENT_VERSION=$(AGENT_VERSION) FILES="Dockerfile debug.Dockerfile"
+
+# Internal: rewrite `<AGENT_DISTRO>:<AGENT_VERSION>` refs in FILES to `<tag>@<manifest digest>`.
+# The dockerfiles pin agent images by digest (the digest is what the build resolves; the tag stays
+# for readability), so every tag bump must re-resolve and rewrite the digest — a tag-only bump
+# would silently keep the OLD image, because the digest wins over the tag.
+# Refusing to resolve also means a bump PR can never reference a tag that does not exist.
+.PHONY: pin-image-agent-digest
+pin-image-agent-digest:
+	@set -e; \
+	ref="public.ecr.aws/odigos/agents/$(AGENT_DISTRO):$(AGENT_VERSION)"; \
+	digest=$$(docker buildx imagetools inspect "$$ref" --format '{{.Manifest.Digest}}'); \
+	if [ -z "$$digest" ]; then echo "ERROR: could not resolve digest for $$ref (does the tag exist?)"; exit 1; fi; \
+	echo "Pinning $$ref@$$digest"; \
+	for f in $(FILES); do \
+		if [ "$$(uname)" = "Darwin" ]; then \
+			sed -i '' -E "s|$(AGENT_DISTRO):$(AGENT_VERSION)([[:space:]])|$(AGENT_DISTRO):$(AGENT_VERSION)@$$digest\1|g" $$f; \
+		else \
+			sed -i -E "s|$(AGENT_DISTRO):$(AGENT_VERSION)([[:space:]])|$(AGENT_DISTRO):$(AGENT_VERSION)@$$digest\1|g" $$f; \
+		fi; \
+	done

--- a/odiglet/debug.Dockerfile
+++ b/odiglet/debug.Dockerfile
@@ -62,24 +62,24 @@ ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/release
 RUN chmod 644 /instrumentations/java/javaagent.jar
 
 # python-community/python-community3.8
-COPY --from=public.ecr.aws/odigos/agents/python-community:v1.0.73-py3.8 /instrumentations/python3.8 /instrumentations/python3.8
-COPY --from=public.ecr.aws/odigos/agents/python-community:v1.0.90 /instrumentations/python /instrumentations/python
+COPY --from=public.ecr.aws/odigos/agents/python-community:v1.0.73-py3.8@sha256:661308cb08d293f4ff3e1823cc7ebc0537ba53dd1fff72f61b411637d62ec3d4 /instrumentations/python3.8 /instrumentations/python3.8
+COPY --from=public.ecr.aws/odigos/agents/python-community:v1.0.90@sha256:26be5a681e6cde7585f0bff6714fd74dbc90515a239d4759f5b6225591a78185 /instrumentations/python /instrumentations/python
 
 # nodejs-community
-COPY --from=public.ecr.aws/odigos/agents/nodejs-community:v0.13.0 /instrumentations/opentelemetry-node /instrumentations/opentelemetry-node
-COPY --from=public.ecr.aws/odigos/agents/nodejs-community:v0.13.0 /instrumentations/nodejs-community /instrumentations/nodejs-community
+COPY --from=public.ecr.aws/odigos/agents/nodejs-community:v0.13.0@sha256:f908dd3a2ae4d9213d923521685b10f138d6739c902ec1f9a20c0ce5b7b435c8 /instrumentations/opentelemetry-node /instrumentations/opentelemetry-node
+COPY --from=public.ecr.aws/odigos/agents/nodejs-community:v0.13.0@sha256:f908dd3a2ae4d9213d923521685b10f138d6739c902ec1f9a20c0ce5b7b435c8 /instrumentations/nodejs-community /instrumentations/nodejs-community
 # nodejs-community-14
-COPY --from=public.ecr.aws/odigos/agents/nodejs-community-14:v0.0.19 /instrumentations/opentelemetry-node-14 /instrumentations/opentelemetry-node-14
-COPY --from=public.ecr.aws/odigos/agents/nodejs-community-14:v0.0.19 /instrumentations/nodejs-community-14 /instrumentations/nodejs-community-14
+COPY --from=public.ecr.aws/odigos/agents/nodejs-community-14:v0.0.19@sha256:c000e785fd525eb4fd5056cf922b7e2c3f12d845d36fb9661c1d505f8a3f3d53 /instrumentations/opentelemetry-node-14 /instrumentations/opentelemetry-node-14
+COPY --from=public.ecr.aws/odigos/agents/nodejs-community-14:v0.0.19@sha256:c000e785fd525eb4fd5056cf922b7e2c3f12d845d36fb9661c1d505f8a3f3d53 /instrumentations/nodejs-community-14 /instrumentations/nodejs-community-14
 
 # dotnet-community
 COPY --from=dotnet-builder /dotnet-instrumentation /instrumentations/dotnet
 
 # php-community
-COPY --from=public.ecr.aws/odigos/agents/php-community:v0.5.0 /instrumentations/php /instrumentations/php
+COPY --from=public.ecr.aws/odigos/agents/php-community:v0.5.0@sha256:2742c2e003ddece79010fd47b4da021b54e3ce046dafd850f1b4a772d38aa08b /instrumentations/php /instrumentations/php
 
 # ruby-community
-COPY --from=public.ecr.aws/odigos/agents/ruby-community:v0.0.8 /instrumentations/ruby /instrumentations/ruby
+COPY --from=public.ecr.aws/odigos/agents/ruby-community:v0.0.8@sha256:a9df41f7684f550a3b7e1693456f7c4eb4ce432aba82d4b9e22d2a73687473b1 /instrumentations/ruby /instrumentations/ruby
 
 # loader
 ARG ODIGOS_LOADER_VERSION=v0.0.8


### PR DESCRIPTION
All `COPY --from` references to agent images used **mutable tags** — any of them could be re-pushed and silently change what every odiglet build contains. This pins all of them as `tag@digest`: the tag stays for readability, the digest is what the build actually resolves.

Companion change in `odiglet/agent-deps.mk`: the version-bump targets now resolve the new manifest digest after rewriting the tag. Without that, the automated agent bumps would rewrite the tag and keep the **old** digest — which wins over the tag — silently shipping stale bits under a new label. A bump also now fails loudly if the requested tag does not exist in the registry.

Tested locally in this branch:
- same-version bumps are idempotent (zero diff)
- cross-version bump rewrites tag and digest together
- the python `-py3.8` pin survives a python-community bump
- a nonexistent tag fails the make

Part of the supply-chain project — replaces separate signing of the agent images (they never run as images in customer clusters; they are build inputs to odiglet, and pinning covers the tamper path directly).

```release-note
Agent images consumed at odiglet build time are now pinned by digest, and agent version bumps keep the digest pin up to date.
```