### PR TITLE
PLAT-1418 | fix(instrumentationrules): drop the NetworkMetrics rule toggle field

### DIFF
--- a/instrumentationrules/data/networkmetrics.yaml
+++ b/instrumentationrules/data/networkmetrics.yaml
@@ -5,17 +5,13 @@ metadata:
   displayName: Network Metrics
 spec:
   docsUrl: https://docs.odigos.io/pipeline/rules/networkmetrics
-  description: The "Network Metrics" rule enables network flow and TCP stats metrics for matching workloads. The metrics are collected in odiglet via OBI and exported over OTLP alongside other workload telemetry.
+  description: The "Network Metrics" rule enables network flow and TCP stats metrics for matching workloads. The metrics are collected in odiglet via OBI and exported over OTLP alongside other workload telemetry. Network flow metrics also require metricsSources.networkMetrics.enabled in the Odigos Helm values.
   # Network metrics are collected at the eBPF/network level and apply regardless of the workload's
   # programming language.
   supportedLanguages:
     - "*"
-  fields:
-    # Enablement is presence-based: a non-nil `networkMetrics` object enables collection. The toggle
-    # writes a boolean that the backend maps to an empty `networkMetrics: {}` config when enabled.
-    - name: networkMetrics
-      displayName: Enable network metrics
-      componentType: toggle
-      initialValue: "true"
-      componentProps:
-        tooltip: Collect network flow and TCP stats metrics for the scoped workloads. Network flow metrics also require metricsSources.networkMetrics.enabled in the Odigos Helm values.
+  # No fields: the rule carries no configuration of its own. Enablement is presence-based on the CRD
+  # (`networkMetrics: {}`), so the rule's existence is what enables collection and `spec.disabled`
+  # turns it off — the same enable/disable control every other rule type uses. Exposing a dedicated
+  # toggle would clear the only field that identifies the rule's type, making a "disabled" rule
+  # indistinguishable from an empty one.


### PR DESCRIPTION
The Network Metrics rule catalog exposed an "Enable network metrics" toggle, but that toggle wrote the very field the backend uses to identify the rule's type. Creating the rule with it turned off produced a rule that reported back as an unknown type and could not be reopened in the UI.

#### What this PR does / why we need it:
`spec.networkMetrics` is presence-based: `getInstrumentationRuleType` classifies a rule as `NetworkMetrics` only when the field is set, and `getNetworkMetricsInput` clears the config when the input is nil or false. So a rule created with the toggle off has nothing left identifying it — it is indistinguishable from an empty rule, which is why it came back as `UnknownType`.

The rule carries no configuration of its own, so the toggle was never really a setting: creating the rule is what enables collection, and `spec.disabled` turns it off, exactly like every other rule type. Removing the `fields` block makes the catalog match that, and the UI renders the rule with no configuration section. `Fields` is documented as optional in the catalog model, and enablement itself is unchanged — the GraphQL layer still maps the presence marker to an empty `NetworkMetricsConfig{}`.

The Helm prerequisite that lived only in the removed toggle's tooltip is folded into the rule description so it stays visible to users.

Paired with odigos-io/ui-kit#1223, which adds the rule type to the UI.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
Fixed the Network Metrics instrumentation rule being created as an unknown, unopenable rule when its "Enable network metrics" toggle was turned off. The rule is now enabled by its existence and disabled with the standard rule disable control.
```