### PR TITLE
RUN-1087 | docs: describe code.function.name in the CodeAttributes rule

### DIFF
--- a/docs/snippets/enterprise/pipeline/rules/codeattributes.mdx
+++ b/docs/snippets/enterprise/pipeline/rules/codeattributes.mdx
@@ -18,7 +18,7 @@
     - This field is *optional*, and defaults to `false`
   </Accordion>
   <Accordion title="function">
-    **function** `boolean` : Indicates whether to record the `code.function` attribute for the method or function name, or equivalent.
+    **function** `boolean` : Indicates whether to record the `code.function.name` attribute, the fully-qualified name of the method or function (for example `com.example.OrderService.processOrder` or `main.checkIfMember`).
     - This field is *optional*, and defaults to `false`
   </Accordion>
   <Accordion title="lineNumber">
@@ -26,7 +26,7 @@
     - This field is *optional*, and defaults to `false`
   </Accordion>
   <Accordion title="namespace">
-    **namespace** `boolean` : Indicates whether to record the `code.namespace` attribute for the “namespace” within which `code.function` is defined. Usually the qualified class or module name, such that `code.namespace` + some separator + `code.function` form a unique identifier for the code unit.
+    **namespace** `boolean` : *Deprecated.* OpenTelemetry merged `code.namespace` into `code.function.name`, which is already fully qualified, so there is no longer a separate namespace attribute to record. This field is still accepted and now behaves as an alias of `function`.
     - This field is *optional*, and defaults to `false`
   </Accordion>
   <Accordion title="stackTrace">

--- a/docs/snippets/enterprise/pipeline/rules/codeattributes.mdx
+++ b/docs/snippets/enterprise/pipeline/rules/codeattributes.mdx
@@ -10,11 +10,11 @@
 
 <AccordionGroup>
   <Accordion title="column">
-    **column** `boolean` : Indicates whether to record the `code.column` attribute for the column number in the `code.filepath` best representing the operation.
+    **column** `boolean` : Indicates whether to record the `code.column.number` attribute for the column number in the `code.file.path` best representing the operation.
     - This field is *optional*, and defaults to `false`
   </Accordion>
   <Accordion title="filePath">
-    **filePath** `boolean` : Indicates whether to record the `code.filepath` attribute for the source code file name that identifies the code unit.
+    **filePath** `boolean` : Indicates whether to record the `code.file.path` attribute for the source code file name that identifies the code unit.
     - This field is *optional*, and defaults to `false`
   </Accordion>
   <Accordion title="function">
@@ -22,7 +22,7 @@
     - This field is *optional*, and defaults to `false`
   </Accordion>
   <Accordion title="lineNumber">
-    **lineNumber** `boolean` : Indicates whether to record the `code.lineno` attribute for the line number in the `code.filepath` best representing the operation.
+    **lineNumber** `boolean` : Indicates whether to record the `code.line.number` attribute for the line number in the `code.file.path` best representing the operation.
     - This field is *optional*, and defaults to `false`
   </Accordion>
   <Accordion title="namespace">

--- a/instrumentationrules/data/codeattributes.yaml
+++ b/instrumentationrules/data/codeattributes.yaml
@@ -23,13 +23,13 @@ spec:
         options:
           - id: filePath
             label: Collect file path
-            tooltip: Indicates whether to record the `code.filepath` attribute.
+            tooltip: Indicates whether to record the `code.file.path` attribute.
           - id: function
             label: Collect function
             tooltip: Indicates whether to record the `code.function.name` attribute, the fully-qualified function name.
           - id: lineNumber
             label: Collect line number
-            tooltip: Indicates whether to record the `code.lineno` attribute.
+            tooltip: Indicates whether to record the `code.line.number` attribute.
     - name: codeAttributes
       displayName: Verbose data to collect
       componentType: checkboxList
@@ -38,7 +38,7 @@ spec:
         options:
           - id: column
             label: Collect column
-            tooltip: Indicates whether to record the `code.column` attribute.
+            tooltip: Indicates whether to record the `code.column.number` attribute.
           - id: namespace
             label: Collect namespace
             tooltip: Deprecated. `code.namespace` was merged into `code.function.name`; this now behaves as an alias of "Collect function".

--- a/instrumentationrules/data/codeattributes.yaml
+++ b/instrumentationrules/data/codeattributes.yaml
@@ -26,7 +26,7 @@ spec:
             tooltip: Indicates whether to record the `code.filepath` attribute.
           - id: function
             label: Collect function
-            tooltip: Indicates whether to record the `code.function` attribute.
+            tooltip: Indicates whether to record the `code.function.name` attribute, the fully-qualified function name.
           - id: lineNumber
             label: Collect line number
             tooltip: Indicates whether to record the `code.lineno` attribute.
@@ -41,7 +41,7 @@ spec:
             tooltip: Indicates whether to record the `code.column` attribute.
           - id: namespace
             label: Collect namespace
-            tooltip: Indicates whether to record the `code.namespace` attribute.
+            tooltip: Deprecated. `code.namespace` was merged into `code.function.name`; this now behaves as an alias of "Collect function".
           - id: stacktrace
             label: Collect stacktrace
             tooltip: Indicates whether to record the `code.stacktrace` attribute.


### PR DESCRIPTION
#### What this PR does / why we need it:

Part of RUN-1087. Docs and tooltips only — **no schema change**.

semconv v1.31.0 merged `code.function` + `code.namespace` into one fully-qualified `code.function.name` and renamed the siblings (`code.filepath` → `code.file.path`, `code.lineno` → `code.line.number`, `code.column` → `code.column.number`).

**Approach:** either toggle enables the merged attribute, implemented agent-side. Every existing rule and `profiles/manifests/code-attributes.yaml` keeps working, with no CRD/GraphQL/helm/gqlgen churn — and it avoids field pruning, since neither CRD sets `x-kubernetes-preserve-unknown-fields` and dropping a field would make existing GitOps manifests silently no-op.

**Worth agreeing on:** `function` is pre-checked under "Recommended", `namespace` is unchecked under "Verbose". Users who deliberately left namespace off start receiving fully-qualified names — unavoidable, the unqualified form no longer exists.

**Follow-up:** the Go doc comments in `common/api/instrumentationrules/code_attributes.go` feed generated CRD descriptions and need `make -C api generate manifests sync-helm-crd docgen`.

Agent PRs: ebpf-java-instrumentation#538, enterprise-go-instrumentation#2211, ebpf-generic-instrumentation#51.

#### Changelog entry:

```release-note
The CodeAttributes instrumentation rule now documents `code.function.name`, `code.file.path`, `code.line.number` and `code.column.number`. The `namespace` field is deprecated and behaves as an alias of `function`, since OpenTelemetry merged `code.namespace` into the fully-qualified `code.function.name`.
```
