### PR TITLE
CORE-1472: Make dev deploy scripts work better for enterprise testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,13 @@ TAG ?= $(shell odigos version --cluster 2>/dev/null || odigos version --cli 2>/d
 ODIGOS_CLI_VERSION ?= $(shell odigos version --cli)
 CLUSTER_NAME ?= local-dev-cluster
 CENTRAL_BACKEND_URL ?=
-ORG ?= docker.io/keyval
+ODIGOS_NS ?= odigos-system
+OSS_ORG ?= docker.io/keyval
+ENTERPRISE_ORG ?= registry.odigos.io
+# Default for builds/pushes. Local deploy/load-to-kind resolve registry + image name
+# via scripts/resolve-dev-image.sh so OSS make deploy works against enterprise
+# installs (registry.odigos.io, odigos-enterprise-ui, etc.).
+ORG ?= $(OSS_ORG)
 # Override ORG for staging pushes
 ifeq ($(STAGING_ORG),true)
     ORG = us-central1-docker.pkg.dev/odigos-cloud/staging-components
@@ -38,6 +44,24 @@ endif
 ifneq ($(strip $(TARGET)),)
   TARGET_FLAG := --target $(TARGET)
 endif
+
+# When ORG is set on the CLI or environment, force that registry in deploy resolution.
+# The Makefile default (OSS_ORG) is not forced so enterprise clusters get ENTERPRISE_ORG.
+ifneq ($(filter command line environment,$(origin ORG)),)
+  DEV_IMAGE_ORG_OVERRIDE := $(ORG)
+endif
+
+# IMAGE=registry/name:tag overrides resolution for a single-component deploy.
+# Otherwise resolve registry + repository from the live cluster / install tier.
+dev_image_repo = $(shell \
+	ODIGOS_NS=$(ODIGOS_NS) \
+	ODIGOS_ENTERPRISE=$(ODIGOS_ENTERPRISE) \
+	ORG_OVERRIDE=$(DEV_IMAGE_ORG_OVERRIDE) \
+	OSS_ORG=$(OSS_ORG) \
+	ENTERPRISE_ORG=$(ENTERPRISE_ORG) \
+	IMG_SUFFIX=$(IMG_SUFFIX) \
+	bash $(CURDIR)/scripts/resolve-dev-image.sh $(1))
+dev_image = $(or $(IMAGE),$(call dev_image_repo,$(1)):$(TAG))
 
 .PHONY: install-golangci-lint
 install-golangci-lint:
@@ -98,9 +122,10 @@ helm-schema-clean:
 	rm -f $(HELM_SCHEMA_BIN)
 
 # Pass DOCKER_BUILD_OPTS=--no-cache to force a clean build (e.g. when go.mod replace changes and cache is stale).
+# IMAGE= overrides the default $(ORG)/odigos-$*$(IMG_SUFFIX):$(TAG) tag (used by deploy-*).
 build-image/%:
 	docker build $(DOCKER_BUILD_OPTS) $(TARGET_FLAG) \
-	-t $(ORG)/odigos-$*$(IMG_SUFFIX):$(TAG) $(BUILD_DIR) -f $(DOCKERFILE) \
+	-t $(or $(IMAGE),$(ORG)/odigos-$*$(IMG_SUFFIX):$(TAG)) $(BUILD_DIR) -f $(DOCKERFILE) \
 	--build-arg SERVICE_NAME="$*" \
 	--build-arg ODIGOS_VERSION=$(TAG) \
 	--build-arg VERSION=$(TAG) \
@@ -222,7 +247,7 @@ push-images-rhel:
 	$(MAKE) push-images RHEL=true TAG=$(TAG) ORG=$(ORG)
 
 load-to-kind-%:
-	kind load docker-image $(ORG)/odigos-$*$(IMG_SUFFIX):$(TAG)
+	kind load docker-image $(call dev_image,$*)
 
 # Victoria Metrics is not built from this repo — pull the published image and retag for e2e.
 # Materialize a single-platform image via buildx --load so kind load does not fail on
@@ -245,35 +270,39 @@ load-to-kind:
 
 .PHONY: restart-ui
 restart-ui:
-	-kubectl rollout restart deployment odigos-ui -n odigos-system
+	-kubectl rollout restart deployment odigos-ui -n $(ODIGOS_NS)
 
 .PHONY: restart-odiglet
 restart-odiglet:
-	-kubectl rollout restart daemonset odiglet -n odigos-system
+	-kubectl rollout restart daemonset odiglet -n $(ODIGOS_NS)
 
 .PHONY: restart-autoscaler
 restart-autoscaler:
-	-kubectl rollout restart deployment odigos-autoscaler -n odigos-system
+	-kubectl rollout restart deployment odigos-autoscaler -n $(ODIGOS_NS)
 
 .PHONY: restart-instrumentor
 restart-instrumentor:
-	-kubectl rollout restart deployment odigos-instrumentor -n odigos-system
+	-kubectl rollout restart deployment odigos-instrumentor -n $(ODIGOS_NS)
 
 .PHONY: restart-scheduler
 restart-scheduler:
-	-kubectl rollout restart deployment odigos-scheduler -n odigos-system
+	-kubectl rollout restart deployment odigos-scheduler -n $(ODIGOS_NS)
 
 .PHONY: restart-collector
 restart-collector:
-	-kubectl rollout restart deployment odigos-gateway -n odigos-system
+	-kubectl rollout restart deployment odigos-gateway -n $(ODIGOS_NS)
 	# DaemonSets don't directly support the rollout restart command in the same way Deployments do. However, you can achieve the same result by updating an environment variable or any other field in the DaemonSet's pod template, triggering a rolling update of the pods managed by the DaemonSet
 	# Restart the odiglet DaemonSet because data-collection Collector is part of it
-	-kubectl -n odigos-system patch daemonset odiglet -p "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"kubectl.kubernetes.io/restartedAt\":\"$(date +%Y-%m-%dT%H:%M:%S%z)\"}}}}}"
+	-kubectl -n $(ODIGOS_NS) patch daemonset odiglet -p "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"kubectl.kubernetes.io/restartedAt\":\"$(date +%Y-%m-%dT%H:%M:%S%z)\"}}}}}"
 
+# Resolves registry + image name for the current install (OSS vs enterprise) so
+# `make deploy-autoscaler` from this repo tags/loads the image the cluster expects.
 deploy-%:
-	$(MAKE) build-$* ORG=$(ORG) TAG=$(TAG) DOCKERFILE=$(DOCKERFILE) IMG_SUFFIX=$(IMG_SUFFIX)
-	$(MAKE) load-to-kind-$* ORG=$(ORG) TAG=$(TAG) IMG_SUFFIX=$(IMG_SUFFIX)
-	@if [ "$*" != "agents" ]; then \
+	@img="$(call dev_image,$*)"; \
+	echo "Deploying $$img"; \
+	$(MAKE) build-$* IMAGE=$$img ORG=$(ORG) TAG=$(TAG) DOCKERFILE=$(DOCKERFILE) IMG_SUFFIX=$(IMG_SUFFIX); \
+	$(MAKE) load-to-kind-$* IMAGE=$$img ORG=$(ORG) TAG=$(TAG) IMG_SUFFIX=$(IMG_SUFFIX); \
+	if [ "$*" != "agents" ]; then \
 		$(MAKE) restart-$* ORG=$(ORG) TAG=$(TAG) IMG_SUFFIX=$(IMG_SUFFIX); \
 	fi
 
@@ -283,11 +312,13 @@ deploy:
 
 .PHONY: debug-odiglet
 debug-odiglet:
-	docker build -t $(ORG)/odigos-odiglet:$(TAG) . -f odiglet/debug.Dockerfile
-	kind load docker-image $(ORG)/odigos-odiglet:$(TAG)
-	kubectl delete pod -n odigos-system -l app.kubernetes.io/name=odiglet
-	kubectl wait --for=condition=ready pod -n odigos-system -l app.kubernetes.io/name=odiglet --timeout=180s
-	kubectl port-forward -n odigos-system daemonset/odiglet 2345:2345
+	@img="$(call dev_image,odiglet)"; \
+	echo "Building debug odiglet as $$img"; \
+	docker build -t $$img . -f odiglet/debug.Dockerfile; \
+	kind load docker-image $$img; \
+	kubectl delete pod -n $(ODIGOS_NS) -l app.kubernetes.io/name=odiglet; \
+	kubectl wait --for=condition=ready pod -n $(ODIGOS_NS) -l app.kubernetes.io/name=odiglet --timeout=180s; \
+	kubectl port-forward -n $(ODIGOS_NS) daemonset/odiglet 2345:2345
 
 ALL_GO_MOD_DIRS := $(shell find . -type f -name 'go.mod' -exec dirname {} \; | sort | grep -v "licenses")
 

--- a/cli.mk
+++ b/cli.mk
@@ -1,7 +1,9 @@
 # CLI-related targets. Included from the root Makefile.
 # Shared vars from the parent Makefile:
 #   TAG                 - image / version tag (auto-detected from cluster/cli/helm if unset)
-#   ORG                 - registry org (default: docker.io/keyval); STAGING_ORG=true for staging GCR
+#   ORG                 - registry org (default: docker.io/keyval); STAGING_ORG=true for staging GCR.
+#                         Local deploy/load-to-kind auto-select registry.odigos.io + enterprise image
+#                         names when the cluster is an enterprise install (see scripts/resolve-dev-image.sh).
 #   IMG_SUFFIX          - image name suffix (empty by default; -rhel-certified when RHEL=true)
 #   ODIGOS_CLI_VERSION  - sets Helm image.tag for install/upgrade (default: `odigos version --cli`)
 #   CLUSTER_NAME        - cluster name for install (default: local-dev-cluster)

--- a/scripts/resolve-dev-image.sh
+++ b/scripts/resolve-dev-image.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Resolve the container image repository (registry/name, no tag) for local
+# make deploy / load-to-kind workflows.
+#
+# Enterprise installs (odigos-pro secret or ODIGOS_TIER=onprem) default to
+# registry.odigos.io and odigos-enterprise-* names where those differ from OSS.
+# When a matching workload already exists in the cluster with the expected image
+# name, its registry/prefix is preserved (custom imagePrefix, mirrors, etc.).
+#
+# Usage: resolve-dev-image.sh <component>
+# Env:
+#   ODIGOS_NS          - namespace (default: odigos-system)
+#   ODIGOS_ENTERPRISE  - true|false to skip auto-detection
+#   ORG_OVERRIDE       - force registry/org (when user set ORG on the CLI/env)
+#   OSS_ORG            - default OSS registry (default: docker.io/keyval)
+#   ENTERPRISE_ORG     - default enterprise registry (default: registry.odigos.io)
+#   IMG_SUFFIX         - optional image suffix (e.g. -rhel-certified)
+
+set -euo pipefail
+
+component="${1:?component name required (e.g. autoscaler, ui, odiglet)}"
+ns="${ODIGOS_NS:-odigos-system}"
+img_suffix="${IMG_SUFFIX:-}"
+oss_org="${OSS_ORG:-docker.io/keyval}"
+enterprise_org="${ENTERPRISE_ORG:-registry.odigos.io}"
+
+is_enterprise() {
+	case "${ODIGOS_ENTERPRISE:-}" in
+		true|1|yes) return 0 ;;
+		false|0|no) return 1 ;;
+	esac
+	local kopts=(--request-timeout=3s)
+	if kubectl "${kopts[@]}" get secret odigos-pro -n "${ns}" >/dev/null 2>&1; then
+		return 0
+	fi
+	tier="$(kubectl "${kopts[@]}" get cm odigos-deployment -n "${ns}" -o jsonpath='{.data.ODIGOS_TIER}' 2>/dev/null || true)"
+	[ "${tier}" = "onprem" ]
+}
+
+# Image repository names that gain an "enterprise-" infix on enterprise installs.
+expected_image_name() {
+	local c="$1"
+	if is_enterprise; then
+		case "${c}" in
+			ui|instrumentor|odiglet|collector|agents)
+				echo "odigos-enterprise-${c}${img_suffix}"
+				return
+				;;
+		esac
+	fi
+	echo "odigos-${c}${img_suffix}"
+}
+
+fallback_org() {
+	if [ -n "${ORG_OVERRIDE:-}" ]; then
+		echo "${ORG_OVERRIDE}"
+		return
+	fi
+	if is_enterprise; then
+		echo "${enterprise_org}"
+	else
+		echo "${oss_org}"
+	fi
+}
+
+# Strip digest and tag, leaving registry/repo.
+repo_without_tag() {
+	local img="${1%%@*}"
+	local name="${img##*/}"
+	case "${name}" in
+		*:*) echo "${img%:*}" ;;
+		*) echo "${img}" ;;
+	esac
+}
+
+image_basename() {
+	local repo="$1"
+	echo "${repo##*/}"
+}
+
+lookup_cluster_image() {
+	local kopts=(--request-timeout=3s)
+	case "$1" in
+		autoscaler)
+			kubectl "${kopts[@]}" get deploy odigos-autoscaler -n "${ns}" \
+				-o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true
+			;;
+		scheduler)
+			kubectl "${kopts[@]}" get deploy odigos-scheduler -n "${ns}" \
+				-o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true
+			;;
+		instrumentor)
+			kubectl "${kopts[@]}" get deploy odigos-instrumentor -n "${ns}" \
+				-o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true
+			;;
+		ui)
+			kubectl "${kopts[@]}" get deploy odigos-ui -n "${ns}" \
+				-o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true
+			;;
+		odiglet)
+			kubectl "${kopts[@]}" get ds odiglet -n "${ns}" \
+				-o jsonpath='{.spec.template.spec.containers[?(@.name=="odiglet")].image}' 2>/dev/null || true
+			;;
+		collector)
+			local img
+			img="$(kubectl "${kopts[@]}" get deploy odigos-gateway -n "${ns}" \
+				-o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)"
+			if [ -z "${img}" ]; then
+				img="$(kubectl "${kopts[@]}" get ds odiglet -n "${ns}" \
+					-o jsonpath='{.spec.template.spec.containers[?(@.name=="data-collection")].image}' 2>/dev/null || true)"
+			fi
+			printf '%s' "${img}"
+			;;
+		agents)
+			kubectl "${kopts[@]}" get ds odiglet -n "${ns}" \
+				-o jsonpath='{.spec.template.spec.initContainers[?(@.name=="odigos-agents-image-pull")].image}' 2>/dev/null || true
+			;;
+		*)
+			printf ''
+			;;
+	esac
+}
+
+expected="$(expected_image_name "${component}")"
+fallback="$(fallback_org)/${expected}"
+
+cluster_img="$(lookup_cluster_image "${component}")"
+if [ -n "${cluster_img}" ]; then
+	cluster_repo="$(repo_without_tag "${cluster_img}")"
+	cluster_base="$(image_basename "${cluster_repo}")"
+	# Only reuse the live image when its name matches what this tier expects.
+	# That preserves custom imagePrefix/mirrors while recovering from a prior
+	# deploy that tagged the wrong OSS name into an enterprise cluster.
+	if [ "${cluster_base}" = "${expected}" ]; then
+		# Shared components (autoscaler/scheduler) keep the same image name on
+		# enterprise, so a prior OSS `make deploy` may have left docker.io/keyval
+		# in the cluster — treat that as stale and use the enterprise registry.
+		if is_enterprise; then
+			case "${cluster_repo}" in
+				"${oss_org}"/*)
+					echo "$(fallback_org)/${expected}"
+					exit 0
+					;;
+			esac
+		fi
+		echo "${cluster_repo}"
+		exit 0
+	fi
+fi
+
+echo "${fallback}"


### PR DESCRIPTION
#### What this PR does / why we need it:
After https://github.com/odigos-io/odigos/pull/5532, OSS defaults to `docker.io/keyval` while enterprise stays on `registry.odigos.io` (and some images rename, e.g. `odigos-ui` → `odigos-enterprise-ui`). Running `make deploy-*` from the OSS repo against an enterprise cluster still tagged/loaded the OSS names, so components like autoscaler/scheduler/ui didn’t match what the cluster was pulling.

Local deploy/load-to-kind paths now resolve the image from the install tier (and the live workload when the name already matches): enterprise → `registry.odigos.io` + `odigos-enterprise-*` where needed; OSS → `docker.io/keyval` / `odigos-*`. Build/push defaults are unchanged.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
