### PR TITLE
chore(ci): widen dependabot coverage for docker and go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,16 +13,23 @@ updates:
       - /autoscaler
       - /cli
       - /common
+      - /config
       - /destinations
+      - /deviceplugin
+      - /distros
       - /frontend
       - /instrumentation
+      - /instrumentationrules
       - /instrumentor
       - /k8sutils
       - /odiglet
+      - /odigosauth
       - /opampserver
+      - /operator
       - /procdiscovery
       - /profiles
       - /scheduler
+      - /status
     schedule:
       day: sunday
       interval: weekly
@@ -76,3 +83,5 @@ updates:
       interval: weekly
     allow:
       - dependency-name: 'registry.access.redhat.com/ubi9*'
+      - dependency-name: 'golang'
+      - dependency-name: 'gcr.io/distroless/*'


### PR DESCRIPTION
Widens Dependabot coverage.

**Docker:** the `allow` list only matched `registry.access.redhat.com/ubi9*`, so other base images in the same Dockerfiles were never proposed. Added `golang` and `gcr.io/distroless/*`.

**Go modules:** added the seven first-party modules that weren't listed — `config`, `deviceplugin`, `distros`, `instrumentationrules`, `odigosauth`, `operator`, `status`.

`collector/odigosotelcol` is deliberately excluded: its `go.mod` is generated by OCB from `builder-config.yaml`, so updates to it would fail `verify-collector-ocb`.

Directory list sorted; all 21 entries verified to contain a `go.mod`.

```release-note
NONE
```
