### PR TITLE
CORE-1221 | ci: add feature-branch release tagging from arbitrary branches

### DIFF
--- a/.github/workflows/create-feature-release.yml
+++ b/.github/workflows/create-feature-release.yml
@@ -9,7 +9,7 @@ on:
         type: string
         default: main
       slug:
-        description: "Feature slug (e.g. otel-metrics). Tag will be v0.0.0-feat.<slug>.<n>"
+        description: "Tag will be v0.0.0-feat.<slug>.<N> slug must be lowercase alphanumeric and hyphens (e.g otel-metrics)"
         required: true
         type: string
       enterprise_branch:

--- a/.github/workflows/create-feature-release.yml
+++ b/.github/workflows/create-feature-release.yml
@@ -1,0 +1,108 @@
+name: 'Create Feature Release'
+
+on:
+  workflow_dispatch:
+    inputs:
+      oss_branch:
+        description: "Base OSS git ref to tag (branch, SHA, or tag)"
+        required: false
+        type: string
+        default: main
+      slug:
+        description: "Feature slug (e.g. otel-metrics). Tag will be v0.0.0-feat.<slug>.<n>"
+        required: true
+        type: string
+      enterprise_branch:
+        description: "odigos-enterprise git ref to build against"
+        required: false
+        type: string
+        default: main
+
+permissions: read-all
+
+jobs:
+  create-feature-release:
+    runs-on: depot-ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Get sts tokens
+        id: sts-create-feature
+        uses: odigos-io/ci-core/sts@main
+        with:
+          scope: odigos-io/odigos
+          identity: push-tags
+          output-git-config: "true"
+
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.oss_branch || 'main' }}
+          token: ${{ steps.sts-create-feature.outputs.GH_TOKEN }}
+
+      - name: Resolve feature tag
+        id: version
+        env:
+          SLUG: ${{ inputs.slug }}
+        run: |
+          if [[ ! "$SLUG" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+            echo "Error: slug must be lowercase alphanumeric and hyphens (e.g. otel-metrics)"
+            exit 1
+          fi
+
+          PREFIX="v0.0.0-feat.${SLUG}."
+          max=-1
+          for existing in $(git tag -l "${PREFIX}*"); do
+            suffix="${existing#"$PREFIX"}"
+            if [[ "$suffix" =~ ^[0-9]+$ ]] && [ "$suffix" -gt "$max" ]; then
+              max=$suffix
+            fi
+          done
+          NEXT=$((max + 1))
+          TAG="${PREFIX}${NEXT}"
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Resolved feature tag $TAG from ${{ inputs.oss_branch || 'main' }}"
+
+      - name: Create and push feature-release tag
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          ENTERPRISE_BRANCH: ${{ inputs.enterprise_branch || 'main' }}
+          OSS_BRANCH: ${{ inputs.oss_branch || 'main' }}
+        run: |
+          if [[ -z "$ENTERPRISE_BRANCH" ]]; then
+            echo "Error: enterprise_branch is required"
+            exit 1
+          fi
+          if [[ "$ENTERPRISE_BRANCH" =~ [[:space:]] ]]; then
+            echo "Error: enterprise_branch must not contain whitespace"
+            exit 1
+          fi
+          if [[ -z "$OSS_BRANCH" ]]; then
+            echo "Error: oss_branch is required"
+            exit 1
+          fi
+          if [[ "$OSS_BRANCH" =~ [[:space:]] ]]; then
+            echo "Error: oss_branch must not contain whitespace"
+            exit 1
+          fi
+
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Error: tag $TAG already exists"
+            exit 1
+          fi
+
+          git tag -a "$TAG" -m "enterprise_branch=${ENTERPRISE_BRANCH}
+
+oss_branch=${OSS_BRANCH}"
+          git push origin "$TAG"
+          echo "Pushed tag $TAG (enterprise branch ${ENTERPRISE_BRANCH}, oss branch ${OSS_BRANCH}) to kick off the release process"
+
+      - name: Notify Slack
+        if: always()
+        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
+        with:
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          success-description: "Successfully created feature-release tag ${{ steps.version.outputs.tag }} (enterprise branch ${{ inputs.enterprise_branch || 'main' }})"
+          failure-description: "ERROR: Failed to create feature-release tag ${{ steps.version.outputs.tag }}"
+          tag: ${{ steps.version.outputs.tag }}

--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -116,10 +116,59 @@ jobs:
   trigger-enterprise-release-pr:
     if: ${{ needs.decide.outputs.skip != 'true' }}
     needs: [decide, tag-modules]
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     permissions:
+      contents: read
       id-token: write
     steps:
+
+      - name: Classify release
+        id: meta
+        env:
+          TAG: ${{ needs.decide.outputs.tag }}
+        run: |
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-feat\. ]]; then
+            echo "kind=feature" >> "$GITHUB_OUTPUT"
+          else
+            echo "kind=official" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout repository
+        if: steps.meta.outputs.kind == 'feature'
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.decide.outputs.tag }}
+
+      - name: Read enterprise branch from tag annotation
+        if: steps.meta.outputs.kind == 'feature'
+        id: branch
+        env:
+          TAG: ${{ needs.decide.outputs.tag }}
+        run: |
+          MSG=$(git tag -l --format='%(contents)' "$TAG")
+          BRANCH=""
+          OSS_BRANCH=""
+          while IFS= read -r line; do
+            if [[ "$line" == enterprise_branch=* ]]; then
+              BRANCH="${line#enterprise_branch=}"
+            elif [[ "$line" == oss_branch=* ]]; then
+              OSS_BRANCH="${line#oss_branch=}"
+            fi
+          done <<< "$MSG"
+          if [ -z "$BRANCH" ]; then
+            echo "ERROR: feature tag $TAG is missing enterprise_branch annotation"
+            exit 1
+          fi
+          if [ -z "$OSS_BRANCH" ]; then
+            echo "ERROR: feature tag $TAG is missing oss_branch annotation"
+            exit 1
+          fi
+          echo "enterprise_branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "oss_branch=${OSS_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "Tag annotation: '${MSG}'"
+          echo "Enterprise branch: '${BRANCH}'"
+          echo "OSS branch: '${OSS_BRANCH}'"
 
       - name: Get sts tokens
         id: sts-enterprise
@@ -130,6 +179,7 @@ jobs:
           output-git-config: "false"
 
       - name: Trigger create release PR workflow
+        if: steps.meta.outputs.kind == 'official'
         uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ steps.sts-enterprise.outputs.GH_TOKEN }}
@@ -137,13 +187,22 @@ jobs:
           event-type: create_release_pr
           client-payload: '{"tag": "${{ needs.decide.outputs.tag }}"}'
 
+      - name: Trigger create feature-release PR workflow
+        if: steps.meta.outputs.kind == 'feature'
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ steps.sts-enterprise.outputs.GH_TOKEN }}
+          repository: odigos-io/odigos-enterprise
+          event-type: create_feature_release_pr
+          client-payload: '{"tag": "${{ needs.decide.outputs.tag }}", "branch": "${{ steps.branch.outputs.enterprise_branch }}", "oss_branch": "${{ steps.branch.outputs.oss_branch }}"}'
+
       - name: Notify Slack
         if: always()
         uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
         with:
           webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-          success-description: "Triggered Odigos Enterprise release PR workflow"
-          failure-description: "ERROR: Failed to trigger Odigos Enterprise release PR workflow"
+          success-description: "Triggered Odigos Enterprise ${{ steps.meta.outputs.kind }} release PR workflow"
+          failure-description: "ERROR: Failed to trigger Odigos Enterprise ${{ steps.meta.outputs.kind }} release PR workflow"
           tag: ${{ needs.decide.outputs.tag }}
 
   publish-images:

--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -130,7 +130,7 @@ jobs:
           if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-feat\. ]]; then
             echo "kind=feature" >> "$GITHUB_OUTPUT"
           else
-            echo "kind=official" >> "$GITHUB_OUTPUT"
+            echo "kind=standard" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout repository
@@ -179,7 +179,7 @@ jobs:
           output-git-config: "false"
 
       - name: Trigger create release PR workflow
-        if: steps.meta.outputs.kind == 'official'
+        if: steps.meta.outputs.kind == 'standard'
         uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ steps.sts-enterprise.outputs.GH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,12 +82,17 @@ jobs:
         run: |
           TAG="${{ env.TAG }}"
 
-          # Check if it's a pre-release (has additional suffix after vX.Y.Z)
-          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+- ]]; then
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-feat\. ]]; then
             echo "IS_PRERELEASE=true" >> $GITHUB_ENV
+            echo "IS_FEATURE_RELEASE=true" >> $GITHUB_ENV
+            echo "This is a feature release: $TAG"
+          elif [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+- ]]; then
+            echo "IS_PRERELEASE=true" >> $GITHUB_ENV
+            echo "IS_FEATURE_RELEASE=false" >> $GITHUB_ENV
             echo "This is a pre-release: $TAG"
           else
             echo "IS_PRERELEASE=false" >> $GITHUB_ENV
+            echo "IS_FEATURE_RELEASE=false" >> $GITHUB_ENV
             echo "This is a stable release: $TAG"
           fi
 
@@ -175,6 +180,13 @@ jobs:
 
       - name: Check if Homebrew tap should be updated
         run: |
+          # Feature drops are not an official channel; do not move the RC tap.
+          if [ "${{ env.IS_FEATURE_RELEASE }}" = "true" ]; then
+            echo "Feature release $TAG — skipping Homebrew tap update"
+            echo "SKIP_HOMEBREW_UPDATE=true" >> $GITHUB_ENV
+            exit 0
+          fi
+
           # Pre-releases always update their respective tap (homebrew-odigos-cli-rc)
           if [ "${{ env.IS_PRERELEASE }}" = "true" ]; then
             echo "Pre-release detected, will update Homebrew RC tap"
@@ -275,6 +287,7 @@ jobs:
           GORELEASER_CURRENT_TAG: ${{ env.TAG }}
 
       - name: Generate and update release notes
+        if: env.IS_FEATURE_RELEASE != 'true'
         uses: odigos-io/ci-core/generate-release-notes@main
         continue-on-error: true
         with:
@@ -283,7 +296,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Notify Slack (release notes)
-        if: always()
+        if: always() && env.IS_FEATURE_RELEASE != 'true'
         uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
         with:
           webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
@@ -393,7 +406,10 @@ jobs:
 
       - name: Set notification messages
         run: |
-          if [ "${{ env.IS_PRERELEASE }}" = "false" ]; then
+          if [ "${{ env.IS_FEATURE_RELEASE }}" = "true" ]; then
+            echo "SUCCESS_MSG=Odigos CLI feature release completed successfully" >> $GITHUB_ENV
+            echo "FAILURE_MSG=ERROR: Failed to publish Odigos CLI image to registries" >> $GITHUB_ENV
+          elif [ "${{ env.IS_PRERELEASE }}" = "false" ]; then
             echo "SUCCESS_MSG=Odigos CLI stable release completed successfully" >> $GITHUB_ENV
             echo "FAILURE_MSG=ERROR: Failed to publish Odigos CLI image to registries" >> $GITHUB_ENV
           else


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds a **Create Feature Release** workflow so we can tag a non-semver feature drop (`v0.0.0-feat.<slug>.<n>`) from an arbitrary OSS branch and record the matching enterprise branch on the annotated tag. Official pre/rc/stable tagging is unchanged; feature tags skip Homebrew and official release notes, and dispatch a dedicated enterprise `create_feature_release_pr` event.

Companion: https://github.com/odigos-io/odigos-enterprise/pull/3474

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```