### PR TITLE
PLAT-1416 | feat: enhance Insights anomaly GraphQL schema with explain/traces/diffs

### DIFF
--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -619,7 +619,27 @@ type ComplexityRoot struct {
 		Transactions        func(childComplexity int, namespace *string, service *string, kind *model.InsightsTransactionKind) int
 	}
 
+	InsightsAnomalyAttrHighlight struct {
+		Key    func(childComplexity int) int
+		SpanID func(childComplexity int) int
+		Value  func(childComplexity int) int
+	}
+
+	InsightsAnomalyClassFinding struct {
+		AttrHighlights func(childComplexity int) int
+		Class          func(childComplexity int) int
+		Kind           func(childComplexity int) int
+		Metric         func(childComplexity int) int
+		RawEvidence    func(childComplexity int) int
+		SpanHighlights func(childComplexity int) int
+		Summary        func(childComplexity int) int
+		Title          func(childComplexity int) int
+	}
+
 	InsightsAnomalyIssue struct {
+		AnomalyTrace     func(childComplexity int) int
+		BaselineTrace    func(childComplexity int) int
+		ClassFindings    func(childComplexity int) int
 		Evidence         func(childComplexity int) int
 		FirstSeen        func(childComplexity int) int
 		Kind             func(childComplexity int) int
@@ -638,6 +658,18 @@ type ComplexityRoot struct {
 		Status           func(childComplexity int) int
 		TransactionID    func(childComplexity int) int
 		TriggeredClasses func(childComplexity int) int
+	}
+
+	InsightsAnomalyMetricComparison struct {
+		Baseline func(childComplexity int) int
+		Observed func(childComplexity int) int
+		Unit     func(childComplexity int) int
+	}
+
+	InsightsAnomalySpanHighlight struct {
+		Reason   func(childComplexity int) int
+		Severity func(childComplexity int) int
+		SpanID   func(childComplexity int) int
 	}
 
 	InsightsAnomalySummary struct {
@@ -4828,6 +4860,104 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Insights.Transactions(childComplexity, args["namespace"].(*string), args["service"].(*string), args["kind"].(*model.InsightsTransactionKind)), true
 
+	case "InsightsAnomalyAttrHighlight.key":
+		if e.complexity.InsightsAnomalyAttrHighlight.Key == nil {
+			break
+		}
+
+		return e.complexity.InsightsAnomalyAttrHighlight.Key(childComplexity), true
+
+	case "InsightsAnomalyAttrHighlight.spanId":
+		if e.complexity.InsightsAnomalyAttrHighlight.SpanID == nil {
+			break
+		}
+
+		return e.complexity.InsightsAnomalyAttrHighlight.SpanID(childComplexity), true
+
+	case "InsightsAnomalyAttrHighlight.value":
+		if e.complexity.InsightsAnomalyAttrHighlight.Value == nil {
+			break
+		}
+
+		return e.complexity.InsightsAnomalyAttrHighlight.Value(childComplexity), true
+
+	case "InsightsAnomalyClassFinding.attrHighlights":
+		if e.complexity.InsightsAnomalyClassFinding.AttrHighlights == nil {
+			break
+		}
+
+		return e.complexity.InsightsAnomalyClassFinding.AttrHighlights(childComplexity), true
+
+	case "InsightsAnomalyClassFinding.class":
+		if e.complexity.InsightsAnomalyClassFinding.Class == nil {
+			break
+		}
+
+		return e.complexity.InsightsAnomalyClassFinding.Class(childComplexity), true
+
+	case "InsightsAnomalyClassFinding.kind":
+		if e.complexity.InsightsAnomalyClassFinding.Kind == nil {
+			break
+		}
+
+		return e.complexity.InsightsAnomalyClassFinding.Kind(childComplexity), true
+
+	case "InsightsAnomalyClassFinding.metric":
+		if e.complexity.InsightsAnomalyClassFinding.Metric == nil {
+			break
+		}
+
+		return e.complexity.InsightsAnomalyClassFinding.Metric(childComplexity), true
+
+	case "InsightsAnomalyClassFinding.rawEvidence":
+		if e.complexity.InsightsAnomalyClassFinding.RawEvidence == nil {
+			break
+		}
+
+		return e.complexity.InsightsAnomalyClassFinding.RawEvidence(childComplexity), true
+
+	case "InsightsAnomalyClassFinding.spanHighlights":
+		if e.complexity.InsightsAnomalyClassFinding.SpanHighlights == nil {
+			break
+		}
+
+		return e.complexity.InsightsAnomalyClassFinding.SpanHighlights(childComplexity), true
+
+	case "InsightsAnomalyClassFinding.summary":
+		if e.complexity.InsightsAnomalyClassFinding.Summary == nil {
+			break
+		}
+
+		return e.complexity.InsightsAnomalyClassFinding.Summary(childComplexity), true
+
+	case "InsightsAnomalyClassFinding.title":
+		if e.complexity.InsightsAnomalyClassFinding.Title == nil {
+			break
+		}
+
+		return e.complexity.InsightsAnomalyClassFinding.Title(childComplexity), true
+
+	case "InsightsAnomalyIssue.anomalyTrace":
+		if e.complexity.InsightsAnomalyIssue.AnomalyTrace == nil {
+			break
+		}
+
+		return e.complexity.InsightsAnomalyIssue.AnomalyTrace(childComplexity), true
+
+	case "InsightsAnomalyIssue.baselineTrace":
+		if e.complexity.InsightsAnomalyIssue.BaselineTrace == nil {
+			break
+		}
+
+		return e.complexity.InsightsAnomalyIssue.BaselineTrace(childComplexity), true
+
+	case "InsightsAnomalyIssue.classFindings":
+		if e.complexity.InsightsAnomalyIssue.ClassFindings == nil {
+			break
+		}
+
+		return e.complexity.InsightsAnomalyIssue.ClassFindings(childComplexity), true
+
 	case "InsightsAnomalyIssue.evidence":
 		if e.complexity.InsightsAnomalyIssue.Evidence == nil {
 			break
@@ -4953,6 +5083,48 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.InsightsAnomalyIssue.TriggeredClasses(childComplexity), true
+
+	case "InsightsAnomalyMetricComparison.baseline":
+		if e.complexity.InsightsAnomalyMetricComparison.Baseline == nil {
+			break
+		}
+
+		return e.complexity.InsightsAnomalyMetricComparison.Baseline(childComplexity), true
+
+	case "InsightsAnomalyMetricComparison.observed":
+		if e.complexity.InsightsAnomalyMetricComparison.Observed == nil {
+			break
+		}
+
+		return e.complexity.InsightsAnomalyMetricComparison.Observed(childComplexity), true
+
+	case "InsightsAnomalyMetricComparison.unit":
+		if e.complexity.InsightsAnomalyMetricComparison.Unit == nil {
+			break
+		}
+
+		return e.complexity.InsightsAnomalyMetricComparison.Unit(childComplexity), true
+
+	case "InsightsAnomalySpanHighlight.reason":
+		if e.complexity.InsightsAnomalySpanHighlight.Reason == nil {
+			break
+		}
+
+		return e.complexity.InsightsAnomalySpanHighlight.Reason(childComplexity), true
+
+	case "InsightsAnomalySpanHighlight.severity":
+		if e.complexity.InsightsAnomalySpanHighlight.Severity == nil {
+			break
+		}
+
+		return e.complexity.InsightsAnomalySpanHighlight.Severity(childComplexity), true
+
+	case "InsightsAnomalySpanHighlight.spanId":
+		if e.complexity.InsightsAnomalySpanHighlight.SpanID == nil {
+			break
+		}
+
+		return e.complexity.InsightsAnomalySpanHighlight.SpanID(childComplexity), true
 
 	case "InsightsAnomalySummary.firstSeen":
 		if e.complexity.InsightsAnomalySummary.FirstSeen == nil {
@@ -31652,6 +31824,12 @@ func (ec *executionContext) fieldContext_Insights_anomaly(ctx context.Context, f
 				return ec.fieldContext_InsightsAnomalyIssue_evidence(ctx, field)
 			case "risk":
 				return ec.fieldContext_InsightsAnomalyIssue_risk(ctx, field)
+			case "classFindings":
+				return ec.fieldContext_InsightsAnomalyIssue_classFindings(ctx, field)
+			case "anomalyTrace":
+				return ec.fieldContext_InsightsAnomalyIssue_anomalyTrace(ctx, field)
+			case "baselineTrace":
+				return ec.fieldContext_InsightsAnomalyIssue_baselineTrace(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type InsightsAnomalyIssue", field.Name)
 		},
@@ -32096,6 +32274,502 @@ func (ec *executionContext) fieldContext_Insights_storageHealth(_ context.Contex
 				return ec.fieldContext_InsightsStorageHealth_writeback(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type InsightsStorageHealth", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsAnomalyAttrHighlight_spanId(ctx context.Context, field graphql.CollectedField, obj *model.InsightsAnomalyAttrHighlight) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsAnomalyAttrHighlight_spanId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SpanID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsAnomalyAttrHighlight_spanId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsAnomalyAttrHighlight",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsAnomalyAttrHighlight_key(ctx context.Context, field graphql.CollectedField, obj *model.InsightsAnomalyAttrHighlight) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsAnomalyAttrHighlight_key(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Key, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsAnomalyAttrHighlight_key(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsAnomalyAttrHighlight",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsAnomalyAttrHighlight_value(ctx context.Context, field graphql.CollectedField, obj *model.InsightsAnomalyAttrHighlight) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsAnomalyAttrHighlight_value(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Value, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsAnomalyAttrHighlight_value(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsAnomalyAttrHighlight",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsAnomalyClassFinding_class(ctx context.Context, field graphql.CollectedField, obj *model.InsightsAnomalyClassFinding) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsAnomalyClassFinding_class(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Class, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.InsightsDeviationClass)
+	fc.Result = res
+	return ec.marshalNInsightsDeviationClass2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsDeviationClass(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsAnomalyClassFinding_class(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsAnomalyClassFinding",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type InsightsDeviationClass does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsAnomalyClassFinding_kind(ctx context.Context, field graphql.CollectedField, obj *model.InsightsAnomalyClassFinding) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsAnomalyClassFinding_kind(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Kind, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.InsightsAnomalyClassFindingKind)
+	fc.Result = res
+	return ec.marshalNInsightsAnomalyClassFindingKind2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsAnomalyClassFindingKind(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsAnomalyClassFinding_kind(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsAnomalyClassFinding",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type InsightsAnomalyClassFindingKind does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsAnomalyClassFinding_title(ctx context.Context, field graphql.CollectedField, obj *model.InsightsAnomalyClassFinding) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsAnomalyClassFinding_title(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Title, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsAnomalyClassFinding_title(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsAnomalyClassFinding",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsAnomalyClassFinding_summary(ctx context.Context, field graphql.CollectedField, obj *model.InsightsAnomalyClassFinding) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsAnomalyClassFinding_summary(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Summary, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsAnomalyClassFinding_summary(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsAnomalyClassFinding",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsAnomalyClassFinding_spanHighlights(ctx context.Context, field graphql.CollectedField, obj *model.InsightsAnomalyClassFinding) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsAnomalyClassFinding_spanHighlights(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SpanHighlights, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.InsightsAnomalySpanHighlight)
+	fc.Result = res
+	return ec.marshalOInsightsAnomalySpanHighlight2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsAnomalySpanHighlightᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsAnomalyClassFinding_spanHighlights(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsAnomalyClassFinding",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "spanId":
+				return ec.fieldContext_InsightsAnomalySpanHighlight_spanId(ctx, field)
+			case "severity":
+				return ec.fieldContext_InsightsAnomalySpanHighlight_severity(ctx, field)
+			case "reason":
+				return ec.fieldContext_InsightsAnomalySpanHighlight_reason(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type InsightsAnomalySpanHighlight", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsAnomalyClassFinding_attrHighlights(ctx context.Context, field graphql.CollectedField, obj *model.InsightsAnomalyClassFinding) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsAnomalyClassFinding_attrHighlights(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AttrHighlights, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.InsightsAnomalyAttrHighlight)
+	fc.Result = res
+	return ec.marshalOInsightsAnomalyAttrHighlight2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsAnomalyAttrHighlightᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsAnomalyClassFinding_attrHighlights(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsAnomalyClassFinding",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "spanId":
+				return ec.fieldContext_InsightsAnomalyAttrHighlight_spanId(ctx, field)
+			case "key":
+				return ec.fieldContext_InsightsAnomalyAttrHighlight_key(ctx, field)
+			case "value":
+				return ec.fieldContext_InsightsAnomalyAttrHighlight_value(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type InsightsAnomalyAttrHighlight", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsAnomalyClassFinding_metric(ctx context.Context, field graphql.CollectedField, obj *model.InsightsAnomalyClassFinding) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsAnomalyClassFinding_metric(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Metric, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.InsightsAnomalyMetricComparison)
+	fc.Result = res
+	return ec.marshalOInsightsAnomalyMetricComparison2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsAnomalyMetricComparison(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsAnomalyClassFinding_metric(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsAnomalyClassFinding",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "observed":
+				return ec.fieldContext_InsightsAnomalyMetricComparison_observed(ctx, field)
+			case "baseline":
+				return ec.fieldContext_InsightsAnomalyMetricComparison_baseline(ctx, field)
+			case "unit":
+				return ec.fieldContext_InsightsAnomalyMetricComparison_unit(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type InsightsAnomalyMetricComparison", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsAnomalyClassFinding_rawEvidence(ctx context.Context, field graphql.CollectedField, obj *model.InsightsAnomalyClassFinding) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsAnomalyClassFinding_rawEvidence(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RawEvidence, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsAnomalyClassFinding_rawEvidence(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsAnomalyClassFinding",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -32880,6 +33554,442 @@ func (ec *executionContext) fieldContext_InsightsAnomalyIssue_risk(_ context.Con
 				return ec.fieldContext_InsightsRiskAssessment_signals(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type InsightsRiskAssessment", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsAnomalyIssue_classFindings(ctx context.Context, field graphql.CollectedField, obj *model.InsightsAnomalyIssue) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsAnomalyIssue_classFindings(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ClassFindings, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.InsightsAnomalyClassFinding)
+	fc.Result = res
+	return ec.marshalNInsightsAnomalyClassFinding2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsAnomalyClassFindingᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsAnomalyIssue_classFindings(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsAnomalyIssue",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "class":
+				return ec.fieldContext_InsightsAnomalyClassFinding_class(ctx, field)
+			case "kind":
+				return ec.fieldContext_InsightsAnomalyClassFinding_kind(ctx, field)
+			case "title":
+				return ec.fieldContext_InsightsAnomalyClassFinding_title(ctx, field)
+			case "summary":
+				return ec.fieldContext_InsightsAnomalyClassFinding_summary(ctx, field)
+			case "spanHighlights":
+				return ec.fieldContext_InsightsAnomalyClassFinding_spanHighlights(ctx, field)
+			case "attrHighlights":
+				return ec.fieldContext_InsightsAnomalyClassFinding_attrHighlights(ctx, field)
+			case "metric":
+				return ec.fieldContext_InsightsAnomalyClassFinding_metric(ctx, field)
+			case "rawEvidence":
+				return ec.fieldContext_InsightsAnomalyClassFinding_rawEvidence(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type InsightsAnomalyClassFinding", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsAnomalyIssue_anomalyTrace(ctx context.Context, field graphql.CollectedField, obj *model.InsightsAnomalyIssue) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsAnomalyIssue_anomalyTrace(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AnomalyTrace, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.InsightsObservation)
+	fc.Result = res
+	return ec.marshalOInsightsObservation2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsObservation(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsAnomalyIssue_anomalyTrace(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsAnomalyIssue",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "traceId":
+				return ec.fieldContext_InsightsObservation_traceId(ctx, field)
+			case "transactionId":
+				return ec.fieldContext_InsightsObservation_transactionId(ctx, field)
+			case "observedAt":
+				return ec.fieldContext_InsightsObservation_observedAt(ctx, field)
+			case "durationMs":
+				return ec.fieldContext_InsightsObservation_durationMs(ctx, field)
+			case "sampleReason":
+				return ec.fieldContext_InsightsObservation_sampleReason(ctx, field)
+			case "rawOtlp":
+				return ec.fieldContext_InsightsObservation_rawOtlp(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type InsightsObservation", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsAnomalyIssue_baselineTrace(ctx context.Context, field graphql.CollectedField, obj *model.InsightsAnomalyIssue) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsAnomalyIssue_baselineTrace(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BaselineTrace, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.InsightsObservation)
+	fc.Result = res
+	return ec.marshalOInsightsObservation2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsObservation(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsAnomalyIssue_baselineTrace(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsAnomalyIssue",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "traceId":
+				return ec.fieldContext_InsightsObservation_traceId(ctx, field)
+			case "transactionId":
+				return ec.fieldContext_InsightsObservation_transactionId(ctx, field)
+			case "observedAt":
+				return ec.fieldContext_InsightsObservation_observedAt(ctx, field)
+			case "durationMs":
+				return ec.fieldContext_InsightsObservation_durationMs(ctx, field)
+			case "sampleReason":
+				return ec.fieldContext_InsightsObservation_sampleReason(ctx, field)
+			case "rawOtlp":
+				return ec.fieldContext_InsightsObservation_rawOtlp(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type InsightsObservation", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsAnomalyMetricComparison_observed(ctx context.Context, field graphql.CollectedField, obj *model.InsightsAnomalyMetricComparison) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsAnomalyMetricComparison_observed(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Observed, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsAnomalyMetricComparison_observed(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsAnomalyMetricComparison",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsAnomalyMetricComparison_baseline(ctx context.Context, field graphql.CollectedField, obj *model.InsightsAnomalyMetricComparison) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsAnomalyMetricComparison_baseline(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Baseline, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsAnomalyMetricComparison_baseline(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsAnomalyMetricComparison",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsAnomalyMetricComparison_unit(ctx context.Context, field graphql.CollectedField, obj *model.InsightsAnomalyMetricComparison) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsAnomalyMetricComparison_unit(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Unit, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsAnomalyMetricComparison_unit(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsAnomalyMetricComparison",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsAnomalySpanHighlight_spanId(ctx context.Context, field graphql.CollectedField, obj *model.InsightsAnomalySpanHighlight) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsAnomalySpanHighlight_spanId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SpanID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsAnomalySpanHighlight_spanId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsAnomalySpanHighlight",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsAnomalySpanHighlight_severity(ctx context.Context, field graphql.CollectedField, obj *model.InsightsAnomalySpanHighlight) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsAnomalySpanHighlight_severity(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Severity, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsAnomalySpanHighlight_severity(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsAnomalySpanHighlight",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsAnomalySpanHighlight_reason(ctx context.Context, field graphql.CollectedField, obj *model.InsightsAnomalySpanHighlight) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsAnomalySpanHighlight_reason(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Reason, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsAnomalySpanHighlight_reason(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsAnomalySpanHighlight",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -81588,6 +82698,117 @@ func (ec *executionContext) _Insights(ctx context.Context, sel ast.SelectionSet,
 	return out
 }
 
+var insightsAnomalyAttrHighlightImplementors = []string{"InsightsAnomalyAttrHighlight"}
+
+func (ec *executionContext) _InsightsAnomalyAttrHighlight(ctx context.Context, sel ast.SelectionSet, obj *model.InsightsAnomalyAttrHighlight) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, insightsAnomalyAttrHighlightImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("InsightsAnomalyAttrHighlight")
+		case "spanId":
+			out.Values[i] = ec._InsightsAnomalyAttrHighlight_spanId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "key":
+			out.Values[i] = ec._InsightsAnomalyAttrHighlight_key(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "value":
+			out.Values[i] = ec._InsightsAnomalyAttrHighlight_value(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var insightsAnomalyClassFindingImplementors = []string{"InsightsAnomalyClassFinding"}
+
+func (ec *executionContext) _InsightsAnomalyClassFinding(ctx context.Context, sel ast.SelectionSet, obj *model.InsightsAnomalyClassFinding) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, insightsAnomalyClassFindingImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("InsightsAnomalyClassFinding")
+		case "class":
+			out.Values[i] = ec._InsightsAnomalyClassFinding_class(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "kind":
+			out.Values[i] = ec._InsightsAnomalyClassFinding_kind(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "title":
+			out.Values[i] = ec._InsightsAnomalyClassFinding_title(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "summary":
+			out.Values[i] = ec._InsightsAnomalyClassFinding_summary(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "spanHighlights":
+			out.Values[i] = ec._InsightsAnomalyClassFinding_spanHighlights(ctx, field, obj)
+		case "attrHighlights":
+			out.Values[i] = ec._InsightsAnomalyClassFinding_attrHighlights(ctx, field, obj)
+		case "metric":
+			out.Values[i] = ec._InsightsAnomalyClassFinding_metric(ctx, field, obj)
+		case "rawEvidence":
+			out.Values[i] = ec._InsightsAnomalyClassFinding_rawEvidence(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var insightsAnomalyIssueImplementors = []string{"InsightsAnomalyIssue"}
 
 func (ec *executionContext) _InsightsAnomalyIssue(ctx context.Context, sel ast.SelectionSet, obj *model.InsightsAnomalyIssue) graphql.Marshaler {
@@ -81665,6 +82886,113 @@ func (ec *executionContext) _InsightsAnomalyIssue(ctx context.Context, sel ast.S
 			}
 		case "risk":
 			out.Values[i] = ec._InsightsAnomalyIssue_risk(ctx, field, obj)
+		case "classFindings":
+			out.Values[i] = ec._InsightsAnomalyIssue_classFindings(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "anomalyTrace":
+			out.Values[i] = ec._InsightsAnomalyIssue_anomalyTrace(ctx, field, obj)
+		case "baselineTrace":
+			out.Values[i] = ec._InsightsAnomalyIssue_baselineTrace(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var insightsAnomalyMetricComparisonImplementors = []string{"InsightsAnomalyMetricComparison"}
+
+func (ec *executionContext) _InsightsAnomalyMetricComparison(ctx context.Context, sel ast.SelectionSet, obj *model.InsightsAnomalyMetricComparison) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, insightsAnomalyMetricComparisonImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("InsightsAnomalyMetricComparison")
+		case "observed":
+			out.Values[i] = ec._InsightsAnomalyMetricComparison_observed(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "baseline":
+			out.Values[i] = ec._InsightsAnomalyMetricComparison_baseline(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "unit":
+			out.Values[i] = ec._InsightsAnomalyMetricComparison_unit(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var insightsAnomalySpanHighlightImplementors = []string{"InsightsAnomalySpanHighlight"}
+
+func (ec *executionContext) _InsightsAnomalySpanHighlight(ctx context.Context, sel ast.SelectionSet, obj *model.InsightsAnomalySpanHighlight) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, insightsAnomalySpanHighlightImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("InsightsAnomalySpanHighlight")
+		case "spanId":
+			out.Values[i] = ec._InsightsAnomalySpanHighlight_spanId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "severity":
+			out.Values[i] = ec._InsightsAnomalySpanHighlight_severity(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "reason":
+			out.Values[i] = ec._InsightsAnomalySpanHighlight_reason(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -94135,6 +95463,80 @@ func (ec *executionContext) marshalNID2string(ctx context.Context, sel ast.Selec
 	return res
 }
 
+func (ec *executionContext) marshalNInsightsAnomalyAttrHighlight2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsAnomalyAttrHighlight(ctx context.Context, sel ast.SelectionSet, v *model.InsightsAnomalyAttrHighlight) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._InsightsAnomalyAttrHighlight(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNInsightsAnomalyClassFinding2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsAnomalyClassFindingᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.InsightsAnomalyClassFinding) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNInsightsAnomalyClassFinding2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsAnomalyClassFinding(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNInsightsAnomalyClassFinding2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsAnomalyClassFinding(ctx context.Context, sel ast.SelectionSet, v *model.InsightsAnomalyClassFinding) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._InsightsAnomalyClassFinding(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNInsightsAnomalyClassFindingKind2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsAnomalyClassFindingKind(ctx context.Context, v any) (model.InsightsAnomalyClassFindingKind, error) {
+	var res model.InsightsAnomalyClassFindingKind
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNInsightsAnomalyClassFindingKind2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsAnomalyClassFindingKind(ctx context.Context, sel ast.SelectionSet, v model.InsightsAnomalyClassFindingKind) graphql.Marshaler {
+	return v
+}
+
 func (ec *executionContext) unmarshalNInsightsAnomalyRefInput2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsAnomalyRefInputᚄ(ctx context.Context, v any) ([]*model.InsightsAnomalyRefInput, error) {
 	var vSlice []any
 	vSlice = graphql.CoerceList(v)
@@ -94163,6 +95565,16 @@ func (ec *executionContext) unmarshalNInsightsAnomalyResolution2githubᚗcomᚋo
 
 func (ec *executionContext) marshalNInsightsAnomalyResolution2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsAnomalyResolution(ctx context.Context, sel ast.SelectionSet, v model.InsightsAnomalyResolution) graphql.Marshaler {
 	return v
+}
+
+func (ec *executionContext) marshalNInsightsAnomalySpanHighlight2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsAnomalySpanHighlight(ctx context.Context, sel ast.SelectionSet, v *model.InsightsAnomalySpanHighlight) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._InsightsAnomalySpanHighlight(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNInsightsAnomalyStatus2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsAnomalyStatus(ctx context.Context, v any) (model.InsightsAnomalyStatus, error) {
@@ -99304,11 +100716,112 @@ func (ec *executionContext) marshalOInsights2ᚖgithubᚗcomᚋodigosᚑioᚋodi
 	return ec._Insights(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalOInsightsAnomalyAttrHighlight2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsAnomalyAttrHighlightᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.InsightsAnomalyAttrHighlight) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNInsightsAnomalyAttrHighlight2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsAnomalyAttrHighlight(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) marshalOInsightsAnomalyIssue2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsAnomalyIssue(ctx context.Context, sel ast.SelectionSet, v *model.InsightsAnomalyIssue) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
 	return ec._InsightsAnomalyIssue(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOInsightsAnomalyMetricComparison2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsAnomalyMetricComparison(ctx context.Context, sel ast.SelectionSet, v *model.InsightsAnomalyMetricComparison) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._InsightsAnomalyMetricComparison(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOInsightsAnomalySpanHighlight2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsAnomalySpanHighlightᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.InsightsAnomalySpanHighlight) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNInsightsAnomalySpanHighlight2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsAnomalySpanHighlight(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) marshalOInsightsEnricherList2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsEnricherList(ctx context.Context, sel ast.SelectionSet, v *model.InsightsEnricherList) graphql.Marshaler {

--- a/frontend/graph/insights.graphqls
+++ b/frontend/graph/insights.graphqls
@@ -153,7 +153,9 @@ type InsightsTransaction {
 type InsightsBaselineClass {
   transactionId: ID!
   class: InsightsDeviationClass!
-  """JSON-encoded baseline data; shape varies per deviation class."""
+  """
+  JSON-encoded baseline data; shape varies per deviation class.
+  """
   data: String
   dataSchemaVersion: Int
   observationCount: Int!
@@ -183,7 +185,9 @@ type InsightsObservation {
   observedAt: String!
   durationMs: Int!
   sampleReason: InsightsSampleReason!
-  """Base64-encoded OTLP protobuf; only available on the single-observation query."""
+  """
+  Base64-encoded OTLP protobuf; only available on the single-observation query.
+  """
   rawOtlp: String!
 }
 
@@ -194,23 +198,33 @@ type InsightsPolicy {
   name: String!
   enabled: Boolean!
   fireAtScore: Int!
-  """JSON-encoded map[string]int of per-signal weights."""
+  """
+  JSON-encoded map[string]int of per-signal weights.
+  """
   signalWeights: String
-  """JSON-encoded map[string][]string of enricher keyword lists."""
+  """
+  JSON-encoded map[string][]string of enricher keyword lists.
+  """
   enricherLists: String
   scope: InsightsPolicyScope!
   scopeKey: String!
 }
 
 input InsightsPolicyInput {
-  """Server-assigned; omit on create (the policy key is scope + scopeKey)."""
+  """
+  Server-assigned; omit on create (the policy key is scope + scopeKey).
+  """
   id: ID
   name: String!
   enabled: Boolean!
   fireAtScore: Int!
-  """JSON-encoded map[string]int of per-signal weights."""
+  """
+  JSON-encoded map[string]int of per-signal weights.
+  """
   signalWeights: String
-  """JSON-encoded map[string][]string of enricher keyword lists."""
+  """
+  JSON-encoded map[string][]string of enricher keyword lists.
+  """
   enricherLists: String
   scope: InsightsPolicyScope!
   scopeKey: String!
@@ -262,15 +276,25 @@ type InsightsFinding {
   severity: InsightsSeverity!
   occurrences: Int!
   lastSeen: String!
-  """Union of anomaly statuses (open|baselined|dismissed) and violation statuses (open|dismissed|allowed)."""
+  """
+  Union of anomaly statuses (open|baselined|dismissed) and violation statuses (open|dismissed|allowed).
+  """
   status: String!
-  """Anomaly drill-down key; set when kind is anomaly."""
+  """
+  Anomaly drill-down key; set when kind is anomaly.
+  """
   transactionId: ID
-  """Anomaly drill-down key; set when kind is anomaly."""
+  """
+  Anomaly drill-down key; set when kind is anomaly.
+  """
   signature: String
-  """Violation drill-down key; set when kind is violation."""
+  """
+  Violation drill-down key; set when kind is violation.
+  """
   scopeKey: String
-  """Violation drill-down key; set when kind is violation."""
+  """
+  Violation drill-down key; set when kind is violation.
+  """
   ruleKey: String
 }
 
@@ -316,6 +340,53 @@ type InsightsAnomalySummary {
   status: InsightsAnomalyStatus!
 }
 
+enum InsightsAnomalyClassFindingKind {
+  structural
+  metric
+}
+
+type InsightsAnomalySpanHighlight {
+  spanId: String!
+  """
+  high | medium | low
+  """
+  severity: String!
+  reason: String!
+}
+
+type InsightsAnomalyAttrHighlight {
+  spanId: String!
+  key: String!
+  value: String!
+}
+
+type InsightsAnomalyMetricComparison {
+  observed: Int!
+  baseline: Int!
+  """
+  us | bytes
+  """
+  unit: String!
+}
+
+"""
+Render-ready explanation of one deviation class within an anomaly issue.
+Built at read time; the UI should render title/summary/highlights and not parse raw evidence.
+"""
+type InsightsAnomalyClassFinding {
+  class: InsightsDeviationClass!
+  kind: InsightsAnomalyClassFindingKind!
+  title: String!
+  summary: String!
+  spanHighlights: [InsightsAnomalySpanHighlight!]
+  attrHighlights: [InsightsAnomalyAttrHighlight!]
+  metric: InsightsAnomalyMetricComparison
+  """
+  JSON-encoded original per-class evidence blob (fallback / debug).
+  """
+  rawEvidence: String
+}
+
 type InsightsAnomalyIssue {
   transactionId: ID!
   signature: String!
@@ -333,9 +404,23 @@ type InsightsAnomalyIssue {
   lastSeen: String
   lastTraceId: String
   status: InsightsAnomalyStatus!
-  """JSON-encoded evidence keyed by deviation class; only available on the single-anomaly query."""
+  """
+  JSON-encoded evidence keyed by deviation class; only available on the single-anomaly query.
+  """
   evidence: String!
   risk: InsightsRiskAssessment
+  """
+  One render-ready finding per triggered class (title, summary, highlights). Always present on detail.
+  """
+  classFindings: [InsightsAnomalyClassFinding!]!
+  """
+  Evidence sample for this issue including rawOtlp. Omitted when no sample was retained.
+  """
+  anomalyTrace: InsightsObservation
+  """
+  Learning-phase example sample including rawOtlp for baseline compare. Omitted when none exist.
+  """
+  baselineTrace: InsightsObservation
 }
 
 input InsightsAnomalyRefInput {
@@ -359,7 +444,9 @@ type InsightsGuardrailRule {
 
 type InsightsGuardrail {
   scope: InsightsPolicyScope!
-  """Format: namespace/service."""
+  """
+  Format: namespace/service.
+  """
   scopeKey: String!
   rules: [InsightsGuardrailRule!]!
 }
@@ -400,7 +487,9 @@ input InsightsViolationActionInput {
 input InsightsGuardrailSeedInput {
   scopeKey: String!
   mode: InsightsRuleMode
-  """JSON-encoded map[string][]string; keys: allowed_callers | allowed_callees | allowed_egress."""
+  """
+  JSON-encoded map[string][]string; keys: allowed_callers | allowed_callees | allowed_egress.
+  """
   items: String!
 }
 
@@ -463,7 +552,9 @@ type InsightsCatalog {
   guardrailRules: [InsightsCatalogGuardrailRule!]!
   severityBands: [InsightsSeverityBand!]!
   correlationBonus: Int!
-  """JSON-encoded map[string]string."""
+  """
+  JSON-encoded map[string]string.
+  """
   tags: String!
 }
 
@@ -553,7 +644,9 @@ type InsightsStorageDisk {
 type InsightsStorageMemory {
   processRssBytes: Int!
   cgroupUsedBytes: Int!
-  """0 means no limit."""
+  """
+  0 means no limit.
+  """
   cgroupTotalBytes: Int!
   uptimeSeconds: Float!
 }
@@ -563,7 +656,9 @@ type InsightsStorageQuery {
   user: String!
   memoryBytes: Int!
   query: String!
-  """Omitted for still-running queries."""
+  """
+  Omitted for still-running queries.
+  """
   finishedAt: String
 }
 
@@ -674,7 +769,9 @@ extend type Mutation {
   resetInsightsTransactionBaselines(transactionId: ID!): Boolean!
   upsertInsightsPolicy(policy: InsightsPolicyInput!): InsightsPolicy!
   deleteInsightsPolicy(scope: InsightsPolicyScope!, scopeKey: String!): Boolean!
-  upsertInsightsLearningPolicy(policy: InsightsLearningPolicyInput!): InsightsLearningPolicy!
+  upsertInsightsLearningPolicy(
+    policy: InsightsLearningPolicyInput!
+  ): InsightsLearningPolicy!
   deleteInsightsLearningPolicy(
     class: InsightsDeviationClass!
     scope: InsightsPolicyScope!
@@ -689,11 +786,21 @@ extend type Mutation {
     resolution: InsightsBulkResolution!
     items: [InsightsAnomalyRefInput!]!
   ): InsightsBulkResolveResult!
-  upsertInsightsGuardrail(guardrail: InsightsGuardrailInput!): InsightsGuardrail!
+  upsertInsightsGuardrail(
+    guardrail: InsightsGuardrailInput!
+  ): InsightsGuardrail!
   deleteInsightsGuardrail(scopeKey: String!): Boolean!
   seedInsightsGuardrail(seed: InsightsGuardrailSeedInput!): Boolean!
-  allowInsightsGuardrailViolation(action: InsightsViolationActionInput!): Boolean!
-  dismissInsightsGuardrailViolation(action: InsightsViolationActionInput!): Boolean!
-  reopenInsightsGuardrailViolation(action: InsightsViolationActionInput!): Boolean!
-  updateInsightsSystemSettings(settings: InsightsSystemSettingsInput!): InsightsSystemSettings!
+  allowInsightsGuardrailViolation(
+    action: InsightsViolationActionInput!
+  ): Boolean!
+  dismissInsightsGuardrailViolation(
+    action: InsightsViolationActionInput!
+  ): Boolean!
+  reopenInsightsGuardrailViolation(
+    action: InsightsViolationActionInput!
+  ): Boolean!
+  updateInsightsSystemSettings(
+    settings: InsightsSystemSettingsInput!
+  ): InsightsSystemSettings!
 }

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -740,6 +740,26 @@ type Insights struct {
 	StorageHealth       *InsightsStorageHealth        `json:"storageHealth"`
 }
 
+type InsightsAnomalyAttrHighlight struct {
+	SpanID string `json:"spanId"`
+	Key    string `json:"key"`
+	Value  string `json:"value"`
+}
+
+// Render-ready explanation of one deviation class within an anomaly issue.
+// Built at read time; the UI should render title/summary/highlights and not parse raw evidence.
+type InsightsAnomalyClassFinding struct {
+	Class          InsightsDeviationClass           `json:"class"`
+	Kind           InsightsAnomalyClassFindingKind  `json:"kind"`
+	Title          string                           `json:"title"`
+	Summary        string                           `json:"summary"`
+	SpanHighlights []*InsightsAnomalySpanHighlight  `json:"spanHighlights,omitempty"`
+	AttrHighlights []*InsightsAnomalyAttrHighlight  `json:"attrHighlights,omitempty"`
+	Metric         *InsightsAnomalyMetricComparison `json:"metric,omitempty"`
+	// JSON-encoded original per-class evidence blob (fallback / debug).
+	RawEvidence *string `json:"rawEvidence,omitempty"`
+}
+
 type InsightsAnomalyIssue struct {
 	TransactionID    string                   `json:"transactionId"`
 	Signature        string                   `json:"signature"`
@@ -760,11 +780,31 @@ type InsightsAnomalyIssue struct {
 	// JSON-encoded evidence keyed by deviation class; only available on the single-anomaly query.
 	Evidence string                  `json:"evidence"`
 	Risk     *InsightsRiskAssessment `json:"risk,omitempty"`
+	// One render-ready finding per triggered class (title, summary, highlights). Always present on detail.
+	ClassFindings []*InsightsAnomalyClassFinding `json:"classFindings"`
+	// Evidence sample for this issue including rawOtlp. Omitted when no sample was retained.
+	AnomalyTrace *InsightsObservation `json:"anomalyTrace,omitempty"`
+	// Learning-phase example sample including rawOtlp for baseline compare. Omitted when none exist.
+	BaselineTrace *InsightsObservation `json:"baselineTrace,omitempty"`
+}
+
+type InsightsAnomalyMetricComparison struct {
+	Observed int `json:"observed"`
+	Baseline int `json:"baseline"`
+	// us | bytes
+	Unit string `json:"unit"`
 }
 
 type InsightsAnomalyRefInput struct {
 	TransactionID string `json:"transactionId"`
 	Signature     string `json:"signature"`
+}
+
+type InsightsAnomalySpanHighlight struct {
+	SpanID string `json:"spanId"`
+	// high | medium | low
+	Severity string `json:"severity"`
+	Reason   string `json:"reason"`
 }
 
 type InsightsAnomalySummary struct {
@@ -2819,6 +2859,47 @@ func (e *FieldType) UnmarshalGQL(v any) error {
 }
 
 func (e FieldType) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type InsightsAnomalyClassFindingKind string
+
+const (
+	InsightsAnomalyClassFindingKindStructural InsightsAnomalyClassFindingKind = "structural"
+	InsightsAnomalyClassFindingKindMetric     InsightsAnomalyClassFindingKind = "metric"
+)
+
+var AllInsightsAnomalyClassFindingKind = []InsightsAnomalyClassFindingKind{
+	InsightsAnomalyClassFindingKindStructural,
+	InsightsAnomalyClassFindingKindMetric,
+}
+
+func (e InsightsAnomalyClassFindingKind) IsValid() bool {
+	switch e {
+	case InsightsAnomalyClassFindingKindStructural, InsightsAnomalyClassFindingKindMetric:
+		return true
+	}
+	return false
+}
+
+func (e InsightsAnomalyClassFindingKind) String() string {
+	return string(e)
+}
+
+func (e *InsightsAnomalyClassFindingKind) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = InsightsAnomalyClassFindingKind(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid InsightsAnomalyClassFindingKind", str)
+	}
+	return nil
+}
+
+func (e InsightsAnomalyClassFindingKind) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 

--- a/frontend/services/insights/client.go
+++ b/frontend/services/insights/client.go
@@ -172,7 +172,46 @@ func (c *Client) GetAnomaly(ctx context.Context, transactionID int64, signature 
 	if err := c.do(ctx, http.MethodGet, c.apiEndpoint("anomalies", strconv.FormatInt(transactionID, 10), signature), nil, &result); err != nil {
 		return nil, err
 	}
+	// Insights detail should embed compare traces; older builds may omit them even
+	// when retained samples exist. Fill from the observations API when missing.
+	c.enrichAnomalyCompareTraces(ctx, &result)
 	return &result, nil
+}
+
+// enrichAnomalyCompareTraces loads anomaly/baseline OTLP samples when the anomaly
+// detail payload omitted anomaly_trace / baseline_trace.
+func (c *Client) enrichAnomalyCompareTraces(ctx context.Context, issue *AnomalyIssue) {
+	if issue == nil {
+		return
+	}
+	if issue.AnomalyTrace == nil {
+		reason := AnomalyEvidenceSampleReason(issue.Signature)
+		if obs := c.firstObservation(ctx, issue.TransactionID, &reason); obs != nil {
+			issue.AnomalyTrace = obs
+		} else if issue.LastTraceID != nil && *issue.LastTraceID != "" {
+			if obs, err := c.GetObservation(ctx, issue.TransactionID, *issue.LastTraceID); err == nil {
+				issue.AnomalyTrace = obs
+			}
+		}
+	}
+	if issue.BaselineTrace == nil {
+		reason := SampleReasonExample
+		if obs := c.firstObservation(ctx, issue.TransactionID, &reason); obs != nil {
+			issue.BaselineTrace = obs
+		}
+	}
+}
+
+func (c *Client) firstObservation(ctx context.Context, transactionID int64, reason *SampleReason) *Observation {
+	samples, err := c.ListObservations(ctx, transactionID, ListObservationsParams{SampleReason: reason})
+	if err != nil || len(samples) == 0 {
+		return nil
+	}
+	obs, err := c.GetObservation(ctx, transactionID, samples[0].TraceID)
+	if err != nil {
+		return nil
+	}
+	return obs
 }
 
 func (c *Client) ResolveAnomaly(ctx context.Context, transactionID int64, signature string, resolution AnomalyResolution) error {

--- a/frontend/services/insights/client_test.go
+++ b/frontend/services/insights/client_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,21 +15,27 @@ import (
 
 func TestClientEscapesPathAndQueryParameters(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/prefix/api/v1/anomalies/42/sig/with spaces", r.URL.Path)
-		assert.Equal(t, "/prefix/api/v1/anomalies/42/sig%2Fwith%20spaces", r.URL.EscapedPath())
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
-			"transaction_id": 42,
-			"signature": "sig/with spaces",
-			"service": "checkout",
-			"namespace": "prod",
-			"triggered_classes": [],
-			"evidence": {},
-			"occurrences": 1,
-			"max_score": 10,
-			"severity": "low",
-			"status": "open"
-		}`))
+		switch {
+		case r.URL.Path == "/prefix/api/v1/anomalies/42/sig/with spaces":
+			assert.Equal(t, "/prefix/api/v1/anomalies/42/sig%2Fwith%20spaces", r.URL.EscapedPath())
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"transaction_id": 42,
+				"signature": "sig/with spaces",
+				"service": "checkout",
+				"namespace": "prod",
+				"triggered_classes": [],
+				"evidence": {},
+				"occurrences": 1,
+				"max_score": 10,
+				"severity": "low",
+				"status": "open"
+			}`))
+		case strings.HasPrefix(r.URL.Path, "/prefix/api/v1/transactions/42/observations"):
+			_, _ = w.Write([]byte(`{"count":0,"items":[]}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
 	}))
 	defer server.Close()
 
@@ -38,6 +45,77 @@ func TestClientEscapesPathAndQueryParameters(t *testing.T) {
 	result, err := client.GetAnomaly(context.Background(), 42, "sig/with spaces")
 	require.NoError(t, err)
 	assert.Equal(t, "sig/with spaces", result.Signature)
+}
+
+func TestGetAnomalyEnrichesMissingCompareTraces(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/anomalies/9/sig":
+			_, _ = w.Write([]byte(`{
+				"transaction_id": 9,
+				"signature": "sig",
+				"service": "checkout",
+				"namespace": "prod",
+				"triggered_classes": ["D2_egress"],
+				"evidence": {},
+				"occurrences": 1,
+				"max_score": 40,
+				"severity": "medium",
+				"status": "open",
+				"last_trace_id": "trace-last"
+			}`))
+		case r.URL.Path == "/api/v1/transactions/9/observations" && r.URL.Query().Get("sample_reason") == "anomaly:sig":
+			_, _ = w.Write([]byte(`{"count":1,"items":[{
+				"trace_id":"trace-anomaly",
+				"transaction_id":9,
+				"observed_at":"2026-08-06T12:00:00Z",
+				"duration_ms":1,
+				"sample_reason":"anomaly:sig"
+			}]}`))
+		case r.URL.Path == "/api/v1/transactions/9/observations" && r.URL.Query().Get("sample_reason") == "example":
+			_, _ = w.Write([]byte(`{"count":1,"items":[{
+				"trace_id":"trace-baseline",
+				"transaction_id":9,
+				"observed_at":"2026-08-06T11:00:00Z",
+				"duration_ms":0,
+				"sample_reason":"example"
+			}]}`))
+		case r.URL.Path == "/api/v1/transactions/9/observations/trace-anomaly":
+			_, _ = w.Write([]byte(`{
+				"trace_id":"trace-anomaly",
+				"transaction_id":9,
+				"observed_at":"2026-08-06T12:00:00Z",
+				"duration_ms":1,
+				"sample_reason":"anomaly:sig",
+				"raw_otlp":"YW5vbQ=="
+			}`))
+		case r.URL.Path == "/api/v1/transactions/9/observations/trace-baseline":
+			_, _ = w.Write([]byte(`{
+				"trace_id":"trace-baseline",
+				"transaction_id":9,
+				"observed_at":"2026-08-06T11:00:00Z",
+				"duration_ms":0,
+				"sample_reason":"example",
+				"raw_otlp":"YmFzZQ=="
+			}`))
+		default:
+			t.Fatalf("unexpected %s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	require.NoError(t, err)
+
+	result, err := client.GetAnomaly(context.Background(), 9, "sig")
+	require.NoError(t, err)
+	require.NotNil(t, result.AnomalyTrace)
+	assert.Equal(t, "trace-anomaly", result.AnomalyTrace.TraceID)
+	assert.Equal(t, "YW5vbQ==", result.AnomalyTrace.RawOTLP)
+	require.NotNil(t, result.BaselineTrace)
+	assert.Equal(t, "trace-baseline", result.BaselineTrace.TraceID)
+	assert.Equal(t, "YmFzZQ==", result.BaselineTrace.RawOTLP)
 }
 
 func TestClientEncodesQueryParameters(t *testing.T) {

--- a/frontend/services/insights/conversions.go
+++ b/frontend/services/insights/conversions.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/odigos-io/odigos/frontend/graph/model"
 )
@@ -218,7 +219,16 @@ func DeviationClassFromModel(class model.InsightsDeviationClass) DeviationClass 
 }
 
 func SampleReasonToModel(reason SampleReason) model.InsightsSampleReason {
-	return model.InsightsSampleReason(reason)
+	s := string(reason)
+	switch {
+	case s == string(model.InsightsSampleReasonExample):
+		return model.InsightsSampleReasonExample
+	case s == string(model.InsightsSampleReasonAnomalyEvidence) || strings.HasPrefix(s, "anomaly:"):
+		// Storage tags evidence as anomaly:<signature>; GraphQL keeps the legacy enum token.
+		return model.InsightsSampleReasonAnomalyEvidence
+	default:
+		return model.InsightsSampleReason(reason)
+	}
 }
 
 func SampleReasonFromModel(reason model.InsightsSampleReason) SampleReason {
@@ -562,6 +572,51 @@ func AnomalySummariesToModel(anomalies []AnomalySummary) []*model.InsightsAnomal
 	return mapSlice(anomalies, AnomalySummaryToModel)
 }
 
+func AnomalySpanHighlightToModel(highlight AnomalySpanHighlight) *model.InsightsAnomalySpanHighlight {
+	return &model.InsightsAnomalySpanHighlight{
+		SpanID:   highlight.SpanID,
+		Severity: highlight.Severity,
+		Reason:   highlight.Reason,
+	}
+}
+
+func AnomalyAttrHighlightToModel(highlight AnomalyAttrHighlight) *model.InsightsAnomalyAttrHighlight {
+	return &model.InsightsAnomalyAttrHighlight{
+		SpanID: highlight.SpanID,
+		Key:    highlight.Key,
+		Value:  highlight.Value,
+	}
+}
+
+func AnomalyMetricComparisonToModel(metric AnomalyMetricComparison) *model.InsightsAnomalyMetricComparison {
+	return &model.InsightsAnomalyMetricComparison{
+		Observed: int64ToInt(metric.Observed),
+		Baseline: int64ToInt(metric.Baseline),
+		Unit:     metric.Unit,
+	}
+}
+
+func AnomalyClassFindingToModel(finding AnomalyClassFinding) (*model.InsightsAnomalyClassFinding, error) {
+	rawEvidence, err := encodeOptionalJSONString(finding.RawEvidence)
+	if err != nil {
+		return nil, err
+	}
+	var metric *model.InsightsAnomalyMetricComparison
+	if finding.Metric != nil {
+		metric = AnomalyMetricComparisonToModel(*finding.Metric)
+	}
+	return &model.InsightsAnomalyClassFinding{
+		Class:          DeviationClassToModel(finding.Class),
+		Kind:           model.InsightsAnomalyClassFindingKind(finding.Kind),
+		Title:          finding.Title,
+		Summary:        finding.Summary,
+		SpanHighlights: mapSlice(finding.SpanHighlights, AnomalySpanHighlightToModel),
+		AttrHighlights: mapSlice(finding.AttrHighlights, AnomalyAttrHighlightToModel),
+		Metric:         metric,
+		RawEvidence:    rawEvidence,
+	}, nil
+}
+
 func AnomalyIssueToModel(anomaly AnomalyIssue) (*model.InsightsAnomalyIssue, error) {
 	evidence := "{}"
 	if len(anomaly.Evidence) > 0 {
@@ -570,6 +625,21 @@ func AnomalyIssueToModel(anomaly AnomalyIssue) (*model.InsightsAnomalyIssue, err
 	var risk *model.InsightsRiskAssessment
 	if anomaly.Risk != nil {
 		risk = RiskAssessmentToModel(*anomaly.Risk)
+	}
+	classFindings, err := mapSliceErr(anomaly.ClassFindings, AnomalyClassFindingToModel)
+	if err != nil {
+		return nil, err
+	}
+	if classFindings == nil {
+		classFindings = []*model.InsightsAnomalyClassFinding{}
+	}
+	var anomalyTrace *model.InsightsObservation
+	if anomaly.AnomalyTrace != nil {
+		anomalyTrace = ObservationToModel(*anomaly.AnomalyTrace)
+	}
+	var baselineTrace *model.InsightsObservation
+	if anomaly.BaselineTrace != nil {
+		baselineTrace = ObservationToModel(*anomaly.BaselineTrace)
 	}
 	return &model.InsightsAnomalyIssue{
 		TransactionID:    FormatID(anomaly.TransactionID),
@@ -590,6 +660,9 @@ func AnomalyIssueToModel(anomaly AnomalyIssue) (*model.InsightsAnomalyIssue, err
 		Status:           AnomalyStatusToModel(anomaly.Status),
 		Evidence:         evidence,
 		Risk:             risk,
+		ClassFindings:    classFindings,
+		AnomalyTrace:     anomalyTrace,
+		BaselineTrace:    baselineTrace,
 	}, nil
 }
 

--- a/frontend/services/insights/conversions_test.go
+++ b/frontend/services/insights/conversions_test.go
@@ -171,10 +171,48 @@ func TestBaselineAndAnomalyEvidenceStayJSONStrings(t *testing.T) {
 		MaxScore:         40,
 		Severity:         "medium",
 		Status:           "open",
+		ClassFindings: []AnomalyClassFinding{
+			{
+				Class:   "D2_egress",
+				Kind:    "structural",
+				Title:   "Unexpected egress",
+				Summary: "New peer 1.2.3.4:443 not in the learned baseline.",
+				SpanHighlights: []AnomalySpanHighlight{
+					{SpanID: "aabb", Severity: "high", Reason: "new egress peer"},
+				},
+				RawEvidence: json.RawMessage(`{"new_peers":["1.2.3.4:443"]}`),
+			},
+		},
+		AnomalyTrace: &Observation{
+			TraceID:       "trace-anomaly",
+			TransactionID: 9,
+			ObservedAt:    "2026-07-20T14:03:22Z",
+			DurationMs:    12,
+			SampleReason:  "anomaly:sig",
+			RawOTLP:       "YmFzZTY0",
+		},
+		BaselineTrace: &Observation{
+			TraceID:       "trace-baseline",
+			TransactionID: 9,
+			ObservedAt:    "2026-07-20T09:15:01Z",
+			DurationMs:    4,
+			SampleReason:  "example",
+			RawOTLP:       "YmFzZTY0",
+		},
 	})
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"D2_egress":{"new_peers":["1.2.3.4:443"]}}`, anomaly.Evidence)
 	assert.Equal(t, "9", anomaly.TransactionID)
+	require.Len(t, anomaly.ClassFindings, 1)
+	assert.Equal(t, model.InsightsAnomalyClassFindingKindStructural, anomaly.ClassFindings[0].Kind)
+	assert.Equal(t, "Unexpected egress", anomaly.ClassFindings[0].Title)
+	require.NotNil(t, anomaly.ClassFindings[0].RawEvidence)
+	assert.JSONEq(t, `{"new_peers":["1.2.3.4:443"]}`, *anomaly.ClassFindings[0].RawEvidence)
+	require.NotNil(t, anomaly.AnomalyTrace)
+	assert.Equal(t, "trace-anomaly", anomaly.AnomalyTrace.TraceID)
+	assert.Equal(t, model.InsightsSampleReasonAnomalyEvidence, anomaly.AnomalyTrace.SampleReason)
+	require.NotNil(t, anomaly.BaselineTrace)
+	assert.Equal(t, model.InsightsSampleReasonExample, anomaly.BaselineTrace.SampleReason)
 }
 
 func TestSystemSettingsAndGuardrailSeedRoundTrip(t *testing.T) {

--- a/frontend/services/insights/types.go
+++ b/frontend/services/insights/types.go
@@ -18,6 +18,17 @@ type LearningConditionType string
 type StorageHealthStatus string
 type StorageDiskStatus string
 
+const (
+	SampleReasonExample SampleReason = "example"
+)
+
+// AnomalyEvidenceSampleReason is the storage tag for an issue's evidence sample
+// (`anomaly:<signature>`). The GraphQL enum still uses the legacy token
+// `anomaly_evidence` for filters/display.
+func AnomalyEvidenceSampleReason(signature string) SampleReason {
+	return SampleReason("anomaly:" + signature)
+}
+
 type ListTransactionsParams struct {
 	Namespace *string
 	Service   *string
@@ -209,25 +220,59 @@ type AnomalySummary struct {
 	Status           AnomalyStatus    `json:"status"`
 }
 
+type AnomalyClassFindingKind string
+
+type AnomalySpanHighlight struct {
+	SpanID   string `json:"span_id"`
+	Severity string `json:"severity"`
+	Reason   string `json:"reason"`
+}
+
+type AnomalyAttrHighlight struct {
+	SpanID string `json:"span_id"`
+	Key    string `json:"key"`
+	Value  string `json:"value"`
+}
+
+type AnomalyMetricComparison struct {
+	Observed int64  `json:"observed"`
+	Baseline int64  `json:"baseline"`
+	Unit     string `json:"unit"`
+}
+
+type AnomalyClassFinding struct {
+	Class          DeviationClass           `json:"class"`
+	Kind           AnomalyClassFindingKind  `json:"kind"`
+	Title          string                   `json:"title"`
+	Summary        string                   `json:"summary"`
+	SpanHighlights []AnomalySpanHighlight   `json:"span_highlights,omitempty"`
+	AttrHighlights []AnomalyAttrHighlight   `json:"attr_highlights,omitempty"`
+	Metric         *AnomalyMetricComparison `json:"metric,omitempty"`
+	RawEvidence    json.RawMessage          `json:"raw_evidence,omitempty"`
+}
+
 type AnomalyIssue struct {
-	TransactionID    int64            `json:"transaction_id"`
-	Signature        string           `json:"signature"`
-	Service          string           `json:"service"`
-	Namespace        string           `json:"namespace"`
-	Operation        *string          `json:"operation,omitempty"`
-	Kind             *TransactionKind `json:"kind,omitempty"`
-	TriggeredClasses []DeviationClass `json:"triggered_classes"`
-	Offending        *string          `json:"offending,omitempty"`
-	Evidence         json.RawMessage  `json:"evidence"`
-	PolicyID         *int64           `json:"policy_id,omitempty"`
-	Occurrences      int64            `json:"occurrences"`
-	MaxScore         int              `json:"max_score"`
-	Severity         Severity         `json:"severity"`
-	FirstSeen        *string          `json:"first_seen,omitempty"`
-	LastSeen         *string          `json:"last_seen,omitempty"`
-	LastTraceID      *string          `json:"last_trace_id,omitempty"`
-	Status           AnomalyStatus    `json:"status"`
-	Risk             *RiskAssessment  `json:"risk,omitempty"`
+	TransactionID    int64                 `json:"transaction_id"`
+	Signature        string                `json:"signature"`
+	Service          string                `json:"service"`
+	Namespace        string                `json:"namespace"`
+	Operation        *string               `json:"operation,omitempty"`
+	Kind             *TransactionKind      `json:"kind,omitempty"`
+	TriggeredClasses []DeviationClass      `json:"triggered_classes"`
+	Offending        *string               `json:"offending,omitempty"`
+	Evidence         json.RawMessage       `json:"evidence"`
+	PolicyID         *int64                `json:"policy_id,omitempty"`
+	Occurrences      int64                 `json:"occurrences"`
+	MaxScore         int                   `json:"max_score"`
+	Severity         Severity              `json:"severity"`
+	FirstSeen        *string               `json:"first_seen,omitempty"`
+	LastSeen         *string               `json:"last_seen,omitempty"`
+	LastTraceID      *string               `json:"last_trace_id,omitempty"`
+	Status           AnomalyStatus         `json:"status"`
+	Risk             *RiskAssessment       `json:"risk,omitempty"`
+	ClassFindings    []AnomalyClassFinding `json:"class_findings"`
+	AnomalyTrace     *Observation          `json:"anomaly_trace,omitempty"`
+	BaselineTrace    *Observation          `json:"baseline_trace,omitempty"`
 }
 
 type AnomalyRef struct {

--- a/frontend/webapp/graphql/queries/insights.ts
+++ b/frontend/webapp/graphql/queries/insights.ts
@@ -373,6 +373,34 @@ export const GET_INSIGHTS_ANOMALIES = gql`
   }
 `;
 
+const OBSERVATION_FIELDS = `
+  ${OBSERVATION_SUMMARY_FIELDS}
+  rawOtlp
+`;
+
+const ANOMALY_CLASS_FINDING_FIELDS = `
+  class
+  kind
+  title
+  summary
+  spanHighlights {
+    spanId
+    severity
+    reason
+  }
+  attrHighlights {
+    spanId
+    key
+    value
+  }
+  metric {
+    observed
+    baseline
+    unit
+  }
+  rawEvidence
+`;
+
 export const GET_INSIGHTS_ANOMALY = gql`
   query GetInsightsAnomaly($transactionId: ID!, $signature: String!) {
     insights {
@@ -380,6 +408,9 @@ export const GET_INSIGHTS_ANOMALY = gql`
         ${ANOMALY_SUMMARY_FIELDS}
         evidence
         risk { ${RISK_ASSESSMENT_FIELDS} }
+        classFindings { ${ANOMALY_CLASS_FINDING_FIELDS} }
+        anomalyTrace { ${OBSERVATION_FIELDS} }
+        baselineTrace { ${OBSERVATION_FIELDS} }
       }
     }
   }


### PR DESCRIPTION
Follow up after: https://github.com/odigos-io/odigos-enterprise/pull/3446

- Introduced new types for `InsightsAnomalyAttrHighlight`, `InsightsAnomalyClassFinding`, `InsightsAnomalyMetricComparison`, and `InsightsAnomalySpanHighlight` to enrich anomaly data representation.
- Updated `InsightsAnomalyIssue` to include `classFindings`, `anomalyTrace`, and `baselineTrace` for improved anomaly detail retrieval.
- Enhanced GraphQL schema with new fields and types to support the updated anomaly model.
- Implemented client-side logic to enrich anomaly data with missing traces from observations.

This update improves the Insights feature by providing more detailed anomaly information and enhancing the overall data structure for better usability in the UI.

```release-note
feat: enhance Insights anomaly GraphQL schema with explain/traces/diffs
```
