### PR TITLE
CORE-1471 | ci: tag recommendations module on release

### DIFF
--- a/.github/actions/tag-modules/action.yml
+++ b/.github/actions/tag-modules/action.yml
@@ -22,6 +22,7 @@ runs:
         git tag collector/exporters/azureblobstorageexporter/${{ inputs.tag }}
         git tag collector/exporters/googlecloudstorageexporter/${{ inputs.tag }}
         git tag collector/exporters/mockdestinationexporter/${{ inputs.tag }}
+        git tag collector/extension/odigoscapabilitiesextension/${{ inputs.tag }}
         git tag collector/extension/odigosconfigk8sextension/${{ inputs.tag }}
         git tag collector/processors/odigosconditionalattributes/${{ inputs.tag }}
         git tag collector/processors/odigosextractattributeprocessor/${{ inputs.tag }}

--- a/.github/actions/tag-modules/action.yml
+++ b/.github/actions/tag-modules/action.yml
@@ -51,4 +51,5 @@ runs:
         git tag procdiscovery/${{ inputs.tag }}
         git tag profiles/${{ inputs.tag }}
         git tag status/${{ inputs.tag }}
+        git tag recommendations/${{ inputs.tag }}
         git push origin --tags


### PR DESCRIPTION
#### What this PR does / why we need it:
Backport: adds missing module tags to the release `tag-modules` action for the v1.35.0 release line:
- `recommendations/<version>`
- `collector/extension/odigoscapabilitiesextension/<version>`

Linear: https://linear.app/odigos/issue/CORE-1471/tag-recommendations-module-on-release

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
```release-note
NONE
```