### PR TITLE
CORE-1492 | feat: add insights profile with infer-db-attributes and url-template presets

### DIFF
--- a/profiles/aggregators/insights.go
+++ b/profiles/aggregators/insights.go
@@ -1,0 +1,17 @@
+package aggregators
+
+import (
+	"github.com/odigos-io/odigos/common"
+	"github.com/odigos-io/odigos/profiles/profile"
+)
+
+var InsightsProfile = profile.Profile{
+	ProfileName: common.ProfileName("insights"),
+	MinimumTier: common.CommunityOdigosTier,
+	ShortDescription: "Bundle profile that includes " +
+		"specific presets for odigos insights.",
+	Dependencies: []common.ProfileName{
+		"infer-db-attributes",
+		"url-template",
+	},
+}

--- a/profiles/allprofiles.go
+++ b/profiles/allprofiles.go
@@ -12,6 +12,7 @@ var AllProfiles = []profile.Profile{
 
 	aggregators.KratosProfile,
 	aggregators.GreatwallProfile,
+	aggregators.InsightsProfile,
 
 	attributes.CategoryAttributesProfile,
 	attributes.CodeAttributesProfile,
@@ -20,6 +21,8 @@ var AllProfiles = []profile.Profile{
 	attributes.FullPayloadCollectionProfile,
 	attributes.DbPayloadCollectionProfile,
 	attributes.QueryOperationDetector,
+	attributes.UrlTemplateProfile,
+	attributes.InferDbAttributesProfile,
 	attributes.SemconvUpgraderProfile,
 	attributes.SemconvDynamoProfile,
 	attributes.SemconvRedisProfile,

--- a/profiles/attributes/inferdbattributes.go
+++ b/profiles/attributes/inferdbattributes.go
@@ -1,0 +1,12 @@
+package attributes
+
+import (
+	"github.com/odigos-io/odigos/common"
+	"github.com/odigos-io/odigos/profiles/profile"
+)
+
+var InferDbAttributesProfile = profile.Profile{
+	ProfileName:      common.ProfileName("infer-db-attributes"),
+	MinimumTier:      common.CommunityOdigosTier,
+	ShortDescription: "Parse database query text to add attributes like db.operation.name and db.collection.name when they are missing",
+}

--- a/profiles/attributes/urltemplate.go
+++ b/profiles/attributes/urltemplate.go
@@ -1,0 +1,12 @@
+package attributes
+
+import (
+	"github.com/odigos-io/odigos/common"
+	"github.com/odigos-io/odigos/profiles/profile"
+)
+
+var UrlTemplateProfile = profile.Profile{
+	ProfileName:      common.ProfileName("url-template"),
+	MinimumTier:      common.CommunityOdigosTier,
+	ShortDescription: "Replace dynamic URL path segments with templates so HTTP span names and attributes stay low-cardinality",
+}

--- a/profiles/manifests/infer-db-attributes.yaml
+++ b/profiles/manifests/infer-db-attributes.yaml
@@ -1,0 +1,10 @@
+apiVersion: odigos.io/v1alpha1
+kind: Action
+metadata:
+  name: infer-db-attributes
+spec:
+  actionName: Infer DB Attributes
+  notes: "Auto generated rule from infer-db-attributes profile. Do not edit."
+  signals:
+    - TRACES
+  inferDbAttributes: {}

--- a/profiles/manifests/url-template.yaml
+++ b/profiles/manifests/url-template.yaml
@@ -1,0 +1,10 @@
+apiVersion: odigos.io/v1alpha1
+kind: Action
+metadata:
+  name: url-template
+spec:
+  actionName: URL Templatization
+  notes: "Auto generated rule from url-template profile. Do not edit."
+  signals:
+    - TRACES
+  urlTemplatization: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a new `insights` bundle profile for Odigos Insights that enables trace attribute enrichment presets:

- **`infer-db-attributes`** — parses database query text to add `db.operation.name` and `db.collection.name` when they are missing
- **`url-template`** — replaces dynamic URL path segments with templates so HTTP span names and attributes stay low-cardinality

This includes profile definitions, action manifests, and registration in `AllProfiles`.

Linear: https://linear.app/odigos/issue/CORE-1492/add-insights-profile-with-infer-db-attributes-and-url-template-presets

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
NONE
```


Made with [Cursor](https://cursor.com)