### PR TITLE
chore: backport Java agent fixes to v1.35.x

### DIFF
--- a/common/fs/agents.go
+++ b/common/fs/agents.go
@@ -295,6 +295,11 @@ func getCriticalFiles(bp string) map[string]struct{} {
 	cf[filepath.Join(bp, "nodejs-ebpf", "build", "Release", "obj.target", "dtrace-injector-native.node")] = struct{}{}
 	cf[filepath.Join(bp, "nodejs-ebpf", "build", "Release", ".deps", "Release", "dtrace-injector-native.node.d")] = struct{}{}
 	cf[filepath.Join(bp, "nodejs-ebpf", "build", "Release", ".deps", "Release", "obj.target", "dtrace-injector-native.node.d")] = struct{}{}
+	// Community Java agent jar, attached via -javaagent at JVM startup. The agent reads its
+	// own classfiles out of the jar lazily, at request time, so rewriting the jar in place
+	// under a live JVM breaks instrumentation ("Failed to read classfile URL") until the pod
+	// restarts. The enterprise agent jar below is preserved for the same reason.
+	cf[filepath.Join(bp, "java", "javaagent.jar")] = struct{}{}
 	cf[filepath.Join(bp, "java-ebpf", "tracing_probes.so")] = struct{}{}
 	cf[filepath.Join(bp, "java-ext-ebpf", "end_span_usdt.so")] = struct{}{}
 	cf[filepath.Join(bp, "java-ext-ebpf", "javaagent.jar")] = struct{}{}

--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -54,7 +54,7 @@ FROM --platform=$BUILDPLATFORM ${ODIGLET_BASE_IMAGE} AS agents-builder
 WORKDIR /instrumentations
 
 # java-community
-ARG JAVA_OTEL_VERSION=v2.10.0
+ARG JAVA_OTEL_VERSION=v2.20.0
 ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/$JAVA_OTEL_VERSION/opentelemetry-javaagent.jar /instrumentations/java/javaagent.jar
 RUN chmod 644 /instrumentations/java/javaagent.jar
 

--- a/odiglet/debug.Dockerfile
+++ b/odiglet/debug.Dockerfile
@@ -75,7 +75,7 @@ RUN go install github.com/go-delve/delve/cmd/dlv@latest
 WORKDIR /instrumentations
 
 # java-community
-ARG JAVA_OTEL_VERSION=v2.10.0
+ARG JAVA_OTEL_VERSION=v2.20.0
 ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/$JAVA_OTEL_VERSION/opentelemetry-javaagent.jar /instrumentations/java/javaagent.jar
 RUN chmod 644 /instrumentations/java/javaagent.jar
 


### PR DESCRIPTION
Backports the Java agent fixes and the deviceplugin dependency update from main to this release line.

## Changes

| Commit | What |
|---|---|
| #5549 | Preserve the community Java agent jar across upgrades |
| #5510 | Java agent v2.10.0 → v2.20.0 |

Both cherry-picked with `-x`, applied cleanly.

## Why the order matters

The agent bump alone breaks upgrades. odiglet syncs agent files with rsync `--inplace`, so changing `javaagent.jar` rewrites it under running JVMs; the agent reads its own classfiles lazily and fails with `Failed to read classfile URL`, killing instrumentation until the pod restarts.

#5549 adds the jar to the `getCriticalFiles` keeplist so it is preserved, which is what makes the version bump safe. On main this was verified by all 6 upgrade e2e tests passing (`cli-upgrade` + `helm-upgrade` × 3 k8s versions) after having failed consistently before.

**Do not cherry-pick the agent bump without the keeplist fix.**

The Java bump moves bundled jackson from 2.18.1 to 2.20.0.

```release-note
Updated the OpenTelemetry Java agent and fixed agent jar preservation across upgrades.
```