### PR TITLE
CORE-1221 | ci: set git identity for annotated feature-release tags

### DIFF
--- a/.github/workflows/create-feature-release.yml
+++ b/.github/workflows/create-feature-release.yml
@@ -64,6 +64,8 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Resolved feature tag $TAG from ${{ inputs.oss_branch || 'main' }}"
 
+      # Annotated tags (git tag -a) record a tagger identity. STS output-git-config
+      # only rewrites GitHub URLs for auth and does not set user.name / user.email.
       - name: Configure Git for bot commits
         run: |
           git config user.email "bot@odigos.io"

--- a/.github/workflows/create-feature-release.yml
+++ b/.github/workflows/create-feature-release.yml
@@ -64,6 +64,11 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Resolved feature tag $TAG from ${{ inputs.oss_branch || 'main' }}"
 
+      - name: Configure Git for bot commits
+        run: |
+          git config user.email "bot@odigos.io"
+          git config user.name "Odigos Release Bot"
+
       - name: Create and push feature-release tag
         env:
           TAG: ${{ steps.version.outputs.tag }}


### PR DESCRIPTION
## Summary

Fixes: CORE-1221

```release-note
NONE
```