### PR TITLE
RUN-1072 | chore: bump odiglet-base to v1.20 on v1.35.x

### DIFF
--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -1,4 +1,4 @@
-ARG ODIGLET_BASE_IMAGE=registry.odigos.io/odiglet-base:v1.19
+ARG ODIGLET_BASE_IMAGE=registry.odigos.io/odiglet-base:v1.20
 
 FROM --platform=$BUILDPLATFORM busybox:1.36.1 AS dotnet-builder
 WORKDIR /dotnet-instrumentation

--- a/odiglet/debug.Dockerfile
+++ b/odiglet/debug.Dockerfile
@@ -1,4 +1,4 @@
-ARG ODIGLET_BASE_IMAGE=registry.odigos.io/odiglet-base:v1.18
+ARG ODIGLET_BASE_IMAGE=registry.odigos.io/odiglet-base:v1.20
 
 
 ######### python Native Community Agent #########


### PR DESCRIPTION
Repoints `ODIGLET_BASE_IMAGE` to v1.20 in `odiglet/Dockerfile` and `odiglet/debug.Dockerfile`.

v1.20 is already published and carries Go 1.26.6. Main picked it up in #5354.

```release-note
Updated the odiglet base image to pick up Go 1.26.6.
```
