### PR TITLE
DEVOPS-74: speed up odiglet builds with OBI Docker layer caching

### DIFF
--- a/odiglet/Dockerfile
+++ b/odiglet/Dockerfile
@@ -120,8 +120,32 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 ######### Odiglet builder #########
 FROM --platform=$BUILDPLATFORM ${ODIGLET_BASE_IMAGE} AS builder
 ENV GOTOOLCHAIN=auto
+
+# 1) Materialize OBI under .obi/ — only obi.mk (OBI_COMMIT / OBI_VERSION). Cache independently of Makefile / go.mod / sources.
+WORKDIR /go/src/github.com/odigos-io/odigos/odiglet
+COPY odiglet/obi.mk .
+RUN make -f obi.mk materialize-obi
+
+# 2) Generate — local replace go.mod/sum only (not full sources). Cache until module metadata changes.
 WORKDIR /go/src/github.com/odigos-io/odigos
-# Copy local modules required by the build
+COPY api/go.mod api/go.sum ./api/
+COPY common/go.mod common/go.sum ./common/
+COPY k8sutils/go.mod k8sutils/go.sum ./k8sutils/
+COPY procdiscovery/go.mod procdiscovery/go.sum ./procdiscovery/
+COPY opampserver/go.mod opampserver/go.sum ./opampserver/
+COPY instrumentation/go.mod instrumentation/go.sum ./instrumentation/
+COPY distros/go.mod distros/go.sum ./distros/
+COPY odiglet/go.mod odiglet/go.sum ./odiglet/
+COPY odiglet/pkg/ebpf/sdks/obi/go.mod odiglet/pkg/ebpf/sdks/obi/go.sum ./odiglet/pkg/ebpf/sdks/obi/
+COPY odiglet/Makefile ./odiglet/
+WORKDIR /go/src/github.com/odigos-io/odigos/odiglet
+# Same /go/pkg cache as compile so generated bpf objects are visible to the build step.
+RUN --mount=type=cache,target=/go/pkg \
+    make -f Makefile generate
+
+# 3) Compile — full sources; re-apply OBI replace (COPY overwrites go.mod) then build only.
+# No re-download: modules (+ generate artifacts) live in the shared /go/pkg cache from the generate layer.
+WORKDIR /go/src/github.com/odigos-io/odigos
 COPY api/ api/
 COPY common/ common/
 COPY k8sutils/ k8sutils/
@@ -129,15 +153,17 @@ COPY procdiscovery/ procdiscovery/
 COPY opampserver/ opampserver/
 COPY instrumentation/ instrumentation/
 COPY distros/ distros/
-WORKDIR /go/src/github.com/odigos-io/odigos/odiglet
-COPY odiglet/ .
+COPY odiglet/ odiglet/
 
 ARG TARGETARCH
 ARG LD_FLAGS
 ARG RHEL=false
+WORKDIR /go/src/github.com/odigos-io/odigos/odiglet
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH LD_FLAGS="${LD_FLAGS}" make build-odiglet
+    make go-mod-replace && \
+    CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH LD_FLAGS="${LD_FLAGS}" make compile-odiglet
+
 # File capabilities so the binary can use eBPF privileges when run as non-root.
 # Setting this caps as the permitted set (=p) so that the binary can be executed with a sub set of these capabilities
 # if the environment does not require all of them. A sub-set can be configured with helm values.
@@ -145,7 +171,6 @@ RUN setcap cap_bpf,cap_perfmon,cap_sys_admin,cap_sys_ptrace,cap_dac_read_search,
 RUN if [ "$RHEL" = "true" ] ; then \
       make licenses ; \
     fi
-
 
 # Download grpc_health_probe this is used by the deviceplugin container to check if the deviceplugin is healthy
 ARG GRPC_HEALTH_PROBE_VERSION=v0.4.55

--- a/odiglet/Makefile
+++ b/odiglet/Makefile
@@ -1,92 +1,43 @@
-.PHONY: build-odiglet generate setup-obi setup-obi-pin setup-obi-release
+.PHONY: build-odiglet generate compile-odiglet debug-build-odiglet tools go-licenses licenses
 
-# ---------------- OBI (go.opentelemetry.io/obi) ----------------
-# The go module cache tarball for OBI does NOT include the bpf2go-generated *_bpfel.go / *.o files,
-# so we materialize them locally and add a local-path go.mod replace before `go build`. Two methods
-# are supported; `setup-obi` dispatches to one via OBI_SETUP (pin|release):
-#   - setup-obi-pin:     clone a pinned commit (OBI_COMMIT) and run OBI's bpf2go codegen in the clone.
-#   - setup-obi-release: download + verify OBI's published source-generated release tarball (OBI_VERSION).
-# Keep the go.opentelemetry.io/obi version in go.mod (require) in sync with the selected method:
-# the OBI_COMMIT pseudo-version for pin, or the OBI_VERSION tag for release.
-OBI_MODULE := go.opentelemetry.io/obi
-OBI_SETUP ?= pin
-OBI_LOCAL_DIR := $(abspath $(CURDIR)/.obi)
-
-# --- pin method (clone commit + bpf2go codegen) ---
-OBI_COMMIT ?= c76a93c8775c4c66dae4af24c66b9a0f409a2e49
-OBI_GIT_URL := https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation
-OBI_CLONE_DIR := $(OBI_LOCAL_DIR)/opentelemetry-ebpf-instrumentation-$(OBI_COMMIT)
-# Relative path for the transient go.mod replace (portable in docker build / bind mounts).
-OBI_PIN_REPLACE_PATH := ./.obi/opentelemetry-ebpf-instrumentation-$(OBI_COMMIT)
-
-# --- release method (source-generated tarball) ---
-OBI_VERSION ?= v0.10.0
-OBI_EXTRACTED := $(OBI_LOCAL_DIR)/obi-$(OBI_VERSION)-source-generated
-OBI_ARCHIVE := obi-$(OBI_VERSION)-source-generated.tar.gz
-OBI_RELEASE_BASE := https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases/download
+include obi.mk
 
 # Libraries with a generate target in the module cache
 LIBRARIES := go.opentelemetry.io/auto \
 			github.com/odigos-io/runtime-detector
 
-# Dispatch to the selected OBI setup method (OBI_SETUP=pin|release).
-# Prerequisite of `generate` (so `build-odiglet` / `make generate` / `test` refresh OBI first).
-setup-obi: setup-obi-$(OBI_SETUP)
+go-mod: go-mod-replace
+	@go mod download
 
-# Pin method: clone the pinned OBI commit and run bpf2go codegen in the clone (generate/all in-tree
-# when docker is unavailable - e.g. inside a docker build; docker-generate on the host), then add a
-# transient local-path go.mod replace so go build can resolve the generated bpf objects.
-setup-obi-pin:
-	@mkdir -p $(OBI_LOCAL_DIR)
-	@if [ ! -d "$(OBI_CLONE_DIR)/.git" ]; then \
-		git init -q "$(OBI_CLONE_DIR)"; \
-		git -C "$(OBI_CLONE_DIR)" remote add origin "$(OBI_GIT_URL)"; \
-	fi
-	@git -C "$(OBI_CLONE_DIR)" fetch --depth 1 origin "$(OBI_COMMIT)"
-	@git -C "$(OBI_CLONE_DIR)" checkout -q --detach FETCH_HEAD
-	@if [ -f /.dockerenv ] || ! command -v docker >/dev/null 2>&1; then \
-		echo "==> Generating OBI bpf2go artifacts in-tree (no docker)"; \
-		$(MAKE) -C "$(OBI_CLONE_DIR)" generate/all; \
-	else \
-		echo "==> Generating OBI bpf2go artifacts via docker-generate"; \
-		$(MAKE) -C "$(OBI_CLONE_DIR)" docker-generate; \
-	fi
-	@go mod edit -replace "$(OBI_MODULE)=$(OBI_PIN_REPLACE_PATH)"
-	@go mod tidy
+# go-mod + each $(LIBRARIES) upstream `make generate` in parallel. Does not clone/materialize OBI.
+generate: go-mod
+	@pids=""; \
+	for lib in $(LIBRARIES); do \
+		( \
+			LIB_PATH=$$(go list -m -f '{{.Dir}}' $${lib%@*}) && \
+			chmod -R +w $$LIB_PATH && \
+			$(MAKE) -C "$$LIB_PATH" generate \
+		) & \
+		pids="$$pids $$!"; \
+	done; \
+	fail=0; \
+	for pid in $$pids; do \
+		wait $$pid || fail=1; \
+	done; \
+	exit $$fail
 
-# Release method: download and verify OBI's source-generated release tarball, extract under .obi/,
-# then add a local-path go.mod replace.
-setup-obi-release:
-	@mkdir -p $(OBI_LOCAL_DIR)/dl
-	@set -e; \
-		download_dir="$(OBI_LOCAL_DIR)/dl"; \
-		versioned_release_url="$(OBI_RELEASE_BASE)/$(OBI_VERSION)"; \
-		tarball_name="$(OBI_ARCHIVE)"; \
-		cd "$$download_dir"; \
-		curl -fsSL "$$versioned_release_url/SHA256SUMS" -o SHA256SUMS; \
-		curl -fsSL "$$versioned_release_url/$$tarball_name" -o "$$tarball_name"; \
-		expected_sha256=$$(grep -F "$$tarball_name" SHA256SUMS | awk '{print $$1}'); \
-		computed_sha256=$$(openssl dgst -sha256 "$$tarball_name" | awk '{print $$NF}'); \
-		test "$$expected_sha256" = "$$computed_sha256" || (echo "OBI archive checksum mismatch" && exit 1); \
-		rm -rf "$(OBI_EXTRACTED)"; \
-		tar -xzf "$$tarball_name" -C $(OBI_LOCAL_DIR)
-	@go mod edit -replace "$(OBI_MODULE)=$(OBI_EXTRACTED)"
-	@go mod tidy
-
-# OBI: `setup-obi` (dispatches to setup-obi-pin or setup-obi-release via OBI_SETUP).
-# Then `go mod download` and each $(LIBRARIES) upstream `make generate`.
-generate: setup-obi
-	go mod download
-	@for lib in $(LIBRARIES); do \
-		LIB_PATH=$$(go list -m -f '{{.Dir}}' $${lib%@*}) && \
-		chmod -R +w $$LIB_PATH && \
-		make -C "$$LIB_PATH" generate; \
-	done
-
-build-odiglet: generate
+# Compile only — no materialize / generate / go-mod. For Docker after those layers have run.
+compile-odiglet:
 	CGO_ENABLED=0 go build -ldflags="$(LD_FLAGS)" -o odiglet cmd/main.go
 
-debug-build-odiglet: generate
+build-odiglet:
+	$(MAKE) materialize-obi
+	$(MAKE) generate
+	$(MAKE) compile-odiglet
+
+debug-build-odiglet:
+	$(MAKE) materialize-obi
+	$(MAKE) generate
 	go build -o odiglet -gcflags "all=-N -l" cmd/main.go
 
 test: generate

--- a/odiglet/Makefile
+++ b/odiglet/Makefile
@@ -40,7 +40,7 @@ debug-build-odiglet:
 	$(MAKE) generate
 	go build -o odiglet -gcflags "all=-N -l" cmd/main.go
 
-test: generate
+test: materialize-obi generate
 	go test -a -v ./...
 
 TOOLS := $(PWD)/.tools

--- a/odiglet/obi.mk
+++ b/odiglet/obi.mk
@@ -1,0 +1,84 @@
+# OBI (go.opentelemetry.io/obi) materialization and go.mod replace.
+# Kept out of the main Makefile so Docker can COPY only this file for the
+# materialize layer (independent of build/generate target changes).
+# Use via `make -f obi.mk <target>` or through the main Makefile (`include`).
+#
+# The go module cache tarball for OBI does NOT include the bpf2go-generated
+# *_bpfel.go / *.o files, so we materialize them locally and add a local-path
+# go.mod replace before `go build`. Two methods are supported; targets
+# dispatch via OBI_SETUP (pin|release):
+#   - materialize-obi: fetch OBI under .obi/ (+ bpf2go for pin). No go.mod.
+#   - go-mod-replace:  go mod edit -replace only (no download).
+# Keep the go.opentelemetry.io/obi version in go.mod (require) in sync with the
+# selected method: the OBI_COMMIT pseudo-version for pin, or the OBI_VERSION
+# tag for release. Pinned to the same OBI commit as OSS odigos.
+
+.PHONY: materialize-obi materialize-obi-pin materialize-obi-release go-mod-replace
+
+OBI_MODULE := go.opentelemetry.io/obi
+OBI_SETUP ?= pin
+OBI_LOCAL_DIR := $(abspath $(CURDIR)/.obi)
+
+# --- pin method (clone commit + bpf2go codegen) ---
+OBI_COMMIT ?= c76a93c8775c4c66dae4af24c66b9a0f409a2e49
+OBI_GIT_URL := https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation
+OBI_CLONE_DIR := $(OBI_LOCAL_DIR)/opentelemetry-ebpf-instrumentation-$(OBI_COMMIT)
+# Relative path for the transient go.mod replace (portable in docker build / bind mounts).
+OBI_PIN_REPLACE_PATH := ./.obi/opentelemetry-ebpf-instrumentation-$(OBI_COMMIT)
+
+# --- release method (source-generated tarball) ---
+OBI_VERSION ?= v0.10.0
+OBI_EXTRACTED := $(OBI_LOCAL_DIR)/obi-$(OBI_VERSION)-source-generated
+OBI_ARCHIVE := obi-$(OBI_VERSION)-source-generated.tar.gz
+OBI_RELEASE_BASE := https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases/download
+OBI_RELEASE_REPLACE_PATH := ./.obi/obi-$(OBI_VERSION)-source-generated
+
+# Local-path replace used by go-mod (relative so Docker bind mounts / workdirs resolve).
+ifeq ($(OBI_SETUP),release)
+OBI_REPLACE_PATH := $(OBI_RELEASE_REPLACE_PATH)
+else
+OBI_REPLACE_PATH := $(OBI_PIN_REPLACE_PATH)
+endif
+
+# Materialize OBI under .obi/ with bpf objects ready (no go.mod). Dispatches via OBI_SETUP.
+# Intended for Docker layer caching: depends only on OBI_COMMIT / OBI_VERSION, not go.mod.
+materialize-obi: materialize-obi-$(OBI_SETUP)
+
+# Clone the pinned OBI commit and run bpf2go codegen (generate/all in-tree when docker is unavailable -
+# e.g. inside a docker build; docker-generate on the host). Does not touch go.mod.
+materialize-obi-pin:
+	@mkdir -p $(OBI_LOCAL_DIR)
+	@if [ ! -d "$(OBI_CLONE_DIR)/.git" ]; then \
+		git init -q "$(OBI_CLONE_DIR)"; \
+		git -C "$(OBI_CLONE_DIR)" remote add origin "$(OBI_GIT_URL)"; \
+	fi
+	@git -C "$(OBI_CLONE_DIR)" fetch --depth 1 origin "$(OBI_COMMIT)"
+	@git -C "$(OBI_CLONE_DIR)" checkout -q --detach FETCH_HEAD
+	@if [ -f /.dockerenv ] || ! command -v docker >/dev/null 2>&1; then \
+		echo "==> Generating OBI bpf2go artifacts in-tree (no docker)"; \
+		$(MAKE) -C "$(OBI_CLONE_DIR)" generate/all; \
+	else \
+		echo "==> Generating OBI bpf2go artifacts via docker-generate"; \
+		$(MAKE) -C "$(OBI_CLONE_DIR)" docker-generate; \
+	fi
+
+# Download and verify OBI's source-generated release tarball, extract under .obi/. Does not touch go.mod.
+materialize-obi-release:
+	@mkdir -p $(OBI_LOCAL_DIR)/dl
+	@set -e; \
+		download_dir="$(OBI_LOCAL_DIR)/dl"; \
+		versioned_release_url="$(OBI_RELEASE_BASE)/$(OBI_VERSION)"; \
+		tarball_name="$(OBI_ARCHIVE)"; \
+		cd "$$download_dir"; \
+		curl -fsSL "$$versioned_release_url/SHA256SUMS" -o SHA256SUMS; \
+		curl -fsSL "$$versioned_release_url/$$tarball_name" -o "$$tarball_name"; \
+		expected_sha256=$$(grep -F "$$tarball_name" SHA256SUMS | awk '{print $$1}'); \
+		computed_sha256=$$(openssl dgst -sha256 "$$tarball_name" | awk '{print $$NF}'); \
+		test "$$expected_sha256" = "$$computed_sha256" || (echo "OBI archive checksum mismatch" && exit 1); \
+		rm -rf "$(OBI_EXTRACTED)"; \
+		tar -xzf "$$tarball_name" -C $(OBI_LOCAL_DIR)
+
+# Wire materialized OBI into go.mod (replace only — no download).
+# Useful after COPY overwrites go.mod in Docker; modules are already in the cache.
+go-mod-replace:
+	@go mod edit -replace "$(OBI_MODULE)=$(OBI_REPLACE_PATH)"


### PR DESCRIPTION
## Summary
- Extract OBI materialization into `odiglet/obi.mk` so Docker can COPY a tiny file and cache OBI pin/codegen independently of Makefile / go.mod / sources ([DEVOPS-74](https://linear.app/odigos/issue/DEVOPS-74/speed-up-odiglet-docker-builds-via-obi-layer-caching))
- Split Makefile into `materialize-obi` → `generate` → `compile-odiglet`, and restructure the Dockerfile builder into matching layers (OBI → mod+generate → compile with `go-mod-replace`)
- Parallelize upstream library `make generate` during the generate step

#### What this PR does / why we need it:
odiglet image builds re-ran expensive OBI materialization (clone + bpf2go) and module generate whenever unrelated odiglet sources or the Makefile changed. Isolating OBI into `obi.mk` and splitting Docker layers lets rebuilds that only touch odiglet code skip those cached steps.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
```release-note
NONE
```
