### PR TITLE
chore: backport Go toolchain 1.26.6 to v1.34.x

### DIFF
--- a/.github/workflows/build-dev-images.yml
+++ b/.github/workflows/build-dev-images.yml
@@ -77,7 +77,7 @@ jobs:
       - uses: ko-build/setup-ko@v0.9
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
       - name: Build CLI Image
         env:
           COMMIT_HASH: ${{ github.sha }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -149,7 +149,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
       - name: Build Instrumentor Image
         uses: docker/build-push-action@v6
         with:
@@ -460,7 +460,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
       - name: Set up Goreleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -473,7 +473,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
       - name: Test k8sutils module
         working-directory: ./k8sutils
         run: |
@@ -485,7 +485,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
       - name: Test common module
         working-directory: ./common
         run: |
@@ -497,7 +497,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
       - name: Test procdiscovery module
         working-directory: ./procdiscovery
         run: |

--- a/.github/workflows/check-operator-manifests.yml
+++ b/.github/workflows/check-operator-manifests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - name: Check operator manifests are up to date
         id: check-manifests

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "~1.26.5"
+          go-version: "~1.26.6"
           check-latest: true
           cache: true
           cache-dependency-path: |
@@ -135,7 +135,7 @@ jobs:
         if: steps.should-run.outputs.skip != 'true' && matrix.test-scenario == 'karpenter-mount-methods'
         uses: actions/setup-go@v6
         with:
-          go-version: "~1.26.5"
+          go-version: "~1.26.6"
           check-latest: true
           cache: true
 

--- a/.github/workflows/full-build.yaml
+++ b/.github/workflows/full-build.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
       - name: Set up Goreleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/go-mod-tidy.yml
+++ b/.github/workflows/go-mod-tidy.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
       - name: run make go-mod-tidy
         run: make go-mod-tidy
       - name: Check clean repository
@@ -27,6 +27,6 @@ jobs:
         uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
       - name: run make verify-go-mod-graph
         run: make verify-go-mod-graph

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
       - name: Generate Helm Schema
         run: make helm-schema
       - name: Check for schema changes

--- a/.github/workflows/publish-collector-linux-packages.yml
+++ b/.github/workflows/publish-collector-linux-packages.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - name: Set GoReleaser tag
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,7 +167,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/verify-api-crds.yml
+++ b/.github/workflows/verify-api-crds.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
       - name: install controller-gen
         run: make controller-gen
       - name: Check API CRDs

--- a/.github/workflows/verify-collector-ocb.yml
+++ b/.github/workflows/verify-collector-ocb.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
       - name: Generate collector with ocb
         working-directory: ./collector
         run: "make genodigoscol generate"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.5 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6 AS builder
 ARG SERVICE_NAME
 
 # Copy only go.mod/go.sum for local modules to cache dependency downloads

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -17,7 +17,7 @@ RUN set -e && \
     done && \
     helm package helm/odigos helm/odigos-central -d /workspace/chart-artifacts
 
-FROM --platform=$BUILDPLATFORM golang:1.26.5 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION

--- a/collector/Dockerfile
+++ b/collector/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.5-trixie AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6-trixie AS builder
 COPY ./collector/ /go/src/collector
 # Need to copy the common folder to the collector for custom connector that uses it
 COPY ./common/ /go/src/common

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -20,7 +20,7 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY frontend/webapp .
 RUN yarn build
 
-FROM --platform=$BUILDPLATFORM golang:1.26.5 AS backend
+FROM --platform=$BUILDPLATFORM golang:1.26.6 AS backend
 WORKDIR /app
 # Copy only the go.mod/go.sum of the frontend module and its locally-replaced
 # deps first. This lets `go mod download` be cached independently of source

--- a/odiglet/base.Dockerfile
+++ b/odiglet/base.Dockerfile
@@ -22,7 +22,7 @@ RUN wget https://download.samba.org/pub/rsync/src/rsync-${RSYNC_VERSION}.tar.gz 
     && cd .. \
     && rm -rf rsync-${RSYNC_VERSION}*
 
-FROM golang:1.26.5-trixie
+FROM golang:1.26.6-trixie
 
 # goreleaser is used to build vmagent
 RUN echo "deb [trusted=yes] https://repo.goreleaser.com/apt/ /" > /etc/apt/sources.list.d/goreleaser.list

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.26.5 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG ODIGOS_VERSION


### PR DESCRIPTION
Backports the Go toolchain bump from main (#5556) to this release line.

## Why

Seven new HIGH advisories were published against `stdlib@go1.26.5` after this branch was cut, all fixed in **1.26.6**:

```
CVE-2026-46600, GO-2026-5026, GO-2026-5942, GO-2026-5972,
GO-2026-6088, GO-2026-6089, GO-2026-6090
```

Nothing regressed — the branch was clean on 1.26.5 when it was cut. Measured on v1.35.0-rc1, these account for 7 HIGH each in autoscaler / instrumentor / scheduler / operator / ui, 9 in collector, and 28 of odiglet's 47. Still 0 CRITICAL.

## Change

Six builder images to `golang:1.26.6`, plus the `setup-go` pins. Verified no `1.26.5` references remain. Identical to the change on main.

`odiglet/base.Dockerfile` is included for consistency but has no effect until `odiglet-base` is republished and `ODIGLET_BASE_IMAGE` repointed.

```release-note
Bumped the Go toolchain to 1.26.6.
```