### PR TITLE
RUN-1034: sign published images and carry signatures across registry mirrors

### DIFF
--- a/.github/workflows/promote-rc-to-stable.yml
+++ b/.github/workflows/promote-rc-to-stable.yml
@@ -86,6 +86,13 @@ jobs:
       - name: Install crane
         uses: imjasonh/setup-crane@v0.4
 
+      # oras is used for the cross-repo mirrors: `oras copy -r` carries the
+      # cosign signature and SBOM referrers with the image, which `crane copy`
+      # drops. The same-repo RC->stable retags keep crane — referrers attach
+      # to the digest, so a retag inside one repo never loses them.
+      - name: Install oras
+        uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
+
       - id: gcp-auth
         name: Authenticate with Google Cloud
         uses: google-github-actions/auth@v3
@@ -144,7 +151,7 @@ jobs:
               # Mirror all GCR images into the private registry (components-private).
               for IMAGE_NAME in "${GCR_IMAGE_NAMES[@]}"; do
                 echo "Mirroring ${GCR_REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.STABLE_TAG }} to ${GCR_PRIVATE_REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.STABLE_TAG }}"
-                if ! crane copy ${GCR_REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.STABLE_TAG }} ${GCR_PRIVATE_REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.STABLE_TAG }}; then
+                if ! oras copy -r ${GCR_REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.STABLE_TAG }} ${GCR_PRIVATE_REPO}/${IMAGE_NAME}${SUFFIX}:${{ env.STABLE_TAG }}; then
                   echo "ERROR: Failed to mirror ${GCR_PRIVATE_REPO}/${IMAGE_NAME}${SUFFIX}"
                   FAILED_COPIES+=("${GCR_PRIVATE_REPO}/${IMAGE_NAME}${SUFFIX}")
                 else
@@ -192,7 +199,7 @@ jobs:
               fi
 
               echo "Mirroring ${GCR_REPO}/${IMAGE_NAME}:${{ env.STABLE_TAG }}-extended to ${GCR_PRIVATE_REPO}/${IMAGE_NAME}:${{ env.STABLE_TAG }}-extended"
-              if ! crane copy ${GCR_REPO}/${IMAGE_NAME}:${{ env.STABLE_TAG }}-extended ${GCR_PRIVATE_REPO}/${IMAGE_NAME}:${{ env.STABLE_TAG }}-extended; then
+              if ! oras copy -r ${GCR_REPO}/${IMAGE_NAME}:${{ env.STABLE_TAG }}-extended ${GCR_PRIVATE_REPO}/${IMAGE_NAME}:${{ env.STABLE_TAG }}-extended; then
                 echo "ERROR: Failed to mirror ${GCR_PRIVATE_REPO}/${IMAGE_NAME} extended"
                 FAILED_COPIES+=("${GCR_PRIVATE_REPO}/${IMAGE_NAME}-extended")
               else

--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -244,6 +244,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Push Docker Image for ${{ matrix.service }}
+        id: build
         uses: docker/build-push-action@v6
         env:
           ODIGOS_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || steps.extract_tag.outputs.tag}}
@@ -270,6 +271,21 @@ jobs:
                 'Dockerfile' }}
           target: >-
             ${{ matrix.service == 'agents' && 'agents' || '' }}
+
+      # Runs in this job so it inherits the registry logins above. One build
+      # writes the same digest to four registries; each ref gets its own
+      # signature, because signatures live beside the image in one registry
+      # and do not travel with a copy. Signing is fail-closed: a signing
+      # failure fails this publish job.
+      - name: Sign image and attach SBOM
+        uses: odigos-io/ci-core/sign-oci@main
+        with:
+          refs: |
+            us-central1-docker.pkg.dev/odigos-cloud/components/odigos-${{ matrix.service }}
+            us-central1-docker.pkg.dev/odigos-cloud/components-private/odigos-${{ matrix.service }}
+            keyval/odigos-${{ matrix.service }}
+            ghcr.io/odigos-io/odigos-${{ matrix.service }}
+          digest: ${{ steps.build.outputs.digest }}
 
       - name: Notify Slack
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -294,6 +294,7 @@ jobs:
       - uses: ko-build/setup-ko@v0.9
 
       - name: publish cli image to docker registries
+        id: ko-cli
         working-directory: ./cli
         env:
           KO_DOCKER_REPO: us-central1-docker.pkg.dev/odigos-cloud/components/odigos-cli
@@ -307,10 +308,28 @@ jobs:
             KO_TAGS="$KO_TAGS --tags latest"
           fi
           echo "ko tags: $KO_TAGS"
-          ko build --bare $KO_TAGS --platform=linux/amd64,linux/arm64
+          # ko prints the pushed ref with its digest; capture it so the image
+          # can be signed by digest rather than by mutable tag.
+          IMAGE_REF=$(ko build --bare $KO_TAGS --platform=linux/amd64,linux/arm64)
+          echo "built: ${IMAGE_REF}"
+          case "$IMAGE_REF" in
+            *@sha256:*) echo "digest=${IMAGE_REF##*@}" >> "$GITHUB_OUTPUT" ;;
+            *) echo "::error::ko did not return a digest ref: ${IMAGE_REF}"; exit 1 ;;
+          esac
+
+      # Sign at the source registry before mirroring, so the mirrors can carry
+      # the signature and SBOM along as OCI referrers. Fail-closed.
+      - name: Sign CLI image and attach SBOM
+        uses: odigos-io/ci-core/sign-oci@main
+        with:
+          refs: us-central1-docker.pkg.dev/odigos-cloud/components/odigos-cli
+          digest: ${{ steps.ko-cli.outputs.digest }}
 
       - name: Install crane
         uses: imjasonh/setup-crane@v0.4
+
+      - name: Install oras
+        uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
 
       - name: Copy CLI image to Docker Hub and private GCR
         env:
@@ -318,19 +337,23 @@ jobs:
           DEST_IMAGE: ${{ env.DOCKERHUB_ORG }}/odigos-cli
           GCR_PRIVATE_DEST_IMAGE: us-central1-docker.pkg.dev/odigos-cloud/components-private/odigos-cli
         run: |
-          crane copy ${SOURCE_IMAGE}:${{ env.TAG }} ${DEST_IMAGE}:${{ env.TAG }}
-          crane copy ${SOURCE_IMAGE}:${{ env.TAG }} ${GCR_PRIVATE_DEST_IMAGE}:${{ env.TAG }}
+          # oras copy -r rather than crane copy: -r copies the referrers graph
+          # (cosign signature and SBOM attestation) along with the image, so
+          # the mirrors stay verifiable. crane copy moves only the manifest.
+          oras copy -r ${SOURCE_IMAGE}:${{ env.TAG }} ${DEST_IMAGE}:${{ env.TAG }}
+          oras copy -r ${SOURCE_IMAGE}:${{ env.TAG }} ${GCR_PRIVATE_DEST_IMAGE}:${{ env.TAG }}
 
           # Mirror :latest only when this release owns it, so the mirrors stay
           # in step with the source registry.
           if [ "${{ env.PUSH_LATEST }}" = "true" ]; then
-            crane copy ${SOURCE_IMAGE}:latest ${DEST_IMAGE}:latest
-            crane copy ${SOURCE_IMAGE}:latest ${GCR_PRIVATE_DEST_IMAGE}:latest
+            oras copy -r ${SOURCE_IMAGE}:latest ${DEST_IMAGE}:latest
+            oras copy -r ${SOURCE_IMAGE}:latest ${GCR_PRIVATE_DEST_IMAGE}:latest
           else
             echo "Skipping :latest mirror for ${{ env.TAG }}"
           fi
 
       - name: Copy VictoriaMetrics image to Docker Hub and GCR
+        id: vm-copy
         env:
           SOURCE_IMAGE: victoriametrics/victoria-metrics:${{ env.VICTORIA_METRICS_VERSION }}
           DOCKERHUB_DEST_IMAGE: ${{ env.DOCKERHUB_ORG }}/odigos-victoria-metrics
@@ -350,6 +373,23 @@ jobs:
           else
             echo "Skipping :latest mirror for ${{ env.TAG }}"
           fi
+
+          # The copy preserves the upstream digest; capture it so our copies
+          # can be signed by digest.
+          echo "digest=$(crane digest ${SOURCE_IMAGE})" >> "$GITHUB_OUTPUT"
+
+      # VictoriaMetrics is a re-host of an upstream image under our name. The
+      # signature attests that WE published this exact digest in our
+      # registries — not that we built it. Signed at the destinations because
+      # there is no upstream cosign signature to carry over.
+      - name: Sign re-hosted VictoriaMetrics image
+        uses: odigos-io/ci-core/sign-oci@main
+        with:
+          refs: |
+            ${{ env.DOCKERHUB_ORG }}/odigos-victoria-metrics
+            us-central1-docker.pkg.dev/odigos-cloud/components/odigos-victoria-metrics
+            us-central1-docker.pkg.dev/odigos-cloud/components-private/odigos-victoria-metrics
+          digest: ${{ steps.vm-copy.outputs.digest }}
 
       - name: Set notification messages
         run: |


### PR DESCRIPTION
Signs everything this repo publishes as OCI images, and makes the signatures survive the mirrors. Nothing odigos publishes is signed today.

## What changes

**`publish-modules.yml`** — captures the build digest (`id: build`) and signs each of the 8 component images with `ci-core/sign-oci`, attaching a CycloneDX SBOM attestation. One build writes the same digest to 4 registries; each ref gets its own signature. **Fail-closed** — a signing failure fails the publish job.

**`release.yml`** — captures the CLI digest from `ko` (nothing captured a digest before), signs the CLI at the source registry, then mirrors with **`oras copy -r`** instead of `crane copy` so the signature and SBOM travel to Docker Hub and components-private as OCI referrers. The re-hosted VictoriaMetrics image is signed at its destinations — attesting that *we published this exact upstream digest*, not that we built it.

**`promote-rc-to-stable.yml`** — the two **cross-repo** mirrors (components → components-private, plain and `-extended`) switch to `oras copy -r`. The five same-repo RC→stable retags deliberately keep `crane`: referrers attach to the digest, and a retag inside one repo does not change it — verified empirically. This is what makes `x.y.0` stable tags verifiable, since they exist only as retags of the RC digest.

## Covers RUN-1035 as well

The cross-repo copy fix is folded in here rather than a separate PR — the signing and the copy semantics are one review.

## Notes for review

- **Stacked on #5486** (the `:latest` guard) — it touches the same `release.yml` regions. Merge #5486 first; this then rebases to just the signing diff.
- `sign-oci` is pinned to a commit on ci-core#95. **Repoint to `@main` after that merges.**
- The pattern is proven end to end on `dynamic-loader` and `wasp-init` against real GAR (signature + SBOM + per-arch children verify, wrong identity rejected). `oras copy -r` carrying referrers is verified locally; the cross-registry (GAR→Docker Hub) leg should be watched on the first test run.
- Identity note for the verification policy: the CLI signs under `refs/heads/main` (dispatch-triggered), components under `refs/tags/v*`.

```release-note
All published odigos container images are now signed with cosign (keyless) and carry CycloneDX SBOM attestations, and signatures follow images across registry mirrors and RC promotion.
```