### PR TITLE
CORE-1286: (insights) Send service graph metrics to insights

### DIFF
--- a/autoscaler/controllers/clustercollector/configmap.go
+++ b/autoscaler/controllers/clustercollector/configmap.go
@@ -210,6 +210,13 @@ func syncConfigMap(enabledDests *odigosv1.DestinationList, allProcessors *odigos
 	}
 	// When on, pipelinegen installs groupbytrace on traces/in so the exporter sees full traces.
 	gatewayOptions.Insights = insightsCfg
+	// Provide the insights OTLP endpoint so pipelinegen (in the common module, which
+	// cannot import api/k8sconsts) can add an OTLP exporter to metrics/servicegraph
+	// for the blast-radius topology. Target the headless Service via dns:/// so
+	// the gateway's gRPC client round_robins across insights replicas.
+	if odigoscommon.InsightsPipelineActive(insightsCfg) {
+		gatewayOptions.InsightsOtlpEndpoint = k8sconsts.InsightsOtlpGrpcDNSEndpoint(env.GetCurrentNamespace())
+	}
 	// Insights can trigger groupbytrace without tail sampling on, in which case
 	// the scheduler hasn't resolved TraceAggregationWaitDuration. Fall back to the
 	// canonical default so we never feed groupbytrace a nil wait_duration.

--- a/common/config/root_test.go
+++ b/common/config/root_test.go
@@ -305,6 +305,98 @@ func TestServiceGraphOptions(t *testing.T) {
 	}
 }
 
+// TestServiceGraphInsights verifies that when insights is active the gateway
+// adds the insights OTLP exporter to the existing metrics/servicegraph pipeline
+// (alongside prometheus/servicegraph) and forces the k8s.namespace.name
+// dimension so edges can be joined to anomalies keyed by (namespace, service).
+func TestServiceGraphInsights(t *testing.T) {
+	on := true
+	gatewayOptions := pipelinegen.GatewayConfigOptions{
+		OdigosNamespace:      "odigos-system",
+		Insights:             &common.InsightsConfiguration{Enabled: &on},
+		InsightsOtlpEndpoint: "dns:///odigos-insights-headless.odigos-system:4317",
+		ServiceGraph: common.ServiceGraphOptions{
+			ExtraDimensions:           []string{"http.method"},
+			VirtualNodePeerAttributes: []string{"peer.service", "server.address"},
+		},
+	}
+	cfg, err, _, _ := pipelinegen.CalculateGatewayConfig(
+		[]config.ExporterConfigurer{DummyTraceDestination{ID: "t1"}},
+		[]config.ProcessorConfigurer{},
+		selfMetricsReceiver(), nil, &gatewayOptions,
+	)
+	require.NoError(t, err)
+	out := marshalConfig(t, cfg)
+
+	// One pipeline, two exporters: prometheus (UI) + OTLP (insights).
+	assert.Contains(t, out, "metrics/servicegraph:")
+	assert.Contains(t, out, "prometheus/servicegraph")
+	assert.Contains(t, out, consts.ServiceGraphInsightsExporterName+":")
+	assert.Contains(t, out, "dns:///odigos-insights-headless.odigos-system:4317")
+	assert.Contains(t, out, "balancer_name: round_robin")
+	assert.NotContains(t, out, "metrics/servicegraph-insights:")
+	assert.Contains(t, out, "resource/pod-name:")
+	assert.Contains(t, out, "k8s.pod.name")
+	assert.Contains(t, out, "${POD_NAME}")
+
+	// Namespace dimension is forced on so edges carry it; user extras and
+	// virtual-node peer attributes are preserved.
+	assert.Contains(t, out, "- k8s.namespace.name\n")
+	assert.Contains(t, out, "- http.method\n")
+	assert.Contains(t, out, "virtual_node_peer_attributes:")
+	assert.Contains(t, out, "- peer.service\n")
+	assert.Contains(t, out, "- server.address\n")
+
+	pipe, ok := cfg.Service.Pipelines["metrics/servicegraph"]
+	require.True(t, ok)
+	assert.Equal(t, []string{"resource/pod-name"}, pipe.Processors)
+	assert.Equal(t, []string{"prometheus/servicegraph", consts.ServiceGraphInsightsExporterName}, pipe.Exporters)
+}
+
+// TestServiceGraphInsightsDisabled verifies the insights exporter is absent
+// when insights is not active, so the default service-graph path is unchanged.
+func TestServiceGraphInsightsDisabled(t *testing.T) {
+	gatewayOptions := pipelinegen.GatewayConfigOptions{OdigosNamespace: "odigos-system"}
+	cfg, err, _, _ := pipelinegen.CalculateGatewayConfig(
+		[]config.ExporterConfigurer{DummyTraceDestination{ID: "t1"}},
+		[]config.ProcessorConfigurer{},
+		selfMetricsReceiver(), nil, &gatewayOptions,
+	)
+	require.NoError(t, err)
+	out := marshalConfig(t, cfg)
+	assert.NotContains(t, out, consts.ServiceGraphInsightsExporterName+":")
+	assert.NotContains(t, out, "metrics/servicegraph-insights:")
+
+	pipe, ok := cfg.Service.Pipelines["metrics/servicegraph"]
+	require.True(t, ok)
+	assert.Empty(t, pipe.Processors)
+	assert.Equal(t, []string{"prometheus/servicegraph"}, pipe.Exporters)
+}
+
+func TestServiceGraphInsightsDoesNotDuplicateNamespaceDimension(t *testing.T) {
+	on := true
+	gatewayOptions := pipelinegen.GatewayConfigOptions{
+		OdigosNamespace:      "odigos-system",
+		Insights:             &common.InsightsConfiguration{Enabled: &on},
+		InsightsOtlpEndpoint: "dns:///odigos-insights-headless.odigos-system:4317",
+		ServiceGraph: common.ServiceGraphOptions{
+			ExtraDimensions: []string{"k8s.namespace.name"},
+		},
+	}
+	cfg, err, _, _ := pipelinegen.CalculateGatewayConfig(
+		[]config.ExporterConfigurer{DummyTraceDestination{ID: "t1"}},
+		[]config.ProcessorConfigurer{},
+		selfMetricsReceiver(), nil, &gatewayOptions,
+	)
+	require.NoError(t, err)
+
+	connector, ok := cfg.Connectors[consts.ServiceGraphConnectorName].(config.GenericMap)
+	require.True(t, ok)
+	dims, ok := connector["dimensions"].([]string)
+	require.True(t, ok)
+	assert.Equal(t, []string{"service.name", "k8s.namespace.name"}, dims)
+}
+
 func TestTracesPipelineSplitAfterGroupByTrace(t *testing.T) {
 	ext := "odigosconfigk8s"
 	enabled := true

--- a/common/consts/consts.go
+++ b/common/consts/consts.go
@@ -60,6 +60,12 @@ const (
 	ServiceGraphConnectorName = "servicegraph"
 	ServiceGraphEndpointPort  = 9090
 
+	// ServiceGraphInsightsExporterName is the OTLP gRPC exporter that ships the
+	// servicegraph connector's metrics to the odigos-insights service so it can
+	// build the blast-radius topology. Added as a second exporter on the existing
+	// metrics/servicegraph pipeline when insights is active.
+	ServiceGraphInsightsExporterName = "otlp_grpc/servicegraph-insights"
+
 	ServiceIOConnectorName                       = "serviceio"
 	TraceCorrelationsMetricsPipelineName         = "metrics/tracecorrelations"
 	TraceCorrelationsMetricsServiceName          = "odigos-correlations-metrics"

--- a/common/pipelinegen/config_builder.go
+++ b/common/pipelinegen/config_builder.go
@@ -36,6 +36,15 @@ type GatewayConfigOptions struct {
 	// so the exporter sees fully assembled traces.
 	Insights *common.InsightsConfiguration
 
+	// InsightsOtlpEndpoint is the in-cluster OTLP gRPC endpoint of the
+	// odigos-insights-headless service in dns:/// form (e.g.
+	// dns:///odigos-insights-headless.<ns>:4317). Set by the caller so
+	// pipelinegen (in the common module) does not depend on the api module
+	// for the endpoint helper. When insights is active this is the destination
+	// for the OTLP exporter added to metrics/servicegraph; the exporter uses
+	// round_robin so traffic fans out across insights replicas.
+	InsightsOtlpEndpoint string
+
 	// Trace correlations configuration for the serviceio connector (service I/O metrics).
 	TraceCorrelationsServiceIO *common.TraceCorrelationsServiceIOConfiguration
 }
@@ -225,7 +234,7 @@ func CalculateGatewayConfig(
 	// - ServiceGraph.Disabled: assume false (enabled) if nil
 	// - ClusterMetricsEnabled: assume false (disabled) if nil
 	if tracesEnabled && (gatewayOptions.ServiceGraph.Disabled == nil || !*gatewayOptions.ServiceGraph.Disabled) {
-		insertServiceGraphPipeline(currentConfig, gatewayOptions.ServiceGraph.ExtraDimensions, gatewayOptions.ServiceGraph.VirtualNodePeerAttributes)
+		insertServiceGraphPipeline(currentConfig, gatewayOptions)
 	}
 	if tracesEnabled {
 		insertTraceCorrelationsServiceIOPipeline(currentConfig, gatewayOptions)
@@ -371,7 +380,11 @@ func applyRootPipelineForSignal(currentConfig *config.Config, signal common.Obse
 	}
 }
 
-func insertServiceGraphPipeline(currentConfig *config.Config, extraDimensions []string, virtualNodePeerAttributes []string) {
+func insertServiceGraphPipeline(currentConfig *config.Config, gatewayOptions *GatewayConfigOptions) {
+	extraDimensions := gatewayOptions.ServiceGraph.ExtraDimensions
+	virtualNodePeerAttributes := gatewayOptions.ServiceGraph.VirtualNodePeerAttributes
+	insightsOn := common.InsightsPipelineActive(gatewayOptions.Insights) && gatewayOptions.InsightsOtlpEndpoint != ""
+
 	// Add the service graph exporter to expose the service graph metrics to prometheus
 	currentConfig.Exporters["prometheus/servicegraph"] = config.GenericMap{
 		"endpoint":  fmt.Sprintf("localhost:%d", consts.ServiceGraphEndpointPort),
@@ -387,6 +400,14 @@ func insertServiceGraphPipeline(currentConfig *config.Config, extraDimensions []
 	// Build dimensions: always include service.name as the base, then append any extras
 	dimensions := []string{string(semconv.ServiceNameKey)}
 	dimensions = append(dimensions, extraDimensions...)
+
+	// When insights is active, the emitted edges must carry the namespace so the
+	// blast-radius topology can be joined to anomalies keyed by (namespace, service).
+	// service.name alone is ambiguous across namespaces, so force k8s.namespace.name
+	// into the connector dimensions (deduped against user-provided extras).
+	if insightsOn && !slices.Contains(dimensions, string(semconv.K8SNamespaceNameKey)) {
+		dimensions = append(dimensions, string(semconv.K8SNamespaceNameKey))
+	}
 
 	// Add the service graph connector to receive the service graph metrics from the root traces pipeline
 	// Retain incomplete edges for up to 15s to allow delayed span matching
@@ -407,10 +428,49 @@ func insertServiceGraphPipeline(currentConfig *config.Config, extraDimensions []
 
 	currentConfig.Connectors[consts.ServiceGraphConnectorName] = connectorCfg
 
-	// Add the service graph pipeline to receive the service graph metrics from the root traces pipeline
+	// metrics/servicegraph receives the connector's metrics and exports them to
+	// the local prometheus/servicegraph endpoint (scraped back for the UI
+	// service map). When insights is active, the same pipeline also fans out
+	// to odigos-insights over OTLP — one connector, one pipeline, two exporters.
+	exporters := []string{"prometheus/servicegraph"}
+	var processors []string
+	if insightsOn {
+		// Stamp the gateway pod name onto the metrics resource so Insights can
+		// key ClickHouse rows by (edge, collector_pod). The connector's counters
+		// are cumulative per pod, and trace load balancing spreads an edge's
+		// spans across gateway replicas; without this, ReplacingMergeTree
+		// last-write-wins across pods. Reuse the self-telemetry processor when
+		// present, otherwise define it here so the pipeline is valid even if
+		// self-telemetry wasn't applied. Harmless on the Prometheus path:
+		// resource_to_telemetry_conversion is off by default, so k8s.pod.name
+		// stays a resource attribute and never becomes a scrape label.
+		if _, ok := currentConfig.Processors["resource/pod-name"]; !ok {
+			currentConfig.Processors["resource/pod-name"] = config.GenericMap{
+				"attributes": []config.GenericMap{
+					{
+						"key":    string(semconv.K8SPodNameKey),
+						"value":  "${POD_NAME}",
+						"action": "upsert",
+					},
+				},
+			}
+		}
+		processors = []string{"resource/pod-name"}
+		currentConfig.Exporters[consts.ServiceGraphInsightsExporterName] = config.GenericMap{
+			"endpoint":      gatewayOptions.InsightsOtlpEndpoint,
+			"balancer_name": "round_robin",
+			"tls":           config.GenericMap{"insecure": true},
+			"compression":   "none",
+			"retry_on_failure": config.GenericMap{
+				"enabled": false,
+			},
+		}
+		exporters = append(exporters, consts.ServiceGraphInsightsExporterName)
+	}
 	currentConfig.Service.Pipelines["metrics/servicegraph"] = config.Pipeline{
-		Receivers: []string{consts.ServiceGraphConnectorName},
-		Exporters: []string{"prometheus/servicegraph"},
+		Receivers:  []string{consts.ServiceGraphConnectorName},
+		Processors: processors,
+		Exporters:  exporters,
 	}
 
 	// Add the service graph exporter to the traces pipeline that routes to destinations


### PR DESCRIPTION
#### What this PR does / why we need it:
This picks up https://github.com/odigos-io/odigos/pull/5378 to send service graph metrics to the odigos insights db

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
