### PR TITLE
CORE-1221 | feat: add create-pre workflow to tag the next pre-release

### DIFF
--- a/.github/workflows/create-pre.yml
+++ b/.github/workflows/create-pre.yml
@@ -1,0 +1,53 @@
+name: 'Create Pre Release'
+
+on:
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  create-pre-release:
+    runs-on: depot-ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Get sts tokens
+        id: sts-create-pre
+        uses: odigos-io/ci-core/sts@main
+        with:
+          scope: odigos-io/odigos
+          identity: push-tags
+          output-git-config: "true"
+
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: main
+          token: ${{ steps.sts-create-pre.outputs.GH_TOKEN }}
+
+      - name: Resolve semver
+        id: version
+        uses: odigos-io/ci-core/semver-info@main
+
+      - name: Create and push pre-release tag
+        env:
+          TAG: ${{ steps.version.outputs.next_pre }}
+        run: |
+
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Error: tag $TAG already exists"
+            exit 1
+          fi
+
+          git tag "$TAG"
+          git push origin "$TAG"
+          echo "Pushed tag $TAG to kick off the release process"
+
+      - name: Notify Slack
+        if: always()
+        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
+        with:
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          success-description: "Successfully created pre-release tag ${{ steps.version.outputs.next_pre }}"
+          failure-description: "ERROR: Failed to create pre-release tag ${{ steps.version.outputs.next_pre }}"
+          tag: ${{ steps.version.outputs.next_pre }}

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,29 +1,11 @@
 # Versioning
 
 Odigos publishes 2 release types:
--  stable releases (`v1.0.X`)
--  release candidates (`v1.0.x-rcY`)
+-  stable releases (`v1.X.Y`)
+-  release candidates (`v1.X.0-rcY`)
+-  pre-release versions (`v1.X.0-preY`)
 
-Stable releases are the default and recommended version to install. Release candidates are opt-in and require the user to explicitly take an action to install them.
-
-## Release Process
-
-### Stable Release Process
-
-The “next stable” version is currently defined as the latest version with its patch number increased by one.
-(In the future, this definition will change to follow proper semantic versioning.)
-
-A stable version is a release candidate that has successfully completed the release‑candidate process and is then promoted to stable.
-
-### Release Candidate Process
-
-Before releasing a new stable version, we release a new "release candidate" (rc) version. This allows the odigos team to test and validate the new version, and for the community to pull in latest bug fixes and features and provide feedback.
-
-If any bugs are found in the release candidate, they should be fixed and a new release candidate should be released with the "rc" suffix incremented by 1.
-
-After a release candidate is tested and validated, it is promoted to a stable release.
-
-Release candidates are always made against the next stable version, with the "-rcY" suffix, where Y is the release candidate number, starting from 0 and incrementing by 1 on every new release candidate to the same stable release version.
+Stable releases are the default and recommended version to install. Release candidates and pre-release versions are opt-in and require the user to explicitly take an action to install them.
 
 ## Consuming Odigos Versions
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds a `Create Pre Release` workflow that computes the next `vX.Y.0-preN` tag with `odigos-io/ci-core/semver-info` and pushes it on `main`, so a pre-release can be started from Actions instead of a manual tag ([CORE-1221](https://linear.app/odigos/issue/CORE-1221/ci-add-an-option-to-release-a-pre-release-from-a-given-brancehs)). Also documents `v1.X.0-preY` in VERSIONING.md.

Depends on [ci-core#101](https://github.com/odigos-io/ci-core/pull/101) (`semver-info` action).

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->

```release-note
NONE
```


Made with [Cursor](https://cursor.com)