### PR TITLE
feat: add SystemDetectionSettings to SystemSettings and preserve detection state during updates

### DIFF
--- a/frontend/services/insights/types.go
+++ b/frontend/services/insights/types.go
@@ -489,12 +489,17 @@ type SystemWritebackSettings struct {
 	FlushIntervalSeconds int `json:"flush_interval_seconds"`
 }
 
+type SystemDetectionSettings struct {
+	AutoTransactionGuardrail bool `json:"auto_transaction_guardrail"`
+}
+
 type SystemSettings struct {
 	Sampling  SystemSamplingSettings  `json:"sampling"`
 	Retention SystemRetentionSettings `json:"retention"`
 	Findings  SystemFindingsSettings  `json:"findings"`
 	Capacity  SystemCapacitySettings  `json:"capacity"`
 	Writeback SystemWritebackSettings `json:"writeback"`
+	Detection SystemDetectionSettings `json:"detection"`
 }
 
 type StorageConnection struct {

--- a/frontend/services/insights/upsert.go
+++ b/frontend/services/insights/upsert.go
@@ -65,6 +65,12 @@ func (c *Client) UpsertGuardrailAndRead(ctx context.Context, guardrail Guardrail
 }
 
 func (c *Client) UpdateSystemSettingsAndRead(ctx context.Context, settings SystemSettings) (SystemSettings, error) {
+	current, err := c.GetSystemSettings(ctx)
+	if err == nil && current != nil {
+		// GraphQL does not expose detection toggles yet; preserve the stored
+		// value so a settings save from the product UI cannot wipe them.
+		settings.Detection = current.Detection
+	}
 	if err := c.UpdateSystemSettings(ctx, settings); err != nil {
 		return SystemSettings{}, err
 	}


### PR DESCRIPTION
- Introduced a new type `SystemDetectionSettings` to encapsulate detection-related settings.
- Updated `SystemSettings` to include the new `Detection` field.
- Modified the `UpdateSystemSettingsAndRead` method to preserve the current detection settings when updating system settings, ensuring that UI changes do not overwrite existing values.

This enhancement improves the management of detection settings within the Insights feature.

```release-note
feat: add SystemDetectionSettings to SystemSettings and preserve detection state during updates
```
