### PR TITLE
CORE-1476 | feat: enhance Insights GraphQL API with learning and stability metrics

### DIFF
--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -698,11 +698,33 @@ type ComplexityRoot struct {
 		Data                         func(childComplexity int) int
 		DataSchemaVersion            func(childComplexity int) int
 		LastChangedAt                func(childComplexity int) int
+		Learning                     func(childComplexity int) int
 		LearningStartedAt            func(childComplexity int) int
 		ObservationCount             func(childComplexity int) int
 		ObservationCountAtLastChange func(childComplexity int) int
 		Promoted                     func(childComplexity int) int
 		TransactionID                func(childComplexity int) int
+	}
+
+	InsightsBaselineLearning struct {
+		Mode                        func(childComplexity int) int
+		ObservationsSinceLastChange func(childComplexity int) int
+		Phase                       func(childComplexity int) int
+		QuietMinutes                func(childComplexity int) int
+		ReadyToPromote              func(childComplexity int) int
+		Stability                   func(childComplexity int) int
+	}
+
+	InsightsBaselineLearningStability struct {
+		Duration     func(childComplexity int) int
+		Observations func(childComplexity int) int
+	}
+
+	InsightsBaselineStabilityProgress struct {
+		Current         func(childComplexity int) int
+		DrivesPromotion func(childComplexity int) int
+		Met             func(childComplexity int) int
+		Target          func(childComplexity int) int
 	}
 
 	InsightsBlastRadiusEdge struct {
@@ -5337,6 +5359,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.InsightsBaselineClass.LastChangedAt(childComplexity), true
 
+	case "InsightsBaselineClass.learning":
+		if e.complexity.InsightsBaselineClass.Learning == nil {
+			break
+		}
+
+		return e.complexity.InsightsBaselineClass.Learning(childComplexity), true
+
 	case "InsightsBaselineClass.learningStartedAt":
 		if e.complexity.InsightsBaselineClass.LearningStartedAt == nil {
 			break
@@ -5371,6 +5400,90 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.InsightsBaselineClass.TransactionID(childComplexity), true
+
+	case "InsightsBaselineLearning.mode":
+		if e.complexity.InsightsBaselineLearning.Mode == nil {
+			break
+		}
+
+		return e.complexity.InsightsBaselineLearning.Mode(childComplexity), true
+
+	case "InsightsBaselineLearning.observationsSinceLastChange":
+		if e.complexity.InsightsBaselineLearning.ObservationsSinceLastChange == nil {
+			break
+		}
+
+		return e.complexity.InsightsBaselineLearning.ObservationsSinceLastChange(childComplexity), true
+
+	case "InsightsBaselineLearning.phase":
+		if e.complexity.InsightsBaselineLearning.Phase == nil {
+			break
+		}
+
+		return e.complexity.InsightsBaselineLearning.Phase(childComplexity), true
+
+	case "InsightsBaselineLearning.quietMinutes":
+		if e.complexity.InsightsBaselineLearning.QuietMinutes == nil {
+			break
+		}
+
+		return e.complexity.InsightsBaselineLearning.QuietMinutes(childComplexity), true
+
+	case "InsightsBaselineLearning.readyToPromote":
+		if e.complexity.InsightsBaselineLearning.ReadyToPromote == nil {
+			break
+		}
+
+		return e.complexity.InsightsBaselineLearning.ReadyToPromote(childComplexity), true
+
+	case "InsightsBaselineLearning.stability":
+		if e.complexity.InsightsBaselineLearning.Stability == nil {
+			break
+		}
+
+		return e.complexity.InsightsBaselineLearning.Stability(childComplexity), true
+
+	case "InsightsBaselineLearningStability.duration":
+		if e.complexity.InsightsBaselineLearningStability.Duration == nil {
+			break
+		}
+
+		return e.complexity.InsightsBaselineLearningStability.Duration(childComplexity), true
+
+	case "InsightsBaselineLearningStability.observations":
+		if e.complexity.InsightsBaselineLearningStability.Observations == nil {
+			break
+		}
+
+		return e.complexity.InsightsBaselineLearningStability.Observations(childComplexity), true
+
+	case "InsightsBaselineStabilityProgress.current":
+		if e.complexity.InsightsBaselineStabilityProgress.Current == nil {
+			break
+		}
+
+		return e.complexity.InsightsBaselineStabilityProgress.Current(childComplexity), true
+
+	case "InsightsBaselineStabilityProgress.drivesPromotion":
+		if e.complexity.InsightsBaselineStabilityProgress.DrivesPromotion == nil {
+			break
+		}
+
+		return e.complexity.InsightsBaselineStabilityProgress.DrivesPromotion(childComplexity), true
+
+	case "InsightsBaselineStabilityProgress.met":
+		if e.complexity.InsightsBaselineStabilityProgress.Met == nil {
+			break
+		}
+
+		return e.complexity.InsightsBaselineStabilityProgress.Met(childComplexity), true
+
+	case "InsightsBaselineStabilityProgress.target":
+		if e.complexity.InsightsBaselineStabilityProgress.Target == nil {
+			break
+		}
+
+		return e.complexity.InsightsBaselineStabilityProgress.Target(childComplexity), true
 
 	case "InsightsBlastRadiusEdge.clientNamespace":
 		if e.complexity.InsightsBlastRadiusEdge.ClientNamespace == nil {
@@ -31952,6 +32065,8 @@ func (ec *executionContext) fieldContext_Insights_baseline(ctx context.Context, 
 				return ec.fieldContext_InsightsBaselineClass_lastChangedAt(ctx, field)
 			case "observationCountAtLastChange":
 				return ec.fieldContext_InsightsBaselineClass_observationCountAtLastChange(ctx, field)
+			case "learning":
+				return ec.fieldContext_InsightsBaselineClass_learning(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type InsightsBaselineClass", field.Name)
 		},
@@ -35663,6 +35778,618 @@ func (ec *executionContext) fieldContext_InsightsBaselineClass_observationCountA
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsBaselineClass_learning(ctx context.Context, field graphql.CollectedField, obj *model.InsightsBaselineClass) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsBaselineClass_learning(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Learning, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.InsightsBaselineLearning)
+	fc.Result = res
+	return ec.marshalNInsightsBaselineLearning2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsBaselineLearning(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsBaselineClass_learning(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsBaselineClass",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "phase":
+				return ec.fieldContext_InsightsBaselineLearning_phase(ctx, field)
+			case "observationsSinceLastChange":
+				return ec.fieldContext_InsightsBaselineLearning_observationsSinceLastChange(ctx, field)
+			case "quietMinutes":
+				return ec.fieldContext_InsightsBaselineLearning_quietMinutes(ctx, field)
+			case "mode":
+				return ec.fieldContext_InsightsBaselineLearning_mode(ctx, field)
+			case "readyToPromote":
+				return ec.fieldContext_InsightsBaselineLearning_readyToPromote(ctx, field)
+			case "stability":
+				return ec.fieldContext_InsightsBaselineLearning_stability(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type InsightsBaselineLearning", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsBaselineLearning_phase(ctx context.Context, field graphql.CollectedField, obj *model.InsightsBaselineLearning) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsBaselineLearning_phase(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Phase, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.InsightsBaselineLearningPhase)
+	fc.Result = res
+	return ec.marshalNInsightsBaselineLearningPhase2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsBaselineLearningPhase(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsBaselineLearning_phase(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsBaselineLearning",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type InsightsBaselineLearningPhase does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsBaselineLearning_observationsSinceLastChange(ctx context.Context, field graphql.CollectedField, obj *model.InsightsBaselineLearning) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsBaselineLearning_observationsSinceLastChange(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ObservationsSinceLastChange, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsBaselineLearning_observationsSinceLastChange(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsBaselineLearning",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsBaselineLearning_quietMinutes(ctx context.Context, field graphql.CollectedField, obj *model.InsightsBaselineLearning) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsBaselineLearning_quietMinutes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.QuietMinutes, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsBaselineLearning_quietMinutes(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsBaselineLearning",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsBaselineLearning_mode(ctx context.Context, field graphql.CollectedField, obj *model.InsightsBaselineLearning) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsBaselineLearning_mode(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Mode, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.InsightsLearningMode)
+	fc.Result = res
+	return ec.marshalNInsightsLearningMode2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsLearningMode(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsBaselineLearning_mode(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsBaselineLearning",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type InsightsLearningMode does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsBaselineLearning_readyToPromote(ctx context.Context, field graphql.CollectedField, obj *model.InsightsBaselineLearning) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsBaselineLearning_readyToPromote(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ReadyToPromote, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsBaselineLearning_readyToPromote(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsBaselineLearning",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsBaselineLearning_stability(ctx context.Context, field graphql.CollectedField, obj *model.InsightsBaselineLearning) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsBaselineLearning_stability(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Stability, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.InsightsBaselineLearningStability)
+	fc.Result = res
+	return ec.marshalNInsightsBaselineLearningStability2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsBaselineLearningStability(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsBaselineLearning_stability(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsBaselineLearning",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "observations":
+				return ec.fieldContext_InsightsBaselineLearningStability_observations(ctx, field)
+			case "duration":
+				return ec.fieldContext_InsightsBaselineLearningStability_duration(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type InsightsBaselineLearningStability", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsBaselineLearningStability_observations(ctx context.Context, field graphql.CollectedField, obj *model.InsightsBaselineLearningStability) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsBaselineLearningStability_observations(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Observations, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.InsightsBaselineStabilityProgress)
+	fc.Result = res
+	return ec.marshalNInsightsBaselineStabilityProgress2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsBaselineStabilityProgress(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsBaselineLearningStability_observations(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsBaselineLearningStability",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "current":
+				return ec.fieldContext_InsightsBaselineStabilityProgress_current(ctx, field)
+			case "target":
+				return ec.fieldContext_InsightsBaselineStabilityProgress_target(ctx, field)
+			case "drivesPromotion":
+				return ec.fieldContext_InsightsBaselineStabilityProgress_drivesPromotion(ctx, field)
+			case "met":
+				return ec.fieldContext_InsightsBaselineStabilityProgress_met(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type InsightsBaselineStabilityProgress", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsBaselineLearningStability_duration(ctx context.Context, field graphql.CollectedField, obj *model.InsightsBaselineLearningStability) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsBaselineLearningStability_duration(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Duration, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.InsightsBaselineStabilityProgress)
+	fc.Result = res
+	return ec.marshalNInsightsBaselineStabilityProgress2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsBaselineStabilityProgress(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsBaselineLearningStability_duration(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsBaselineLearningStability",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "current":
+				return ec.fieldContext_InsightsBaselineStabilityProgress_current(ctx, field)
+			case "target":
+				return ec.fieldContext_InsightsBaselineStabilityProgress_target(ctx, field)
+			case "drivesPromotion":
+				return ec.fieldContext_InsightsBaselineStabilityProgress_drivesPromotion(ctx, field)
+			case "met":
+				return ec.fieldContext_InsightsBaselineStabilityProgress_met(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type InsightsBaselineStabilityProgress", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsBaselineStabilityProgress_current(ctx context.Context, field graphql.CollectedField, obj *model.InsightsBaselineStabilityProgress) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsBaselineStabilityProgress_current(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Current, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsBaselineStabilityProgress_current(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsBaselineStabilityProgress",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsBaselineStabilityProgress_target(ctx context.Context, field graphql.CollectedField, obj *model.InsightsBaselineStabilityProgress) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsBaselineStabilityProgress_target(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Target, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsBaselineStabilityProgress_target(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsBaselineStabilityProgress",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsBaselineStabilityProgress_drivesPromotion(ctx context.Context, field graphql.CollectedField, obj *model.InsightsBaselineStabilityProgress) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsBaselineStabilityProgress_drivesPromotion(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DrivesPromotion, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsBaselineStabilityProgress_drivesPromotion(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsBaselineStabilityProgress",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsBaselineStabilityProgress_met(ctx context.Context, field graphql.CollectedField, obj *model.InsightsBaselineStabilityProgress) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsBaselineStabilityProgress_met(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Met, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsBaselineStabilityProgress_met(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsBaselineStabilityProgress",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -85207,6 +85934,173 @@ func (ec *executionContext) _InsightsBaselineClass(ctx context.Context, sel ast.
 			out.Values[i] = ec._InsightsBaselineClass_lastChangedAt(ctx, field, obj)
 		case "observationCountAtLastChange":
 			out.Values[i] = ec._InsightsBaselineClass_observationCountAtLastChange(ctx, field, obj)
+		case "learning":
+			out.Values[i] = ec._InsightsBaselineClass_learning(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var insightsBaselineLearningImplementors = []string{"InsightsBaselineLearning"}
+
+func (ec *executionContext) _InsightsBaselineLearning(ctx context.Context, sel ast.SelectionSet, obj *model.InsightsBaselineLearning) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, insightsBaselineLearningImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("InsightsBaselineLearning")
+		case "phase":
+			out.Values[i] = ec._InsightsBaselineLearning_phase(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "observationsSinceLastChange":
+			out.Values[i] = ec._InsightsBaselineLearning_observationsSinceLastChange(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "quietMinutes":
+			out.Values[i] = ec._InsightsBaselineLearning_quietMinutes(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "mode":
+			out.Values[i] = ec._InsightsBaselineLearning_mode(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "readyToPromote":
+			out.Values[i] = ec._InsightsBaselineLearning_readyToPromote(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "stability":
+			out.Values[i] = ec._InsightsBaselineLearning_stability(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var insightsBaselineLearningStabilityImplementors = []string{"InsightsBaselineLearningStability"}
+
+func (ec *executionContext) _InsightsBaselineLearningStability(ctx context.Context, sel ast.SelectionSet, obj *model.InsightsBaselineLearningStability) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, insightsBaselineLearningStabilityImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("InsightsBaselineLearningStability")
+		case "observations":
+			out.Values[i] = ec._InsightsBaselineLearningStability_observations(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "duration":
+			out.Values[i] = ec._InsightsBaselineLearningStability_duration(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var insightsBaselineStabilityProgressImplementors = []string{"InsightsBaselineStabilityProgress"}
+
+func (ec *executionContext) _InsightsBaselineStabilityProgress(ctx context.Context, sel ast.SelectionSet, obj *model.InsightsBaselineStabilityProgress) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, insightsBaselineStabilityProgressImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("InsightsBaselineStabilityProgress")
+		case "current":
+			out.Values[i] = ec._InsightsBaselineStabilityProgress_current(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "target":
+			out.Values[i] = ec._InsightsBaselineStabilityProgress_target(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "drivesPromotion":
+			out.Values[i] = ec._InsightsBaselineStabilityProgress_drivesPromotion(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "met":
+			out.Values[i] = ec._InsightsBaselineStabilityProgress_met(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -98026,6 +98920,46 @@ func (ec *executionContext) marshalNInsightsBaselineClass2ᚖgithubᚗcomᚋodig
 		return graphql.Null
 	}
 	return ec._InsightsBaselineClass(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNInsightsBaselineLearning2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsBaselineLearning(ctx context.Context, sel ast.SelectionSet, v *model.InsightsBaselineLearning) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._InsightsBaselineLearning(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNInsightsBaselineLearningPhase2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsBaselineLearningPhase(ctx context.Context, v any) (model.InsightsBaselineLearningPhase, error) {
+	var res model.InsightsBaselineLearningPhase
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNInsightsBaselineLearningPhase2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsBaselineLearningPhase(ctx context.Context, sel ast.SelectionSet, v model.InsightsBaselineLearningPhase) graphql.Marshaler {
+	return v
+}
+
+func (ec *executionContext) marshalNInsightsBaselineLearningStability2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsBaselineLearningStability(ctx context.Context, sel ast.SelectionSet, v *model.InsightsBaselineLearningStability) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._InsightsBaselineLearningStability(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNInsightsBaselineStabilityProgress2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsBaselineStabilityProgress(ctx context.Context, sel ast.SelectionSet, v *model.InsightsBaselineStabilityProgress) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._InsightsBaselineStabilityProgress(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNInsightsBlastRadiusEdge2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsBlastRadiusEdgeᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.InsightsBlastRadiusEdge) graphql.Marshaler {

--- a/frontend/graph/insights.graphqls
+++ b/frontend/graph/insights.graphqls
@@ -94,6 +94,17 @@ enum InsightsLearningMode {
   k_of
 }
 
+"""
+Coarse learning state for one baseline class. `promoted` means the baseline is
+frozen. `empty` means it has never grown. `learning` means it has grown and is
+still in the learning phase.
+"""
+enum InsightsBaselineLearningPhase {
+  promoted
+  empty
+  learning
+}
+
 enum InsightsLearningConditionType {
   min_observations
   min_duration
@@ -191,6 +202,41 @@ type InsightsTransaction {
 
 # Baselines / observations
 
+"""
+One stability dimension. For observations, current/target is a count. For
+duration, both are minutes. `target` is 0 when there is no policy target —
+still render `current` as "grew N ago".
+"""
+type InsightsBaselineStabilityProgress {
+  current: Int!
+  target: Int!
+  drivesPromotion: Boolean!
+  met: Boolean!
+}
+
+"""
+Both stability signals so the UI can show "X / Y observations" and
+"grew N minutes ago" together. Under `all`, one dimension `met` does not mean
+the class promotes — use `readyToPromote`.
+"""
+type InsightsBaselineLearningStability {
+  observations: InsightsBaselineStabilityProgress!
+  duration: InsightsBaselineStabilityProgress!
+}
+
+"""
+Computed learning/stability snapshot for one baseline class against its
+resolved learning policy. Always present, including on placeholder classes.
+"""
+type InsightsBaselineLearning {
+  phase: InsightsBaselineLearningPhase!
+  observationsSinceLastChange: Int!
+  quietMinutes: Int!
+  mode: InsightsLearningMode!
+  readyToPromote: Boolean!
+  stability: InsightsBaselineLearningStability!
+}
+
 type InsightsBaselineClass {
   transactionId: ID!
   class: InsightsDeviationClass!
@@ -204,6 +250,7 @@ type InsightsBaselineClass {
   learningStartedAt: String
   lastChangedAt: String
   observationCountAtLastChange: Int
+  learning: InsightsBaselineLearning!
 }
 
 type InsightsPromoteResult {

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -834,13 +834,43 @@ type InsightsBaselineClass struct {
 	TransactionID string                 `json:"transactionId"`
 	Class         InsightsDeviationClass `json:"class"`
 	// JSON-encoded baseline data; shape varies per deviation class.
-	Data                         *string `json:"data,omitempty"`
-	DataSchemaVersion            *int    `json:"dataSchemaVersion,omitempty"`
-	ObservationCount             int     `json:"observationCount"`
-	Promoted                     bool    `json:"promoted"`
-	LearningStartedAt            *string `json:"learningStartedAt,omitempty"`
-	LastChangedAt                *string `json:"lastChangedAt,omitempty"`
-	ObservationCountAtLastChange *int    `json:"observationCountAtLastChange,omitempty"`
+	Data                         *string                   `json:"data,omitempty"`
+	DataSchemaVersion            *int                      `json:"dataSchemaVersion,omitempty"`
+	ObservationCount             int                       `json:"observationCount"`
+	Promoted                     bool                      `json:"promoted"`
+	LearningStartedAt            *string                   `json:"learningStartedAt,omitempty"`
+	LastChangedAt                *string                   `json:"lastChangedAt,omitempty"`
+	ObservationCountAtLastChange *int                      `json:"observationCountAtLastChange,omitempty"`
+	Learning                     *InsightsBaselineLearning `json:"learning"`
+}
+
+// Computed learning/stability snapshot for one baseline class against its
+// resolved learning policy. Always present, including on placeholder classes.
+type InsightsBaselineLearning struct {
+	Phase                       InsightsBaselineLearningPhase      `json:"phase"`
+	ObservationsSinceLastChange int                                `json:"observationsSinceLastChange"`
+	QuietMinutes                int                                `json:"quietMinutes"`
+	Mode                        InsightsLearningMode               `json:"mode"`
+	ReadyToPromote              bool                               `json:"readyToPromote"`
+	Stability                   *InsightsBaselineLearningStability `json:"stability"`
+}
+
+// Both stability signals so the UI can show "X / Y observations" and
+// "grew N minutes ago" together. Under `all`, one dimension `met` does not mean
+// the class promotes — use `readyToPromote`.
+type InsightsBaselineLearningStability struct {
+	Observations *InsightsBaselineStabilityProgress `json:"observations"`
+	Duration     *InsightsBaselineStabilityProgress `json:"duration"`
+}
+
+// One stability dimension. For observations, current/target is a count. For
+// duration, both are minutes. `target` is 0 when there is no policy target —
+// still render `current` as "grew N ago".
+type InsightsBaselineStabilityProgress struct {
+	Current         int  `json:"current"`
+	Target          int  `json:"target"`
+	DrivesPromotion bool `json:"drivesPromotion"`
+	Met             bool `json:"met"`
 }
 
 // A directed client -> server edge from the gateway servicegraph connector.
@@ -3043,6 +3073,52 @@ func (e *InsightsAnomalyStatus) UnmarshalGQL(v any) error {
 }
 
 func (e InsightsAnomalyStatus) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Coarse learning state for one baseline class. `promoted` means the baseline is
+// frozen. `empty` means it has never grown. `learning` means it has grown and is
+// still in the learning phase.
+type InsightsBaselineLearningPhase string
+
+const (
+	InsightsBaselineLearningPhasePromoted InsightsBaselineLearningPhase = "promoted"
+	InsightsBaselineLearningPhaseEmpty    InsightsBaselineLearningPhase = "empty"
+	InsightsBaselineLearningPhaseLearning InsightsBaselineLearningPhase = "learning"
+)
+
+var AllInsightsBaselineLearningPhase = []InsightsBaselineLearningPhase{
+	InsightsBaselineLearningPhasePromoted,
+	InsightsBaselineLearningPhaseEmpty,
+	InsightsBaselineLearningPhaseLearning,
+}
+
+func (e InsightsBaselineLearningPhase) IsValid() bool {
+	switch e {
+	case InsightsBaselineLearningPhasePromoted, InsightsBaselineLearningPhaseEmpty, InsightsBaselineLearningPhaseLearning:
+		return true
+	}
+	return false
+}
+
+func (e InsightsBaselineLearningPhase) String() string {
+	return string(e)
+}
+
+func (e *InsightsBaselineLearningPhase) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = InsightsBaselineLearningPhase(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid InsightsBaselineLearningPhase", str)
+	}
+	return nil
+}
+
+func (e InsightsBaselineLearningPhase) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 

--- a/frontend/services/insights/conversions.go
+++ b/frontend/services/insights/conversions.go
@@ -431,7 +431,31 @@ func BaselineClassToModel(baseline BaselineClass) (*model.InsightsBaselineClass,
 		LearningStartedAt:            baseline.LearningStartedAt,
 		LastChangedAt:                baseline.LastChangedAt,
 		ObservationCountAtLastChange: int64PtrToIntPtr(baseline.ObservationCountAtLastChange),
+		Learning:                     BaselineLearningToModel(baseline.Learning),
 	}, nil
+}
+
+func BaselineLearningToModel(learning BaselineLearning) *model.InsightsBaselineLearning {
+	return &model.InsightsBaselineLearning{
+		Phase:                       model.InsightsBaselineLearningPhase(learning.Phase),
+		ObservationsSinceLastChange: int64ToInt(learning.ObservationsSinceLastChange),
+		QuietMinutes:                int64ToInt(learning.QuietMinutes),
+		Mode:                        LearningModeToModel(learning.Mode),
+		ReadyToPromote:              learning.ReadyToPromote,
+		Stability: &model.InsightsBaselineLearningStability{
+			Observations: BaselineStabilityProgressToModel(learning.Stability.Observations),
+			Duration:     BaselineStabilityProgressToModel(learning.Stability.Duration),
+		},
+	}
+}
+
+func BaselineStabilityProgressToModel(progress BaselineStabilityProgress) *model.InsightsBaselineStabilityProgress {
+	return &model.InsightsBaselineStabilityProgress{
+		Current:         int64ToInt(progress.Current),
+		Target:          int64ToInt(progress.Target),
+		DrivesPromotion: progress.DrivesPromotion,
+		Met:             progress.Met,
+	}
 }
 
 func BaselineClassesToModel(baselines []BaselineClass) ([]*model.InsightsBaselineClass, error) {

--- a/frontend/services/insights/conversions_test.go
+++ b/frontend/services/insights/conversions_test.go
@@ -154,11 +154,30 @@ func TestBaselineAndAnomalyEvidenceStayJSONStrings(t *testing.T) {
 		Data:             json.RawMessage(`{"p99_ms":120}`),
 		ObservationCount: 3,
 		Promoted:         true,
+		Learning: BaselineLearning{
+			Phase:                       BaselineLearningPhasePromoted,
+			ObservationsSinceLastChange: 2,
+			QuietMinutes:                60,
+			Mode:                        "any",
+			ReadyToPromote:              false,
+			Stability: BaselineLearningStability{
+				Observations: BaselineStabilityProgress{Current: 2, Target: 50, DrivesPromotion: true, Met: false},
+				Duration:     BaselineStabilityProgress{Current: 60, Target: 0, DrivesPromotion: false, Met: false},
+			},
+		},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, baseline.Data)
 	assert.JSONEq(t, `{"p99_ms":120}`, *baseline.Data)
 	assert.Equal(t, "9", baseline.TransactionID)
+	require.NotNil(t, baseline.Learning)
+	assert.Equal(t, model.InsightsBaselineLearningPhasePromoted, baseline.Learning.Phase)
+	assert.Equal(t, 2, baseline.Learning.ObservationsSinceLastChange)
+	assert.Equal(t, 60, baseline.Learning.QuietMinutes)
+	assert.Equal(t, model.InsightsLearningModeAny, baseline.Learning.Mode)
+	require.NotNil(t, baseline.Learning.Stability)
+	require.NotNil(t, baseline.Learning.Stability.Observations)
+	assert.Equal(t, 50, baseline.Learning.Stability.Observations.Target)
 
 	anomaly, err := AnomalyIssueToModel(AnomalyIssue{
 		TransactionID:    9,

--- a/frontend/services/insights/types.go
+++ b/frontend/services/insights/types.go
@@ -121,15 +121,49 @@ type Transaction struct {
 }
 
 type BaselineClass struct {
-	TransactionID                int64           `json:"transaction_id"`
-	Class                        DeviationClass  `json:"class"`
-	Data                         json.RawMessage `json:"data,omitempty"`
-	DataSchemaVersion            *int            `json:"data_schema_version,omitempty"`
-	ObservationCount             int64           `json:"observation_count"`
-	Promoted                     bool            `json:"promoted"`
-	LearningStartedAt            *string         `json:"learning_started_at,omitempty"`
-	LastChangedAt                *string         `json:"last_changed_at,omitempty"`
-	ObservationCountAtLastChange *int64          `json:"observation_count_at_last_change,omitempty"`
+	TransactionID                int64            `json:"transaction_id"`
+	Class                        DeviationClass   `json:"class"`
+	Data                         json.RawMessage  `json:"data,omitempty"`
+	DataSchemaVersion            *int             `json:"data_schema_version,omitempty"`
+	ObservationCount             int64            `json:"observation_count"`
+	Promoted                     bool             `json:"promoted"`
+	LearningStartedAt            *string          `json:"learning_started_at,omitempty"`
+	LastChangedAt                *string          `json:"last_changed_at,omitempty"`
+	ObservationCountAtLastChange *int64           `json:"observation_count_at_last_change,omitempty"`
+	Learning                     BaselineLearning `json:"learning"`
+}
+
+// BaselineLearningPhase is the coarse learning state for one baseline class.
+type BaselineLearningPhase string
+
+const (
+	BaselineLearningPhasePromoted BaselineLearningPhase = "promoted"
+	BaselineLearningPhaseEmpty    BaselineLearningPhase = "empty"
+	BaselineLearningPhaseLearning BaselineLearningPhase = "learning"
+)
+
+// BaselineStabilityProgress is one stability dimension (observations count or duration minutes).
+type BaselineStabilityProgress struct {
+	Current         int64 `json:"current"`
+	Target          int64 `json:"target"`
+	DrivesPromotion bool  `json:"drives_promotion"`
+	Met             bool  `json:"met"`
+}
+
+// BaselineLearningStability holds both stability signals for UI progress copy.
+type BaselineLearningStability struct {
+	Observations BaselineStabilityProgress `json:"observations"`
+	Duration     BaselineStabilityProgress `json:"duration"`
+}
+
+// BaselineLearning is the computed learning/stability snapshot on each baseline row.
+type BaselineLearning struct {
+	Phase                       BaselineLearningPhase     `json:"phase"`
+	ObservationsSinceLastChange int64                     `json:"observations_since_last_change"`
+	QuietMinutes                int64                     `json:"quiet_minutes"`
+	Mode                        LearningMode              `json:"mode"`
+	ReadyToPromote              bool                      `json:"ready_to_promote"`
+	Stability                   BaselineLearningStability `json:"stability"`
 }
 
 type PromoteResult struct {

--- a/frontend/webapp/graphql/queries/insights.ts
+++ b/frontend/webapp/graphql/queries/insights.ts
@@ -38,6 +38,27 @@ const BASELINE_CLASS_FIELDS = `
   learningStartedAt
   lastChangedAt
   observationCountAtLastChange
+  learning {
+    phase
+    observationsSinceLastChange
+    quietMinutes
+    mode
+    readyToPromote
+    stability {
+      observations {
+        current
+        target
+        drivesPromotion
+        met
+      }
+      duration {
+        current
+        target
+        drivesPromotion
+        met
+      }
+    }
+  }
 `;
 
 const OBSERVATION_SUMMARY_FIELDS = `


### PR DESCRIPTION
Follow up after: https://github.com/odigos-io/odigos-enterprise/pull/3468

- Added new types and fields for `InsightsBaselineLearning`, `InsightsBaselineLearningStability`, and `InsightsBaselineStabilityProgress` to represent learning states and stability metrics for baseline classes.
- Updated the `InsightsBaselineClass` type to include a `learning` field that encapsulates the new learning metrics.
- Enhanced the GraphQL schema and resolvers to support the retrieval of learning and stability data.
- Updated client-side queries to fetch the new learning metrics, improving the Insights feature's data representation and usability.

This update provides users with a comprehensive view of baseline learning states and stability, enhancing the overall Insights experience.

```release-note
feat: enhance Insights GraphQL API with learning and stability metrics
```
