### PR TITLE
ci: bump check-links runner to ubuntu-24.04

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-links:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5


### PR DESCRIPTION
GitHub is retiring the `ubuntu-22.04` runner image.
Deprecation starts on September 17, 2026, with scheduled
brownouts that fail jobs, and the image becomes fully
unsupported on April 17, 2027.
Ref: https://github.com/actions/runner-images/issues/14254

This bumps the `check-links` job to `ubuntu-24.04`.

This workflow only runs a link checker, so it has no
dependency on the runner's OS version. No other workflows
are touched in this PR — some of them appear to pin
`ubuntu-22.04` intentionally.

Happy to adjust or close if you'd prefer `ubuntu-latest`
or a different approach.