### PR TITLE
RUN-1051 | fix(ci): read build scan results from file, not step output

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,13 +34,15 @@ jobs:
         continue-on-error: true
       - name: Save autoscaler scan JSON
         if: always()
+        env:
+          RESULTS_FILE: ${{ steps.scan-autoscaler.outputs.results-file }}
         run: |
           mkdir -p /tmp/scan-results
-          cat > /tmp/scan-results/odigos-autoscaler.json << 'EOF'
-          ${{ steps.scan-autoscaler.outputs.results-json }}
-          EOF
-          jq --arg img "odigos-autoscaler" --arg tag "pr-${{ github.event.number || github.run_number }}" '. + {imageName: $img, imageTag: $tag}' /tmp/scan-results/odigos-autoscaler.json > /tmp/scan-results/odigos-autoscaler_enriched.json
-          mv /tmp/scan-results/odigos-autoscaler_enriched.json /tmp/scan-results/odigos-autoscaler.json
+          if [ -z "${RESULTS_FILE:-}" ] || [ ! -s "$RESULTS_FILE" ]; then
+            echo "::error::No scan results produced; expected a report at '${RESULTS_FILE:-<unset>}'."
+            exit 1
+          fi
+          jq --arg img "odigos-autoscaler" --arg tag "pr-${{ github.event.number || github.run_number }}" '. + {imageName: $img, imageTag: $tag}' "$RESULTS_FILE" > /tmp/scan-results/odigos-autoscaler.json
       - name: Upload autoscaler scan results
         if: always()
         uses: actions/upload-artifact@v4
@@ -81,13 +83,15 @@ jobs:
         continue-on-error: true
       - name: Save scheduler scan JSON
         if: always()
+        env:
+          RESULTS_FILE: ${{ steps.scan-scheduler.outputs.results-file }}
         run: |
           mkdir -p /tmp/scan-results
-          cat > /tmp/scan-results/odigos-scheduler.json << 'EOF'
-          ${{ steps.scan-scheduler.outputs.results-json }}
-          EOF
-          jq --arg img "odigos-scheduler" --arg tag "pr-${{ github.event.number || github.run_number }}" '. + {imageName: $img, imageTag: $tag}' /tmp/scan-results/odigos-scheduler.json > /tmp/scan-results/odigos-scheduler_enriched.json
-          mv /tmp/scan-results/odigos-scheduler_enriched.json /tmp/scan-results/odigos-scheduler.json
+          if [ -z "${RESULTS_FILE:-}" ] || [ ! -s "$RESULTS_FILE" ]; then
+            echo "::error::No scan results produced; expected a report at '${RESULTS_FILE:-<unset>}'."
+            exit 1
+          fi
+          jq --arg img "odigos-scheduler" --arg tag "pr-${{ github.event.number || github.run_number }}" '. + {imageName: $img, imageTag: $tag}' "$RESULTS_FILE" > /tmp/scan-results/odigos-scheduler.json
       - name: Upload scheduler scan results
         if: always()
         uses: actions/upload-artifact@v4
@@ -125,13 +129,15 @@ jobs:
         continue-on-error: true
       - name: Save agents scan JSON
         if: always()
+        env:
+          RESULTS_FILE: ${{ steps.scan-agents.outputs.results-file }}
         run: |
           mkdir -p /tmp/scan-results
-          cat > /tmp/scan-results/odigos-agents.json << 'EOF'
-          ${{ steps.scan-agents.outputs.results-json }}
-          EOF
-          jq --arg img "odigos-agents" --arg tag "pr-${{ github.event.number || github.run_number }}" '. + {imageName: $img, imageTag: $tag}' /tmp/scan-results/odigos-agents.json > /tmp/scan-results/odigos-agents_enriched.json
-          mv /tmp/scan-results/odigos-agents_enriched.json /tmp/scan-results/odigos-agents.json
+          if [ -z "${RESULTS_FILE:-}" ] || [ ! -s "$RESULTS_FILE" ]; then
+            echo "::error::No scan results produced; expected a report at '${RESULTS_FILE:-<unset>}'."
+            exit 1
+          fi
+          jq --arg img "odigos-agents" --arg tag "pr-${{ github.event.number || github.run_number }}" '. + {imageName: $img, imageTag: $tag}' "$RESULTS_FILE" > /tmp/scan-results/odigos-agents.json
       - name: Upload agents scan results
         if: always()
         uses: actions/upload-artifact@v4
@@ -171,13 +177,15 @@ jobs:
         continue-on-error: true
       - name: Save instrumentor scan JSON
         if: always()
+        env:
+          RESULTS_FILE: ${{ steps.scan-instrumentor.outputs.results-file }}
         run: |
           mkdir -p /tmp/scan-results
-          cat > /tmp/scan-results/odigos-instrumentor.json << 'EOF'
-          ${{ steps.scan-instrumentor.outputs.results-json }}
-          EOF
-          jq --arg img "odigos-instrumentor" --arg tag "pr-${{ github.event.number || github.run_number }}" '. + {imageName: $img, imageTag: $tag}' /tmp/scan-results/odigos-instrumentor.json > /tmp/scan-results/odigos-instrumentor_enriched.json
-          mv /tmp/scan-results/odigos-instrumentor_enriched.json /tmp/scan-results/odigos-instrumentor.json
+          if [ -z "${RESULTS_FILE:-}" ] || [ ! -s "$RESULTS_FILE" ]; then
+            echo "::error::No scan results produced; expected a report at '${RESULTS_FILE:-<unset>}'."
+            exit 1
+          fi
+          jq --arg img "odigos-instrumentor" --arg tag "pr-${{ github.event.number || github.run_number }}" '. + {imageName: $img, imageTag: $tag}' "$RESULTS_FILE" > /tmp/scan-results/odigos-instrumentor.json
       - name: Upload instrumentor scan results
         if: always()
         uses: actions/upload-artifact@v4
@@ -217,13 +225,15 @@ jobs:
         continue-on-error: true
       - name: Save collector scan JSON
         if: always()
+        env:
+          RESULTS_FILE: ${{ steps.scan-collector.outputs.results-file }}
         run: |
           mkdir -p /tmp/scan-results
-          cat > /tmp/scan-results/odigos-collector.json << 'EOF'
-          ${{ steps.scan-collector.outputs.results-json }}
-          EOF
-          jq --arg img "odigos-collector" --arg tag "pr-${{ github.event.number || github.run_number }}" '. + {imageName: $img, imageTag: $tag}' /tmp/scan-results/odigos-collector.json > /tmp/scan-results/odigos-collector_enriched.json
-          mv /tmp/scan-results/odigos-collector_enriched.json /tmp/scan-results/odigos-collector.json
+          if [ -z "${RESULTS_FILE:-}" ] || [ ! -s "$RESULTS_FILE" ]; then
+            echo "::error::No scan results produced; expected a report at '${RESULTS_FILE:-<unset>}'."
+            exit 1
+          fi
+          jq --arg img "odigos-collector" --arg tag "pr-${{ github.event.number || github.run_number }}" '. + {imageName: $img, imageTag: $tag}' "$RESULTS_FILE" > /tmp/scan-results/odigos-collector.json
       - name: Upload collector scan results
         if: always()
         uses: actions/upload-artifact@v4
@@ -266,13 +276,15 @@ jobs:
         continue-on-error: true
       - name: Save odiglet scan JSON
         if: always()
+        env:
+          RESULTS_FILE: ${{ steps.scan-odiglet.outputs.results-file }}
         run: |
           mkdir -p /tmp/scan-results
-          cat > /tmp/scan-results/odigos-odiglet.json << 'EOF'
-          ${{ steps.scan-odiglet.outputs.results-json }}
-          EOF
-          jq --arg img "odigos-odiglet" --arg tag "pr-${{ github.event.number || github.run_number }}" '. + {imageName: $img, imageTag: $tag}' /tmp/scan-results/odigos-odiglet.json > /tmp/scan-results/odigos-odiglet_enriched.json
-          mv /tmp/scan-results/odigos-odiglet_enriched.json /tmp/scan-results/odigos-odiglet.json
+          if [ -z "${RESULTS_FILE:-}" ] || [ ! -s "$RESULTS_FILE" ]; then
+            echo "::error::No scan results produced; expected a report at '${RESULTS_FILE:-<unset>}'."
+            exit 1
+          fi
+          jq --arg img "odigos-odiglet" --arg tag "pr-${{ github.event.number || github.run_number }}" '. + {imageName: $img, imageTag: $tag}' "$RESULTS_FILE" > /tmp/scan-results/odigos-odiglet.json
       - name: Upload odiglet scan results
         if: always()
         uses: actions/upload-artifact@v4
@@ -310,13 +322,15 @@ jobs:
         continue-on-error: true
       - name: Save frontend webapp scan JSON
         if: always()
+        env:
+          RESULTS_FILE: ${{ steps.scan-frontend-webapp.outputs.results-file }}
         run: |
           mkdir -p /tmp/scan-results
-          cat > /tmp/scan-results/odigos-ui-webapp.json << 'EOF'
-          ${{ steps.scan-frontend-webapp.outputs.results-json }}
-          EOF
-          jq --arg img "odigos-ui-webapp" --arg tag "pr-${{ github.event.number || github.run_number }}" '. + {imageName: $img, imageTag: $tag}' /tmp/scan-results/odigos-ui-webapp.json > /tmp/scan-results/odigos-ui-webapp_enriched.json
-          mv /tmp/scan-results/odigos-ui-webapp_enriched.json /tmp/scan-results/odigos-ui-webapp.json
+          if [ -z "${RESULTS_FILE:-}" ] || [ ! -s "$RESULTS_FILE" ]; then
+            echo "::error::No scan results produced; expected a report at '${RESULTS_FILE:-<unset>}'."
+            exit 1
+          fi
+          jq --arg img "odigos-ui-webapp" --arg tag "pr-${{ github.event.number || github.run_number }}" '. + {imageName: $img, imageTag: $tag}' "$RESULTS_FILE" > /tmp/scan-results/odigos-ui-webapp.json
       - name: Upload frontend webapp scan results
         if: always()
         uses: actions/upload-artifact@v4
@@ -348,13 +362,15 @@ jobs:
         continue-on-error: true
       - name: Save frontend scan JSON
         if: always()
+        env:
+          RESULTS_FILE: ${{ steps.scan-frontend.outputs.results-file }}
         run: |
           mkdir -p /tmp/scan-results
-          cat > /tmp/scan-results/odigos-ui.json << 'EOF'
-          ${{ steps.scan-frontend.outputs.results-json }}
-          EOF
-          jq --arg img "odigos-ui" --arg tag "pr-${{ github.event.number || github.run_number }}" '. + {imageName: $img, imageTag: $tag}' /tmp/scan-results/odigos-ui.json > /tmp/scan-results/odigos-ui_enriched.json
-          mv /tmp/scan-results/odigos-ui_enriched.json /tmp/scan-results/odigos-ui.json
+          if [ -z "${RESULTS_FILE:-}" ] || [ ! -s "$RESULTS_FILE" ]; then
+            echo "::error::No scan results produced; expected a report at '${RESULTS_FILE:-<unset>}'."
+            exit 1
+          fi
+          jq --arg img "odigos-ui" --arg tag "pr-${{ github.event.number || github.run_number }}" '. + {imageName: $img, imageTag: $tag}' "$RESULTS_FILE" > /tmp/scan-results/odigos-ui.json
       - name: Upload frontend scan results
         if: always()
         uses: actions/upload-artifact@v4
@@ -400,13 +416,15 @@ jobs:
         continue-on-error: true
       - name: Save operator scan JSON
         if: always()
+        env:
+          RESULTS_FILE: ${{ steps.scan-operator.outputs.results-file }}
         run: |
           mkdir -p /tmp/scan-results
-          cat > /tmp/scan-results/odigos-operator.json << 'EOF'
-          ${{ steps.scan-operator.outputs.results-json }}
-          EOF
-          jq --arg img "odigos-operator" --arg tag "pr-${{ github.event.number || github.run_number }}" '. + {imageName: $img, imageTag: $tag}' /tmp/scan-results/odigos-operator.json > /tmp/scan-results/odigos-operator_enriched.json
-          mv /tmp/scan-results/odigos-operator_enriched.json /tmp/scan-results/odigos-operator.json
+          if [ -z "${RESULTS_FILE:-}" ] || [ ! -s "$RESULTS_FILE" ]; then
+            echo "::error::No scan results produced; expected a report at '${RESULTS_FILE:-<unset>}'."
+            exit 1
+          fi
+          jq --arg img "odigos-operator" --arg tag "pr-${{ github.event.number || github.run_number }}" '. + {imageName: $img, imageTag: $tag}' "$RESULTS_FILE" > /tmp/scan-results/odigos-operator.json
       - name: Upload operator scan results
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Depends on odigos-io/ci-core#97. Companion to #5508, which fixes the standalone `vulnerability-scan.yaml`; this covers the 9 call sites in `build.yaml`.

## Problem

Same truncation, nine more times. Every scan block does:

```yaml
cat > /tmp/scan-results/odigos-autoscaler.json << 'EOF'
${{ steps.scan-autoscaler.outputs.results-json }}
EOF
```

A report past the Actions expression limit makes the step fail with `Maximum object size exceeded`, the heredoc expands to nothing, and the artifact uploads **empty while the job stays green**. Odiglet's report is ~4.1 MB, so this happens on every build — not just the manual scan where it was found.

## Change

Read from `results-file` (a path, no size ceiling) and **fail the step when the report is missing or empty**, instead of silently uploading an empty artifact.

All 9 sites: autoscaler, scheduler, agents, instrumentor, collector, odiglet, frontend-webapp, frontend, operator.

The `_enriched.json` temp file and its `mv` are gone too — `jq` now writes straight to the target.

Verified no `results-json` references remain and the workflow still parses with all 13 jobs intact.

## Why this matters even with enterprise scanning downstream

Enterprise scans the published images, but these blocks scan **PR builds** — they're the pre-merge signal. Truncated results here mean a PR can introduce a CRITICAL and still show green.

```release-note
NONE
```