### PR TITLE
feat: add transaction guardrail management to Insights GraphQL API

### DIFF
--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -1044,6 +1044,10 @@ type ComplexityRoot struct {
 		MaxResidentTransactions func(childComplexity int) int
 	}
 
+	InsightsSystemDetectionSettings struct {
+		AutoTransactionGuardrail func(childComplexity int) int
+	}
+
 	InsightsSystemFindingsSettings struct {
 		DefaultWindowHours func(childComplexity int) int
 		MaxWindowHours     func(childComplexity int) int
@@ -1060,6 +1064,7 @@ type ComplexityRoot struct {
 
 	InsightsSystemSettings struct {
 		Capacity  func(childComplexity int) int
+		Detection func(childComplexity int) int
 		Findings  func(childComplexity int) int
 		Retention func(childComplexity int) int
 		Sampling  func(childComplexity int) int
@@ -1569,8 +1574,10 @@ type ComplexityRoot struct {
 		DeleteInsightsTransaction           func(childComplexity int, transactionID string) int
 		DeleteInstrumentationRule           func(childComplexity int, ruleID string) int
 		DeleteNoisyOperationRule            func(childComplexity int, samplingID string, ruleID string) int
+		DisableInsightsTransactionGuardrail func(childComplexity int, namespace string, service string) int
 		DisableSourceProfiling              func(childComplexity int, namespace string, kind string, name string) int
 		DismissInsightsGuardrailViolation   func(childComplexity int, action model.InsightsViolationActionInput) int
+		EnableInsightsTransactionGuardrail  func(childComplexity int, namespace string, service string) int
 		EnableSourceProfiling               func(childComplexity int, namespace string, kind string, name string) int
 		ForcePromoteInsightsService         func(childComplexity int, namespace string, service string) int
 		PauseOdigos                         func(childComplexity int) int
@@ -2193,6 +2200,8 @@ type MutationResolver interface {
 	ResetInsightsBaselineClass(ctx context.Context, transactionID string, class model.InsightsDeviationClass) (bool, error)
 	ResetInsightsTransactionBaselines(ctx context.Context, transactionID string) (bool, error)
 	ForcePromoteInsightsService(ctx context.Context, namespace string, service string) (bool, error)
+	EnableInsightsTransactionGuardrail(ctx context.Context, namespace string, service string) (bool, error)
+	DisableInsightsTransactionGuardrail(ctx context.Context, namespace string, service string) (bool, error)
 	DeleteInsightsTransaction(ctx context.Context, transactionID string) (bool, error)
 	UpsertInsightsPolicy(ctx context.Context, policy model.InsightsPolicyInput) (*model.InsightsPolicy, error)
 	DeleteInsightsPolicy(ctx context.Context, scope model.InsightsPolicyScope, scopeKey string) (bool, error)
@@ -6998,6 +7007,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.InsightsSystemCapacitySettings.MaxResidentTransactions(childComplexity), true
 
+	case "InsightsSystemDetectionSettings.autoTransactionGuardrail":
+		if e.complexity.InsightsSystemDetectionSettings.AutoTransactionGuardrail == nil {
+			break
+		}
+
+		return e.complexity.InsightsSystemDetectionSettings.AutoTransactionGuardrail(childComplexity), true
+
 	case "InsightsSystemFindingsSettings.defaultWindowHours":
 		if e.complexity.InsightsSystemFindingsSettings.DefaultWindowHours == nil {
 			break
@@ -7039,6 +7055,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.InsightsSystemSettings.Capacity(childComplexity), true
+
+	case "InsightsSystemSettings.detection":
+		if e.complexity.InsightsSystemSettings.Detection == nil {
+			break
+		}
+
+		return e.complexity.InsightsSystemSettings.Detection(childComplexity), true
 
 	case "InsightsSystemSettings.findings":
 		if e.complexity.InsightsSystemSettings.Findings == nil {
@@ -9348,6 +9371,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.DeleteNoisyOperationRule(childComplexity, args["samplingId"].(string), args["ruleId"].(string)), true
 
+	case "Mutation.disableInsightsTransactionGuardrail":
+		if e.complexity.Mutation.DisableInsightsTransactionGuardrail == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_disableInsightsTransactionGuardrail_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DisableInsightsTransactionGuardrail(childComplexity, args["namespace"].(string), args["service"].(string)), true
+
 	case "Mutation.disableSourceProfiling":
 		if e.complexity.Mutation.DisableSourceProfiling == nil {
 			break
@@ -9371,6 +9406,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.DismissInsightsGuardrailViolation(childComplexity, args["action"].(model.InsightsViolationActionInput)), true
+
+	case "Mutation.enableInsightsTransactionGuardrail":
+		if e.complexity.Mutation.EnableInsightsTransactionGuardrail == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_enableInsightsTransactionGuardrail_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.EnableInsightsTransactionGuardrail(childComplexity, args["namespace"].(string), args["service"].(string)), true
 
 	case "Mutation.enableSourceProfiling":
 		if e.complexity.Mutation.EnableSourceProfiling == nil {
@@ -11848,6 +11895,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputInsightsLearningPolicyInput,
 		ec.unmarshalInputInsightsPolicyInput,
 		ec.unmarshalInputInsightsSystemCapacitySettingsInput,
+		ec.unmarshalInputInsightsSystemDetectionSettingsInput,
 		ec.unmarshalInputInsightsSystemFindingsSettingsInput,
 		ec.unmarshalInputInsightsSystemRetentionSettingsInput,
 		ec.unmarshalInputInsightsSystemSamplingSettingsInput,
@@ -13895,6 +13943,57 @@ func (ec *executionContext) field_Mutation_deleteNoisyOperationRule_argsRuleID(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation_disableInsightsTransactionGuardrail_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_disableInsightsTransactionGuardrail_argsNamespace(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["namespace"] = arg0
+	arg1, err := ec.field_Mutation_disableInsightsTransactionGuardrail_argsService(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["service"] = arg1
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_disableInsightsTransactionGuardrail_argsNamespace(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (string, error) {
+	if _, ok := rawArgs["namespace"]; !ok {
+		var zeroVal string
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("namespace"))
+	if tmp, ok := rawArgs["namespace"]; ok {
+		return ec.unmarshalNString2string(ctx, tmp)
+	}
+
+	var zeroVal string
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_disableInsightsTransactionGuardrail_argsService(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (string, error) {
+	if _, ok := rawArgs["service"]; !ok {
+		var zeroVal string
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("service"))
+	if tmp, ok := rawArgs["service"]; ok {
+		return ec.unmarshalNString2string(ctx, tmp)
+	}
+
+	var zeroVal string
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation_disableSourceProfiling_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -13994,6 +14093,57 @@ func (ec *executionContext) field_Mutation_dismissInsightsGuardrailViolation_arg
 	}
 
 	var zeroVal model.InsightsViolationActionInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_enableInsightsTransactionGuardrail_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_enableInsightsTransactionGuardrail_argsNamespace(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["namespace"] = arg0
+	arg1, err := ec.field_Mutation_enableInsightsTransactionGuardrail_argsService(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["service"] = arg1
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_enableInsightsTransactionGuardrail_argsNamespace(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (string, error) {
+	if _, ok := rawArgs["namespace"]; !ok {
+		var zeroVal string
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("namespace"))
+	if tmp, ok := rawArgs["namespace"]; ok {
+		return ec.unmarshalNString2string(ctx, tmp)
+	}
+
+	var zeroVal string
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_enableInsightsTransactionGuardrail_argsService(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (string, error) {
+	if _, ok := rawArgs["service"]; !ok {
+		var zeroVal string
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("service"))
+	if tmp, ok := rawArgs["service"]; ok {
+		return ec.unmarshalNString2string(ctx, tmp)
+	}
+
+	var zeroVal string
 	return zeroVal, nil
 }
 
@@ -33448,6 +33598,8 @@ func (ec *executionContext) fieldContext_Insights_systemSettings(_ context.Conte
 				return ec.fieldContext_InsightsSystemSettings_capacity(ctx, field)
 			case "writeback":
 				return ec.fieldContext_InsightsSystemSettings_writeback(ctx, field)
+			case "detection":
+				return ec.fieldContext_InsightsSystemSettings_detection(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type InsightsSystemSettings", field.Name)
 		},
@@ -46229,6 +46381,50 @@ func (ec *executionContext) fieldContext_InsightsSystemCapacitySettings_maxBasel
 	return fc, nil
 }
 
+func (ec *executionContext) _InsightsSystemDetectionSettings_autoTransactionGuardrail(ctx context.Context, field graphql.CollectedField, obj *model.InsightsSystemDetectionSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsSystemDetectionSettings_autoTransactionGuardrail(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AutoTransactionGuardrail, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsSystemDetectionSettings_autoTransactionGuardrail(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsSystemDetectionSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _InsightsSystemFindingsSettings_defaultWindowHours(ctx context.Context, field graphql.CollectedField, obj *model.InsightsSystemFindingsSettings) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_InsightsSystemFindingsSettings_defaultWindowHours(ctx, field)
 	if err != nil {
@@ -46690,6 +46886,54 @@ func (ec *executionContext) fieldContext_InsightsSystemSettings_writeback(_ cont
 				return ec.fieldContext_InsightsSystemWritebackSettings_flushIntervalSeconds(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type InsightsSystemWritebackSettings", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsSystemSettings_detection(ctx context.Context, field graphql.CollectedField, obj *model.InsightsSystemSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsSystemSettings_detection(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Detection, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.InsightsSystemDetectionSettings)
+	fc.Result = res
+	return ec.marshalNInsightsSystemDetectionSettings2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemDetectionSettings(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsSystemSettings_detection(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsSystemSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "autoTransactionGuardrail":
+				return ec.fieldContext_InsightsSystemDetectionSettings_autoTransactionGuardrail(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type InsightsSystemDetectionSettings", field.Name)
 		},
 	}
 	return fc, nil
@@ -61095,6 +61339,116 @@ func (ec *executionContext) fieldContext_Mutation_forcePromoteInsightsService(ct
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_enableInsightsTransactionGuardrail(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_enableInsightsTransactionGuardrail(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().EnableInsightsTransactionGuardrail(rctx, fc.Args["namespace"].(string), fc.Args["service"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_enableInsightsTransactionGuardrail(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_enableInsightsTransactionGuardrail_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_disableInsightsTransactionGuardrail(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_disableInsightsTransactionGuardrail(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DisableInsightsTransactionGuardrail(rctx, fc.Args["namespace"].(string), fc.Args["service"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_disableInsightsTransactionGuardrail(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_disableInsightsTransactionGuardrail_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation_deleteInsightsTransaction(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation_deleteInsightsTransaction(ctx, field)
 	if err != nil {
@@ -61905,6 +62259,8 @@ func (ec *executionContext) fieldContext_Mutation_updateInsightsSystemSettings(c
 				return ec.fieldContext_InsightsSystemSettings_capacity(ctx, field)
 			case "writeback":
 				return ec.fieldContext_InsightsSystemSettings_writeback(ctx, field)
+			case "detection":
+				return ec.fieldContext_InsightsSystemSettings_detection(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type InsightsSystemSettings", field.Name)
 		},
@@ -80897,6 +81253,33 @@ func (ec *executionContext) unmarshalInputInsightsSystemCapacitySettingsInput(ct
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputInsightsSystemDetectionSettingsInput(ctx context.Context, obj any) (model.InsightsSystemDetectionSettingsInput, error) {
+	var it model.InsightsSystemDetectionSettingsInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"autoTransactionGuardrail"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "autoTransactionGuardrail":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("autoTransactionGuardrail"))
+			data, err := ec.unmarshalNBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AutoTransactionGuardrail = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputInsightsSystemFindingsSettingsInput(ctx context.Context, obj any) (model.InsightsSystemFindingsSettingsInput, error) {
 	var it model.InsightsSystemFindingsSettingsInput
 	asMap := map[string]any{}
@@ -80999,7 +81382,7 @@ func (ec *executionContext) unmarshalInputInsightsSystemSettingsInput(ctx contex
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"sampling", "retention", "findings", "capacity", "writeback"}
+	fieldsInOrder := [...]string{"sampling", "retention", "findings", "capacity", "writeback", "detection"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -81041,6 +81424,13 @@ func (ec *executionContext) unmarshalInputInsightsSystemSettingsInput(ctx contex
 				return it, err
 			}
 			it.Writeback = data
+		case "detection":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("detection"))
+			data, err := ec.unmarshalNInsightsSystemDetectionSettingsInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemDetectionSettingsInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Detection = data
 		}
 	}
 
@@ -90230,6 +90620,45 @@ func (ec *executionContext) _InsightsSystemCapacitySettings(ctx context.Context,
 	return out
 }
 
+var insightsSystemDetectionSettingsImplementors = []string{"InsightsSystemDetectionSettings"}
+
+func (ec *executionContext) _InsightsSystemDetectionSettings(ctx context.Context, sel ast.SelectionSet, obj *model.InsightsSystemDetectionSettings) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, insightsSystemDetectionSettingsImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("InsightsSystemDetectionSettings")
+		case "autoTransactionGuardrail":
+			out.Values[i] = ec._InsightsSystemDetectionSettings_autoTransactionGuardrail(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var insightsSystemFindingsSettingsImplementors = []string{"InsightsSystemFindingsSettings"}
 
 func (ec *executionContext) _InsightsSystemFindingsSettings(ctx context.Context, sel ast.SelectionSet, obj *model.InsightsSystemFindingsSettings) graphql.Marshaler {
@@ -90390,6 +90819,11 @@ func (ec *executionContext) _InsightsSystemSettings(ctx context.Context, sel ast
 			}
 		case "writeback":
 			out.Values[i] = ec._InsightsSystemSettings_writeback(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "detection":
+			out.Values[i] = ec._InsightsSystemSettings_detection(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -94519,6 +94953,20 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "forcePromoteInsightsService":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_forcePromoteInsightsService(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "enableInsightsTransactionGuardrail":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_enableInsightsTransactionGuardrail(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "disableInsightsTransactionGuardrail":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_disableInsightsTransactionGuardrail(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -102605,6 +103053,21 @@ func (ec *executionContext) marshalNInsightsSystemCapacitySettings2ᚖgithubᚗc
 
 func (ec *executionContext) unmarshalNInsightsSystemCapacitySettingsInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemCapacitySettingsInput(ctx context.Context, v any) (*model.InsightsSystemCapacitySettingsInput, error) {
 	res, err := ec.unmarshalInputInsightsSystemCapacitySettingsInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNInsightsSystemDetectionSettings2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemDetectionSettings(ctx context.Context, sel ast.SelectionSet, v *model.InsightsSystemDetectionSettings) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._InsightsSystemDetectionSettings(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNInsightsSystemDetectionSettingsInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemDetectionSettingsInput(ctx context.Context, v any) (*model.InsightsSystemDetectionSettingsInput, error) {
+	res, err := ec.unmarshalInputInsightsSystemDetectionSettingsInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/frontend/graph/insights.graphqls
+++ b/frontend/graph/insights.graphqls
@@ -705,12 +705,22 @@ type InsightsSystemWritebackSettings {
   flushIntervalSeconds: Int!
 }
 
+type InsightsSystemDetectionSettings {
+  """
+  When true, automatically create an enforced allowed_transactions guardrail
+  when a service finishes promoting. Applies only going forward — already-promoted
+  services are not backfilled. Per-service disable uses rule mode off.
+  """
+  autoTransactionGuardrail: Boolean!
+}
+
 type InsightsSystemSettings {
   sampling: InsightsSystemSamplingSettings!
   retention: InsightsSystemRetentionSettings!
   findings: InsightsSystemFindingsSettings!
   capacity: InsightsSystemCapacitySettings!
   writeback: InsightsSystemWritebackSettings!
+  detection: InsightsSystemDetectionSettings!
 }
 
 input InsightsSystemSamplingSettingsInput {
@@ -736,12 +746,17 @@ input InsightsSystemWritebackSettingsInput {
   flushIntervalSeconds: Int!
 }
 
+input InsightsSystemDetectionSettingsInput {
+  autoTransactionGuardrail: Boolean!
+}
+
 input InsightsSystemSettingsInput {
   sampling: InsightsSystemSamplingSettingsInput!
   retention: InsightsSystemRetentionSettingsInput!
   findings: InsightsSystemFindingsSettingsInput!
   capacity: InsightsSystemCapacitySettingsInput!
   writeback: InsightsSystemWritebackSettingsInput!
+  detection: InsightsSystemDetectionSettingsInput!
 }
 
 # Storage health (ClickHouse + writeback snapshot, for the settings/health page)
@@ -911,6 +926,22 @@ extend type Mutation {
   the transaction guardrail when the global setting is on.
   """
   forcePromoteInsightsService(namespace: String!, service: String!): Boolean!
+  """
+  Enable a service's transaction guardrail (POST /api/v1/services/transaction-guardrail/enable).
+  Seeds allowed_transactions from current ops and sets the rule to enforce.
+  """
+  enableInsightsTransactionGuardrail(
+    namespace: String!
+    service: String!
+  ): Boolean!
+  """
+  Disable a service's transaction guardrail (POST /api/v1/services/transaction-guardrail/disable).
+  Sets allowed_transactions to mode off so auto-enable will not recreate it.
+  """
+  disableInsightsTransactionGuardrail(
+    namespace: String!
+    service: String!
+  ): Boolean!
   """
   Permanently removes a transaction and related state (baselines, samples, issues, txn-scoped policies).
   """

--- a/frontend/graph/insights.resolvers.go
+++ b/frontend/graph/insights.resolvers.go
@@ -400,6 +400,30 @@ func (r *mutationResolver) ForcePromoteInsightsService(ctx context.Context, name
 	return true, nil
 }
 
+// EnableInsightsTransactionGuardrail is the resolver for the enableInsightsTransactionGuardrail field.
+func (r *mutationResolver) EnableInsightsTransactionGuardrail(ctx context.Context, namespace string, service string) (bool, error) {
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return false, err
+	}
+	if err := client.EnableTransactionGuardrail(ctx, namespace, service); err != nil {
+		return false, insights.GraphQLError(ctx, err)
+	}
+	return true, nil
+}
+
+// DisableInsightsTransactionGuardrail is the resolver for the disableInsightsTransactionGuardrail field.
+func (r *mutationResolver) DisableInsightsTransactionGuardrail(ctx context.Context, namespace string, service string) (bool, error) {
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return false, err
+	}
+	if err := client.DisableTransactionGuardrail(ctx, namespace, service); err != nil {
+		return false, insights.GraphQLError(ctx, err)
+	}
+	return true, nil
+}
+
 // DeleteInsightsTransaction is the resolver for the deleteInsightsTransaction field.
 func (r *mutationResolver) DeleteInsightsTransaction(ctx context.Context, transactionID string) (bool, error) {
 	client, err := r.insightsClient(ctx)

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -1270,6 +1270,17 @@ type InsightsSystemCapacitySettingsInput struct {
 	MaxBaselineSetMembers   int `json:"maxBaselineSetMembers"`
 }
 
+type InsightsSystemDetectionSettings struct {
+	// When true, automatically create an enforced allowed_transactions guardrail
+	// when a service finishes promoting. Applies only going forward — already-promoted
+	// services are not backfilled. Per-service disable uses rule mode off.
+	AutoTransactionGuardrail bool `json:"autoTransactionGuardrail"`
+}
+
+type InsightsSystemDetectionSettingsInput struct {
+	AutoTransactionGuardrail bool `json:"autoTransactionGuardrail"`
+}
+
 type InsightsSystemFindingsSettings struct {
 	DefaultWindowHours int `json:"defaultWindowHours"`
 	MaxWindowHours     int `json:"maxWindowHours"`
@@ -1304,6 +1315,7 @@ type InsightsSystemSettings struct {
 	Findings  *InsightsSystemFindingsSettings  `json:"findings"`
 	Capacity  *InsightsSystemCapacitySettings  `json:"capacity"`
 	Writeback *InsightsSystemWritebackSettings `json:"writeback"`
+	Detection *InsightsSystemDetectionSettings `json:"detection"`
 }
 
 type InsightsSystemSettingsInput struct {
@@ -1312,6 +1324,7 @@ type InsightsSystemSettingsInput struct {
 	Findings  *InsightsSystemFindingsSettingsInput  `json:"findings"`
 	Capacity  *InsightsSystemCapacitySettingsInput  `json:"capacity"`
 	Writeback *InsightsSystemWritebackSettingsInput `json:"writeback"`
+	Detection *InsightsSystemDetectionSettingsInput `json:"detection"`
 }
 
 type InsightsSystemWritebackSettings struct {

--- a/frontend/services/insights/client.go
+++ b/frontend/services/insights/client.go
@@ -122,6 +122,28 @@ func (c *Client) ForcePromoteService(ctx context.Context, namespace, service str
 	return c.do(ctx, http.MethodPost, endpoint, nil, nil)
 }
 
+// EnableTransactionGuardrail enables a service's allowed_transactions guardrail
+// (POST /api/v1/services/transaction-guardrail/enable).
+func (c *Client) EnableTransactionGuardrail(ctx context.Context, namespace, service string) error {
+	endpoint := c.apiEndpoint("services", "transaction-guardrail", "enable")
+	query := endpoint.Query()
+	query.Set("namespace", namespace)
+	query.Set("service", service)
+	endpoint.RawQuery = query.Encode()
+	return c.do(ctx, http.MethodPost, endpoint, nil, nil)
+}
+
+// DisableTransactionGuardrail disables a service's allowed_transactions guardrail
+// (POST /api/v1/services/transaction-guardrail/disable).
+func (c *Client) DisableTransactionGuardrail(ctx context.Context, namespace, service string) error {
+	endpoint := c.apiEndpoint("services", "transaction-guardrail", "disable")
+	query := endpoint.Query()
+	query.Set("namespace", namespace)
+	query.Set("service", service)
+	endpoint.RawQuery = query.Encode()
+	return c.do(ctx, http.MethodPost, endpoint, nil, nil)
+}
+
 func (c *Client) ResetBaselineClass(ctx context.Context, transactionID int64, class DeviationClass) error {
 	return c.do(ctx, http.MethodPost, c.transactionEndpoint(transactionID, "baseline", string(class), "reset"), nil, nil)
 }

--- a/frontend/services/insights/conversions.go
+++ b/frontend/services/insights/conversions.go
@@ -900,6 +900,9 @@ func SystemSettingsToModel(settings SystemSettings) *model.InsightsSystemSetting
 		Writeback: &model.InsightsSystemWritebackSettings{
 			FlushIntervalSeconds: settings.Writeback.FlushIntervalSeconds,
 		},
+		Detection: &model.InsightsSystemDetectionSettings{
+			AutoTransactionGuardrail: settings.Detection.AutoTransactionGuardrail,
+		},
 	}
 }
 
@@ -1093,7 +1096,7 @@ func BulkAnomalyRequestFromInput(resolution model.InsightsBulkResolution, items 
 }
 
 func SystemSettingsFromInput(input model.InsightsSystemSettingsInput) (SystemSettings, error) {
-	if input.Sampling == nil || input.Retention == nil || input.Findings == nil || input.Capacity == nil || input.Writeback == nil {
+	if input.Sampling == nil || input.Retention == nil || input.Findings == nil || input.Capacity == nil || input.Writeback == nil || input.Detection == nil {
 		return SystemSettings{}, fmt.Errorf("%w: system settings input is incomplete", ErrBadRequest)
 	}
 	return SystemSettings{
@@ -1114,6 +1117,9 @@ func SystemSettingsFromInput(input model.InsightsSystemSettingsInput) (SystemSet
 		},
 		Writeback: SystemWritebackSettings{
 			FlushIntervalSeconds: input.Writeback.FlushIntervalSeconds,
+		},
+		Detection: SystemDetectionSettings{
+			AutoTransactionGuardrail: input.Detection.AutoTransactionGuardrail,
 		},
 	}, nil
 }

--- a/frontend/services/insights/conversions_test.go
+++ b/frontend/services/insights/conversions_test.go
@@ -241,6 +241,7 @@ func TestSystemSettingsAndGuardrailSeedRoundTrip(t *testing.T) {
 		Findings:  SystemFindingsSettings{DefaultWindowHours: 24, MaxWindowHours: 168},
 		Capacity:  SystemCapacitySettings{MaxResidentTransactions: 1000, MaxBaselineSetMembers: 500},
 		Writeback: SystemWritebackSettings{FlushIntervalSeconds: 30},
+		Detection: SystemDetectionSettings{AutoTransactionGuardrail: true},
 	}
 	gql := SystemSettingsToModel(settings)
 	back, err := SystemSettingsFromInput(model.InsightsSystemSettingsInput{
@@ -249,6 +250,7 @@ func TestSystemSettingsAndGuardrailSeedRoundTrip(t *testing.T) {
 		Findings:  &model.InsightsSystemFindingsSettingsInput{DefaultWindowHours: gql.Findings.DefaultWindowHours, MaxWindowHours: gql.Findings.MaxWindowHours},
 		Capacity:  &model.InsightsSystemCapacitySettingsInput{MaxResidentTransactions: gql.Capacity.MaxResidentTransactions, MaxBaselineSetMembers: gql.Capacity.MaxBaselineSetMembers},
 		Writeback: &model.InsightsSystemWritebackSettingsInput{FlushIntervalSeconds: gql.Writeback.FlushIntervalSeconds},
+		Detection: &model.InsightsSystemDetectionSettingsInput{AutoTransactionGuardrail: gql.Detection.AutoTransactionGuardrail},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, settings, back)

--- a/frontend/services/insights/upsert.go
+++ b/frontend/services/insights/upsert.go
@@ -65,12 +65,6 @@ func (c *Client) UpsertGuardrailAndRead(ctx context.Context, guardrail Guardrail
 }
 
 func (c *Client) UpdateSystemSettingsAndRead(ctx context.Context, settings SystemSettings) (SystemSettings, error) {
-	current, err := c.GetSystemSettings(ctx)
-	if err == nil && current != nil {
-		// GraphQL does not expose detection toggles yet; preserve the stored
-		// value so a settings save from the product UI cannot wipe them.
-		settings.Detection = current.Detection
-	}
 	if err := c.UpdateSystemSettings(ctx, settings); err != nil {
 		return SystemSettings{}, err
 	}

--- a/frontend/webapp/graphql/mutations/insights.ts
+++ b/frontend/webapp/graphql/mutations/insights.ts
@@ -56,6 +56,9 @@ const SYSTEM_SETTINGS_FIELDS = `
   writeback {
     flushIntervalSeconds
   }
+  detection {
+    autoTransactionGuardrail
+  }
 `;
 
 export const PROMOTE_INSIGHTS_BASELINE_CLASS = gql`
@@ -83,6 +86,18 @@ export const RESET_INSIGHTS_TRANSACTION_BASELINES = gql`
 export const FORCE_PROMOTE_INSIGHTS_SERVICE = gql`
   mutation ForcePromoteInsightsService($namespace: String!, $service: String!) {
     forcePromoteInsightsService(namespace: $namespace, service: $service)
+  }
+`;
+
+export const ENABLE_INSIGHTS_TRANSACTION_GUARDRAIL = gql`
+  mutation EnableInsightsTransactionGuardrail($namespace: String!, $service: String!) {
+    enableInsightsTransactionGuardrail(namespace: $namespace, service: $service)
+  }
+`;
+
+export const DISABLE_INSIGHTS_TRANSACTION_GUARDRAIL = gql`
+  mutation DisableInsightsTransactionGuardrail($namespace: String!, $service: String!) {
+    disableInsightsTransactionGuardrail(namespace: $namespace, service: $service)
   }
 `;
 

--- a/frontend/webapp/graphql/queries/insights.ts
+++ b/frontend/webapp/graphql/queries/insights.ts
@@ -243,6 +243,9 @@ const SYSTEM_SETTINGS_FIELDS = `
   writeback {
     flushIntervalSeconds
   }
+  detection {
+    autoTransactionGuardrail
+  }
 `;
 
 const STORAGE_HEALTH_FIELDS = `

--- a/frontend/webapp/lib/odigos-api-adapter.tsx
+++ b/frontend/webapp/lib/odigos-api-adapter.tsx
@@ -167,6 +167,8 @@ import {
   RESET_INSIGHTS_BASELINE_CLASS,
   RESET_INSIGHTS_TRANSACTION_BASELINES,
   FORCE_PROMOTE_INSIGHTS_SERVICE,
+  ENABLE_INSIGHTS_TRANSACTION_GUARDRAIL,
+  DISABLE_INSIGHTS_TRANSACTION_GUARDRAIL,
   DELETE_INSIGHTS_TRANSACTION,
   UPSERT_INSIGHTS_POLICY,
   DELETE_INSIGHTS_POLICY,
@@ -554,6 +556,14 @@ const operations: OdigosApiOperations = {
   FORCE_PROMOTE_INSIGHTS_SERVICE: {
     document: FORCE_PROMOTE_INSIGHTS_SERVICE,
     transformResult: (raw: unknown) => (raw as { forcePromoteInsightsService?: boolean } | null | undefined)?.forcePromoteInsightsService ?? false,
+  },
+  ENABLE_INSIGHTS_TRANSACTION_GUARDRAIL: {
+    document: ENABLE_INSIGHTS_TRANSACTION_GUARDRAIL,
+    transformResult: (raw: unknown) => (raw as { enableInsightsTransactionGuardrail?: boolean } | null | undefined)?.enableInsightsTransactionGuardrail ?? false,
+  },
+  DISABLE_INSIGHTS_TRANSACTION_GUARDRAIL: {
+    document: DISABLE_INSIGHTS_TRANSACTION_GUARDRAIL,
+    transformResult: (raw: unknown) => (raw as { disableInsightsTransactionGuardrail?: boolean } | null | undefined)?.disableInsightsTransactionGuardrail ?? false,
   },
   DELETE_INSIGHTS_TRANSACTION: {
     document: DELETE_INSIGHTS_TRANSACTION,

--- a/frontend/webapp/package.json
+++ b/frontend/webapp/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@apollo/client": "^4.2.9",
-    "@odigos/ui-kit": "0.0.286-dev.520",
+    "@odigos/ui-kit": "0.0.287",
     "graphql": "^16.14.2",
     "next": "15.5.21",
     "react": "19.2.8",

--- a/frontend/webapp/yarn.lock
+++ b/frontend/webapp/yarn.lock
@@ -579,10 +579,10 @@
   resolved "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
-"@odigos/ui-kit@0.0.286-dev.520":
-  version "0.0.286-dev.520"
-  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.286-dev.520.tgz#50b66e08803a313096a5c4b65d9270ea3c7a7c7c"
-  integrity sha512-ViA3xyVxHzjpsMjEIwgkhWOfq+svhRHxhZIOKkXnl3GpX0l798EgSQRTilcW1g3qtHhYQQDgFNr4UsSnkiwU2g==
+"@odigos/ui-kit@0.0.287":
+  version "0.0.287"
+  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.287.tgz#d16301ed90a26658f47619cbfb704f8366e71e6f"
+  integrity sha512-+jg2MXpptcHUcIPq8KHXMMSSPmP4Dnu3FrHVU752AkHr7ZHemZR84iTVG3FgKL4NY8c4mLjB8w4dMf+iq0EF3w==
   dependencies:
     "@xyflow/react" "^12.11.2"
     elkjs "^0.12.0"


### PR DESCRIPTION
- Introduced new mutations `enableInsightsTransactionGuardrail` and `disableInsightsTransactionGuardrail` to manage transaction guardrails for services.
- Updated the GraphQL schema to include `InsightsSystemDetectionSettings` and related input types.
- Implemented resolvers for the new mutations, enhancing the Insights feature's capabilities for transaction management.

This addition improves the flexibility and control over transaction guardrails within the Insights feature.

```release-note
feat: add transaction guardrail management to Insights GraphQL API
```
