### PR TITLE
test(e2e): add log collection scenario and share the query runner | RUN-656

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -106,6 +106,7 @@ jobs:
           - "instrumentation-rollback-stability-window"
           - "environment-variables"
           - "trace-collection"
+          - "log-collection"
           - "source"
           - "webhooks"
           - "env-injection"

--- a/tests/common/apply/add-simple-trace-db-destination-logs.yaml
+++ b/tests/common/apply/add-simple-trace-db-destination-logs.yaml
@@ -1,0 +1,21 @@
+# Destination declaring both TRACES and LOGS.
+#
+# The LOGS signal is what causes a logs pipeline to be generated at all: the node collector only
+# builds one once the cluster collector reports that a destination receives logs. Without it no
+# logs reach any destination and log assertions fail in a way that looks like broken collection.
+#
+# Kept separate from add-simple-trace-db-destination.yaml, which nearly every scenario applies and
+# which should stay traces-only so they do not all start collecting logs.
+apiVersion: odigos.io/v1alpha1
+kind: Destination
+metadata:
+  name: odigos.io.dest.simple-trace-db
+  namespace: odigos-test
+spec:
+  data:
+    OTLP_HTTP_ENDPOINT: http://simple-trace-db.traces:4318
+  destinationName: e2e-tests
+  signals:
+    - TRACES
+    - LOGS
+  type: otlphttp

--- a/tests/common/apply/simple-trace-db-deployment.yaml
+++ b/tests/common/apply/simple-trace-db-deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: simple-trace-db
-          image: ghcr.io/odigos-io/simple-trace-db/simple-trace-db:0.0.8
+          image: ghcr.io/odigos-io/simple-trace-db/simple-trace-db:v0.0.12
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 4318

--- a/tests/common/simple_trace_db_query_runner.sh
+++ b/tests/common/simple_trace_db_query_runner.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# Runs a query from a test file against simple-trace-db and compares the number of results to the
+# expectation in the file.
+#
+# The test file may set an optional `endpoint` to query a signal other than traces, e.g.
+# `endpoint: /v1/logs`. It defaults to /v1/traces.
+#
+# Note what is being counted differs by endpoint: /v1/traces returns an object keyed by trace id so
+# the count is traces, while /v1/logs returns an array so the count is individual log records.
+
 # Ensure the script fails if any command fails
 set -e
 
@@ -42,12 +51,18 @@ function process_yaml_file() {
   echo "Dest service: $dest_service"
   echo "Dest port: $dest_port"
 
+  endpoint=$(yq e '.endpoint' "$file")
+  if [ "$endpoint" == "null" ] || [ -z "$endpoint" ]; then
+    endpoint="/v1/traces"
+  fi
+  echo "Endpoint: $endpoint"
+
   query=$(yq '.query' "$file")
   encoded_query=$(urlencode "$query")
   expected_count=$(yq e '.expected.count' "$file")
   minimum_count=$(yq e '.expected.minimum' "$file")
 
-  response=$(kubectl get --raw /api/v1/namespaces/$dest_namespace/services/$dest_service:$dest_port/proxy/v1/traces\?jmespath=$encoded_query)
+  response=$(kubectl get --raw /api/v1/namespaces/$dest_namespace/services/$dest_service:$dest_port/proxy$endpoint\?jmespath=$encoded_query)
 
   if [ "$verbose" == "true" ]; then
     echo "============== Raw response from trace db ===================="
@@ -55,25 +70,25 @@ function process_yaml_file() {
     echo "========================================================="
   fi
 
-  num_of_traces=$(echo "$response" | jq 'keys | length')
+  num_of_results=$(echo "$response" | jq 'length')
 
   if [ "$expected_count" != "null" ]; then
-    # if num_of_traces not equal to expected_count
-    if [ "$num_of_traces" -ne "$expected_count" ]; then
-      echo "Test FAILED: expected $expected_count got $num_of_traces"
+    # if num_of_results not equal to expected_count
+    if [ "$num_of_results" -ne "$expected_count" ]; then
+      echo "Test FAILED: expected $expected_count got $num_of_results"
       exit 1
     else
-      echo "Test PASSED: expected $expected_count got $num_of_traces"
+      echo "Test PASSED: expected $expected_count got $num_of_results"
       exit 0
     fi
   fi
 
   if [ "$minimum_count" != "null" ]; then
-    if [ "$num_of_traces" -lt "$minimum_count" ]; then
-      echo "Test FAILED: expected at least $minimum_count got $num_of_traces"
+    if [ "$num_of_results" -lt "$minimum_count" ]; then
+      echo "Test FAILED: expected at least $minimum_count got $num_of_results"
       exit 1
     else
-      echo "Test PASSED: expected at least $minimum_count got $num_of_traces"
+      echo "Test PASSED: expected at least $minimum_count got $num_of_results"
       exit 0
     fi
   fi

--- a/tests/e2e/log-collection/README.md
+++ b/tests/e2e/log-collection/README.md
@@ -1,0 +1,26 @@
+# Log Collection E2E Test
+
+Verifies log collection through the **filelog receiver**: container stdout from instrumented
+workloads is scraped, enriched with kubernetes resource attributes, and delivered to a destination
+that declares the `LOGS` signal.
+
+## What it covers
+
+- A logs pipeline is generated once a destination declares `LOGS`, and not before.
+- The filelog receiver collects application output written during the traffic run, not only startup
+  lines.
+- `odigoslogsresourceattrsprocessor` resolves the pod from the log file path and adds
+  `k8s.pod.name`, `k8s.namespace.name`, `k8s.container.name` and a `service.name` the application
+  never sent.
+
+## Ordering
+
+Two constraints make this test order-sensitive, and both are waited on explicitly:
+
+- The node collector does not build a logs pipeline until the cluster collector reports that a
+  destination receives logs.
+- filelog is configured with `start_at: end`, so anything written before the receiver is running is
+  never collected.
+
+Traffic generated before the pipeline exists produces no logs, which is indistinguishable from
+collection being broken.

--- a/tests/e2e/log-collection/assert-logs-pipeline.yaml
+++ b/tests/e2e/log-collection/assert-logs-pipeline.yaml
@@ -1,0 +1,10 @@
+# The node collector only builds a logs pipeline once the cluster collector reports that a
+# destination receives logs, so this waits for the logs config domain to exist and to be using the
+# filelog receiver. pipeline-ready.yaml does not cover this: it asserts the collector groups are
+# ready and their config maps are non-empty, not which signals are configured.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: odigos-node-collector-config-domains
+  namespace: odigos-test
+(contains(data.logs, 'filelog')): true

--- a/tests/e2e/log-collection/chainsaw-test.yaml
+++ b/tests/e2e/log-collection/chainsaw-test.yaml
@@ -1,0 +1,155 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: log-collection
+spec:
+  description: |
+    This e2e test verifies log collection through the filelog receiver: container stdout from
+    instrumented workloads is scraped, enriched with kubernetes resource attributes, and delivered
+    to a destination that declares the LOGS signal.
+  skipDelete: true
+  steps:
+    - name: Prepare destination
+      try:
+        - apply:
+            file: ../../common/apply/simple-trace-db-deployment.yaml
+
+    - name: Install Test Apps
+      try:
+        - apply:
+            file: ../../common/apply/install-simple-demo.yaml
+
+    - name: Install Odigos
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              # The pwd is the directory of this file, so we have to walk up to the project root to find the helm chart
+              P="../../.."
+              helm upgrade --install odigos $P/helm/odigos --create-namespace --namespace odigos-test \
+                --set image.tag=e2e-test \
+                --set nodeSelector."kubernetes\.io/os"=linux \
+                --set collectorNode.memoryLimit=560 \
+                --set collectorNode.limitCPUm=550
+              kubectl label namespace odigos-test odigos.io/system-object="true"
+              ../../common/verify_odigos_installation.sh odigos-test
+        - assert:
+            timeout: 1m10s
+            file: ../../common/assert/odigos-installed.yaml
+
+    - name: Assert Trace DB is up
+      try:
+        - assert:
+            timeout: 1m10s
+            file: ../../common/assert/simple-trace-db-running.yaml
+
+    - name: Assert Apps Installed
+      try:
+        - assert:
+            timeout: 1m40s
+            file: ../../common/assert/simple-demo-installed.yaml
+
+    - name: Instrument Namespace
+      try:
+        - apply:
+            file: ../../common/apply/instrument-default-ns.yaml
+
+    - name: Assert Runtime Detected
+      try:
+        - assert:
+            timeout: 1m40s
+            file: ../../common/assert/simple-demo-runtime-detected.yaml
+
+    - name: Add Destination With Logs
+      try:
+        - apply:
+            file: ../../common/apply/add-simple-trace-db-destination-logs.yaml
+
+    # Instrumenting the namespace rolls the workloads, so this waits for the new pods rather than
+    # the ones that were running before. simple-demo-installed.yaml checks updatedReplicas, so it
+    # is only satisfied once the instrumented replica set is the ready one. Without this the
+    # traffic job can be scheduled while the frontend is still rolling and never complete.
+    - name: Assert Apps Ready After Instrumentation
+      try:
+        - assert:
+            timeout: 2m
+            file: ../../common/assert/simple-demo-installed.yaml
+
+    - name: Assert Pipeline
+      try:
+        - assert:
+            timeout: 1m10s
+            file: ../../common/assert/pipeline-ready.yaml
+
+    # Generating traffic before the logs pipeline exists produces no logs at all, which looks
+    # identical to collection being broken. filelog is also configured to start at the end of each
+    # file, so anything written before the receiver is running is never collected.
+    - name: Assert Logs Pipeline Ready
+      try:
+        - assert:
+            timeout: 3m
+            file: assert-logs-pipeline.yaml
+      catch:
+        - script:
+            content: |
+              kubectl get configmap odigos-node-collector-config-domains -n odigos-test -o yaml
+
+    ############# Generate Traffic #############
+    # The log line asserted below is written at the end of the /buy handler, after calls to several
+    # other services, so it only appears if the whole request succeeds. The demo workloads declare
+    # no readiness probes, which means a deployment reports ready as soon as its container starts
+    # rather than when the application is listening, and the shared one-shot traffic job would send
+    # its single request before the JVM finishes booting. curl also exits 0 on a 5xx, so a failed
+    # request looks like a successful job.
+    #
+    # Retrying until the request actually returns 200 removes both problems and makes the log line
+    # a guarantee rather than a race.
+    - name: Generate Traffic
+      try:
+        - script:
+            timeout: 3m
+            content: |
+              kubectl delete pod traffic-generator -n default --ignore-not-found
+              # Several successful requests rather than one: filelog discovers new log files on a
+              # poll interval, so the first line written after a pod starts can be missed.
+              kubectl run traffic-generator -n default --image=curlimages/curl:8.4.0 --restart=Never --command -- \
+                sh -c 'ok=0
+                       for i in $(seq 1 30); do
+                         code=$(curl -s -o /dev/null -w "%{http_code}" -X POST "http://frontend:8080/buy?id=123")
+                         echo "attempt $i: HTTP $code"
+                         [ "$code" = "200" ] && ok=$((ok+1))
+                         [ "$ok" -ge 3 ] && exit 0
+                         sleep 5
+                       done
+                       exit 1'
+              kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/traffic-generator -n default --timeout=160s
+              kubectl logs traffic-generator -n default
+              kubectl delete pod traffic-generator -n default --ignore-not-found
+      catch:
+        - script:
+            content: |
+              kubectl logs traffic-generator -n default || true
+              kubectl describe pod traffic-generator -n default || true
+
+    ############# Verify Logs #############
+    - name: Assert Logs Collected And Enriched
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              while true; do
+                ../../common/simple_trace_db_query_runner.sh log-collection-validation.yaml
+                if [ $? -eq 0 ]; then
+                  break
+                fi
+                sleep 2
+              done
+      catch:
+        - script:
+            content: |
+              echo "Logs currently in the trace db:"
+              kubectl get --raw /api/v1/namespaces/traces/services/simple-trace-db:4318/proxy/v1/logs | jq -c '.[] | {serviceName, bodyText}'
+              echo "Frontend output that should have been collected:"
+              kubectl logs -n default -l app=frontend --tail=50 || true
+              echo "Node collector logs:"
+              kubectl logs -n odigos-test -l odigos.io/collector-role=NODE_COLLECTOR --tail=100 || true

--- a/tests/e2e/log-collection/log-collection-validation.yaml
+++ b/tests/e2e/log-collection/log-collection-validation.yaml
@@ -1,0 +1,23 @@
+apiVersion: e2e.tests.odigos.io/v1
+kind: LogTest
+endpoint: /v1/logs
+description: |
+  This test verifies that the filelog receiver collects container stdout from instrumented
+  workloads and that the logs pipeline enriches each record with kubernetes resource attributes.
+
+  It keys on a log line the frontend writes while handling POST /buy, so it also confirms that
+  collection is picking up output produced during the traffic run rather than only startup lines.
+
+  serviceName is not reported by the application here - it is resolved by the logs processor from
+  the pod uid in the log file path - so asserting on it exercises that enrichment rather than
+  anything the workload sends.
+query: |
+  [?(
+    serviceName == 'frontend' &&
+    contains(bodyText, 'Buying product with id') &&
+    resourceAttributes."k8s.namespace.name" == 'default' &&
+    resourceAttributes."k8s.pod.name" != null &&
+    resourceAttributes."k8s.container.name" == 'frontend'
+  )]
+expected:
+  minimum: 1


### PR DESCRIPTION
#### What this PR does / why we need it:

Nothing exercises the **filelog receiver** today. This adds a log collection scenario, and extends the existing query runner to reach the logs endpoint rather than adding a second script.

Follows review feedback on odigos-io/odigos-enterprise#3434, where a logs query runner initially lived. It had nothing eBPF- or enterprise-specific in it, and it turned out to differ from `simple_trace_db_query_runner.sh` by two lines — so instead of moving a near-duplicate here, the existing runner now takes an optional `endpoint` field.

**What's here**

- `simple_trace_db_query_runner.sh` gains an optional `endpoint` in the test file, defaulting to `/v1/traces`. Counting moves from `keys | length` to `length`: the same value for the object `/v1/traces` returns, and correct for the array `/v1/logs` returns. Existing query files are unchanged and unaffected.
- A `log-collection` scenario: declares the `LOGS` signal, generates traffic, and asserts container stdout is collected and enriched by `odigoslogsresourceattrsprocessor` — including a `service.name` the application never sent, which is what makes it cover the enrichment rather than only delivery.
- Bumps `simple-trace-db` to `v0.0.12`, the first release serving the logs endpoints. The pin was four releases behind; trace endpoints are unchanged.

The scenario asserts nothing about trace context in either direction, since whether collected records carry it depends on the collection path in use.

Installed with helm, and the logs-pipeline wait is a declarative `assert` on the node collector's logs config domain — `pipeline-ready.yaml` doesn't cover that, since it asserts the collector groups are ready rather than which signals they're configured for.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
NONE
```