### PR TITLE
CORE-1478: Diagnose with source workloads client rate limit exceeded

### DIFF
--- a/frontend/services/diagnose.go
+++ b/frontend/services/diagnose.go
@@ -74,12 +74,19 @@ func DiagnoseGraphQL(
 
 	isDryRun := dryRun != nil && *dryRun
 
+	// Detach from the GraphQL/HTTP request context. Selecting source workloads
+	// issues many concurrent API calls alongside pprof collection; if the
+	// request is aborted (proxy timeout, client cancel) client-go reports
+	// "client rate limiter Wait returned an error: context canceled".
+	collectCtx, collectCancel := diagnose.CollectionContext(ctx)
+	defer collectCancel()
+
 	if isDryRun {
 		// Create dry-run builder to estimate size
 		builder := diagnose.NewDryRunBuilder()
 
 		if err := diagnose.RunDiagnose(
-			ctx,
+			collectCtx,
 			kube.DefaultClient,
 			kube.DefaultClient.DynamicClient,
 			kube.DefaultClient.Discovery(),
@@ -142,7 +149,7 @@ func DiagnoseGraphQL(
 	}
 
 	// Channel for stage completion; send SSE for each completed stage (stage id, status success/error, and message on error).
-	stageCh := make(chan diagnose.StageResult, 10)
+	stageCh := make(chan diagnose.StageResult, len(stagesRequested)+1)
 	done := make(chan struct{})
 	go func() {
 		for result := range stageCh {
@@ -165,7 +172,7 @@ func DiagnoseGraphQL(
 
 	// Run the diagnose collection
 	if err := diagnose.RunDiagnose(
-		ctx,
+		collectCtx,
 		kube.DefaultClient,
 		kube.DefaultClient.DynamicClient,
 		kube.DefaultClient.Discovery(),

--- a/k8sutils/pkg/diagnose/concurrency.go
+++ b/k8sutils/pkg/diagnose/concurrency.go
@@ -1,0 +1,41 @@
+package diagnose
+
+import (
+	"context"
+	"time"
+)
+
+type limiter struct {
+	sem chan struct{}
+}
+
+func newLimiter(n int) *limiter {
+	if n < 1 {
+		n = 1
+	}
+	return &limiter{sem: make(chan struct{}, n)}
+}
+
+func (l *limiter) acquire(ctx context.Context) error {
+	select {
+	case l.sem <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (l *limiter) release() {
+	<-l.sem
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}

--- a/k8sutils/pkg/diagnose/concurrency.go
+++ b/k8sutils/pkg/diagnose/concurrency.go
@@ -9,11 +9,8 @@ type limiter struct {
 	sem chan struct{}
 }
 
-func newLimiter(n int) *limiter {
-	if n < 1 {
-		n = 1
-	}
-	return &limiter{sem: make(chan struct{}, n)}
+func newLimiter() *limiter {
+	return &limiter{sem: make(chan struct{}, maxConcurrentK8sOps)}
 }
 
 func (l *limiter) acquire(ctx context.Context) error {

--- a/k8sutils/pkg/diagnose/concurrency_test.go
+++ b/k8sutils/pkg/diagnose/concurrency_test.go
@@ -1,0 +1,46 @@
+package diagnose
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectionContextIndependentOfParentCancel(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+	ctx, stop := CollectionContext(parent)
+	defer stop()
+
+	cancel()
+
+	require.NoError(t, ctx.Err(), "collection context should not be canceled when the HTTP/parent context is canceled")
+	_, hasDeadline := ctx.Deadline()
+	require.True(t, hasDeadline)
+}
+
+func TestCollectionContextHonorsOwnCancel(t *testing.T) {
+	ctx, stop := CollectionContext(context.Background())
+	stop()
+	require.Error(t, ctx.Err())
+}
+
+func TestLimiterAcquireCanceledContext(t *testing.T) {
+	lim := newLimiter(1)
+	require.NoError(t, lim.acquire(context.Background()))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, lim.acquire(ctx), context.Canceled)
+	lim.release()
+}
+
+func TestSleepWithContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start := time.Now()
+	ok := sleepWithContext(ctx, time.Second)
+	require.False(t, ok)
+	require.Less(t, time.Since(start), 200*time.Millisecond)
+}

--- a/k8sutils/pkg/diagnose/concurrency_test.go
+++ b/k8sutils/pkg/diagnose/concurrency_test.go
@@ -27,12 +27,23 @@ func TestCollectionContextHonorsOwnCancel(t *testing.T) {
 }
 
 func TestLimiterAcquireCanceledContext(t *testing.T) {
-	lim := newLimiter(1)
-	require.NoError(t, lim.acquire(context.Background()))
+	lim := newLimiter()
+	for i := 0; i < maxConcurrentK8sOps; i++ {
+		require.NoError(t, lim.acquire(context.Background()))
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	require.ErrorIs(t, lim.acquire(ctx), context.Canceled)
+
+	for i := 0; i < maxConcurrentK8sOps; i++ {
+		lim.release()
+	}
+}
+
+func TestLimiterAcquireRelease(t *testing.T) {
+	lim := newLimiter()
+	require.NoError(t, lim.acquire(context.Background()))
 	lim.release()
 }
 

--- a/k8sutils/pkg/diagnose/diagnose.go
+++ b/k8sutils/pkg/diagnose/diagnose.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
@@ -12,6 +13,21 @@ import (
 
 	odigosv1alpha1 "github.com/odigos-io/odigos/api/generated/odigos/clientset/versioned/typed/odigos/v1alpha1"
 )
+
+// collectionTimeout bounds diagnose collection when it is detached from an HTTP
+// request context (see CollectionContext).
+const collectionTimeout = 10 * time.Minute
+
+// maxConcurrentK8sOps caps parallel Kubernetes API calls within a diagnose stage
+// so the shared client-go rate limiter is not saturated by logs/profiles/metrics.
+const maxConcurrentK8sOps = 16
+
+// CollectionContext returns a context for diagnose collection that is not canceled
+// when parent is (for example when a GraphQL client aborts or a proxy times out).
+// A timeout is still applied so collection cannot run forever.
+func CollectionContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(parent), collectionTimeout)
+}
 
 // Stage identifies a single phase of diagnose collection.
 // When a stage completes, a StageResult is sent on the onStageComplete channel (if non-nil).
@@ -111,7 +127,10 @@ func RunDiagnose(
 
 	if opts.IncludeSourceWorkloads {
 		runStage(&wg, StageSourceWorkloads, onStageComplete, func() error {
-			return FetchSourceWorkloads(ctx, client, dynamicClient, odigosClient, builder, rootDir, opts.SourceWorkloadNamespaces, opts.IncludeLogs)
+			// Source workloads collect YAMLs only. IncludeLogs is for Odigos
+			// component pods; fetching logs from every instrumented application
+			// saturates the API client and cancels in-flight profile lists.
+			return FetchSourceWorkloads(ctx, client, dynamicClient, odigosClient, builder, rootDir, opts.SourceWorkloadNamespaces, false)
 		})
 	}
 

--- a/k8sutils/pkg/diagnose/logs.go
+++ b/k8sutils/pkg/diagnose/logs.go
@@ -18,7 +18,7 @@ func FetchWorkloadLogs(
 	namespace, workloadDir string,
 	pods []corev1.Pod,
 ) error {
-	lim := newLimiter(maxConcurrentK8sOps)
+	lim := newLimiter()
 	var wg sync.WaitGroup
 
 	for i := 0; i < len(pods); i++ {

--- a/k8sutils/pkg/diagnose/logs.go
+++ b/k8sutils/pkg/diagnose/logs.go
@@ -18,13 +18,19 @@ func FetchWorkloadLogs(
 	namespace, workloadDir string,
 	pods []corev1.Pod,
 ) error {
+	lim := newLimiter(maxConcurrentK8sOps)
 	var wg sync.WaitGroup
 
 	for i := 0; i < len(pods); i++ {
+		if err := lim.acquire(ctx); err != nil {
+			wg.Wait()
+			return err
+		}
 		pod := &pods[i]
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			defer lim.release()
 			for i := 0; i < len(pod.Spec.Containers); i++ {
 				container := &pod.Spec.Containers[i]
 				addContainerLogs(ctx, client, builder, namespace, workloadDir, pod.Name, container.Name, false)

--- a/k8sutils/pkg/diagnose/metrics.go
+++ b/k8sutils/pkg/diagnose/metrics.go
@@ -67,15 +67,21 @@ func fetchMetricsFromOdigletPods(ctx context.Context, client kubernetes.Interfac
 		{k8sconsts.OdigosNodeCollectorContainerName, k8sconsts.OdigosNodeCollectorOwnTelemetryPortDefault},
 	}
 
+	lim := newLimiter(maxConcurrentK8sOps)
 	var wg sync.WaitGroup
 	for i := range pods.Items {
 		pod := &pods.Items[i]
 		podName := pod.Name
 		for _, ep := range endpoints {
+			if err := lim.acquire(ctx); err != nil {
+				wg.Wait()
+				return err
+			}
 			ep := ep
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
+				defer lim.release()
 				klog.V(2).InfoS("Fetching metrics for odiglet pod", "podName", podName, "container", ep.fileSuffix)
 				data, err := captureMetrics(ctx, client, podName, namespace, ep.port)
 				if err != nil {
@@ -106,13 +112,19 @@ func fetchMetricsFromGatewayPods(ctx context.Context, client kubernetes.Interfac
 	}
 
 	port := k8sconsts.OdigosClusterCollectorOwnTelemetryPortDefault
+	lim := newLimiter(maxConcurrentK8sOps)
 	var wg sync.WaitGroup
 	for i := range pods.Items {
+		if err := lim.acquire(ctx); err != nil {
+			wg.Wait()
+			return err
+		}
 		pod := &pods.Items[i]
 		podName := pod.Name
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			defer lim.release()
 			klog.V(2).InfoS("Fetching metrics for gateway pod", "podName", podName)
 			data, err := captureMetrics(ctx, client, podName, namespace, port)
 			if err != nil {

--- a/k8sutils/pkg/diagnose/metrics.go
+++ b/k8sutils/pkg/diagnose/metrics.go
@@ -67,7 +67,7 @@ func fetchMetricsFromOdigletPods(ctx context.Context, client kubernetes.Interfac
 		{k8sconsts.OdigosNodeCollectorContainerName, k8sconsts.OdigosNodeCollectorOwnTelemetryPortDefault},
 	}
 
-	lim := newLimiter(maxConcurrentK8sOps)
+	lim := newLimiter()
 	var wg sync.WaitGroup
 	for i := range pods.Items {
 		pod := &pods.Items[i]
@@ -112,7 +112,7 @@ func fetchMetricsFromGatewayPods(ctx context.Context, client kubernetes.Interfac
 	}
 
 	port := k8sconsts.OdigosClusterCollectorOwnTelemetryPortDefault
-	lim := newLimiter(maxConcurrentK8sOps)
+	lim := newLimiter()
 	var wg sync.WaitGroup
 	for i := range pods.Items {
 		if err := lim.acquire(ctx); err != nil {

--- a/k8sutils/pkg/diagnose/profiles.go
+++ b/k8sutils/pkg/diagnose/profiles.go
@@ -150,7 +150,7 @@ func FetchServiceProfiles(ctx context.Context, client kubernetes.Interface, buil
 		return nil
 	}
 
-	lim := newLimiter(maxConcurrentK8sOps)
+	lim := newLimiter()
 	var podsWaitGroup sync.WaitGroup
 	for i := range podsToProfile.Items {
 		pod := &podsToProfile.Items[i]

--- a/k8sutils/pkg/diagnose/profiles.go
+++ b/k8sutils/pkg/diagnose/profiles.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -32,6 +33,7 @@ func ProfileServiceNames() []string {
 	for name := range servicesProfilingMetadata {
 		names = append(names, name)
 	}
+	sort.Strings(names)
 	return names
 }
 
@@ -142,6 +144,13 @@ func FetchServiceProfiles(ctx context.Context, client kubernetes.Interface, buil
 		return nil
 	}
 
+	// Dry-run only needs to confirm pods exist; capturing pprof (especially CPU
+	// profiles) is slow and would hit the API for data that is discarded.
+	if _, dryRun := builder.(*DryRunBuilder); dryRun {
+		return nil
+	}
+
+	lim := newLimiter(maxConcurrentK8sOps)
 	var podsWaitGroup sync.WaitGroup
 	for i := range podsToProfile.Items {
 		pod := &podsToProfile.Items[i]
@@ -155,10 +164,14 @@ func FetchServiceProfiles(ctx context.Context, client kubernetes.Interface, buil
 
 			var profileWaitGroup sync.WaitGroup
 			for _, profileMetricFunction := range ProfilingMetricsFunctions {
+				if err := lim.acquire(ctx); err != nil {
+					break
+				}
 				profileFunc := profileMetricFunction
 				profileWaitGroup.Add(1)
 
 				go func(profileFunc ProfileInterface) {
+					defer lim.release()
 					defer profileWaitGroup.Done()
 
 					const maxRetries = 3
@@ -178,7 +191,9 @@ func FetchServiceProfiles(ctx context.Context, client kubernetes.Interface, buil
 							"attempt", attempt)
 
 						if attempt < maxRetries {
-							time.Sleep(5 * time.Second)
+							if !sleepWithContext(ctx, 5*time.Second) {
+								return
+							}
 						} else {
 							klog.V(1).ErrorS(err, "Max retries reached, giving up",
 								"podName", pod.Name,

--- a/k8sutils/pkg/diagnose/profiles_test.go
+++ b/k8sutils/pkg/diagnose/profiles_test.go
@@ -1,0 +1,68 @@
+package diagnose
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/odigos-io/odigos/api/k8sconsts"
+)
+
+func TestRequestedStagesIncludesSortedProfilesAndSourceWorkloads(t *testing.T) {
+	stages := RequestedStages(Options{
+		IncludeCRDs:            true,
+		IncludeProfiles:        true,
+		IncludeMetrics:         true,
+		IncludeConfigMaps:      true,
+		IncludeSourceWorkloads: true,
+	})
+	require.Equal(t, []Stage{
+		StageWorkloads,
+		StageCRDs,
+		"profiles/data-collection",
+		"profiles/gateway",
+		"profiles/odiglet",
+		"profiles/ui",
+		StageMetrics,
+		StageConfigMaps,
+		StageSourceWorkloads,
+	}, stages)
+}
+
+func TestProfileServiceNamesStableOrder(t *testing.T) {
+	first := ProfileServiceNames()
+	second := ProfileServiceNames()
+	require.Equal(t, first, second)
+	require.Equal(t, []string{"data-collection", "gateway", "odiglet", "ui"}, first)
+}
+
+func TestFetchServiceProfilesCanceledParentDoesNotFailList(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ctx, stop := CollectionContext(parent)
+	defer stop()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "odigos-ui-abc",
+			Namespace: "odigos-system",
+			Labels: map[string]string{
+				"app": k8sconsts.UIAppLabelValue,
+			},
+		},
+	}
+	client := fake.NewSimpleClientset(pod)
+
+	err := FetchServiceProfiles(ctx, client, NewDryRunBuilder(), "/tmp/profiles", "odigos-system", "ui")
+	require.NoError(t, err)
+}
+
+func TestFetchServiceProfilesUnknownService(t *testing.T) {
+	err := FetchServiceProfiles(context.Background(), fake.NewSimpleClientset(), NewDryRunBuilder(), "/tmp", "ns", "not-a-service")
+	require.ErrorContains(t, err, "unknown profiling service")
+}

--- a/k8sutils/pkg/diagnose/workloads_test.go
+++ b/k8sutils/pkg/diagnose/workloads_test.go
@@ -1,0 +1,72 @@
+package diagnose
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/odigos-io/odigos/api/k8sconsts"
+	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
+)
+
+func TestCategorizeSourcesForDiagnose(t *testing.T) {
+	sources := []odigosv1.Source{
+		{Spec: odigosv1.SourceSpec{Workload: k8sconsts.PodWorkload{
+			Kind: k8sconsts.WorkloadKindNamespace, Name: "payments", Namespace: "payments",
+		}}},
+		{Spec: odigosv1.SourceSpec{Workload: k8sconsts.PodWorkload{
+			Kind: k8sconsts.WorkloadKindDeployment, Name: "checkout", Namespace: "shop",
+		}}},
+		{Spec: odigosv1.SourceSpec{
+			DisableInstrumentation: true,
+			Workload: k8sconsts.PodWorkload{
+				Kind: k8sconsts.WorkloadKindDeployment, Name: "skip-me", Namespace: "payments",
+			},
+		}},
+		{Spec: odigosv1.SourceSpec{Workload: k8sconsts.PodWorkload{
+			Kind: k8sconsts.WorkloadKindStaticPod, Name: "static", Namespace: "shop",
+		}}},
+	}
+
+	plan := categorizeSourcesForDiagnose(sources, nil)
+
+	require.True(t, plan.namespaceSources["payments"])
+	require.Equal(t, []k8sconsts.PodWorkload{{
+		Namespace: "shop", Name: "checkout", Kind: k8sconsts.WorkloadKindDeployment,
+	}}, plan.explicitWorkloads)
+	require.Equal(t, []disabledWorkloadExclusion{{
+		Namespace: "payments", Kind: k8sconsts.WorkloadKindDeployment, Name: "skip-me",
+	}}, plan.disabledExclusions)
+}
+
+func TestCategorizeSourcesForDiagnoseNamespaceFilter(t *testing.T) {
+	sources := []odigosv1.Source{
+		{Spec: odigosv1.SourceSpec{Workload: k8sconsts.PodWorkload{
+			Kind: k8sconsts.WorkloadKindDeployment, Name: "a", Namespace: "keep",
+		}}},
+		{Spec: odigosv1.SourceSpec{Workload: k8sconsts.PodWorkload{
+			Kind: k8sconsts.WorkloadKindDeployment, Name: "b", Namespace: "drop",
+		}}},
+	}
+
+	plan := categorizeSourcesForDiagnose(sources, []string{"keep"})
+	require.Len(t, plan.explicitWorkloads, 1)
+	require.Equal(t, "a", plan.explicitWorkloads[0].Name)
+}
+
+func TestIsWorkloadExcluded(t *testing.T) {
+	exclusions := []disabledWorkloadExclusion{
+		{Namespace: "ns", Kind: k8sconsts.WorkloadKindDeployment, Name: "exact"},
+		{Namespace: "ns", Kind: k8sconsts.WorkloadKindDeployment, Name: "foo-.*", Regex: true},
+	}
+
+	require.True(t, isWorkloadExcluded(k8sconsts.PodWorkload{
+		Namespace: "ns", Kind: k8sconsts.WorkloadKindDeployment, Name: "exact",
+	}, exclusions))
+	require.True(t, isWorkloadExcluded(k8sconsts.PodWorkload{
+		Namespace: "ns", Kind: k8sconsts.WorkloadKindDeployment, Name: "foo-bar",
+	}, exclusions))
+	require.False(t, isWorkloadExcluded(k8sconsts.PodWorkload{
+		Namespace: "ns", Kind: k8sconsts.WorkloadKindDeployment, Name: "other",
+	}, exclusions))
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
In large clusters, selecting source workloads could fail with an error `Failed to list pods for service ui: client rate limiter Wait returned an error: context canceled`

The toast was a canceled GraphQL request, not the API server rejecting the UI pod list. Selecting **Source Workloads** makes diagnose issue a large burst of Kubernetes calls (namespace sources expand to every workload) in parallel with 10s CPU profiles. Those share one client-go rate limiter. When the HTTP request is aborted — proxy timeout or the progress UI remounting — the next `List` fails as:

`client rate limiter Wait returned an error: context canceled`

`profiles/ui` is a typical victim because that list often runs after the other profile stages.

**What changed**

- Diagnose collection is detached from the GraphQL/HTTP context, with a 10-minute timeout, so a canceled browser/proxy request no longer fails in-flight `List` calls.
- Concurrent API work in profiles, logs, and metrics is capped at 16.
- Source workloads now collect workload/pod YAMLs only, not application logs (those were saturating the client).
- Dry-run no longer captures real pprof data.

cherry-pick:v1.35

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
fix: improve concurrency for diagnose workloads on large clusters
```
