### PR TITLE
CORE-1472: Use dockerhub for default OSS registry

### DIFF
--- a/.github/workflows/build-dev-images.yml
+++ b/.github/workflows/build-dev-images.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Build and Tag Docker Images
         env:
           COMMIT_HASH: ${{ github.sha }}
-          DOCKER_REGISTRY: registry.odigos.io
+          DOCKER_REGISTRY: docker.io/keyval
         run: |
           # Build images
           make build-images TAG=${COMMIT_HASH}
@@ -81,7 +81,7 @@ jobs:
       - name: Build CLI Image
         env:
           COMMIT_HASH: ${{ github.sha }}
-          DOCKER_REGISTRY: registry.odigos.io
+          DOCKER_REGISTRY: docker.io/keyval
         run: |
           make build-cli-image TAG=${COMMIT_HASH}
           docker tag ${DOCKER_REGISTRY}/odigos-cli:${COMMIT_HASH} public.ecr.aws/y2v0v6s7/odigos-cli:${COMMIT_HASH}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -65,19 +65,19 @@ jobs:
       - name: Build CLI Image
         run: |
           TAG=e2e-test make build-cli-image
-          docker save registry.odigos.io/odigos-cli:e2e-test -o cli-image.tar
+          docker save docker.io/keyval/odigos-cli:e2e-test -o cli-image.tar
 
       # Victoria Metrics is published, not built in this repo. Materialize a single-platform
       # image (buildx --load) so kind load does not fail on multi-arch manifests.
       - name: Prepare Victoria Metrics Image
         run: |
-          printf 'FROM registry.odigos.io/odigos-victoria-metrics:latest\n' | docker buildx build \
+          printf 'FROM docker.io/keyval/odigos-victoria-metrics:latest\n' | docker buildx build \
             --platform=linux/$(docker version -f '{{.Server.Arch}}') \
             --pull \
-            -t registry.odigos.io/odigos-victoria-metrics:e2e-test \
+            -t docker.io/keyval/odigos-victoria-metrics:e2e-test \
             --load \
             -
-          docker save registry.odigos.io/odigos-victoria-metrics:e2e-test -o victoria-metrics-image.tar
+          docker save docker.io/keyval/odigos-victoria-metrics:e2e-test -o victoria-metrics-image.tar
 
       - name: Save Odigos images to cache
         uses: actions/cache/save@v4

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TAG ?= $(shell odigos version --cluster 2>/dev/null || odigos version --cli 2>/d
 ODIGOS_CLI_VERSION ?= $(shell odigos version --cli)
 CLUSTER_NAME ?= local-dev-cluster
 CENTRAL_BACKEND_URL ?=
-ORG ?= registry.odigos.io
+ORG ?= docker.io/keyval
 # Override ORG for staging pushes
 ifeq ($(STAGING_ORG),true)
     ORG = us-central1-docker.pkg.dev/odigos-cloud/staging-components

--- a/cli.mk
+++ b/cli.mk
@@ -1,7 +1,7 @@
 # CLI-related targets. Included from the root Makefile.
 # Shared vars from the parent Makefile:
 #   TAG                 - image / version tag (auto-detected from cluster/cli/helm if unset)
-#   ORG                 - registry org (default: registry.odigos.io); STAGING_ORG=true for staging GCR
+#   ORG                 - registry org (default: docker.io/keyval); STAGING_ORG=true for staging GCR
 #   IMG_SUFFIX          - image name suffix (empty by default; -rhel-certified when RHEL=true)
 #   ODIGOS_CLI_VERSION  - sets Helm image.tag for install/upgrade (default: `odigos version --cli`)
 #   CLUSTER_NAME        - cluster name for install (default: local-dev-cluster)

--- a/docs/snippets/enterprise/setup/docker-registry.mdx
+++ b/docs/snippets/enterprise/setup/docker-registry.mdx
@@ -14,7 +14,7 @@ Replace `<YOUR-DESIRED-VERSION>` with the version of the Odigos images you want 
 ---
 
 ### Step 2: Pull the Images
-Start by pulling the required images from the official Odigos registry onto your local machine or CI environment:
+Start by pulling the required images from the enterprise registry (`registry.odigos.io`) onto your local machine or CI environment:
 
 ```bash
 docker pull registry.odigos.io/odigos-scheduler:$VERSION
@@ -60,7 +60,7 @@ docker tag registry.odigos.io/odigos-enterprise-collector:$VERSION $CUSTOM_DOCKE
 ```
 
 
-> **Note:** Prior to v1.0.155, Odigos images were prefixed with `keyval/` (such as `keyval/odigos-scheduler`) In v1.0.155+, this is no longer the case, and Odigos does not assume this prefix. If you were hosting custom images prior to this version, you may have to re-tag your images to remove the `keyval/` prefix.
+> **Note:** Enterprise images are hosted at `registry.odigos.io`. Image names are `odigos-<component>` or `odigos-enterprise-<component>` without an embedded `keyval/` path segment. If you previously mirrored images under an older layout, re-tag them to match this naming when pushing to your custom registry.
 
 > **Note:** Odigos Enterprise now runs a dedicated collector image, `odigos-enterprise-collector`, in place of `odigos-collector`. If you were already mirroring `odigos-collector`, mirror `odigos-enterprise-collector` as well before upgrading, otherwise the gateway and the node collectors will fail to pull.
 

--- a/docs/snippets/oss/setup/docker-registry.mdx
+++ b/docs/snippets/oss/setup/docker-registry.mdx
@@ -14,16 +14,16 @@ Replace `<YOUR-DESIRED-VERSION>` with the version of the Odigos images you want 
 ---
 
 ### Step 2: Pull the Images
-Start by pulling the required images from the official Odigos registry onto your local machine or CI environment:
+Start by pulling the required images from the default community registry (`docker.io/keyval`) onto your local machine or CI environment:
 
 ```bash
-docker pull registry.odigos.io/odigos-scheduler:$VERSION
-docker pull registry.odigos.io/odigos-instrumentor:$VERSION
-docker pull registry.odigos.io/odigos-ui:$VERSION
-docker pull registry.odigos.io/odigos-autoscaler:$VERSION
-docker pull registry.odigos.io/odigos-odiglet:$VERSION
-docker pull registry.odigos.io/odigos-collector:$VERSION
-docker pull registry.odigos.io/odigos-victoria-metrics:$VERSION
+docker pull docker.io/keyval/odigos-scheduler:$VERSION
+docker pull docker.io/keyval/odigos-instrumentor:$VERSION
+docker pull docker.io/keyval/odigos-ui:$VERSION
+docker pull docker.io/keyval/odigos-autoscaler:$VERSION
+docker pull docker.io/keyval/odigos-odiglet:$VERSION
+docker pull docker.io/keyval/odigos-collector:$VERSION
+docker pull docker.io/keyval/odigos-victoria-metrics:$VERSION
 ```
 
 If you are using the [k8s-init-container](../instrumentations/configuration/mount-method#3-InitContainer) mount method
@@ -31,13 +31,13 @@ make sure the odigos-agents image is also pulled, as it's required by the inject
 **This is not the default configuration**, if you're unsure what this means, you can safely ignore this step and continue with the standard setup.
 
 ```bash
-docker pull registry.odigos.io/odigos-agents:$VERSION
+docker pull docker.io/keyval/odigos-agents:$VERSION
 ```
 
 If you are using [image mirrored Go offsets updates](../instrumentations/golang/ebpf#about-go-offsets), also mirror the offsets image:
 
 ```
-docker pull registry.odigos.io/cli-offsets:latest
+docker pull docker.io/keyval/cli-offsets:latest
 ```
 
 Keeping this image regularly up-to-date is necessary to pull the latest offsets into your cluster.
@@ -47,30 +47,30 @@ Odigos component images are published in multi-arch for ARM64 and AMD64 architec
 </Warning>
 
 ```bash
-docker pull --platform $PLATFORM registry.odigos.io/odigos-scheduler:$VERSION
-docker pull --platform $PLATFORM registry.odigos.io/odigos-instrumentor:$VERSION
-docker pull --platform $PLATFORM registry.odigos.io/odigos-ui:$VERSION
-docker pull --platform $PLATFORM registry.odigos.io/odigos-autoscaler:$VERSION
-docker pull --platform $PLATFORM registry.odigos.io/odigos-odiglet:$VERSION
-docker pull --platform $PLATFORM registry.odigos.io/odigos-collector:$VERSION
-docker pull --platform $PLATFORM registry.odigos.io/odigos-victoria-metrics:$VERSION
+docker pull --platform $PLATFORM docker.io/keyval/odigos-scheduler:$VERSION
+docker pull --platform $PLATFORM docker.io/keyval/odigos-instrumentor:$VERSION
+docker pull --platform $PLATFORM docker.io/keyval/odigos-ui:$VERSION
+docker pull --platform $PLATFORM docker.io/keyval/odigos-autoscaler:$VERSION
+docker pull --platform $PLATFORM docker.io/keyval/odigos-odiglet:$VERSION
+docker pull --platform $PLATFORM docker.io/keyval/odigos-collector:$VERSION
+docker pull --platform $PLATFORM docker.io/keyval/odigos-victoria-metrics:$VERSION
 ```
 
 ### Step 3: Tag the Images
 Next, Tag each image with your custom Docker registry prefix:
 
 ```bash
-docker tag registry.odigos.io/odigos-scheduler:$VERSION $CUSTOM_DOCKER_REGISTRY/odigos-scheduler:$VERSION
-docker tag registry.odigos.io/odigos-instrumentor:$VERSION $CUSTOM_DOCKER_REGISTRY/odigos-instrumentor:$VERSION
-docker tag registry.odigos.io/odigos-ui:$VERSION $CUSTOM_DOCKER_REGISTRY/odigos-ui:$VERSION
-docker tag registry.odigos.io/odigos-autoscaler:$VERSION $CUSTOM_DOCKER_REGISTRY/odigos-autoscaler:$VERSION
-docker tag registry.odigos.io/odigos-odiglet:$VERSION $CUSTOM_DOCKER_REGISTRY/odigos-odiglet:$VERSION
-docker tag registry.odigos.io/odigos-collector:$VERSION $CUSTOM_DOCKER_REGISTRY/odigos-collector:$VERSION
-docker tag registry.odigos.io/odigos-collector:$VERSION $CUSTOM_DOCKER_REGISTRY/odigos-victoria-metrics:$VERSION
+docker tag docker.io/keyval/odigos-scheduler:$VERSION $CUSTOM_DOCKER_REGISTRY/odigos-scheduler:$VERSION
+docker tag docker.io/keyval/odigos-instrumentor:$VERSION $CUSTOM_DOCKER_REGISTRY/odigos-instrumentor:$VERSION
+docker tag docker.io/keyval/odigos-ui:$VERSION $CUSTOM_DOCKER_REGISTRY/odigos-ui:$VERSION
+docker tag docker.io/keyval/odigos-autoscaler:$VERSION $CUSTOM_DOCKER_REGISTRY/odigos-autoscaler:$VERSION
+docker tag docker.io/keyval/odigos-odiglet:$VERSION $CUSTOM_DOCKER_REGISTRY/odigos-odiglet:$VERSION
+docker tag docker.io/keyval/odigos-collector:$VERSION $CUSTOM_DOCKER_REGISTRY/odigos-collector:$VERSION
+docker tag docker.io/keyval/odigos-collector:$VERSION $CUSTOM_DOCKER_REGISTRY/odigos-victoria-metrics:$VERSION
 ```
 
 
-> **Note:** Prior to v1.0.155, Odigos images were prefixed with `keyval/` (such as `keyval/odigos-scheduler`) In v1.0.155+, this is no longer the case, and Odigos does not assume this prefix. If you were hosting custom images prior to this version, you may have to re-tag your images to remove the `keyval/` prefix.
+> **Note:** Community images use the registry prefix `docker.io/keyval` (for example `docker.io/keyval/odigos-scheduler`). Image names themselves are `odigos-<component>` without an embedded `keyval/` path segment. If you previously mirrored images under an older layout, re-tag them to match this naming when pushing to your custom registry.
 
 ### Step 4: Push the Images
 Now, push the tagged images to your custom Docker registry:

--- a/docs/snippets/shared/api-reference/operator.odigos.io.v1alpha1.mdx
+++ b/docs/snippets/shared/api-reference/operator.odigos.io.v1alpha1.mdx
@@ -196,8 +196,9 @@ Default=false</p>
 <td>
    <p>(Optional) ImagePrefix is a prefix for all container images.
 This should only be used if you are pulling Odigos images from the non-default registry.
-Default: registry.odigos.io
-Default (OpenShift): registry.connect.redhat.com</p>
+Default (community): docker.io/keyval
+Default (enterprise): registry.odigos.io
+Default (OpenShift): registry.connect.redhat.com/odigos</p>
 </td>
 </tr>
 <tr>

--- a/helm/README.md
+++ b/helm/README.md
@@ -37,7 +37,7 @@ helm upgrade --install odigos odigos/odigos --namespace odigos-system --create-n
 
 #### Using a Custom Docker Registry
 
-By default, images are pulled from odigos registry at `registry.odigos.io`. To use a custom Docker registry instead, set the `imagePrefix` value during installation:
+By default, community installs pull images from `docker.io/keyval` and enterprise installs (with an on-prem token) pull from `registry.odigos.io`. To use a custom Docker registry instead, set the `imagePrefix` value during installation:
 
 ```sh
 helm upgrade --install odigos odigos/odigos \

--- a/helm/odigos-central/values.yaml
+++ b/helm/odigos-central/values.yaml
@@ -2,7 +2,7 @@
 # -- Override image tag for all Odigos components (empty = chart default)
 image:
   tag: ''
-# -- Prefix/registry for all Odigos images (empty = built-in defaults)
+# -- Prefix/registry for all Odigos images (empty = registry.odigos.io)
 imagePrefix: ''
 # -- Image pull secrets for private registries (k8s secret names)
 imagePullSecrets: []

--- a/helm/odigos/templates/_helpers.tpl
+++ b/helm/odigos/templates/_helpers.tpl
@@ -1,14 +1,15 @@
 {{- define "utils.imagePrefix" -}}
-{{- $defaultRegistry := "registry.odigos.io" -}}
+{{- $enterpriseRegistry := "registry.odigos.io" -}}
+{{- $communityRegistry := "docker.io/keyval" -}}
 {{- $redHatRegistry := "registry.connect.redhat.com/odigos" -}}
 {{- if $.Values.imagePrefix -}}
     {{- $.Values.imagePrefix -}}
+{{- else if $.Values.openshift.enabled -}}
+    {{- $redHatRegistry -}}
+{{- else if include "odigos.secretExists" . -}}
+    {{- $enterpriseRegistry -}}
 {{- else -}}
-    {{- if $.Values.openshift.enabled -}}
-        {{- $redHatRegistry -}}
-    {{- else -}}
-        {{- $defaultRegistry -}}
-    {{- end -}}
+    {{- $communityRegistry -}}
 {{- end -}}
 {{- end -}}
 
@@ -45,7 +46,7 @@ true
 {{- end -}}
 
 {{- define "odigos.usesOdigosRegistry" -}}
-{{- if eq (include "utils.imagePrefix" (dict "Values" .Values)) "registry.odigos.io" -}}
+{{- if eq (include "utils.imagePrefix" .) "registry.odigos.io" -}}
 true
 {{- end -}}
 {{- end -}}
@@ -79,7 +80,7 @@ true
   {{- if hasKey $.Values.openshift "certifiedImageTags" }}
     {{- $certified = $.Values.openshift.certifiedImageTags }}
   {{- end }}
-  {{- $prefix := include "utils.imagePrefix" (dict "Values" $.Values) -}}
+  {{- $prefix := include "utils.imagePrefix" . -}}
   {{- printf "%s/odigos-%s%s:%s" $prefix .Component (ternary "-rhel-certified" "" (and $.Values.openshift.enabled $certified)) .Tag }}
 {{- end -}}
 {{- end -}}

--- a/helm/odigos/templates/autoscaler/deployment.yaml
+++ b/helm/odigos/templates/autoscaler/deployment.yaml
@@ -49,7 +49,7 @@ spec:
           - --leader-elect
         command:
           - /app
-        image: {{ template "utils.imageName" (dict "Values" .Values "Component" "autoscaler" "Tag" $imageTag) }}
+        image: {{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "autoscaler" "Tag" $imageTag) }}
         env:
           {{- if .Values.autoscaler.deploymentName }}
           - name: ODIGOS_COMPONENT_DEPLOYMENT_NAME
@@ -72,9 +72,9 @@ spec:
                 name: odigos-deployment
           - name: ODIGOS_COLLECTOR_IMAGE
             {{- if include "odigos.secretExists" . }}
-            value: '{{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-collector" "Tag" $imageTag) }}'
+            value: '{{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "enterprise-collector" "Tag" $imageTag) }}'
             {{- else }}
-            value: '{{ template "utils.imageName" (dict "Values" .Values "Component" "collector" "Tag" $imageTag) }}'
+            value: '{{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "collector" "Tag" $imageTag) }}'
             {{- end }}
           - name: GOMEMLIMIT
             value: {{ include "odigos.gomemlimitFromResources" (dict "Resources" .Values.autoscaler.resources) }}

--- a/helm/odigos/templates/centralproxy/deployment.yaml
+++ b/helm/odigos/templates/centralproxy/deployment.yaml
@@ -46,7 +46,7 @@ spec:
       containers:
         - name: central-proxy
           {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
-          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-central-proxy" "Tag" $imageTag) }}
+          image: {{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "enterprise-central-proxy" "Tag" $imageTag) }}
           ports:
             - containerPort: 8080
               name: http

--- a/helm/odigos/templates/cleanup/cleanup-job.yaml
+++ b/helm/odigos/templates/cleanup/cleanup-job.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: cleanup-sa
       containers:
       - name: cleanup
-        image: {{ template "utils.imageName" (dict "Values" .Values "Component" "cli" "Tag" $imageTag) }}
+        image: {{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "cli" "Tag" $imageTag) }}
         args: ["cleanup", "--yes", "--instrumentation-only", "--namespace", "{{ .Release.Namespace }}"]
       restartPolicy: Never
       {{ include "odigos.renderPullSecrets" . | nindent 6 }}

--- a/helm/odigos/templates/instrumentor/deployment.yaml
+++ b/helm/odigos/templates/instrumentor/deployment.yaml
@@ -64,9 +64,9 @@ spec:
         {{- end -}}
         {{- $agentsImageTag := printf "%s%s" $imageTag $extendedSuffix -}}
         {{- if include "odigos.secretExists" . }}
-        image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-instrumentor" "Tag" $imageTag) }}
+        image: {{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "enterprise-instrumentor" "Tag" $imageTag) }}
         {{- else }}
-        image: {{ template "utils.imageName" (dict "Values" .Values "Component" "instrumentor" "Tag" $imageTag) }}
+        image: {{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "instrumentor" "Tag" $imageTag) }}
         {{- end }}
         ports:
           - containerPort: 9443
@@ -104,9 +104,9 @@ spec:
           {{- end }}
           - name: ODIGOS_INIT_CONTAINER_IMAGE
             {{- if include "odigos.secretExists" . }}
-            value: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-agents" "Tag" $agentsImageTag) }}
+            value: {{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "enterprise-agents" "Tag" $agentsImageTag) }}
             {{- else }}
-            value: {{ template "utils.imageName" (dict "Values" .Values "Component" "agents" "Tag" $imageTag) }}
+            value: {{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "agents" "Tag" $imageTag) }}
             {{- end }}
           - name: GOMEMLIMIT
             value: {{ include "odigos.gomemlimitFromResources" (dict "Resources" .Values.instrumentor.resources) }}

--- a/helm/odigos/templates/metricsstore/deployment.yaml
+++ b/helm/odigos/templates/metricsstore/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: vm
         {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
-        image: {{ template "utils.imageName" (dict "Values" .Values "Component" "victoria-metrics" "Tag" $imageTag) }}
+        image: {{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "victoria-metrics" "Tag" $imageTag) }}
         args:
           - "-httpListenAddr=0.0.0.0:8428"
           - "-storageDataPath=/vm-data"

--- a/helm/odigos/templates/odiglet/daemonset.yaml
+++ b/helm/odigos/templates/odiglet/daemonset.yaml
@@ -76,9 +76,9 @@ spec:
       {{- if (not (eq .Values.instrumentor.mountMethod "k8s-init-container")) }}
         - name: init
           {{- if include "odigos.secretExists" . }}
-          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-odiglet" "Tag" $odigletImageTag) }}
+          image: {{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "enterprise-odiglet" "Tag" $odigletImageTag) }}
           {{- else }}
-          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "odiglet" "Tag" $imageTag) }}
+          image: {{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "odiglet" "Tag" $imageTag) }}
           {{- end }}
           imagePullPolicy: IfNotPresent
           command:
@@ -134,9 +134,9 @@ spec:
         # so it's available in the image cache when user pods need it
         - name: odigos-agents-image-pull
           {{- if include "odigos.secretExists" . }}
-          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-agents" "Tag" $odigletImageTag) }}
+          image: {{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "enterprise-agents" "Tag" $odigletImageTag) }}
           {{- else }}
-          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "agents" "Tag" $imageTag) }}
+          image: {{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "agents" "Tag" $imageTag) }}
           {{- end }}
           imagePullPolicy: IfNotPresent
           # # it does not run any actual code, just pulls the image
@@ -156,9 +156,9 @@ spec:
       containers:
         - name: odiglet
           {{- if include "odigos.secretExists" . }}
-          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-odiglet" "Tag" $odigletImageTag) }}
+          image: {{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "enterprise-odiglet" "Tag" $odigletImageTag) }}
           {{- else }}
-          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "odiglet" "Tag" $imageTag) }}
+          image: {{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "odiglet" "Tag" $imageTag) }}
           {{- end }}
           args:
             - --health-probe-bind-port={{ .Values.odiglet.odiglet.livenessProbe.httpGet.port }}
@@ -285,9 +285,9 @@ spec:
               mountPath: /var/exchange
         - name: data-collection
           {{- if include "odigos.secretExists" . }}
-          image: '{{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-collector" "Tag" $imageTag) }}'
+          image: '{{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "enterprise-collector" "Tag" $imageTag) }}'
           {{- else }}
-          image: '{{ template "utils.imageName" (dict "Values" .Values "Component" "collector" "Tag" $imageTag) }}'
+          image: '{{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "collector" "Tag" $imageTag) }}'
           {{- end }}
           imagePullPolicy: IfNotPresent
           command:
@@ -405,9 +405,9 @@ spec:
 {{- if or (eq .Values.instrumentor.mountMethod "") (eq .Values.instrumentor.mountMethod "k8s-virtual-device") }}
         - name: deviceplugin
           {{- if include "odigos.secretExists" . }}
-          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-odiglet" "Tag" $odigletImageTag) }}
+          image: {{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "enterprise-odiglet" "Tag" $odigletImageTag) }}
           {{- else }}
-          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "odiglet" "Tag" $imageTag) }}
+          image: {{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "odiglet" "Tag" $imageTag) }}
           {{- end }}
           imagePullPolicy: IfNotPresent
           command:
@@ -456,9 +456,9 @@ spec:
 {{- if eq .Values.instrumentor.mountMethod "k8s-csi-driver" }}
         - name: csi-driver
           {{- if include "odigos.secretExists" . }}
-          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "enterprise-odiglet" "Tag" $imageTag) }}
+          image: {{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "enterprise-odiglet" "Tag" $imageTag) }}
           {{- else }}
-          image: {{ template "utils.imageName" (dict "Values" .Values "Component" "odiglet" "Tag" $imageTag) }}
+          image: {{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "odiglet" "Tag" $imageTag) }}
           {{- end }}
           command:
             - /root/odigos-csi-driver

--- a/helm/odigos/templates/odigos-configuration-cm.yaml
+++ b/helm/odigos/templates/odigos-configuration-cm.yaml
@@ -36,7 +36,7 @@ data:
     {{- if .Values.centralProxy.centralBackendURL }}
     centralBackendURL: {{ .Values.centralProxy.centralBackendURL }}
     {{- end }}
-    imagePrefix: {{ template "utils.imagePrefix" (dict "Values" .Values) }}
+    imagePrefix: {{ template "utils.imagePrefix" . }}
     {{- if .Values.ui.uiMode }}
     uiMode: {{ .Values.ui.uiMode }}
     {{- end }}

--- a/helm/odigos/templates/scheduler/deployment.yaml
+++ b/helm/odigos/templates/scheduler/deployment.yaml
@@ -49,7 +49,7 @@ spec:
         command:
           - /app
         {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
-        image: {{ template "utils.imageName" (dict "Values" .Values "Component" "scheduler" "Tag" $imageTag) }}
+        image: {{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "scheduler" "Tag" $imageTag) }}
         env:
           {{- if .Values.scheduler.deploymentName }}
           - name: ODIGOS_COMPONENT_DEPLOYMENT_NAME

--- a/helm/odigos/templates/tracecorrelationsmetricsstore/deployment.yaml
+++ b/helm/odigos/templates/tracecorrelationsmetricsstore/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: vm
         {{ $imageTag := .Values.image.tag | default .Chart.AppVersion }}
-        image: {{ template "utils.imageName" (dict "Values" .Values "Component" "victoria-metrics" "Tag" $imageTag) }}
+        image: {{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "victoria-metrics" "Tag" $imageTag) }}
         args:
           - "-httpListenAddr=0.0.0.0:8428"
           - "-storageDataPath=/vm-data"

--- a/helm/odigos/templates/ui/deployment.yaml
+++ b/helm/odigos/templates/ui/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         {{- $imageTag := .Values.image.tag | default .Chart.AppVersion }}
         {{- $isEnterprise := not (empty (include "odigos.secretExists" .)) }}
         {{- $uiComponent := ternary "enterprise-ui" "ui" $isEnterprise }}
-        image: {{ template "utils.imageName" (dict "Values" .Values "Component" $uiComponent "Tag" $imageTag) }}
+        image: {{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" $uiComponent "Tag" $imageTag) }}
         args:
           - --namespace=$(CURRENT_NS)
           - --address=0.0.0.0

--- a/helm/odigos/values.schema.json
+++ b/helm/odigos/values.schema.json
@@ -616,7 +616,7 @@
     },
     "imagePrefix": {
       "default": "",
-      "description": "By default, images are pulled from odigos registry at `registry.odigos.io`\nIf you use custom or internal registry to serve in your cluster, you can set the imagePrefix to your registry.\nFor example, if you set imagePrefix to `myregistry.io/odigos`, the images will be pulled from `myregistry.io/odigos/odigos-\u003ccomponent\u003e:\u003ctag\u003e`",
+      "description": "Default image registry prefix. When unset:\n  - community installs use `docker.io/keyval`\n  - enterprise installs (onPremToken / odigos-pro secret) use `registry.odigos.io`\n  - OpenShift installs use `registry.connect.redhat.com/odigos`\nIf you use a custom or internal registry, set imagePrefix to your registry.\nFor example, if you set imagePrefix to `myregistry.io/odigos`, the images will be pulled from `myregistry.io/odigos/odigos-\u003ccomponent\u003e:\u003ctag\u003e`",
       "required": [],
       "title": "imagePrefix"
     },

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -12,8 +12,11 @@ imagePullSecrets: []
 
 # @schema
 # description: |-
-#   By default, images are pulled from odigos registry at `registry.odigos.io`
-#   If you use custom or internal registry to serve in your cluster, you can set the imagePrefix to your registry.
+#   Default image registry prefix. When unset:
+#     - community installs use `docker.io/keyval`
+#     - enterprise installs (onPremToken / odigos-pro secret) use `registry.odigos.io`
+#     - OpenShift installs use `registry.connect.redhat.com/odigos`
+#   If you use a custom or internal registry, set imagePrefix to your registry.
 #   For example, if you set imagePrefix to `myregistry.io/odigos`, the images will be pulled from `myregistry.io/odigos/odigos-<component>:<tag>`
 # @schema
 imagePrefix:

--- a/operator/api/v1alpha1/odigos_types.go
+++ b/operator/api/v1alpha1/odigos_types.go
@@ -75,8 +75,9 @@ type OdigosSpec struct {
 
 	// (Optional) ImagePrefix is a prefix for all container images.
 	// This should only be used if you are pulling Odigos images from the non-default registry.
-	// Default: registry.odigos.io
-	// Default (OpenShift): registry.connect.redhat.com
+	// Default (community): docker.io/keyval
+	// Default (enterprise): registry.odigos.io
+	// Default (OpenShift): registry.connect.redhat.com/odigos
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	ImagePrefix string `json:"imagePrefix,omitempty"`
 

--- a/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/odigos-operator.clusterserviceversion.yaml
@@ -82,8 +82,9 @@ spec:
           - description: |-
               (Optional) ImagePrefix is a prefix for all container images.
               This should only be used if you are pulling Odigos images from the non-default registry.
-              Default: registry.odigos.io
-              Default (OpenShift): registry.connect.redhat.com
+              Default (community): docker.io/keyval
+              Default (enterprise): registry.odigos.io
+              Default (OpenShift): registry.connect.redhat.com/odigos
             displayName: Image Prefix
             path: imagePrefix
           - description: |-

--- a/operator/bundle/manifests/operator.odigos.io_odigos.yaml
+++ b/operator/bundle/manifests/operator.odigos.io_odigos.yaml
@@ -64,8 +64,9 @@ spec:
                 description: |-
                   (Optional) ImagePrefix is a prefix for all container images.
                   This should only be used if you are pulling Odigos images from the non-default registry.
-                  Default: registry.odigos.io
-                  Default (OpenShift): registry.connect.redhat.com
+                  Default (community): docker.io/keyval
+                  Default (enterprise): registry.odigos.io
+                  Default (OpenShift): registry.connect.redhat.com/odigos
                 type: string
               logLevel:
                 description: |-

--- a/operator/config/crd/bases/operator.odigos.io_odigos.yaml
+++ b/operator/config/crd/bases/operator.odigos.io_odigos.yaml
@@ -64,8 +64,9 @@ spec:
                 description: |-
                   (Optional) ImagePrefix is a prefix for all container images.
                   This should only be used if you are pulling Odigos images from the non-default registry.
-                  Default: registry.odigos.io
-                  Default (OpenShift): registry.connect.redhat.com
+                  Default (community): docker.io/keyval
+                  Default (enterprise): registry.odigos.io
+                  Default (OpenShift): registry.connect.redhat.com/odigos
                 type: string
               logLevel:
                 description: |-

--- a/operator/config/manifests/bases/odigos-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/odigos-operator.clusterserviceversion.yaml
@@ -71,8 +71,9 @@ spec:
       - description: |-
           (Optional) ImagePrefix is a prefix for all container images.
           This should only be used if you are pulling Odigos images from the non-default registry.
-          Default: registry.odigos.io
-          Default (OpenShift): registry.connect.redhat.com
+          Default (community): docker.io/keyval
+          Default (enterprise): registry.odigos.io
+          Default (OpenShift): registry.connect.redhat.com/odigos
         displayName: Image Prefix
         path: imagePrefix
       - description: |-

--- a/tests/common/assert/odigos-upgraded.yaml
+++ b/tests/common/assert/odigos-upgraded.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   containers:
     - name: manager
-      image: registry.odigos.io/odigos-autoscaler:e2e-test
+      image: docker.io/keyval/odigos-autoscaler:e2e-test
 status:
   containerStatuses:
     - name: manager
@@ -32,7 +32,7 @@ metadata:
 spec:
   containers:
     - name: manager
-      image: registry.odigos.io/odigos-scheduler:e2e-test
+      image: docker.io/keyval/odigos-scheduler:e2e-test
 status:
   containerStatuses:
     - name: manager
@@ -50,7 +50,7 @@ metadata:
 spec:
   containers:
     - name: manager
-      image: registry.odigos.io/odigos-instrumentor:e2e-test
+      image: docker.io/keyval/odigos-instrumentor:e2e-test
 status:
   containerStatuses:
     - name: manager
@@ -77,7 +77,7 @@ spec:
     - resources: {}
       securityContext:
         privileged: true
-      image: registry.odigos.io/odigos-odiglet:e2e-test
+      image: docker.io/keyval/odigos-odiglet:e2e-test
   (containers[?name=='data-collection']):
     - securityContext:
         privileged: true
@@ -151,7 +151,7 @@ spec:
     - resources: {}
       securityContext:
         privileged: true
-      image: registry.odigos.io/odigos-odiglet:e2e-test
+      image: docker.io/keyval/odigos-odiglet:e2e-test
   (containers[?name=='data-collection']):
     - securityContext:
         privileged: true
@@ -216,7 +216,7 @@ metadata:
 spec:
   containers:
     - name: gateway
-      image: registry.odigos.io/odigos-collector:e2e-test
+      image: docker.io/keyval/odigos-collector:e2e-test
 status:
   containerStatuses:
     - name: gateway

--- a/tests/e2e/cli-upgrade/chainsaw-test.yaml
+++ b/tests/e2e/cli-upgrade/chainsaw-test.yaml
@@ -125,7 +125,7 @@ spec:
     - name: Upgrade to HEAD version with the current compiled cli
       try:
         - script:
-            content: ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test --set imagePrefix=registry.odigos.io
+            content: ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test --set imagePrefix=docker.io/keyval
             timeout: 1m10s
         - assert:
             file: ../../common/assert/odigos-upgraded.yaml

--- a/tests/e2e/mount-method/odiglet-ready-with-csi-driver.yaml
+++ b/tests/e2e/mount-method/odiglet-ready-with-csi-driver.yaml
@@ -13,13 +13,13 @@ metadata:
 spec:
   initContainers:
     - name: init
-      image: registry.odigos.io/odigos-odiglet:e2e-test
+      image: docker.io/keyval/odigos-odiglet:e2e-test
   containers:
     - name: odiglet
       resources: {}
       securityContext:
         privileged: true
-      image: registry.odigos.io/odigos-odiglet:e2e-test
+      image: docker.io/keyval/odigos-odiglet:e2e-test
     - name: data-collection
       securityContext:
         privileged: true
@@ -53,7 +53,7 @@ spec:
         limits:
           (memory != null): true
     - name: csi-driver
-      image: registry.odigos.io/odigos-odiglet:e2e-test
+      image: docker.io/keyval/odigos-odiglet:e2e-test
       securityContext:
         privileged: true
       resources:
@@ -98,13 +98,13 @@ metadata:
 spec:
   initContainers:
     - name: init
-      image: registry.odigos.io/odigos-odiglet:e2e-test
+      image: docker.io/keyval/odigos-odiglet:e2e-test
   containers:
     - name: odiglet
       resources: {}
       securityContext:
         privileged: true
-      image: registry.odigos.io/odigos-odiglet:e2e-test
+      image: docker.io/keyval/odigos-odiglet:e2e-test
     - name: data-collection
       securityContext:
         privileged: true
@@ -138,7 +138,7 @@ spec:
         limits:
           (memory != null): true
     - name: csi-driver
-      image: registry.odigos.io/odigos-odiglet:e2e-test
+      image: docker.io/keyval/odigos-odiglet:e2e-test
       securityContext:
         privileged: true
       resources:

--- a/tests/e2e/mount-method/odiglet-ready.yaml
+++ b/tests/e2e/mount-method/odiglet-ready.yaml
@@ -13,13 +13,13 @@ metadata:
 spec:
   initContainers:
     - name: odigos-agents-image-pull
-      image: registry.odigos.io/odigos-agents:e2e-test
+      image: docker.io/keyval/odigos-agents:e2e-test
   containers:
     - name: odiglet
       resources: {}
       securityContext:
         privileged: true
-      image: registry.odigos.io/odigos-odiglet:e2e-test
+      image: docker.io/keyval/odigos-odiglet:e2e-test
     - name: data-collection
       securityContext:
         privileged: true
@@ -85,13 +85,13 @@ metadata:
 spec:
   initContainers:
     - name: odigos-agents-image-pull
-      image: registry.odigos.io/odigos-agents:e2e-test
+      image: docker.io/keyval/odigos-agents:e2e-test
   containers:
     - name: odiglet
       resources: {}
       securityContext:
         privileged: true
-      image: registry.odigos.io/odigos-odiglet:e2e-test
+      image: docker.io/keyval/odigos-odiglet:e2e-test
     - name: data-collection
       securityContext:
         privileged: true


### PR DESCRIPTION
#### What this PR does / why we need it:
We are moving toward serving registry.odigos.io as an enterprise service. This updates the helm chart to use the `docker.io/keyval` images by default for OSS, unless an enterprise token is present, then it uses registry.odigos.io.

This just updates the imageName and imagePrefix helpers to be able to check if the odigos enterprise token exists. This is why `.Release` is now passed to the imageName util (so it can look up in `odigos.onPremToken`) and calls to `imagePrefix` now take more than just `.Values`

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
OSS: Switch to docker.io/keyval as default container image registry
```
