### PR TITLE
CORE-1530 | Reduce default resource requests for odiglet and node collector

### DIFF
--- a/docs/snippets/enterprise/setup/system-requirements.mdx
+++ b/docs/snippets/enterprise/setup/system-requirements.mdx
@@ -54,7 +54,7 @@ A DaemonSet running on every node in the cluster, consuming resources as outline
 
 | Component Name | Memory Request | Memory Limit | CPU Request | CPU Limit |
 |---------------|---------------|-------------|------------|----------|
-| odiglet | 500Mi         | 500Mi       | 500m       | 500m     |
+| odiglet | 250Mi         | 500Mi       | 250m       | 500m     |
 | data-collection | 250Mi         | 500Mi       | 250m       | 500m     |
 | deviceplugin | 200Mi         | 300Mi       | 40m       | 100m     |
 

--- a/docs/snippets/oss/setup/system-requirements.mdx
+++ b/docs/snippets/oss/setup/system-requirements.mdx
@@ -46,7 +46,7 @@ A DaemonSet running on every node in the cluster, consuming resources as outline
 
 | Component Name | Memory Request | Memory Limit | CPU Request | CPU Limit |
 |---------------|---------------|-------------|------------|----------|
-| odiglet | 500Mi         | 500Mi       | 500m       | 500m     |
+| odiglet | 250Mi         | 500Mi       | 250m       | 500m     |
 | data-collection | 250Mi         | 500Mi       | 250m       | 500m     |
 | deviceplugin | 200Mi         | 300Mi       | 40m       | 100m     |
 

--- a/docs/snippets/shared/pipeline/configuration.mdx
+++ b/docs/snippets/shared/pipeline/configuration.mdx
@@ -40,8 +40,8 @@ Don't know which size is the right one for your cluster? Read more in [Benchmark
 |----------|----------------------|-------------------| ---------------------|-------------------|
 | `size_s` | **150Mi**            | **300Mi**         | **150m**             | **300m**          |
 | `size_m` | **250Mi**            | **500Mi**         | **250m**             | **500m**          |
-| `size_l` | **500Mi**            | **750Mi**         | **500m**             | **750m**          |
-| `size_xl`| **1024Mi**           | **1024Mi**          | **1000m**            | **1000m**         |
+| `size_l` | **375Mi**            | **750Mi**         | **375m**             | **750m**          |
+| `size_xl`| **512Mi**            | **1024Mi**        | **500m**             | **1000m**         |
 
 
 #### 2. Advanced Pipeline Configuration

--- a/helm/odigos/templates/NOTES.txt
+++ b/helm/odigos/templates/NOTES.txt
@@ -8,3 +8,10 @@ brew install odigos-io/odigos-cli/odigos
 odigos ui
 
 Then, go to: http://localhost:3000
+
+{{- $odigletPriorityClass := .Values.odiglet.priorityClassName | default "" }}
+{{- if ne $odigletPriorityClass "system-node-critical" }}
+
+WARNING: odiglet.priorityClassName is set to {{ $odigletPriorityClass | quote }} instead of "system-node-critical".
+Odiglet may be evicted from nodes under memory or CPU pressure. Keep "system-node-critical" unless you intentionally accept that risk.
+{{- end }}

--- a/helm/odigos/templates/_helpers.tpl
+++ b/helm/odigos/templates/_helpers.tpl
@@ -115,6 +115,38 @@ true
   {{- regexReplaceAll "-.*" .Capabilities.KubeVersion.Version "" -}}
   {{- end }}
 
+{{/*
+  Halve a Kubernetes resource quantity (e.g. "500m" → "250m", "512Mi" → "256Mi", "1Gi" → "512Mi").
+  Bare integer CPU cores are treated as whole cores and returned in millicores.
+  Gi/Ti are converted to Mi before dividing so odd multiples (e.g. 1Gi) do not truncate to 0.
+*/}}
+{{- define "odigos.halfQuantity" -}}
+{{- $raw := . | toString -}}
+{{- $number := regexFind "^[0-9]+" $raw -}}
+{{- $unit := regexFind "[a-zA-Z]+$" $raw -}}
+{{- if not $number -}}
+  {{- fail (printf "Invalid resource quantity for halving: %q" $raw) -}}
+{{- end -}}
+{{- $num := int $number -}}
+{{- if and (not $unit) (eq $raw $number) -}}
+  {{- printf "%dm" (div (mul $num 1000) 2) -}}
+{{- else if eq $unit "Gi" -}}
+  {{- printf "%dMi" (div (mul $num 1024) 2) -}}
+{{- else if eq $unit "Ti" -}}
+  {{- printf "%dMi" (div (mul $num 1048576) 2) -}}
+{{- else -}}
+  {{- printf "%d%s" (div $num 2) $unit -}}
+{{- end -}}
+{{- end }}
+
+{{- define "odigos.halfResources" -}}
+{{- $out := dict -}}
+{{- range $k, $v := . -}}
+  {{- $_ := set $out $k (include "odigos.halfQuantity" $v) -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end }}
+
 {{- define "odigos.odiglet.resolvedResources" -}}
 {{- $defaults := dict "cpu" "500m" "memory" "512Mi" -}}
 {{- $resources := deepCopy (.Values.odiglet.resources | default dict) -}}
@@ -126,17 +158,17 @@ true
   {{- $_ := set $resources "limits" $requests -}}
 
 {{- else if and (empty $requests) (not (empty $limits)) -}}
-  {{- $_ := set $resources "requests" $limits -}}
+  {{- $_ := set $resources "requests" (include "odigos.halfResources" $limits | fromYaml) -}}
 
 {{- else if and (empty $limits) (empty $requests) -}}
   {{- $sizingYaml := include "odigos.odiglet.sizing.resources" . -}}
   {{- $sizing := $sizingYaml | fromYaml -}}
   {{- if $sizing }}
     {{- $_ := set $resources "limits" $sizing -}}
-    {{- $_ := set $resources "requests" $sizing -}}
+    {{- $_ := set $resources "requests" (include "odigos.halfResources" $sizing | fromYaml) -}}
   {{- else }}
     {{- $_ := set $resources "limits" $defaults -}}
-    {{- $_ := set $resources "requests" $defaults -}}
+    {{- $_ := set $resources "requests" (include "odigos.halfResources" $defaults | fromYaml) -}}
   {{- end }}
 {{- end }}
 

--- a/helm/odigos/templates/_sizing-helpers.tpl
+++ b/helm/odigos/templates/_sizing-helpers.tpl
@@ -58,9 +58,9 @@
   gatewayMemoryLimit: 850
   gatewayCPURequest: 1250
   gatewayCPULimit: 1250
-  nodeMemoryRequest: 500
+  nodeMemoryRequest: 375
   nodeMemoryLimit: 750
-  nodeCPURequest: 500
+  nodeCPURequest: 375
   nodeCPULimit: 750
   {{- else if eq $s "size_xl" }}
   gatewayMinReplicas: 5
@@ -69,9 +69,9 @@
   gatewayMemoryLimit: 2000
   gatewayCPURequest: 1500
   gatewayCPULimit: 1500
-  nodeMemoryRequest: 1024
+  nodeMemoryRequest: 512
   nodeMemoryLimit: 1024
-  nodeCPURequest: 1000
+  nodeCPURequest: 500
   nodeCPULimit: 1000
   {{- else }} {{/* default size_m */}}
   gatewayMinReplicas: 2

--- a/helm/odigos/values.schema.json
+++ b/helm/odigos/values.schema.json
@@ -1592,7 +1592,7 @@
         },
         "priorityClassName": {
           "default": "system-node-critical",
-          "description": "Priority class name. Set to empty string to disable.",
+          "description": "Priority class name for the odiglet DaemonSet. Default is system-node-critical so\nodiglet is treated as a critical node pod and is not evicted under resource pressure.\nSet to empty string to disable. Using any other value may allow eviction on low-resource\nnodes; Helm prints a warning on install/upgrade in that case.",
           "required": [],
           "title": "priorityClassName"
         },

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -989,7 +989,11 @@ odiglet:
   affinity: {}
 
   # @schema
-  # description: Priority class name. Set to empty string to disable.
+  # description: |-
+  #   Priority class name for the odiglet DaemonSet. Default is system-node-critical so
+  #   odiglet is treated as a critical node pod and is not evicted under resource pressure.
+  #   Set to empty string to disable. Using any other value may allow eviction on low-resource
+  #   nodes; Helm prints a warning on install/upgrade in that case.
   # @schema
   priorityClassName: 'system-node-critical'
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Lower default CPU/memory **requests** for odiglet and the node data-collection collector to half of their limits (limits stay the same).

Odiglet is a critical node DaemonSet pod (`priorityClassName: system-node-critical`). Under node resource pressure it is not subject to normal eviction the way lower-priority pods are, so we can request fewer resources by default without worrying about odiglet being terminated, while still keeping the same limits for burst capacity.

The same half-request defaults are applied to node collector sizing presets (`size_l` / `size_xl`; `size_s` / `size_m` already had requests at half of limits) to free schedulable capacity on each node. Docs are updated to match.

Linear: https://linear.app/odigos/issue/CORE-1530/reduce-default-resource-requests-for-odiglet-and-node-collector

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
```release-note
Reduce default resource requests for odiglet and the node collector to half of their limits (limits unchanged), freeing node capacity for workloads.
```

Made with [Cursor](https://cursor.com)