### PR TITLE
feat: add forcePromoteInsightsService mutation to Insights GraphQL API

### DIFF
--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -1572,6 +1572,7 @@ type ComplexityRoot struct {
 		DisableSourceProfiling              func(childComplexity int, namespace string, kind string, name string) int
 		DismissInsightsGuardrailViolation   func(childComplexity int, action model.InsightsViolationActionInput) int
 		EnableSourceProfiling               func(childComplexity int, namespace string, kind string, name string) int
+		ForcePromoteInsightsService         func(childComplexity int, namespace string, service string) int
 		PauseOdigos                         func(childComplexity int) int
 		PersistK8sNamespaces                func(childComplexity int, namespaces []*model.PersistNamespaceItemInput) int
 		PersistK8sSources                   func(childComplexity int, sources []*model.PersistNamespaceSourceInput) int
@@ -2191,6 +2192,7 @@ type MutationResolver interface {
 	PromoteInsightsBaselineClass(ctx context.Context, transactionID string, class model.InsightsDeviationClass) (*model.InsightsPromoteResult, error)
 	ResetInsightsBaselineClass(ctx context.Context, transactionID string, class model.InsightsDeviationClass) (bool, error)
 	ResetInsightsTransactionBaselines(ctx context.Context, transactionID string) (bool, error)
+	ForcePromoteInsightsService(ctx context.Context, namespace string, service string) (bool, error)
 	DeleteInsightsTransaction(ctx context.Context, transactionID string) (bool, error)
 	UpsertInsightsPolicy(ctx context.Context, policy model.InsightsPolicyInput) (*model.InsightsPolicy, error)
 	DeleteInsightsPolicy(ctx context.Context, scope model.InsightsPolicyScope, scopeKey string) (bool, error)
@@ -9382,6 +9384,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.EnableSourceProfiling(childComplexity, args["namespace"].(string), args["kind"].(string), args["name"].(string)), true
 
+	case "Mutation.forcePromoteInsightsService":
+		if e.complexity.Mutation.ForcePromoteInsightsService == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_forcePromoteInsightsService_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.ForcePromoteInsightsService(childComplexity, args["namespace"].(string), args["service"].(string)), true
+
 	case "Mutation.pauseOdigos":
 		if e.complexity.Mutation.PauseOdigos == nil {
 			break
@@ -14050,6 +14064,57 @@ func (ec *executionContext) field_Mutation_enableSourceProfiling_argsName(
 
 	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
 	if tmp, ok := rawArgs["name"]; ok {
+		return ec.unmarshalNString2string(ctx, tmp)
+	}
+
+	var zeroVal string
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_forcePromoteInsightsService_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_forcePromoteInsightsService_argsNamespace(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["namespace"] = arg0
+	arg1, err := ec.field_Mutation_forcePromoteInsightsService_argsService(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["service"] = arg1
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_forcePromoteInsightsService_argsNamespace(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (string, error) {
+	if _, ok := rawArgs["namespace"]; !ok {
+		var zeroVal string
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("namespace"))
+	if tmp, ok := rawArgs["namespace"]; ok {
+		return ec.unmarshalNString2string(ctx, tmp)
+	}
+
+	var zeroVal string
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_forcePromoteInsightsService_argsService(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (string, error) {
+	if _, ok := rawArgs["service"]; !ok {
+		var zeroVal string
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("service"))
+	if tmp, ok := rawArgs["service"]; ok {
 		return ec.unmarshalNString2string(ctx, tmp)
 	}
 
@@ -60975,6 +61040,61 @@ func (ec *executionContext) fieldContext_Mutation_resetInsightsTransactionBaseli
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_forcePromoteInsightsService(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_forcePromoteInsightsService(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().ForcePromoteInsightsService(rctx, fc.Args["namespace"].(string), fc.Args["service"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_forcePromoteInsightsService(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_forcePromoteInsightsService_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation_deleteInsightsTransaction(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation_deleteInsightsTransaction(ctx, field)
 	if err != nil {
@@ -94392,6 +94512,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "resetInsightsTransactionBaselines":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_resetInsightsTransactionBaselines(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "forcePromoteInsightsService":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_forcePromoteInsightsService(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++

--- a/frontend/graph/insights.graphqls
+++ b/frontend/graph/insights.graphqls
@@ -906,6 +906,12 @@ extend type Mutation {
   ): Boolean!
   resetInsightsTransactionBaselines(transactionId: ID!): Boolean!
   """
+  Force-promote every scored baseline class on every transaction of a service
+  (POST /api/v1/services/transaction-guardrail/force-promote). May auto-enable
+  the transaction guardrail when the global setting is on.
+  """
+  forcePromoteInsightsService(namespace: String!, service: String!): Boolean!
+  """
   Permanently removes a transaction and related state (baselines, samples, issues, txn-scoped policies).
   """
   deleteInsightsTransaction(transactionId: ID!): Boolean!

--- a/frontend/graph/insights.resolvers.go
+++ b/frontend/graph/insights.resolvers.go
@@ -388,6 +388,18 @@ func (r *mutationResolver) ResetInsightsTransactionBaselines(ctx context.Context
 	return true, nil
 }
 
+// ForcePromoteInsightsService is the resolver for the forcePromoteInsightsService field.
+func (r *mutationResolver) ForcePromoteInsightsService(ctx context.Context, namespace string, service string) (bool, error) {
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return false, err
+	}
+	if err := client.ForcePromoteService(ctx, namespace, service); err != nil {
+		return false, insights.GraphQLError(ctx, err)
+	}
+	return true, nil
+}
+
 // DeleteInsightsTransaction is the resolver for the deleteInsightsTransaction field.
 func (r *mutationResolver) DeleteInsightsTransaction(ctx context.Context, transactionID string) (bool, error) {
 	client, err := r.insightsClient(ctx)

--- a/frontend/services/insights/client.go
+++ b/frontend/services/insights/client.go
@@ -111,6 +111,17 @@ func (c *Client) PromoteBaselineClass(ctx context.Context, transactionID int64, 
 	return &result, nil
 }
 
+// ForcePromoteService promotes every scored baseline class on every transaction
+// of the service (POST /api/v1/services/transaction-guardrail/force-promote).
+func (c *Client) ForcePromoteService(ctx context.Context, namespace, service string) error {
+	endpoint := c.apiEndpoint("services", "transaction-guardrail", "force-promote")
+	query := endpoint.Query()
+	query.Set("namespace", namespace)
+	query.Set("service", service)
+	endpoint.RawQuery = query.Encode()
+	return c.do(ctx, http.MethodPost, endpoint, nil, nil)
+}
+
 func (c *Client) ResetBaselineClass(ctx context.Context, transactionID int64, class DeviationClass) error {
 	return c.do(ctx, http.MethodPost, c.transactionEndpoint(transactionID, "baseline", string(class), "reset"), nil, nil)
 }

--- a/frontend/webapp/graphql/mutations/insights.ts
+++ b/frontend/webapp/graphql/mutations/insights.ts
@@ -80,6 +80,12 @@ export const RESET_INSIGHTS_TRANSACTION_BASELINES = gql`
   }
 `;
 
+export const FORCE_PROMOTE_INSIGHTS_SERVICE = gql`
+  mutation ForcePromoteInsightsService($namespace: String!, $service: String!) {
+    forcePromoteInsightsService(namespace: $namespace, service: $service)
+  }
+`;
+
 export const DELETE_INSIGHTS_TRANSACTION = gql`
   mutation DeleteInsightsTransaction($transactionId: ID!) {
     deleteInsightsTransaction(transactionId: $transactionId)

--- a/frontend/webapp/lib/odigos-api-adapter.tsx
+++ b/frontend/webapp/lib/odigos-api-adapter.tsx
@@ -166,6 +166,7 @@ import {
   PROMOTE_INSIGHTS_BASELINE_CLASS,
   RESET_INSIGHTS_BASELINE_CLASS,
   RESET_INSIGHTS_TRANSACTION_BASELINES,
+  FORCE_PROMOTE_INSIGHTS_SERVICE,
   DELETE_INSIGHTS_TRANSACTION,
   UPSERT_INSIGHTS_POLICY,
   DELETE_INSIGHTS_POLICY,
@@ -549,6 +550,10 @@ const operations: OdigosApiOperations = {
   RESET_INSIGHTS_TRANSACTION_BASELINES: {
     document: RESET_INSIGHTS_TRANSACTION_BASELINES,
     transformResult: (raw: unknown) => (raw as { resetInsightsTransactionBaselines?: boolean } | null | undefined)?.resetInsightsTransactionBaselines ?? false,
+  },
+  FORCE_PROMOTE_INSIGHTS_SERVICE: {
+    document: FORCE_PROMOTE_INSIGHTS_SERVICE,
+    transformResult: (raw: unknown) => (raw as { forcePromoteInsightsService?: boolean } | null | undefined)?.forcePromoteInsightsService ?? false,
   },
   DELETE_INSIGHTS_TRANSACTION: {
     document: DELETE_INSIGHTS_TRANSACTION,


### PR DESCRIPTION
- Introduced a new mutation `forcePromoteInsightsService` to promote every scored baseline class on every transaction of a specified service.
- Updated the GraphQL schema and resolvers to support this new mutation, enhancing the Insights feature's capabilities.
- Implemented corresponding client-side logic to facilitate the mutation call.

This addition improves the management of insights by allowing bulk promotion of baseline classes, streamlining the process for users.

```release-note
feat: add forcePromoteInsightsService mutation to Insights GraphQL API
```
