### PR TITLE
CORE-1516 | Enable span metrics by default for all metrics destinations

### DIFF
--- a/destinations/data/coralogix.yaml
+++ b/destinations/data/coralogix.yaml
@@ -11,7 +11,6 @@ spec:
       supported: true
     metrics:
       supported: true
-      spanMetricsEnabledByDefault: true
     logs:
       supported: true
     profiles:

--- a/destinations/data/prometheus.yaml
+++ b/destinations/data/prometheus.yaml
@@ -11,7 +11,6 @@ spec:
       supported: false
     metrics:
       supported: true
-      spanMetricsEnabledByDefault: true
     logs:
       supported: false
     profiles:

--- a/destinations/data/victoriametricscloud.yaml
+++ b/destinations/data/victoriametricscloud.yaml
@@ -11,7 +11,6 @@ spec:
       supported: false
     metrics:
       supported: true
-      spanMetricsEnabledByDefault: true
     logs:
       supported: false
     profiles:

--- a/destinations/model.go
+++ b/destinations/model.go
@@ -23,11 +23,6 @@ type Spec struct {
 		}
 		Metrics struct {
 			Supported bool `yaml:"supported"`
-			// if true, it means that this destination will add spanmetrics connector by default
-			// which will aggregate the spans for various opeartion and calculate metrics based on them.
-			// some destinations are already doing this by default, and thus odigos does not need to do it again.
-			// on-prem destinations, or those that only accept metrics and not traces, should set this to true.
-			SpanMetricsEnabledByDefault bool `yaml:"spanMetricsEnabledByDefault"`
 		}
 		Logs struct {
 			Supported bool `yaml:"supported"`

--- a/scheduler/controllers/nodecollectorsgroup/common.go
+++ b/scheduler/controllers/nodecollectorsgroup/common.go
@@ -132,13 +132,6 @@ func getResourceSettings(odigosConfiguration common.OdigosConfiguration) odigosv
 	}
 }
 
-func calculateSpanMetricsEnabled(userSettings *bool, destinationTypeManifest destinations.Destination) bool {
-	if userSettings == nil {
-		return destinationTypeManifest.Spec.Signals.Metrics.SpanMetricsEnabledByDefault
-	}
-	return *userSettings
-}
-
 func getHostMetricsConfiguration(odigosConfiguration *common.OdigosConfiguration) *common.MetricsSourceHostMetricsConfiguration {
 
 	var hostMetricsCopy common.MetricsSourceHostMetricsConfiguration
@@ -211,22 +204,17 @@ func updateMetricsSettingsForDestination(metricsConfig *odigosv1.CollectorsGroup
 		metricsConfig.AgentsTelemetry = &odigosv1.AgentsTelemetrySettings{}
 		metricsConfig.HostMetrics = getHostMetricsConfiguration(odigosConfiguration)
 		metricsConfig.KubeletStats = getKubeletStatsConfiguration(odigosConfiguration)
-		if calculateSpanMetricsEnabled(nil, destinationTypeManifest) {
-			metricsConfig.SpanMetrics = getSpanMetricsConfiguration(odigosConfiguration)
-		}
+		metricsConfig.SpanMetrics = getSpanMetricsConfiguration(odigosConfiguration)
 		return
 	}
 
-	// is span metrics not set, use the destination manifest default
-	if calculateSpanMetricsEnabled(metricsSettings.CollectSpanMetrics, destinationTypeManifest) {
+	if metricsSettings.CollectSpanMetrics == nil || *metricsSettings.CollectSpanMetrics {
 		metricsConfig.SpanMetrics = getSpanMetricsConfiguration(odigosConfiguration)
 	}
 
-	// default host metrics collection to "true"
 	if metricsSettings.CollectHostMetrics == nil || *metricsSettings.CollectHostMetrics {
 		metricsConfig.HostMetrics = getHostMetricsConfiguration(odigosConfiguration)
 	}
-	// default kubelet stats collection to "true"
 	if metricsSettings.CollectKubeletStats == nil || *metricsSettings.CollectKubeletStats {
 		metricsConfig.KubeletStats = getKubeletStatsConfiguration(odigosConfiguration)
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
Previously we selectively decided which destinations could generate span metrics via `spanMetricsEnabledByDefault` on destination manifests. That was confusing, and destinations without the flag also do not calculate span metrics themselves — so customers on those destinations were missing useful span-derived metrics.

This change removes the per-destination default flag and enables span metrics by default for **all** metrics destinations. Users can still opt out with `collectSpanMetrics: false`.

Linear: https://linear.app/odigos/issue/CORE-1516/enable-span-metrics-by-default-for-all-metrics-destinations

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
```release-note
Span metrics are now enabled by default for all metrics destinations. Use collectSpanMetrics: false to opt out.
```

Made with [Cursor](https://cursor.com)