### PR TITLE
chore: bump grpc_health_probe to v0.4.55

### DIFF
--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -154,7 +154,7 @@ RUN if [ "$RHEL" = "true" ] ; then \
 
 
 # Download grpc_health_probe this is used by the deviceplugin container to check if the deviceplugin is healthy
-ARG GRPC_HEALTH_PROBE_VERSION=v0.4.54
+ARG GRPC_HEALTH_PROBE_VERSION=v0.4.55
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
         GRPC_ARCH="arm64"; \
     else \


### PR DESCRIPTION
Bumps `GRPC_HEALTH_PROBE_VERSION` from v0.4.54 to v0.4.55 in `odiglet/Dockerfile`.

v0.4.55 is built with go1.26.6, matching the toolchain used elsewhere in the repo. Both `linux/amd64` and `linux/arm64` assets are available.

```release-note
Bumped grpc_health_probe to v0.4.55.
```
