### PR TITLE
CORE-1520: Support mTLS in OTLP destinations

### DIFF
--- a/common/config/genericotlp.go
+++ b/common/config/genericotlp.go
@@ -13,6 +13,9 @@ const (
 	genericOtlpUrlKey             = "OTLP_GRPC_ENDPOINT"
 	genericOtlpTlsKey             = "OTLP_GRPC_TLS_ENABLED"
 	genericOtlpCaPemKey           = "OTLP_GRPC_CA_PEM"
+	genericOtlpMtlsEnabledKey     = "OTLP_GRPC_MTLS_ENABLED"
+	genericOtlpClientCertPemKey   = "OTLP_GRPC_CLIENT_CERT_PEM"
+	genericOtlpClientKeyPemKey    = "OTLP_GRPC_CLIENT_KEY_PEM"
 	genericOtlpInsecureSkipVerify = "OTLP_GRPC_INSECURE_SKIP_VERIFY"
 	otlpGrpcOAuth2EnabledKey      = "OTLP_GRPC_OAUTH2_ENABLED"
 	otlpGrpcOAuth2ClientIdKey     = "OTLP_GRPC_OAUTH2_CLIENT_ID"
@@ -39,6 +42,7 @@ func (g *GenericOTLP) ModifyConfig(dest ExporterConfigurer, currentConfig *Confi
 	}
 
 	userTlsEnabled := dest.GetConfig()[genericOtlpTlsKey] == "true"
+	mtlsEnabled := dest.GetConfig()[genericOtlpMtlsEnabledKey] == "true"
 
 	// Check for OAuth2 authentication early to determine TLS requirements
 	oauth2ExtensionName, oauth2ExtensionConf, err := applyGrpcOAuth2Auth(dest)
@@ -47,8 +51,8 @@ func (g *GenericOTLP) ModifyConfig(dest ExporterConfigurer, currentConfig *Confi
 	}
 	oauth2Enabled := oauth2ExtensionName != ""
 
-	// Determine final TLS setting: gRPC requires TLS when using authentication credentials like OAuth2
-	finalTlsEnabled := userTlsEnabled || oauth2Enabled
+	// Determine final TLS setting: gRPC requires TLS when using authentication credentials like OAuth2 or mTLS
+	finalTlsEnabled := userTlsEnabled || oauth2Enabled || mtlsEnabled
 
 	grpcEndpoint, err := parseOtlpGrpcUrl(url, finalTlsEnabled)
 	if err != nil {
@@ -59,21 +63,7 @@ func (g *GenericOTLP) ModifyConfig(dest ExporterConfigurer, currentConfig *Confi
 		"endpoint": grpcEndpoint,
 	}
 
-	// Only add TLS config if TLS is needed (user-enabled or OAuth2-required)
-	tlsConfig := GenericMap{
-		"insecure": !finalTlsEnabled,
-	}
-	if finalTlsEnabled {
-		caPem, caExists := config[genericOtlpCaPemKey]
-		if caExists && caPem != "" {
-			tlsConfig["ca_pem"] = caPem
-		}
-		insecureSkipVerify, skipExists := config[genericOtlpInsecureSkipVerify]
-		if skipExists && insecureSkipVerify != "" {
-			tlsConfig["insecure_skip_verify"] = parseBool(insecureSkipVerify)
-		}
-	}
-	exporterConf["tls"] = tlsConfig
+	exporterConf["tls"] = buildGenericOtlpTlsConfig(config, finalTlsEnabled, mtlsEnabled)
 
 	// add OAuth2 authenticator extension if configured
 	if oauth2ExtensionName != "" && oauth2ExtensionConf != nil {
@@ -144,6 +134,27 @@ func (g *GenericOTLP) ModifyConfig(dest ExporterConfigurer, currentConfig *Confi
 	}
 
 	return pipelineNames, nil
+}
+
+func buildGenericOtlpTlsConfig(config map[string]string, finalTlsEnabled, mtlsEnabled bool) GenericMap {
+	tlsConfig := GenericMap{
+		"insecure": !finalTlsEnabled,
+	}
+	if !finalTlsEnabled {
+		return tlsConfig
+	}
+	if caPem, caExists := config[genericOtlpCaPemKey]; caExists && caPem != "" {
+		tlsConfig["ca_pem"] = caPem
+	}
+	if insecureSkipVerify, skipExists := config[genericOtlpInsecureSkipVerify]; skipExists && insecureSkipVerify != "" {
+		tlsConfig["insecure_skip_verify"] = parseBool(insecureSkipVerify)
+	}
+	// Client cert/key are stored in the Destination Secret and injected as env vars
+	if mtlsEnabled {
+		tlsConfig["cert_pem"] = fmt.Sprintf("${%s}", genericOtlpClientCertPemKey)
+		tlsConfig["key_pem"] = fmt.Sprintf("${%s}", genericOtlpClientKeyPemKey)
+	}
+	return tlsConfig
 }
 
 func applyGrpcOAuth2Auth(dest ExporterConfigurer) (extensionName string, extensionConf *GenericMap, err error) {

--- a/common/config/genericotlp_test.go
+++ b/common/config/genericotlp_test.go
@@ -55,6 +55,29 @@ func TestGrpcOAuth2AutoTLS(t *testing.T) {
 			expectTLSConfig: true, // TLS config should be present
 		},
 		{
+			name: "mTLS enabled adds client cert and key env placeholders",
+			config: map[string]string{
+				"OTLP_GRPC_ENDPOINT":     "example.com:4317",
+				"OTLP_GRPC_TLS_ENABLED":  "true",
+				"OTLP_GRPC_MTLS_ENABLED": "true",
+				"OTLP_GRPC_CA_PEM":       "-----BEGIN CERTIFICATE-----\nCA\n-----END CERTIFICATE-----",
+			},
+			expectedTLS:     true,
+			expectedAuth:    false,
+			expectTLSConfig: true,
+		},
+		{
+			name: "mTLS enabled forces TLS when TLS was disabled",
+			config: map[string]string{
+				"OTLP_GRPC_ENDPOINT":     "example.com:4317",
+				"OTLP_GRPC_TLS_ENABLED":  "false",
+				"OTLP_GRPC_MTLS_ENABLED": "true",
+			},
+			expectedTLS:     true,
+			expectedAuth:    false,
+			expectTLSConfig: true,
+		},
+		{
 			name: "Neither TLS nor OAuth2 enabled - no TLS config",
 			config: map[string]string{
 				"OTLP_GRPC_ENDPOINT": "example.com:4317",
@@ -118,6 +141,18 @@ func TestGrpcOAuth2AutoTLS(t *testing.T) {
 					assert.False(t, tlsConfig["insecure"].(bool), "TLS should be enabled (insecure=false)")
 				} else {
 					assert.True(t, tlsConfig["insecure"].(bool), "TLS should be disabled (insecure=true)")
+				}
+
+				if tt.config["OTLP_GRPC_MTLS_ENABLED"] == "true" {
+					assert.Equal(t, "${OTLP_GRPC_CLIENT_CERT_PEM}", tlsConfig["cert_pem"])
+					assert.Equal(t, "${OTLP_GRPC_CLIENT_KEY_PEM}", tlsConfig["key_pem"])
+				} else {
+					assert.NotContains(t, tlsConfig, "cert_pem")
+					assert.NotContains(t, tlsConfig, "key_pem")
+				}
+
+				if caPem, ok := tt.config["OTLP_GRPC_CA_PEM"]; ok && caPem != "" {
+					assert.Equal(t, caPem, tlsConfig["ca_pem"])
 				}
 			} else {
 				assert.NotContains(t, exporterConfig, "tls", "TLS config should NOT be present when neither TLS nor OAuth2 are enabled")

--- a/common/config/otlphttp.go
+++ b/common/config/otlphttp.go
@@ -17,6 +17,9 @@ const (
 	otlpHttpProfilesEndpointKey   = "OTLP_HTTP_PROFILES_ENDPOINT"
 	otlpHttpTlsKey                = "OTLP_HTTP_TLS_ENABLED"
 	otlpHttpCaPemKey              = "OTLP_HTTP_CA_PEM"
+	otlpHttpMtlsEnabledKey        = "OTLP_HTTP_MTLS_ENABLED"
+	otlpHttpClientCertPemKey      = "OTLP_HTTP_CLIENT_CERT_PEM"
+	otlpHttpClientKeyPemKey       = "OTLP_HTTP_CLIENT_KEY_PEM"
 	otlpHttpInsecureSkipVerify    = "OTLP_HTTP_INSECURE_SKIP_VERIFY"
 	otlpHttpBasicAuthUsernameKey  = "OTLP_HTTP_BASIC_AUTH_USERNAME"
 	otlpHttpBasicAuthPasswordKey  = "OTLP_HTTP_BASIC_AUTH_PASSWORD"
@@ -52,6 +55,8 @@ func (g *OTLPHttp) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) 
 	}
 
 	userTlsEnabled := dest.GetConfig()[otlpHttpTlsKey] == "true"
+	mtlsEnabled := dest.GetConfig()[otlpHttpMtlsEnabledKey] == "true"
+	finalTlsEnabled := userTlsEnabled || mtlsEnabled
 
 	var parsedBase string
 	var err error
@@ -95,16 +100,21 @@ func (g *OTLPHttp) ModifyConfig(dest ExporterConfigurer, currentConfig *Config) 
 		exporterConf["endpoint"] = parsedBase
 	}
 
-	// Only add TLS config if TLS is explicitly enabled or authentication is being used
+	// Only add TLS config if TLS is explicitly enabled, mTLS is enabled, or authentication is being used
 	tlsConfig := GenericMap{
-		"insecure": !userTlsEnabled,
+		"insecure": !finalTlsEnabled,
 	}
-	if userTlsEnabled || hasAuthentication {
+	if finalTlsEnabled || hasAuthentication {
 		if caPem, ok := config[otlpHttpCaPemKey]; ok && caPem != "" {
 			tlsConfig["ca_pem"] = caPem
 		}
 		if insecureSkipVerify, ok := config[otlpHttpInsecureSkipVerify]; ok && insecureSkipVerify != "" {
 			tlsConfig["insecure_skip_verify"] = parseBool(insecureSkipVerify)
+		}
+		// Client cert/key are stored in the Destination Secret and injected as env vars
+		if mtlsEnabled {
+			tlsConfig["cert_pem"] = fmt.Sprintf("${%s}", otlpHttpClientCertPemKey)
+			tlsConfig["key_pem"] = fmt.Sprintf("${%s}", otlpHttpClientKeyPemKey)
 		}
 	}
 	exporterConf["tls"] = tlsConfig

--- a/common/config/otlphttp_test.go
+++ b/common/config/otlphttp_test.go
@@ -259,6 +259,27 @@ func TestOAuth2Configuration(t *testing.T) {
 			expectTLSConfig: true,
 		},
 		{
+			name: "mTLS enabled adds client cert and key env placeholders",
+			config: map[string]string{
+				"OTLP_HTTP_ENDPOINT":     "https://example.com:4318",
+				"OTLP_HTTP_TLS_ENABLED":  "true",
+				"OTLP_HTTP_MTLS_ENABLED": "true",
+				"OTLP_HTTP_CA_PEM":       "-----BEGIN CERTIFICATE-----\nCA\n-----END CERTIFICATE-----",
+			},
+			expectedAuth:    false,
+			expectTLSConfig: true,
+		},
+		{
+			name: "mTLS enabled forces TLS when TLS was disabled",
+			config: map[string]string{
+				"OTLP_HTTP_ENDPOINT":     "https://example.com:4318",
+				"OTLP_HTTP_TLS_ENABLED":  "false",
+				"OTLP_HTTP_MTLS_ENABLED": "true",
+			},
+			expectedAuth:    false,
+			expectTLSConfig: true,
+		},
+		{
 			name: "Basic Auth without TLS",
 			config: map[string]string{
 				"OTLP_HTTP_ENDPOINT":            "https://example.com:4318",
@@ -373,10 +394,22 @@ func TestOAuth2Configuration(t *testing.T) {
 				assert.Contains(t, exporterConfig, "tls", "TLS config should be present")
 				tlsConfig := exporterConfig["tls"].(GenericMap)
 				// When authentication is used without explicit TLS, it should be insecure: true
-				// When TLS is explicitly enabled, it should be insecure: false
-				userTlsEnabled := tt.config["OTLP_HTTP_TLS_ENABLED"] == "true"
-				expectedInsecure := !userTlsEnabled
+				// When TLS or mTLS is explicitly enabled, it should be insecure: false
+				finalTlsEnabled := tt.config["OTLP_HTTP_TLS_ENABLED"] == "true" || tt.config["OTLP_HTTP_MTLS_ENABLED"] == "true"
+				expectedInsecure := !finalTlsEnabled
 				assert.Equal(t, expectedInsecure, tlsConfig["insecure"].(bool))
+
+				if tt.config["OTLP_HTTP_MTLS_ENABLED"] == "true" {
+					assert.Equal(t, "${OTLP_HTTP_CLIENT_CERT_PEM}", tlsConfig["cert_pem"])
+					assert.Equal(t, "${OTLP_HTTP_CLIENT_KEY_PEM}", tlsConfig["key_pem"])
+				} else {
+					assert.NotContains(t, tlsConfig, "cert_pem")
+					assert.NotContains(t, tlsConfig, "key_pem")
+				}
+
+				if caPem, ok := tt.config["OTLP_HTTP_CA_PEM"]; ok && caPem != "" {
+					assert.Equal(t, caPem, tlsConfig["ca_pem"])
+				}
 			} else {
 				assert.NotContains(t, exporterConfig, "tls", "TLS config should NOT be present when neither TLS nor authentication are enabled")
 			}

--- a/destinations/data/dynamic.yaml
+++ b/destinations/data/dynamic.yaml
@@ -30,4 +30,4 @@ spec:
       componentProps:
         type: textarea
         required: true
-        tooltip: The raw YAML config for the Collector Exporter for this destination.
+        tooltip: "The raw YAML config for the Collector Exporter for this destination. To inject secrets (e.g. TLS PEMs), use ${ENV_VAR} placeholders and set Destination.spec.secretRef to a Secret in the same namespace whose keys match those variable names."

--- a/destinations/data/otlp.yaml
+++ b/destinations/data/otlp.yaml
@@ -128,6 +128,41 @@ spec:
         tooltip: "When using TLS, provide the CA certificate in PEM format to verify the server. If empty uses system root CA"
       renderCondition: ["OTLP_GRPC_TLS_ENABLED", "==", "true"]
       hideFromReadData: ["true"]
+    - name: OTLP_GRPC_MTLS_ENABLED
+      displayName: Enable mTLS
+      componentType: checkbox
+      initialValue: false
+      componentProps:
+        required: false
+        tooltip: "Use a client certificate and key for mutual TLS authentication with the destination"
+      renderCondition: ["OTLP_GRPC_TLS_ENABLED", "==", "true"]
+      customReadDataLabels:
+        - condition: "true"
+          title: "mTLS"
+          value: "Enabled"
+        - condition: "false"
+          title: "mTLS"
+          value: "Disabled"
+    - name: OTLP_GRPC_CLIENT_CERT_PEM
+      displayName: Client Certificate
+      componentType: textarea
+      componentProps:
+        required: false
+        placeholder: "-----BEGIN CERTIFICATE-----"
+        tooltip: "Client certificate in PEM format for mutual TLS authentication"
+      renderCondition: ["OTLP_GRPC_MTLS_ENABLED", "==", "true"]
+      hideFromReadData: ["true"]
+      secret: true
+    - name: OTLP_GRPC_CLIENT_KEY_PEM
+      displayName: Client Key
+      componentType: textarea
+      componentProps:
+        required: false
+        placeholder: "-----BEGIN PRIVATE KEY-----"
+        tooltip: "Client private key in PEM format for mutual TLS authentication"
+      renderCondition: ["OTLP_GRPC_MTLS_ENABLED", "==", "true"]
+      hideFromReadData: ["true"]
+      secret: true
     - name: OTLP_GRPC_INSECURE_SKIP_VERIFY
       displayName: Insecure Skip Verify
       componentType: checkbox

--- a/destinations/data/otlphttp.yaml
+++ b/destinations/data/otlphttp.yaml
@@ -191,6 +191,41 @@ spec:
         tooltip: "When using TLS, provide the CA certificate in PEM format to verify the server. If empty uses system root CA"
       renderCondition: ["OTLP_HTTP_TLS_ENABLED", "==", "true"]
       hideFromReadData: ["true"]
+    - name: OTLP_HTTP_MTLS_ENABLED
+      displayName: Enable mTLS
+      componentType: checkbox
+      initialValue: false
+      componentProps:
+        required: false
+        tooltip: "Use a client certificate and key for mutual TLS authentication with the destination"
+      renderCondition: ["OTLP_HTTP_TLS_ENABLED", "==", "true"]
+      customReadDataLabels:
+        - condition: "true"
+          title: "mTLS"
+          value: "Enabled"
+        - condition: "false"
+          title: "mTLS"
+          value: "Disabled"
+    - name: OTLP_HTTP_CLIENT_CERT_PEM
+      displayName: Client Certificate
+      componentType: textarea
+      componentProps:
+        required: false
+        placeholder: "-----BEGIN CERTIFICATE-----"
+        tooltip: "Client certificate in PEM format for mutual TLS authentication"
+      renderCondition: ["OTLP_HTTP_MTLS_ENABLED", "==", "true"]
+      hideFromReadData: ["true"]
+      secret: true
+    - name: OTLP_HTTP_CLIENT_KEY_PEM
+      displayName: Client Key
+      componentType: textarea
+      componentProps:
+        required: false
+        placeholder: "-----BEGIN PRIVATE KEY-----"
+        tooltip: "Client private key in PEM format for mutual TLS authentication"
+      renderCondition: ["OTLP_HTTP_MTLS_ENABLED", "==", "true"]
+      hideFromReadData: ["true"]
+      secret: true
     - name: OTLP_HTTP_INSECURE_SKIP_VERIFY
       displayName: Insecure Skip Verify
       componentType: checkbox

--- a/docs/snippets/shared/backends/dynamic.mdx
+++ b/docs/snippets/shared/backends/dynamic.mdx
@@ -24,6 +24,12 @@ icon: 'signal-stream'
     !! START CUSTOM EDIT !!
 */}
 
+Use Dynamic Destination when you need a collector exporter configuration that is not covered by a built-in destination type (for example, OTLP with client mTLS via freeform YAML).
+
+<Note>
+  Environment variable placeholders such as `${OTLP_CA_PEM}` in `DYNAMIC_CONFIGURATION_DATA` are expanded by the gateway collector from pod environment variables. To inject those values, create a Secret in the **same namespace** as the Destination (the Odigos system namespace) whose keys match the placeholder names, and set `spec.secretRef.name` on the Destination. Without `secretRef`, the autoscaler will not mount the Secret into the gateway and the placeholders remain unset.
+</Note>
+
 {/*
     !! Do not remove this comment, this acts as a key indicator in `docs/sync-dest-doc.py` !!
     !! END CUSTOM EDIT !!
@@ -41,7 +47,7 @@ icon: 'signal-stream'
 - **DYNAMIC_DESTINATION_TYPE** `string` : Destination Type. The type of OpenTelemetry Collector Exporter to use for the destination.
   - This field is required
   - Example: `otlp`
-- **DYNAMIC_CONFIGURATION_DATA** `string` : Config. The raw YAML config for the Collector Exporter for this destination.
+- **DYNAMIC_CONFIGURATION_DATA** `string` : Config. The raw YAML config for the Collector Exporter for this destination. To inject secrets (e.g. TLS PEMs), use ${ENV_VAR} placeholders and set Destination.spec.secretRef to a Secret in the same namespace whose keys match those variable names.
   - This field is required
 
 ### Adding Destination to Odigos

--- a/docs/snippets/shared/backends/otlp.mdx
+++ b/docs/snippets/shared/backends/otlp.mdx
@@ -77,6 +77,14 @@ For advanced users trying to implement complex observability pipelines, Odigos s
 - **OTLP_GRPC_CA_PEM** `string` : Certificate Authority. When using TLS, provide the CA certificate in PEM format to verify the server. If empty uses system root CA
   - This field is optional
   - Example: `-----BEGIN CERTIFICATE-----`
+- **OTLP_GRPC_MTLS_ENABLED** `boolean` : Enable mTLS. Use a client certificate and key for mutual TLS authentication with the destination
+  - This field is optional and defaults to `False`
+- **OTLP_GRPC_CLIENT_CERT_PEM** `string` : Client Certificate. Client certificate in PEM format for mutual TLS authentication
+  - This field is optional
+  - Example: `-----BEGIN CERTIFICATE-----`
+- **OTLP_GRPC_CLIENT_KEY_PEM** `string` : Client Key. Client private key in PEM format for mutual TLS authentication
+  - This field is optional
+  - Example: `-----BEGIN PRIVATE KEY-----`
 - **OTLP_GRPC_INSECURE_SKIP_VERIFY** `boolean` : Insecure Skip Verify. Skip TLS certificate verification
   - This field is optional and defaults to `False`
 
@@ -122,6 +130,7 @@ There are two primary methods for configuring destinations in Odigos:
         # OTLP_GRPC_OAUTH2_AUDIENCE: <OAuth2 Audience>
         # OTLP_GRPC_TLS_ENABLED: <Enable TLS>
         # OTLP_GRPC_CA_PEM: <Certificate Authority>
+        # OTLP_GRPC_MTLS_ENABLED: <Enable mTLS>
         # OTLP_GRPC_INSECURE_SKIP_VERIFY: <Insecure Skip Verify>
       destinationName: otlp
       # Uncomment the 'secretRef' below if you are using the optional Secret.
@@ -139,6 +148,8 @@ There are two primary methods for configuring destinations in Odigos:
     # The following Secret is optional. Uncomment the entire block if you need to use it.
     # apiVersion: v1
     # data:
+    #   OTLP_GRPC_CLIENT_CERT_PEM: <Base64 Client Certificate>
+    #   OTLP_GRPC_CLIENT_KEY_PEM: <Base64 Client Key>
     #   OTLP_GRPC_OAUTH2_CLIENT_SECRET: <Base64 OAuth2 Client Secret>
     # kind: Secret
     # metadata:

--- a/docs/snippets/shared/backends/otlphttp.mdx
+++ b/docs/snippets/shared/backends/otlphttp.mdx
@@ -101,6 +101,14 @@ To configure basic authentication, use the optional config options `Basic Auth U
 - **OTLP_HTTP_CA_PEM** `string` : Certificate Authority. When using TLS, provide the CA certificate in PEM format to verify the server. If empty uses system root CA
   - This field is optional
   - Example: `-----BEGIN CERTIFICATE-----`
+- **OTLP_HTTP_MTLS_ENABLED** `boolean` : Enable mTLS. Use a client certificate and key for mutual TLS authentication with the destination
+  - This field is optional and defaults to `False`
+- **OTLP_HTTP_CLIENT_CERT_PEM** `string` : Client Certificate. Client certificate in PEM format for mutual TLS authentication
+  - This field is optional
+  - Example: `-----BEGIN CERTIFICATE-----`
+- **OTLP_HTTP_CLIENT_KEY_PEM** `string` : Client Key. Client private key in PEM format for mutual TLS authentication
+  - This field is optional
+  - Example: `-----BEGIN PRIVATE KEY-----`
 - **OTLP_HTTP_INSECURE_SKIP_VERIFY** `boolean` : Insecure Skip Verify. Skip TLS certificate verification
   - This field is optional and defaults to `False`
 
@@ -151,6 +159,7 @@ There are two primary methods for configuring destinations in Odigos:
         # OTLP_HTTP_PROFILES_ENDPOINT: <OTLP http profiles Endpoint>
         # OTLP_HTTP_TLS_ENABLED: <Enable TLS>
         # OTLP_HTTP_CA_PEM: <Certificate Authority>
+        # OTLP_HTTP_MTLS_ENABLED: <Enable mTLS>
         # OTLP_HTTP_INSECURE_SKIP_VERIFY: <Insecure Skip Verify>
       destinationName: otlphttp
       # Uncomment the 'secretRef' below if you are using the optional Secret.
@@ -169,6 +178,8 @@ There are two primary methods for configuring destinations in Odigos:
     # apiVersion: v1
     # data:
     #   OTLP_HTTP_BASIC_AUTH_PASSWORD: <Base64 Basic Auth Password>
+    #   OTLP_HTTP_CLIENT_CERT_PEM: <Base64 Client Certificate>
+    #   OTLP_HTTP_CLIENT_KEY_PEM: <Base64 Client Key>
     #   OTLP_HTTP_OAUTH2_CLIENT_SECRET: <Base64 OAuth2 Client Secret>
     # kind: Secret
     # metadata:


### PR DESCRIPTION
#### What this PR does / why we need it:
This adds support for mTLS fields in OTLP destinations (grpc/http). Currently using mTLS requires a dynamic destination and manual secret config, this puts that all in the ui.

Tested with sample app at https://github.com/damemi/mtls-test-app
added to a shared repo https://github.com/odigos-io/synthetic-apps/pull/8

<img width="1346" height="1210" alt="Screenshot 2026-08-20 at 11 17 00 AM" src="https://github.com/user-attachments/assets/706a5ae0-07c1-473a-9996-f4f9007a47e1" />

cherry-pick:v1.35

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
feat(destinations): support mTLS in OTLP destinations
```
