### PR TITLE
RUN-1061 | fix(odiglet): preserve the community Java agent jar across upgrades

### DIFF
--- a/common/fs/agents.go
+++ b/common/fs/agents.go
@@ -295,6 +295,11 @@ func getCriticalFiles(bp string) map[string]struct{} {
 	cf[filepath.Join(bp, "nodejs-ebpf", "build", "Release", "obj.target", "dtrace-injector-native.node")] = struct{}{}
 	cf[filepath.Join(bp, "nodejs-ebpf", "build", "Release", ".deps", "Release", "dtrace-injector-native.node.d")] = struct{}{}
 	cf[filepath.Join(bp, "nodejs-ebpf", "build", "Release", ".deps", "Release", "obj.target", "dtrace-injector-native.node.d")] = struct{}{}
+	// Community Java agent jar, attached via -javaagent at JVM startup. The agent reads its
+	// own classfiles out of the jar lazily, at request time, so rewriting the jar in place
+	// under a live JVM breaks instrumentation ("Failed to read classfile URL") until the pod
+	// restarts. The enterprise agent jar below is preserved for the same reason.
+	cf[filepath.Join(bp, "java", "javaagent.jar")] = struct{}{}
 	cf[filepath.Join(bp, "java-ebpf", "tracing_probes.so")] = struct{}{}
 	cf[filepath.Join(bp, "java-ext-ebpf", "end_span_usdt.so")] = struct{}{}
 	cf[filepath.Join(bp, "java-ext-ebpf", "javaagent.jar")] = struct{}{}


### PR DESCRIPTION
#### What this PR does / why we need it:

Any change to `JAVA_OTEL_VERSION` fails all 6 upgrade e2e tests (`cli-upgrade` + `helm-upgrade` × k8s 1.21.12 / 1.23 / 1.32): the instrumented app dies with `IllegalStateException: Failed to read classfile URL` and emits no spans. This blocks every Java agent bump, including the nightly `update-otel-versions` automation.

The agents sync rsyncs with `--inplace`, which rewrites the existing inode, and the Java agent reads its own classfiles out of `javaagent.jar` lazily at request time — so JVMs attached before the upgrade start reading bytes that changed underneath them.

`getCriticalFiles` exists for exactly this hazard ("may be memory-mapped by running processes") and already lists the **enterprise** jar `java-ext-ebpf/javaagent.jar`, but not the **community** `java/javaagent.jar` that `JAVA_OTEL_VERSION` controls. Adding it makes the upgrade rename the old jar to `javaagent_hash_version-<hash>.jar` — preserving the inode running JVMs hold open — while rsync writes the new jar at the canonical path for new pods.

**Trade-off worth a conscious call:** running pods keep the old agent until they restart, so a CVE bump is partial remediation. You cannot hot-swap a jar under a live JVM, so the alternative isn't "running pods get patched", it's "running pods lose instrumentation". Each bump also leaves a ~20 MB copy of the previous jar per node.

Alternatives considered: a version-scoped path (`java/<version>/javaagent.jar`) is cleaner but injection hardcodes the path in `distros/yamls/java-community.yaml`; dropping `--inplace` fixes the whole class of problem but reintroduces the disk pressure the flag was added for.

#### Testing

E2E ran on #5510 (the v2.20.0 bump, stacked on this branch): **all 6 upgrade tests pass**, against all 6 failing before. One unrelated flake, `1.23 tail-sampling-nodejs` — a fresh-install scenario, which doesn't reach this code path at all.

No unit test here. The assertion worth making is that a descriptor opened before the sync still reads valid bytes afterwards, which needs the real rsync path rather than the keep-map bookkeeping in isolation; the upgrade e2e scenarios already cover that end to end.

Ref: RUN-1061 · unblocks #5510 (RUN-1056)

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
Fixed the Java agent jar being rewritten in place during an Odigos upgrade, which broke instrumentation in already-running JVMs whenever the agent version changed. Running pods now keep their existing agent until they restart; newly started pods pick up the new one.
```
