### PR TITLE
fix: clean up unused findings lookback from Insights system settings GraphQL

### DIFF
--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -751,6 +751,10 @@ type ComplexityRoot struct {
 		Root  func(childComplexity int) int
 	}
 
+	InsightsBulkDeleteResult struct {
+		Deleted func(childComplexity int) int
+	}
+
 	InsightsBulkPromoteResult struct {
 		Promoted func(childComplexity int) int
 	}
@@ -1558,6 +1562,7 @@ type ComplexityRoot struct {
 	Mutation struct {
 		AllowInsightsGuardrailViolation     func(childComplexity int, action model.InsightsViolationActionInput) int
 		ApplyRecommendationRemediation      func(childComplexity int, recommendationType model.RecommendationType, remediationType string) int
+		BulkDeleteInsightsTransactions      func(childComplexity int, transactionIds []string) int
 		BulkPromoteInsightsTransactions     func(childComplexity int, transactionIds []string) int
 		BulkResolveInsightsAnomalies        func(childComplexity int, resolution model.InsightsBulkResolution, items []*model.InsightsAnomalyRefInput) int
 		ClearSourceProfilingBuffer          func(childComplexity int, namespace string, kind string, name string) int
@@ -2211,6 +2216,7 @@ type MutationResolver interface {
 	EnableInsightsTransactionGuardrail(ctx context.Context, namespace string, service string) (bool, error)
 	DisableInsightsTransactionGuardrail(ctx context.Context, namespace string, service string) (bool, error)
 	DeleteInsightsTransaction(ctx context.Context, transactionID string) (bool, error)
+	BulkDeleteInsightsTransactions(ctx context.Context, transactionIds []string) (*model.InsightsBulkDeleteResult, error)
 	UpsertInsightsPolicy(ctx context.Context, policy model.InsightsPolicyInput) (*model.InsightsPolicy, error)
 	DeleteInsightsPolicy(ctx context.Context, scope model.InsightsPolicyScope, scopeKey string) (bool, error)
 	UpsertInsightsLearningPolicy(ctx context.Context, policy model.InsightsLearningPolicyInput) (*model.InsightsLearningPolicy, error)
@@ -5656,6 +5662,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.InsightsBlastRadiusSubgraph.Root(childComplexity), true
+
+	case "InsightsBulkDeleteResult.deleted":
+		if e.complexity.InsightsBulkDeleteResult.Deleted == nil {
+			break
+		}
+
+		return e.complexity.InsightsBulkDeleteResult.Deleted(childComplexity), true
 
 	case "InsightsBulkPromoteResult.promoted":
 		if e.complexity.InsightsBulkPromoteResult.Promoted == nil {
@@ -9145,6 +9158,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.ApplyRecommendationRemediation(childComplexity, args["recommendationType"].(model.RecommendationType), args["remediationType"].(string)), true
+
+	case "Mutation.bulkDeleteInsightsTransactions":
+		if e.complexity.Mutation.BulkDeleteInsightsTransactions == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_bulkDeleteInsightsTransactions_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.BulkDeleteInsightsTransactions(childComplexity, args["transactionIds"].([]string)), true
 
 	case "Mutation.bulkPromoteInsightsTransactions":
 		if e.complexity.Mutation.BulkPromoteInsightsTransactions == nil {
@@ -13051,6 +13076,34 @@ func (ec *executionContext) field_Mutation_applyRecommendationRemediation_argsRe
 	}
 
 	var zeroVal string
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_bulkDeleteInsightsTransactions_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_bulkDeleteInsightsTransactions_argsTransactionIds(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["transactionIds"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_bulkDeleteInsightsTransactions_argsTransactionIds(
+	ctx context.Context,
+	rawArgs map[string]any,
+) ([]string, error) {
+	if _, ok := rawArgs["transactionIds"]; !ok {
+		var zeroVal []string
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("transactionIds"))
+	if tmp, ok := rawArgs["transactionIds"]; ok {
+		return ec.unmarshalNID2ᚕstringᚄ(ctx, tmp)
+	}
+
+	var zeroVal []string
 	return zeroVal, nil
 }
 
@@ -37808,6 +37861,50 @@ func (ec *executionContext) fieldContext_InsightsBlastRadiusSubgraph_edges(_ con
 	return fc, nil
 }
 
+func (ec *executionContext) _InsightsBulkDeleteResult_deleted(ctx context.Context, field graphql.CollectedField, obj *model.InsightsBulkDeleteResult) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsBulkDeleteResult_deleted(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Deleted, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsBulkDeleteResult_deleted(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsBulkDeleteResult",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _InsightsBulkPromoteResult_promoted(ctx context.Context, field graphql.CollectedField, obj *model.InsightsBulkPromoteResult) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_InsightsBulkPromoteResult_promoted(ctx, field)
 	if err != nil {
@@ -61751,6 +61848,65 @@ func (ec *executionContext) fieldContext_Mutation_deleteInsightsTransaction(ctx 
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_deleteInsightsTransaction_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_bulkDeleteInsightsTransactions(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_bulkDeleteInsightsTransactions(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().BulkDeleteInsightsTransactions(rctx, fc.Args["transactionIds"].([]string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.InsightsBulkDeleteResult)
+	fc.Result = res
+	return ec.marshalNInsightsBulkDeleteResult2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsBulkDeleteResult(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_bulkDeleteInsightsTransactions(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "deleted":
+				return ec.fieldContext_InsightsBulkDeleteResult_deleted(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type InsightsBulkDeleteResult", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_bulkDeleteInsightsTransactions_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -88901,6 +89057,45 @@ func (ec *executionContext) _InsightsBlastRadiusSubgraph(ctx context.Context, se
 	return out
 }
 
+var insightsBulkDeleteResultImplementors = []string{"InsightsBulkDeleteResult"}
+
+func (ec *executionContext) _InsightsBulkDeleteResult(ctx context.Context, sel ast.SelectionSet, obj *model.InsightsBulkDeleteResult) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, insightsBulkDeleteResultImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("InsightsBulkDeleteResult")
+		case "deleted":
+			out.Values[i] = ec._InsightsBulkDeleteResult_deleted(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var insightsBulkPromoteResultImplementors = []string{"InsightsBulkPromoteResult"}
 
 func (ec *executionContext) _InsightsBulkPromoteResult(ctx context.Context, sel ast.SelectionSet, obj *model.InsightsBulkPromoteResult) graphql.Marshaler {
@@ -95280,6 +95475,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "deleteInsightsTransaction":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_deleteInsightsTransaction(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "bulkDeleteInsightsTransactions":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_bulkDeleteInsightsTransactions(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -102145,6 +102347,20 @@ func (ec *executionContext) marshalNInsightsBlastRadiusSubgraph2ᚖgithubᚗcom�
 		return graphql.Null
 	}
 	return ec._InsightsBlastRadiusSubgraph(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNInsightsBulkDeleteResult2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsBulkDeleteResult(ctx context.Context, sel ast.SelectionSet, v model.InsightsBulkDeleteResult) graphql.Marshaler {
+	return ec._InsightsBulkDeleteResult(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNInsightsBulkDeleteResult2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsBulkDeleteResult(ctx context.Context, sel ast.SelectionSet, v *model.InsightsBulkDeleteResult) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._InsightsBulkDeleteResult(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNInsightsBulkPromoteResult2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsBulkPromoteResult(ctx context.Context, sel ast.SelectionSet, v model.InsightsBulkPromoteResult) graphql.Marshaler {

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -1048,11 +1048,6 @@ type ComplexityRoot struct {
 		AutoTransactionGuardrail func(childComplexity int) int
 	}
 
-	InsightsSystemFindingsSettings struct {
-		DefaultWindowHours func(childComplexity int) int
-		MaxWindowHours     func(childComplexity int) int
-	}
-
 	InsightsSystemRetentionSettings struct {
 		ObservationRetentionDays func(childComplexity int) int
 	}
@@ -1065,7 +1060,6 @@ type ComplexityRoot struct {
 	InsightsSystemSettings struct {
 		Capacity  func(childComplexity int) int
 		Detection func(childComplexity int) int
-		Findings  func(childComplexity int) int
 		Retention func(childComplexity int) int
 		Sampling  func(childComplexity int) int
 		Writeback func(childComplexity int) int
@@ -7014,20 +7008,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.InsightsSystemDetectionSettings.AutoTransactionGuardrail(childComplexity), true
 
-	case "InsightsSystemFindingsSettings.defaultWindowHours":
-		if e.complexity.InsightsSystemFindingsSettings.DefaultWindowHours == nil {
-			break
-		}
-
-		return e.complexity.InsightsSystemFindingsSettings.DefaultWindowHours(childComplexity), true
-
-	case "InsightsSystemFindingsSettings.maxWindowHours":
-		if e.complexity.InsightsSystemFindingsSettings.MaxWindowHours == nil {
-			break
-		}
-
-		return e.complexity.InsightsSystemFindingsSettings.MaxWindowHours(childComplexity), true
-
 	case "InsightsSystemRetentionSettings.observationRetentionDays":
 		if e.complexity.InsightsSystemRetentionSettings.ObservationRetentionDays == nil {
 			break
@@ -7062,13 +7042,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.InsightsSystemSettings.Detection(childComplexity), true
-
-	case "InsightsSystemSettings.findings":
-		if e.complexity.InsightsSystemSettings.Findings == nil {
-			break
-		}
-
-		return e.complexity.InsightsSystemSettings.Findings(childComplexity), true
 
 	case "InsightsSystemSettings.retention":
 		if e.complexity.InsightsSystemSettings.Retention == nil {
@@ -11896,7 +11869,6 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputInsightsPolicyInput,
 		ec.unmarshalInputInsightsSystemCapacitySettingsInput,
 		ec.unmarshalInputInsightsSystemDetectionSettingsInput,
-		ec.unmarshalInputInsightsSystemFindingsSettingsInput,
 		ec.unmarshalInputInsightsSystemRetentionSettingsInput,
 		ec.unmarshalInputInsightsSystemSamplingSettingsInput,
 		ec.unmarshalInputInsightsSystemSettingsInput,
@@ -33592,8 +33564,6 @@ func (ec *executionContext) fieldContext_Insights_systemSettings(_ context.Conte
 				return ec.fieldContext_InsightsSystemSettings_sampling(ctx, field)
 			case "retention":
 				return ec.fieldContext_InsightsSystemSettings_retention(ctx, field)
-			case "findings":
-				return ec.fieldContext_InsightsSystemSettings_findings(ctx, field)
 			case "capacity":
 				return ec.fieldContext_InsightsSystemSettings_capacity(ctx, field)
 			case "writeback":
@@ -46425,94 +46395,6 @@ func (ec *executionContext) fieldContext_InsightsSystemDetectionSettings_autoTra
 	return fc, nil
 }
 
-func (ec *executionContext) _InsightsSystemFindingsSettings_defaultWindowHours(ctx context.Context, field graphql.CollectedField, obj *model.InsightsSystemFindingsSettings) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_InsightsSystemFindingsSettings_defaultWindowHours(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.DefaultWindowHours, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(int)
-	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_InsightsSystemFindingsSettings_defaultWindowHours(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "InsightsSystemFindingsSettings",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _InsightsSystemFindingsSettings_maxWindowHours(ctx context.Context, field graphql.CollectedField, obj *model.InsightsSystemFindingsSettings) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_InsightsSystemFindingsSettings_maxWindowHours(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.MaxWindowHours, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(int)
-	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_InsightsSystemFindingsSettings_maxWindowHours(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "InsightsSystemFindingsSettings",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _InsightsSystemRetentionSettings_observationRetentionDays(ctx context.Context, field graphql.CollectedField, obj *model.InsightsSystemRetentionSettings) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_InsightsSystemRetentionSettings_observationRetentionDays(ctx, field)
 	if err != nil {
@@ -46738,56 +46620,6 @@ func (ec *executionContext) fieldContext_InsightsSystemSettings_retention(_ cont
 				return ec.fieldContext_InsightsSystemRetentionSettings_observationRetentionDays(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type InsightsSystemRetentionSettings", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _InsightsSystemSettings_findings(ctx context.Context, field graphql.CollectedField, obj *model.InsightsSystemSettings) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_InsightsSystemSettings_findings(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Findings, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*model.InsightsSystemFindingsSettings)
-	fc.Result = res
-	return ec.marshalNInsightsSystemFindingsSettings2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemFindingsSettings(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_InsightsSystemSettings_findings(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "InsightsSystemSettings",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "defaultWindowHours":
-				return ec.fieldContext_InsightsSystemFindingsSettings_defaultWindowHours(ctx, field)
-			case "maxWindowHours":
-				return ec.fieldContext_InsightsSystemFindingsSettings_maxWindowHours(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type InsightsSystemFindingsSettings", field.Name)
 		},
 	}
 	return fc, nil
@@ -62253,8 +62085,6 @@ func (ec *executionContext) fieldContext_Mutation_updateInsightsSystemSettings(c
 				return ec.fieldContext_InsightsSystemSettings_sampling(ctx, field)
 			case "retention":
 				return ec.fieldContext_InsightsSystemSettings_retention(ctx, field)
-			case "findings":
-				return ec.fieldContext_InsightsSystemSettings_findings(ctx, field)
 			case "capacity":
 				return ec.fieldContext_InsightsSystemSettings_capacity(ctx, field)
 			case "writeback":
@@ -81280,40 +81110,6 @@ func (ec *executionContext) unmarshalInputInsightsSystemDetectionSettingsInput(c
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputInsightsSystemFindingsSettingsInput(ctx context.Context, obj any) (model.InsightsSystemFindingsSettingsInput, error) {
-	var it model.InsightsSystemFindingsSettingsInput
-	asMap := map[string]any{}
-	for k, v := range obj.(map[string]any) {
-		asMap[k] = v
-	}
-
-	fieldsInOrder := [...]string{"defaultWindowHours", "maxWindowHours"}
-	for _, k := range fieldsInOrder {
-		v, ok := asMap[k]
-		if !ok {
-			continue
-		}
-		switch k {
-		case "defaultWindowHours":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("defaultWindowHours"))
-			data, err := ec.unmarshalNInt2int(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.DefaultWindowHours = data
-		case "maxWindowHours":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("maxWindowHours"))
-			data, err := ec.unmarshalNInt2int(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.MaxWindowHours = data
-		}
-	}
-
-	return it, nil
-}
-
 func (ec *executionContext) unmarshalInputInsightsSystemRetentionSettingsInput(ctx context.Context, obj any) (model.InsightsSystemRetentionSettingsInput, error) {
 	var it model.InsightsSystemRetentionSettingsInput
 	asMap := map[string]any{}
@@ -81382,7 +81178,7 @@ func (ec *executionContext) unmarshalInputInsightsSystemSettingsInput(ctx contex
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"sampling", "retention", "findings", "capacity", "writeback", "detection"}
+	fieldsInOrder := [...]string{"sampling", "retention", "capacity", "writeback", "detection"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -81403,13 +81199,6 @@ func (ec *executionContext) unmarshalInputInsightsSystemSettingsInput(ctx contex
 				return it, err
 			}
 			it.Retention = data
-		case "findings":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("findings"))
-			data, err := ec.unmarshalNInsightsSystemFindingsSettingsInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemFindingsSettingsInput(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Findings = data
 		case "capacity":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("capacity"))
 			data, err := ec.unmarshalNInsightsSystemCapacitySettingsInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemCapacitySettingsInput(ctx, v)
@@ -90659,50 +90448,6 @@ func (ec *executionContext) _InsightsSystemDetectionSettings(ctx context.Context
 	return out
 }
 
-var insightsSystemFindingsSettingsImplementors = []string{"InsightsSystemFindingsSettings"}
-
-func (ec *executionContext) _InsightsSystemFindingsSettings(ctx context.Context, sel ast.SelectionSet, obj *model.InsightsSystemFindingsSettings) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, insightsSystemFindingsSettingsImplementors)
-
-	out := graphql.NewFieldSet(fields)
-	deferred := make(map[string]*graphql.FieldSet)
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("InsightsSystemFindingsSettings")
-		case "defaultWindowHours":
-			out.Values[i] = ec._InsightsSystemFindingsSettings_defaultWindowHours(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "maxWindowHours":
-			out.Values[i] = ec._InsightsSystemFindingsSettings_maxWindowHours(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch(ctx)
-	if out.Invalids > 0 {
-		return graphql.Null
-	}
-
-	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
-
-	for label, dfs := range deferred {
-		ec.processDeferredGroup(graphql.DeferredGroup{
-			Label:    label,
-			Path:     graphql.GetPath(ctx),
-			FieldSet: dfs,
-			Context:  ctx,
-		})
-	}
-
-	return out
-}
-
 var insightsSystemRetentionSettingsImplementors = []string{"InsightsSystemRetentionSettings"}
 
 func (ec *executionContext) _InsightsSystemRetentionSettings(ctx context.Context, sel ast.SelectionSet, obj *model.InsightsSystemRetentionSettings) graphql.Marshaler {
@@ -90804,11 +90549,6 @@ func (ec *executionContext) _InsightsSystemSettings(ctx context.Context, sel ast
 			}
 		case "retention":
 			out.Values[i] = ec._InsightsSystemSettings_retention(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "findings":
-			out.Values[i] = ec._InsightsSystemSettings_findings(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -103068,21 +102808,6 @@ func (ec *executionContext) marshalNInsightsSystemDetectionSettings2ᚖgithubᚗ
 
 func (ec *executionContext) unmarshalNInsightsSystemDetectionSettingsInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemDetectionSettingsInput(ctx context.Context, v any) (*model.InsightsSystemDetectionSettingsInput, error) {
 	res, err := ec.unmarshalInputInsightsSystemDetectionSettingsInput(ctx, v)
-	return &res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalNInsightsSystemFindingsSettings2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemFindingsSettings(ctx context.Context, sel ast.SelectionSet, v *model.InsightsSystemFindingsSettings) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-		return graphql.Null
-	}
-	return ec._InsightsSystemFindingsSettings(ctx, sel, v)
-}
-
-func (ec *executionContext) unmarshalNInsightsSystemFindingsSettingsInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemFindingsSettingsInput(ctx context.Context, v any) (*model.InsightsSystemFindingsSettingsInput, error) {
-	res, err := ec.unmarshalInputInsightsSystemFindingsSettingsInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -640,27 +640,29 @@ type ComplexityRoot struct {
 	}
 
 	InsightsAnomalyIssue struct {
-		AnomalyTrace     func(childComplexity int) int
-		BaselineTrace    func(childComplexity int) int
-		ClassFindings    func(childComplexity int) int
-		Evidence         func(childComplexity int) int
-		FirstSeen        func(childComplexity int) int
-		Kind             func(childComplexity int) int
-		LastSeen         func(childComplexity int) int
-		LastTraceID      func(childComplexity int) int
-		MaxScore         func(childComplexity int) int
-		Namespace        func(childComplexity int) int
-		Occurrences      func(childComplexity int) int
-		Offending        func(childComplexity int) int
-		Operation        func(childComplexity int) int
-		PolicyID         func(childComplexity int) int
-		Risk             func(childComplexity int) int
-		Service          func(childComplexity int) int
-		Severity         func(childComplexity int) int
-		Signature        func(childComplexity int) int
-		Status           func(childComplexity int) int
-		TransactionID    func(childComplexity int) int
-		TriggeredClasses func(childComplexity int) int
+		AnomalyTrace       func(childComplexity int) int
+		BaselineTrace      func(childComplexity int) int
+		ClassFindings      func(childComplexity int) int
+		Evidence           func(childComplexity int) int
+		FirstSeen          func(childComplexity int) int
+		IdentityDimensions func(childComplexity int) int
+		Kind               func(childComplexity int) int
+		LastSeen           func(childComplexity int) int
+		LastTraceID        func(childComplexity int) int
+		MaxScore           func(childComplexity int) int
+		Namespace          func(childComplexity int) int
+		Occurrences        func(childComplexity int) int
+		Offending          func(childComplexity int) int
+		Operation          func(childComplexity int) int
+		OperationName      func(childComplexity int) int
+		PolicyID           func(childComplexity int) int
+		Risk               func(childComplexity int) int
+		Service            func(childComplexity int) int
+		Severity           func(childComplexity int) int
+		Signature          func(childComplexity int) int
+		Status             func(childComplexity int) int
+		TransactionID      func(childComplexity int) int
+		TriggeredClasses   func(childComplexity int) int
 	}
 
 	InsightsAnomalyMetricComparison struct {
@@ -676,26 +678,30 @@ type ComplexityRoot struct {
 	}
 
 	InsightsAnomalySummary struct {
-		FirstSeen        func(childComplexity int) int
-		Kind             func(childComplexity int) int
-		LastSeen         func(childComplexity int) int
-		LastTraceID      func(childComplexity int) int
-		MaxScore         func(childComplexity int) int
-		Namespace        func(childComplexity int) int
-		Occurrences      func(childComplexity int) int
-		Offending        func(childComplexity int) int
-		Operation        func(childComplexity int) int
-		PolicyID         func(childComplexity int) int
-		Service          func(childComplexity int) int
-		Severity         func(childComplexity int) int
-		Signature        func(childComplexity int) int
-		Status           func(childComplexity int) int
-		TransactionID    func(childComplexity int) int
-		TriggeredClasses func(childComplexity int) int
+		FirstSeen          func(childComplexity int) int
+		IdentityDimensions func(childComplexity int) int
+		Kind               func(childComplexity int) int
+		LastSeen           func(childComplexity int) int
+		LastTraceID        func(childComplexity int) int
+		MaxScore           func(childComplexity int) int
+		Namespace          func(childComplexity int) int
+		Occurrences        func(childComplexity int) int
+		Offending          func(childComplexity int) int
+		Operation          func(childComplexity int) int
+		OperationName      func(childComplexity int) int
+		PolicyID           func(childComplexity int) int
+		Service            func(childComplexity int) int
+		Severity           func(childComplexity int) int
+		Signature          func(childComplexity int) int
+		Status             func(childComplexity int) int
+		TransactionID      func(childComplexity int) int
+		TriggeredClasses   func(childComplexity int) int
 	}
 
 	InsightsBaselineClass struct {
 		Class                        func(childComplexity int) int
+		ClassDescription             func(childComplexity int) int
+		ClassLabel                   func(childComplexity int) int
 		Data                         func(childComplexity int) int
 		DataSchemaVersion            func(childComplexity int) int
 		LastChangedAt                func(childComplexity int) int
@@ -783,14 +789,16 @@ type ComplexityRoot struct {
 	}
 
 	InsightsCatalogClass struct {
-		Category      func(childComplexity int) int
-		CategoryLabel func(childComplexity int) int
-		Description   func(childComplexity int) int
-		ID            func(childComplexity int) int
-		Label         func(childComplexity int) int
-		Mitre         func(childComplexity int) int
-		Owasp         func(childComplexity int) int
-		Weight        func(childComplexity int) int
+		BaselineDescription func(childComplexity int) int
+		BaselineLabel       func(childComplexity int) int
+		Category            func(childComplexity int) int
+		CategoryLabel       func(childComplexity int) int
+		Description         func(childComplexity int) int
+		ID                  func(childComplexity int) int
+		Label               func(childComplexity int) int
+		Mitre               func(childComplexity int) int
+		Owasp               func(childComplexity int) int
+		Weight              func(childComplexity int) int
 	}
 
 	InsightsCatalogEnricher struct {
@@ -820,21 +828,24 @@ type ComplexityRoot struct {
 	}
 
 	InsightsFinding struct {
-		Kind             func(childComplexity int) int
-		LastSeen         func(childComplexity int) int
-		Namespace        func(childComplexity int) int
-		Occurrences      func(childComplexity int) int
-		Offending        func(childComplexity int) int
-		RuleKey          func(childComplexity int) int
-		ScopeKey         func(childComplexity int) int
-		Score            func(childComplexity int) int
-		Service          func(childComplexity int) int
-		Severity         func(childComplexity int) int
-		Signature        func(childComplexity int) int
-		Status           func(childComplexity int) int
-		Title            func(childComplexity int) int
-		TransactionID    func(childComplexity int) int
-		TriggeredClasses func(childComplexity int) int
+		IdentityDimensions func(childComplexity int) int
+		Kind               func(childComplexity int) int
+		LastSeen           func(childComplexity int) int
+		Namespace          func(childComplexity int) int
+		Occurrences        func(childComplexity int) int
+		Offending          func(childComplexity int) int
+		Operation          func(childComplexity int) int
+		OperationName      func(childComplexity int) int
+		RuleKey            func(childComplexity int) int
+		ScopeKey           func(childComplexity int) int
+		Score              func(childComplexity int) int
+		Service            func(childComplexity int) int
+		Severity           func(childComplexity int) int
+		Signature          func(childComplexity int) int
+		Status             func(childComplexity int) int
+		Title              func(childComplexity int) int
+		TransactionID      func(childComplexity int) int
+		TriggeredClasses   func(childComplexity int) int
 	}
 
 	InsightsGuardrail struct {
@@ -1061,6 +1072,10 @@ type ComplexityRoot struct {
 		MaxWindowHours     func(childComplexity int) int
 	}
 
+	InsightsSystemIdentitySettings struct {
+		TransactionIdentityDimensions func(childComplexity int) int
+	}
+
 	InsightsSystemRetentionSettings struct {
 		ObservationRetentionDays func(childComplexity int) int
 	}
@@ -1074,9 +1089,15 @@ type ComplexityRoot struct {
 		Capacity  func(childComplexity int) int
 		Detection func(childComplexity int) int
 		Findings  func(childComplexity int) int
+		Identity  func(childComplexity int) int
 		Retention func(childComplexity int) int
 		Sampling  func(childComplexity int) int
 		Writeback func(childComplexity int) int
+	}
+
+	InsightsSystemTransactionIdentityDimension struct {
+		Enabled func(childComplexity int) int
+		Key     func(childComplexity int) int
 	}
 
 	InsightsSystemWritebackSettings struct {
@@ -1084,23 +1105,32 @@ type ComplexityRoot struct {
 	}
 
 	InsightsTransaction struct {
-		ID        func(childComplexity int) int
-		Kind      func(childComplexity int) int
-		Namespace func(childComplexity int) int
-		Operation func(childComplexity int) int
-		Service   func(childComplexity int) int
+		ID                 func(childComplexity int) int
+		IdentityDimensions func(childComplexity int) int
+		Kind               func(childComplexity int) int
+		Namespace          func(childComplexity int) int
+		Operation          func(childComplexity int) int
+		OperationName      func(childComplexity int) int
+		Service            func(childComplexity int) int
+	}
+
+	InsightsTransactionIdentityValue struct {
+		Key   func(childComplexity int) int
+		Value func(childComplexity int) int
 	}
 
 	InsightsTransactionStat struct {
-		HasBaseline func(childComplexity int) int
-		ID          func(childComplexity int) int
-		Kind        func(childComplexity int) int
-		LastSeen    func(childComplexity int) int
-		Namespace   func(childComplexity int) int
-		Operation   func(childComplexity int) int
-		Promoted    func(childComplexity int) int
-		Service     func(childComplexity int) int
-		Volume      func(childComplexity int) int
+		HasBaseline        func(childComplexity int) int
+		ID                 func(childComplexity int) int
+		IdentityDimensions func(childComplexity int) int
+		Kind               func(childComplexity int) int
+		LastSeen           func(childComplexity int) int
+		Namespace          func(childComplexity int) int
+		Operation          func(childComplexity int) int
+		OperationName      func(childComplexity int) int
+		Promoted           func(childComplexity int) int
+		Service            func(childComplexity int) int
+		Volume             func(childComplexity int) int
 	}
 
 	InstrumentationInstanceAnalyze struct {
@@ -5145,6 +5175,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.InsightsAnomalyIssue.FirstSeen(childComplexity), true
 
+	case "InsightsAnomalyIssue.identityDimensions":
+		if e.complexity.InsightsAnomalyIssue.IdentityDimensions == nil {
+			break
+		}
+
+		return e.complexity.InsightsAnomalyIssue.IdentityDimensions(childComplexity), true
+
 	case "InsightsAnomalyIssue.kind":
 		if e.complexity.InsightsAnomalyIssue.Kind == nil {
 			break
@@ -5200,6 +5237,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.InsightsAnomalyIssue.Operation(childComplexity), true
+
+	case "InsightsAnomalyIssue.operationName":
+		if e.complexity.InsightsAnomalyIssue.OperationName == nil {
+			break
+		}
+
+		return e.complexity.InsightsAnomalyIssue.OperationName(childComplexity), true
 
 	case "InsightsAnomalyIssue.policyId":
 		if e.complexity.InsightsAnomalyIssue.PolicyID == nil {
@@ -5306,6 +5350,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.InsightsAnomalySummary.FirstSeen(childComplexity), true
 
+	case "InsightsAnomalySummary.identityDimensions":
+		if e.complexity.InsightsAnomalySummary.IdentityDimensions == nil {
+			break
+		}
+
+		return e.complexity.InsightsAnomalySummary.IdentityDimensions(childComplexity), true
+
 	case "InsightsAnomalySummary.kind":
 		if e.complexity.InsightsAnomalySummary.Kind == nil {
 			break
@@ -5362,6 +5413,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.InsightsAnomalySummary.Operation(childComplexity), true
 
+	case "InsightsAnomalySummary.operationName":
+		if e.complexity.InsightsAnomalySummary.OperationName == nil {
+			break
+		}
+
+		return e.complexity.InsightsAnomalySummary.OperationName(childComplexity), true
+
 	case "InsightsAnomalySummary.policyId":
 		if e.complexity.InsightsAnomalySummary.PolicyID == nil {
 			break
@@ -5417,6 +5475,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.InsightsBaselineClass.Class(childComplexity), true
+
+	case "InsightsBaselineClass.classDescription":
+		if e.complexity.InsightsBaselineClass.ClassDescription == nil {
+			break
+		}
+
+		return e.complexity.InsightsBaselineClass.ClassDescription(childComplexity), true
+
+	case "InsightsBaselineClass.classLabel":
+		if e.complexity.InsightsBaselineClass.ClassLabel == nil {
+			break
+		}
+
+		return e.complexity.InsightsBaselineClass.ClassLabel(childComplexity), true
 
 	case "InsightsBaselineClass.data":
 		if e.complexity.InsightsBaselineClass.Data == nil {
@@ -5775,6 +5847,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.InsightsCatalogCategory.Owasp(childComplexity), true
 
+	case "InsightsCatalogClass.baselineDescription":
+		if e.complexity.InsightsCatalogClass.BaselineDescription == nil {
+			break
+		}
+
+		return e.complexity.InsightsCatalogClass.BaselineDescription(childComplexity), true
+
+	case "InsightsCatalogClass.baselineLabel":
+		if e.complexity.InsightsCatalogClass.BaselineLabel == nil {
+			break
+		}
+
+		return e.complexity.InsightsCatalogClass.BaselineLabel(childComplexity), true
+
 	case "InsightsCatalogClass.category":
 		if e.complexity.InsightsCatalogClass.Category == nil {
 			break
@@ -5950,6 +6036,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.InsightsEnricherList.Label(childComplexity), true
 
+	case "InsightsFinding.identityDimensions":
+		if e.complexity.InsightsFinding.IdentityDimensions == nil {
+			break
+		}
+
+		return e.complexity.InsightsFinding.IdentityDimensions(childComplexity), true
+
 	case "InsightsFinding.kind":
 		if e.complexity.InsightsFinding.Kind == nil {
 			break
@@ -5984,6 +6077,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.InsightsFinding.Offending(childComplexity), true
+
+	case "InsightsFinding.operation":
+		if e.complexity.InsightsFinding.Operation == nil {
+			break
+		}
+
+		return e.complexity.InsightsFinding.Operation(childComplexity), true
+
+	case "InsightsFinding.operationName":
+		if e.complexity.InsightsFinding.OperationName == nil {
+			break
+		}
+
+		return e.complexity.InsightsFinding.OperationName(childComplexity), true
 
 	case "InsightsFinding.ruleKey":
 		if e.complexity.InsightsFinding.RuleKey == nil {
@@ -7056,6 +7163,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.InsightsSystemFindingsSettings.MaxWindowHours(childComplexity), true
 
+	case "InsightsSystemIdentitySettings.transactionIdentityDimensions":
+		if e.complexity.InsightsSystemIdentitySettings.TransactionIdentityDimensions == nil {
+			break
+		}
+
+		return e.complexity.InsightsSystemIdentitySettings.TransactionIdentityDimensions(childComplexity), true
+
 	case "InsightsSystemRetentionSettings.observationRetentionDays":
 		if e.complexity.InsightsSystemRetentionSettings.ObservationRetentionDays == nil {
 			break
@@ -7098,6 +7212,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.InsightsSystemSettings.Findings(childComplexity), true
 
+	case "InsightsSystemSettings.identity":
+		if e.complexity.InsightsSystemSettings.Identity == nil {
+			break
+		}
+
+		return e.complexity.InsightsSystemSettings.Identity(childComplexity), true
+
 	case "InsightsSystemSettings.retention":
 		if e.complexity.InsightsSystemSettings.Retention == nil {
 			break
@@ -7119,6 +7240,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.InsightsSystemSettings.Writeback(childComplexity), true
 
+	case "InsightsSystemTransactionIdentityDimension.enabled":
+		if e.complexity.InsightsSystemTransactionIdentityDimension.Enabled == nil {
+			break
+		}
+
+		return e.complexity.InsightsSystemTransactionIdentityDimension.Enabled(childComplexity), true
+
+	case "InsightsSystemTransactionIdentityDimension.key":
+		if e.complexity.InsightsSystemTransactionIdentityDimension.Key == nil {
+			break
+		}
+
+		return e.complexity.InsightsSystemTransactionIdentityDimension.Key(childComplexity), true
+
 	case "InsightsSystemWritebackSettings.flushIntervalSeconds":
 		if e.complexity.InsightsSystemWritebackSettings.FlushIntervalSeconds == nil {
 			break
@@ -7132,6 +7267,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.InsightsTransaction.ID(childComplexity), true
+
+	case "InsightsTransaction.identityDimensions":
+		if e.complexity.InsightsTransaction.IdentityDimensions == nil {
+			break
+		}
+
+		return e.complexity.InsightsTransaction.IdentityDimensions(childComplexity), true
 
 	case "InsightsTransaction.kind":
 		if e.complexity.InsightsTransaction.Kind == nil {
@@ -7154,12 +7296,33 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.InsightsTransaction.Operation(childComplexity), true
 
+	case "InsightsTransaction.operationName":
+		if e.complexity.InsightsTransaction.OperationName == nil {
+			break
+		}
+
+		return e.complexity.InsightsTransaction.OperationName(childComplexity), true
+
 	case "InsightsTransaction.service":
 		if e.complexity.InsightsTransaction.Service == nil {
 			break
 		}
 
 		return e.complexity.InsightsTransaction.Service(childComplexity), true
+
+	case "InsightsTransactionIdentityValue.key":
+		if e.complexity.InsightsTransactionIdentityValue.Key == nil {
+			break
+		}
+
+		return e.complexity.InsightsTransactionIdentityValue.Key(childComplexity), true
+
+	case "InsightsTransactionIdentityValue.value":
+		if e.complexity.InsightsTransactionIdentityValue.Value == nil {
+			break
+		}
+
+		return e.complexity.InsightsTransactionIdentityValue.Value(childComplexity), true
 
 	case "InsightsTransactionStat.hasBaseline":
 		if e.complexity.InsightsTransactionStat.HasBaseline == nil {
@@ -7174,6 +7337,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.InsightsTransactionStat.ID(childComplexity), true
+
+	case "InsightsTransactionStat.identityDimensions":
+		if e.complexity.InsightsTransactionStat.IdentityDimensions == nil {
+			break
+		}
+
+		return e.complexity.InsightsTransactionStat.IdentityDimensions(childComplexity), true
 
 	case "InsightsTransactionStat.kind":
 		if e.complexity.InsightsTransactionStat.Kind == nil {
@@ -7202,6 +7372,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.InsightsTransactionStat.Operation(childComplexity), true
+
+	case "InsightsTransactionStat.operationName":
+		if e.complexity.InsightsTransactionStat.OperationName == nil {
+			break
+		}
+
+		return e.complexity.InsightsTransactionStat.OperationName(childComplexity), true
 
 	case "InsightsTransactionStat.promoted":
 		if e.complexity.InsightsTransactionStat.Promoted == nil {
@@ -11961,9 +12138,11 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputInsightsSystemCapacitySettingsInput,
 		ec.unmarshalInputInsightsSystemDetectionSettingsInput,
 		ec.unmarshalInputInsightsSystemFindingsSettingsInput,
+		ec.unmarshalInputInsightsSystemIdentitySettingsInput,
 		ec.unmarshalInputInsightsSystemRetentionSettingsInput,
 		ec.unmarshalInputInsightsSystemSamplingSettingsInput,
 		ec.unmarshalInputInsightsSystemSettingsInput,
+		ec.unmarshalInputInsightsSystemTransactionIdentityDimensionInput,
 		ec.unmarshalInputInsightsSystemWritebackSettingsInput,
 		ec.unmarshalInputInsightsViolationActionInput,
 		ec.unmarshalInputInstrumentationLibraryGlobalIdInput,
@@ -32730,6 +32909,10 @@ func (ec *executionContext) fieldContext_Insights_transactions(ctx context.Conte
 				return ec.fieldContext_InsightsTransactionStat_namespace(ctx, field)
 			case "operation":
 				return ec.fieldContext_InsightsTransactionStat_operation(ctx, field)
+			case "operationName":
+				return ec.fieldContext_InsightsTransactionStat_operationName(ctx, field)
+			case "identityDimensions":
+				return ec.fieldContext_InsightsTransactionStat_identityDimensions(ctx, field)
 			case "kind":
 				return ec.fieldContext_InsightsTransactionStat_kind(ctx, field)
 			case "volume":
@@ -32802,6 +32985,10 @@ func (ec *executionContext) fieldContext_Insights_transaction(ctx context.Contex
 				return ec.fieldContext_InsightsTransaction_namespace(ctx, field)
 			case "operation":
 				return ec.fieldContext_InsightsTransaction_operation(ctx, field)
+			case "operationName":
+				return ec.fieldContext_InsightsTransaction_operationName(ctx, field)
+			case "identityDimensions":
+				return ec.fieldContext_InsightsTransaction_identityDimensions(ctx, field)
 			case "kind":
 				return ec.fieldContext_InsightsTransaction_kind(ctx, field)
 			}
@@ -32865,6 +33052,10 @@ func (ec *executionContext) fieldContext_Insights_baseline(ctx context.Context, 
 				return ec.fieldContext_InsightsBaselineClass_transactionId(ctx, field)
 			case "class":
 				return ec.fieldContext_InsightsBaselineClass_class(ctx, field)
+			case "classLabel":
+				return ec.fieldContext_InsightsBaselineClass_classLabel(ctx, field)
+			case "classDescription":
+				return ec.fieldContext_InsightsBaselineClass_classDescription(ctx, field)
 			case "data":
 				return ec.fieldContext_InsightsBaselineClass_data(ctx, field)
 			case "dataSchemaVersion":
@@ -33079,6 +33270,12 @@ func (ec *executionContext) fieldContext_Insights_findings(ctx context.Context, 
 				return ec.fieldContext_InsightsFinding_namespace(ctx, field)
 			case "title":
 				return ec.fieldContext_InsightsFinding_title(ctx, field)
+			case "operation":
+				return ec.fieldContext_InsightsFinding_operation(ctx, field)
+			case "operationName":
+				return ec.fieldContext_InsightsFinding_operationName(ctx, field)
+			case "identityDimensions":
+				return ec.fieldContext_InsightsFinding_identityDimensions(ctx, field)
 			case "offending":
 				return ec.fieldContext_InsightsFinding_offending(ctx, field)
 			case "score":
@@ -33168,6 +33365,10 @@ func (ec *executionContext) fieldContext_Insights_anomalies(ctx context.Context,
 				return ec.fieldContext_InsightsAnomalySummary_namespace(ctx, field)
 			case "operation":
 				return ec.fieldContext_InsightsAnomalySummary_operation(ctx, field)
+			case "operationName":
+				return ec.fieldContext_InsightsAnomalySummary_operationName(ctx, field)
+			case "identityDimensions":
+				return ec.fieldContext_InsightsAnomalySummary_identityDimensions(ctx, field)
 			case "kind":
 				return ec.fieldContext_InsightsAnomalySummary_kind(ctx, field)
 			case "triggeredClasses":
@@ -33254,6 +33455,10 @@ func (ec *executionContext) fieldContext_Insights_anomaly(ctx context.Context, f
 				return ec.fieldContext_InsightsAnomalyIssue_namespace(ctx, field)
 			case "operation":
 				return ec.fieldContext_InsightsAnomalyIssue_operation(ctx, field)
+			case "operationName":
+				return ec.fieldContext_InsightsAnomalyIssue_operationName(ctx, field)
+			case "identityDimensions":
+				return ec.fieldContext_InsightsAnomalyIssue_identityDimensions(ctx, field)
 			case "kind":
 				return ec.fieldContext_InsightsAnomalyIssue_kind(ctx, field)
 			case "triggeredClasses":
@@ -33748,6 +33953,8 @@ func (ec *executionContext) fieldContext_Insights_systemSettings(_ context.Conte
 				return ec.fieldContext_InsightsSystemSettings_writeback(ctx, field)
 			case "detection":
 				return ec.fieldContext_InsightsSystemSettings_detection(ctx, field)
+			case "identity":
+				return ec.fieldContext_InsightsSystemSettings_identity(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type InsightsSystemSettings", field.Name)
 		},
@@ -34512,11 +34719,14 @@ func (ec *executionContext) _InsightsAnomalyIssue_operation(ctx context.Context,
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_InsightsAnomalyIssue_operation(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -34527,6 +34737,100 @@ func (ec *executionContext) fieldContext_InsightsAnomalyIssue_operation(_ contex
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsAnomalyIssue_operationName(ctx context.Context, field graphql.CollectedField, obj *model.InsightsAnomalyIssue) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsAnomalyIssue_operationName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OperationName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsAnomalyIssue_operationName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsAnomalyIssue",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsAnomalyIssue_identityDimensions(ctx context.Context, field graphql.CollectedField, obj *model.InsightsAnomalyIssue) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsAnomalyIssue_identityDimensions(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IdentityDimensions, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.InsightsTransactionIdentityValue)
+	fc.Result = res
+	return ec.marshalNInsightsTransactionIdentityValue2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsTransactionIdentityValueᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsAnomalyIssue_identityDimensions(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsAnomalyIssue",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "key":
+				return ec.fieldContext_InsightsTransactionIdentityValue_key(ctx, field)
+			case "value":
+				return ec.fieldContext_InsightsTransactionIdentityValue_value(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type InsightsTransactionIdentityValue", field.Name)
 		},
 	}
 	return fc, nil
@@ -35732,11 +36036,14 @@ func (ec *executionContext) _InsightsAnomalySummary_operation(ctx context.Contex
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_InsightsAnomalySummary_operation(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -35747,6 +36054,100 @@ func (ec *executionContext) fieldContext_InsightsAnomalySummary_operation(_ cont
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsAnomalySummary_operationName(ctx context.Context, field graphql.CollectedField, obj *model.InsightsAnomalySummary) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsAnomalySummary_operationName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OperationName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsAnomalySummary_operationName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsAnomalySummary",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsAnomalySummary_identityDimensions(ctx context.Context, field graphql.CollectedField, obj *model.InsightsAnomalySummary) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsAnomalySummary_identityDimensions(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IdentityDimensions, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.InsightsTransactionIdentityValue)
+	fc.Result = res
+	return ec.marshalNInsightsTransactionIdentityValue2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsTransactionIdentityValueᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsAnomalySummary_identityDimensions(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsAnomalySummary",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "key":
+				return ec.fieldContext_InsightsTransactionIdentityValue_key(ctx, field)
+			case "value":
+				return ec.fieldContext_InsightsTransactionIdentityValue_value(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type InsightsTransactionIdentityValue", field.Name)
 		},
 	}
 	return fc, nil
@@ -36301,6 +36702,94 @@ func (ec *executionContext) fieldContext_InsightsBaselineClass_class(_ context.C
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type InsightsDeviationClass does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsBaselineClass_classLabel(ctx context.Context, field graphql.CollectedField, obj *model.InsightsBaselineClass) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsBaselineClass_classLabel(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ClassLabel, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsBaselineClass_classLabel(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsBaselineClass",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsBaselineClass_classDescription(ctx context.Context, field graphql.CollectedField, obj *model.InsightsBaselineClass) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsBaselineClass_classDescription(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ClassDescription, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsBaselineClass_classDescription(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsBaselineClass",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -38082,6 +38571,10 @@ func (ec *executionContext) fieldContext_InsightsCatalog_deviationClasses(_ cont
 				return ec.fieldContext_InsightsCatalogClass_label(ctx, field)
 			case "description":
 				return ec.fieldContext_InsightsCatalogClass_description(ctx, field)
+			case "baselineLabel":
+				return ec.fieldContext_InsightsCatalogClass_baselineLabel(ctx, field)
+			case "baselineDescription":
+				return ec.fieldContext_InsightsCatalogClass_baselineDescription(ctx, field)
 			case "category":
 				return ec.fieldContext_InsightsCatalogClass_category(ctx, field)
 			case "categoryLabel":
@@ -38742,6 +39235,91 @@ func (ec *executionContext) _InsightsCatalogClass_description(ctx context.Contex
 }
 
 func (ec *executionContext) fieldContext_InsightsCatalogClass_description(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsCatalogClass",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsCatalogClass_baselineLabel(ctx context.Context, field graphql.CollectedField, obj *model.InsightsCatalogClass) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsCatalogClass_baselineLabel(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BaselineLabel, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsCatalogClass_baselineLabel(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsCatalogClass",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsCatalogClass_baselineDescription(ctx context.Context, field graphql.CollectedField, obj *model.InsightsCatalogClass) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsCatalogClass_baselineDescription(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BaselineDescription, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsCatalogClass_baselineDescription(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "InsightsCatalogClass",
 		Field:      field,
@@ -39876,6 +40454,135 @@ func (ec *executionContext) fieldContext_InsightsFinding_title(_ context.Context
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsFinding_operation(ctx context.Context, field graphql.CollectedField, obj *model.InsightsFinding) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsFinding_operation(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Operation, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsFinding_operation(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsFinding",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsFinding_operationName(ctx context.Context, field graphql.CollectedField, obj *model.InsightsFinding) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsFinding_operationName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OperationName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsFinding_operationName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsFinding",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsFinding_identityDimensions(ctx context.Context, field graphql.CollectedField, obj *model.InsightsFinding) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsFinding_identityDimensions(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IdentityDimensions, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.InsightsTransactionIdentityValue)
+	fc.Result = res
+	return ec.marshalOInsightsTransactionIdentityValue2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsTransactionIdentityValueᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsFinding_identityDimensions(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsFinding",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "key":
+				return ec.fieldContext_InsightsTransactionIdentityValue_key(ctx, field)
+			case "value":
+				return ec.fieldContext_InsightsTransactionIdentityValue_value(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type InsightsTransactionIdentityValue", field.Name)
 		},
 	}
 	return fc, nil
@@ -46749,6 +47456,56 @@ func (ec *executionContext) fieldContext_InsightsSystemFindingsSettings_maxWindo
 	return fc, nil
 }
 
+func (ec *executionContext) _InsightsSystemIdentitySettings_transactionIdentityDimensions(ctx context.Context, field graphql.CollectedField, obj *model.InsightsSystemIdentitySettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsSystemIdentitySettings_transactionIdentityDimensions(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TransactionIdentityDimensions, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.InsightsSystemTransactionIdentityDimension)
+	fc.Result = res
+	return ec.marshalNInsightsSystemTransactionIdentityDimension2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemTransactionIdentityDimensionᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsSystemIdentitySettings_transactionIdentityDimensions(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsSystemIdentitySettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "key":
+				return ec.fieldContext_InsightsSystemTransactionIdentityDimension_key(ctx, field)
+			case "enabled":
+				return ec.fieldContext_InsightsSystemTransactionIdentityDimension_enabled(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type InsightsSystemTransactionIdentityDimension", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _InsightsSystemRetentionSettings_observationRetentionDays(ctx context.Context, field graphql.CollectedField, obj *model.InsightsSystemRetentionSettings) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_InsightsSystemRetentionSettings_observationRetentionDays(ctx, field)
 	if err != nil {
@@ -47175,6 +47932,142 @@ func (ec *executionContext) fieldContext_InsightsSystemSettings_detection(_ cont
 	return fc, nil
 }
 
+func (ec *executionContext) _InsightsSystemSettings_identity(ctx context.Context, field graphql.CollectedField, obj *model.InsightsSystemSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsSystemSettings_identity(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Identity, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.InsightsSystemIdentitySettings)
+	fc.Result = res
+	return ec.marshalNInsightsSystemIdentitySettings2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemIdentitySettings(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsSystemSettings_identity(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsSystemSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "transactionIdentityDimensions":
+				return ec.fieldContext_InsightsSystemIdentitySettings_transactionIdentityDimensions(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type InsightsSystemIdentitySettings", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsSystemTransactionIdentityDimension_key(ctx context.Context, field graphql.CollectedField, obj *model.InsightsSystemTransactionIdentityDimension) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsSystemTransactionIdentityDimension_key(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Key, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsSystemTransactionIdentityDimension_key(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsSystemTransactionIdentityDimension",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsSystemTransactionIdentityDimension_enabled(ctx context.Context, field graphql.CollectedField, obj *model.InsightsSystemTransactionIdentityDimension) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsSystemTransactionIdentityDimension_enabled(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Enabled, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsSystemTransactionIdentityDimension_enabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsSystemTransactionIdentityDimension",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _InsightsSystemWritebackSettings_flushIntervalSeconds(ctx context.Context, field graphql.CollectedField, obj *model.InsightsSystemWritebackSettings) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_InsightsSystemWritebackSettings_flushIntervalSeconds(ctx, field)
 	if err != nil {
@@ -47395,6 +48288,100 @@ func (ec *executionContext) fieldContext_InsightsTransaction_operation(_ context
 	return fc, nil
 }
 
+func (ec *executionContext) _InsightsTransaction_operationName(ctx context.Context, field graphql.CollectedField, obj *model.InsightsTransaction) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsTransaction_operationName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OperationName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsTransaction_operationName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsTransaction",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsTransaction_identityDimensions(ctx context.Context, field graphql.CollectedField, obj *model.InsightsTransaction) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsTransaction_identityDimensions(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IdentityDimensions, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.InsightsTransactionIdentityValue)
+	fc.Result = res
+	return ec.marshalNInsightsTransactionIdentityValue2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsTransactionIdentityValueᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsTransaction_identityDimensions(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsTransaction",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "key":
+				return ec.fieldContext_InsightsTransactionIdentityValue_key(ctx, field)
+			case "value":
+				return ec.fieldContext_InsightsTransactionIdentityValue_value(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type InsightsTransactionIdentityValue", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _InsightsTransaction_kind(ctx context.Context, field graphql.CollectedField, obj *model.InsightsTransaction) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_InsightsTransaction_kind(ctx, field)
 	if err != nil {
@@ -47434,6 +48421,94 @@ func (ec *executionContext) fieldContext_InsightsTransaction_kind(_ context.Cont
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type InsightsTransactionKind does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsTransactionIdentityValue_key(ctx context.Context, field graphql.CollectedField, obj *model.InsightsTransactionIdentityValue) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsTransactionIdentityValue_key(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Key, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsTransactionIdentityValue_key(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsTransactionIdentityValue",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsTransactionIdentityValue_value(ctx context.Context, field graphql.CollectedField, obj *model.InsightsTransactionIdentityValue) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsTransactionIdentityValue_value(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Value, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsTransactionIdentityValue_value(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsTransactionIdentityValue",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -47610,6 +48685,100 @@ func (ec *executionContext) fieldContext_InsightsTransactionStat_operation(_ con
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsTransactionStat_operationName(ctx context.Context, field graphql.CollectedField, obj *model.InsightsTransactionStat) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsTransactionStat_operationName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OperationName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsTransactionStat_operationName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsTransactionStat",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsTransactionStat_identityDimensions(ctx context.Context, field graphql.CollectedField, obj *model.InsightsTransactionStat) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsTransactionStat_identityDimensions(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IdentityDimensions, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.InsightsTransactionIdentityValue)
+	fc.Result = res
+	return ec.marshalNInsightsTransactionIdentityValue2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsTransactionIdentityValueᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsTransactionStat_identityDimensions(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsTransactionStat",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "key":
+				return ec.fieldContext_InsightsTransactionIdentityValue_key(ctx, field)
+			case "value":
+				return ec.fieldContext_InsightsTransactionIdentityValue_value(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type InsightsTransactionIdentityValue", field.Name)
 		},
 	}
 	return fc, nil
@@ -62670,6 +63839,8 @@ func (ec *executionContext) fieldContext_Mutation_updateInsightsSystemSettings(c
 				return ec.fieldContext_InsightsSystemSettings_writeback(ctx, field)
 			case "detection":
 				return ec.fieldContext_InsightsSystemSettings_detection(ctx, field)
+			case "identity":
+				return ec.fieldContext_InsightsSystemSettings_identity(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type InsightsSystemSettings", field.Name)
 		},
@@ -81723,6 +82894,33 @@ func (ec *executionContext) unmarshalInputInsightsSystemFindingsSettingsInput(ct
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputInsightsSystemIdentitySettingsInput(ctx context.Context, obj any) (model.InsightsSystemIdentitySettingsInput, error) {
+	var it model.InsightsSystemIdentitySettingsInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"transactionIdentityDimensions"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "transactionIdentityDimensions":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("transactionIdentityDimensions"))
+			data, err := ec.unmarshalNInsightsSystemTransactionIdentityDimensionInput2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemTransactionIdentityDimensionInputᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.TransactionIdentityDimensions = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputInsightsSystemRetentionSettingsInput(ctx context.Context, obj any) (model.InsightsSystemRetentionSettingsInput, error) {
 	var it model.InsightsSystemRetentionSettingsInput
 	asMap := map[string]any{}
@@ -81791,7 +82989,7 @@ func (ec *executionContext) unmarshalInputInsightsSystemSettingsInput(ctx contex
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"sampling", "retention", "findings", "capacity", "writeback", "detection"}
+	fieldsInOrder := [...]string{"sampling", "retention", "findings", "capacity", "writeback", "detection", "identity", "resetTransactions"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -81840,6 +83038,54 @@ func (ec *executionContext) unmarshalInputInsightsSystemSettingsInput(ctx contex
 				return it, err
 			}
 			it.Detection = data
+		case "identity":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("identity"))
+			data, err := ec.unmarshalNInsightsSystemIdentitySettingsInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemIdentitySettingsInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Identity = data
+		case "resetTransactions":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("resetTransactions"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ResetTransactions = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputInsightsSystemTransactionIdentityDimensionInput(ctx context.Context, obj any) (model.InsightsSystemTransactionIdentityDimensionInput, error) {
+	var it model.InsightsSystemTransactionIdentityDimensionInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"key", "enabled"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "key":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("key"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Key = data
+		case "enabled":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("enabled"))
+			data, err := ec.unmarshalNBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Enabled = data
 		}
 	}
 
@@ -88387,6 +89633,19 @@ func (ec *executionContext) _InsightsAnomalyIssue(ctx context.Context, sel ast.S
 			}
 		case "operation":
 			out.Values[i] = ec._InsightsAnomalyIssue_operation(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "operationName":
+			out.Values[i] = ec._InsightsAnomalyIssue_operationName(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "identityDimensions":
+			out.Values[i] = ec._InsightsAnomalyIssue_identityDimensions(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "kind":
 			out.Values[i] = ec._InsightsAnomalyIssue_kind(ctx, field, obj)
 		case "triggeredClasses":
@@ -88594,6 +89853,19 @@ func (ec *executionContext) _InsightsAnomalySummary(ctx context.Context, sel ast
 			}
 		case "operation":
 			out.Values[i] = ec._InsightsAnomalySummary_operation(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "operationName":
+			out.Values[i] = ec._InsightsAnomalySummary_operationName(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "identityDimensions":
+			out.Values[i] = ec._InsightsAnomalySummary_identityDimensions(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "kind":
 			out.Values[i] = ec._InsightsAnomalySummary_kind(ctx, field, obj)
 		case "triggeredClasses":
@@ -88672,6 +89944,16 @@ func (ec *executionContext) _InsightsBaselineClass(ctx context.Context, sel ast.
 			}
 		case "class":
 			out.Values[i] = ec._InsightsBaselineClass_class(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "classLabel":
+			out.Values[i] = ec._InsightsBaselineClass_classLabel(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "classDescription":
+			out.Values[i] = ec._InsightsBaselineClass_classDescription(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -89324,6 +90606,13 @@ func (ec *executionContext) _InsightsCatalogClass(ctx context.Context, sel ast.S
 			}
 		case "description":
 			out.Values[i] = ec._InsightsCatalogClass_description(ctx, field, obj)
+		case "baselineLabel":
+			out.Values[i] = ec._InsightsCatalogClass_baselineLabel(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "baselineDescription":
+			out.Values[i] = ec._InsightsCatalogClass_baselineDescription(ctx, field, obj)
 		case "category":
 			out.Values[i] = ec._InsightsCatalogClass_category(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -89563,6 +90852,12 @@ func (ec *executionContext) _InsightsFinding(ctx context.Context, sel ast.Select
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "operation":
+			out.Values[i] = ec._InsightsFinding_operation(ctx, field, obj)
+		case "operationName":
+			out.Values[i] = ec._InsightsFinding_operationName(ctx, field, obj)
+		case "identityDimensions":
+			out.Values[i] = ec._InsightsFinding_identityDimensions(ctx, field, obj)
 		case "offending":
 			out.Values[i] = ec._InsightsFinding_offending(ctx, field, obj)
 		case "score":
@@ -91190,6 +92485,45 @@ func (ec *executionContext) _InsightsSystemFindingsSettings(ctx context.Context,
 	return out
 }
 
+var insightsSystemIdentitySettingsImplementors = []string{"InsightsSystemIdentitySettings"}
+
+func (ec *executionContext) _InsightsSystemIdentitySettings(ctx context.Context, sel ast.SelectionSet, obj *model.InsightsSystemIdentitySettings) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, insightsSystemIdentitySettingsImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("InsightsSystemIdentitySettings")
+		case "transactionIdentityDimensions":
+			out.Values[i] = ec._InsightsSystemIdentitySettings_transactionIdentityDimensions(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var insightsSystemRetentionSettingsImplementors = []string{"InsightsSystemRetentionSettings"}
 
 func (ec *executionContext) _InsightsSystemRetentionSettings(ctx context.Context, sel ast.SelectionSet, obj *model.InsightsSystemRetentionSettings) graphql.Marshaler {
@@ -91314,6 +92648,55 @@ func (ec *executionContext) _InsightsSystemSettings(ctx context.Context, sel ast
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "identity":
+			out.Values[i] = ec._InsightsSystemSettings_identity(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var insightsSystemTransactionIdentityDimensionImplementors = []string{"InsightsSystemTransactionIdentityDimension"}
+
+func (ec *executionContext) _InsightsSystemTransactionIdentityDimension(ctx context.Context, sel ast.SelectionSet, obj *model.InsightsSystemTransactionIdentityDimension) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, insightsSystemTransactionIdentityDimensionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("InsightsSystemTransactionIdentityDimension")
+		case "key":
+			out.Values[i] = ec._InsightsSystemTransactionIdentityDimension_key(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "enabled":
+			out.Values[i] = ec._InsightsSystemTransactionIdentityDimension_enabled(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -91407,8 +92790,62 @@ func (ec *executionContext) _InsightsTransaction(ctx context.Context, sel ast.Se
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "operationName":
+			out.Values[i] = ec._InsightsTransaction_operationName(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "identityDimensions":
+			out.Values[i] = ec._InsightsTransaction_identityDimensions(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "kind":
 			out.Values[i] = ec._InsightsTransaction_kind(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var insightsTransactionIdentityValueImplementors = []string{"InsightsTransactionIdentityValue"}
+
+func (ec *executionContext) _InsightsTransactionIdentityValue(ctx context.Context, sel ast.SelectionSet, obj *model.InsightsTransactionIdentityValue) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, insightsTransactionIdentityValueImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("InsightsTransactionIdentityValue")
+		case "key":
+			out.Values[i] = ec._InsightsTransactionIdentityValue_key(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "value":
+			out.Values[i] = ec._InsightsTransactionIdentityValue_value(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -91463,6 +92900,16 @@ func (ec *executionContext) _InsightsTransactionStat(ctx context.Context, sel as
 			}
 		case "operation":
 			out.Values[i] = ec._InsightsTransactionStat_operation(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "operationName":
+			out.Values[i] = ec._InsightsTransactionStat_operationName(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "identityDimensions":
+			out.Values[i] = ec._InsightsTransactionStat_identityDimensions(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -103652,6 +105099,21 @@ func (ec *executionContext) unmarshalNInsightsSystemFindingsSettingsInput2ᚖgit
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) marshalNInsightsSystemIdentitySettings2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemIdentitySettings(ctx context.Context, sel ast.SelectionSet, v *model.InsightsSystemIdentitySettings) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._InsightsSystemIdentitySettings(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNInsightsSystemIdentitySettingsInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemIdentitySettingsInput(ctx context.Context, v any) (*model.InsightsSystemIdentitySettingsInput, error) {
+	res, err := ec.unmarshalInputInsightsSystemIdentitySettingsInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) marshalNInsightsSystemRetentionSettings2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemRetentionSettings(ctx context.Context, sel ast.SelectionSet, v *model.InsightsSystemRetentionSettings) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -103701,6 +105163,80 @@ func (ec *executionContext) unmarshalNInsightsSystemSettingsInput2githubᚗcom�
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) marshalNInsightsSystemTransactionIdentityDimension2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemTransactionIdentityDimensionᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.InsightsSystemTransactionIdentityDimension) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNInsightsSystemTransactionIdentityDimension2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemTransactionIdentityDimension(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNInsightsSystemTransactionIdentityDimension2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemTransactionIdentityDimension(ctx context.Context, sel ast.SelectionSet, v *model.InsightsSystemTransactionIdentityDimension) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._InsightsSystemTransactionIdentityDimension(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNInsightsSystemTransactionIdentityDimensionInput2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemTransactionIdentityDimensionInputᚄ(ctx context.Context, v any) ([]*model.InsightsSystemTransactionIdentityDimensionInput, error) {
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]*model.InsightsSystemTransactionIdentityDimensionInput, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNInsightsSystemTransactionIdentityDimensionInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemTransactionIdentityDimensionInput(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalNInsightsSystemTransactionIdentityDimensionInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemTransactionIdentityDimensionInput(ctx context.Context, v any) (*model.InsightsSystemTransactionIdentityDimensionInput, error) {
+	res, err := ec.unmarshalInputInsightsSystemTransactionIdentityDimensionInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) marshalNInsightsSystemWritebackSettings2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemWritebackSettings(ctx context.Context, sel ast.SelectionSet, v *model.InsightsSystemWritebackSettings) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -103714,6 +105250,60 @@ func (ec *executionContext) marshalNInsightsSystemWritebackSettings2ᚖgithubᚗ
 func (ec *executionContext) unmarshalNInsightsSystemWritebackSettingsInput2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsSystemWritebackSettingsInput(ctx context.Context, v any) (*model.InsightsSystemWritebackSettingsInput, error) {
 	res, err := ec.unmarshalInputInsightsSystemWritebackSettingsInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNInsightsTransactionIdentityValue2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsTransactionIdentityValueᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.InsightsTransactionIdentityValue) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNInsightsTransactionIdentityValue2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsTransactionIdentityValue(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNInsightsTransactionIdentityValue2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsTransactionIdentityValue(ctx context.Context, sel ast.SelectionSet, v *model.InsightsTransactionIdentityValue) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._InsightsTransactionIdentityValue(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNInsightsTransactionKind2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsTransactionKind(ctx context.Context, v any) (model.InsightsTransactionKind, error) {
@@ -108016,6 +109606,53 @@ func (ec *executionContext) marshalOInsightsTransaction2ᚖgithubᚗcomᚋodigos
 		return graphql.Null
 	}
 	return ec._InsightsTransaction(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOInsightsTransactionIdentityValue2ᚕᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsTransactionIdentityValueᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.InsightsTransactionIdentityValue) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNInsightsTransactionIdentityValue2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsTransactionIdentityValue(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) unmarshalOInsightsTransactionKind2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsTransactionKind(ctx context.Context, v any) (*model.InsightsTransactionKind, error) {

--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -751,6 +751,10 @@ type ComplexityRoot struct {
 		Root  func(childComplexity int) int
 	}
 
+	InsightsBulkPromoteResult struct {
+		Promoted func(childComplexity int) int
+	}
+
 	InsightsBulkResolveResult struct {
 		Resolution func(childComplexity int) int
 		Resolved   func(childComplexity int) int
@@ -1554,6 +1558,7 @@ type ComplexityRoot struct {
 	Mutation struct {
 		AllowInsightsGuardrailViolation     func(childComplexity int, action model.InsightsViolationActionInput) int
 		ApplyRecommendationRemediation      func(childComplexity int, recommendationType model.RecommendationType, remediationType string) int
+		BulkPromoteInsightsTransactions     func(childComplexity int, transactionIds []string) int
 		BulkResolveInsightsAnomalies        func(childComplexity int, resolution model.InsightsBulkResolution, items []*model.InsightsAnomalyRefInput) int
 		ClearSourceProfilingBuffer          func(childComplexity int, namespace string, kind string, name string) int
 		ConfigureProfilingCache             func(childComplexity int, maxSlots *int, slotMaxBytes *int, slotTTLSeconds *int) int
@@ -1584,6 +1589,7 @@ type ComplexityRoot struct {
 		PersistK8sNamespaces                func(childComplexity int, namespaces []*model.PersistNamespaceItemInput) int
 		PersistK8sSources                   func(childComplexity int, sources []*model.PersistNamespaceSourceInput) int
 		PromoteInsightsBaselineClass        func(childComplexity int, transactionID string, class model.InsightsDeviationClass) int
+		PromoteInsightsTransactionBaselines func(childComplexity int, transactionID string) int
 		RecoverFromRollbackForWorkload      func(childComplexity int, sourceID model.K8sSourceID) int
 		ReopenInsightsGuardrailViolation    func(childComplexity int, action model.InsightsViolationActionInput) int
 		ResetInsightsBaselineClass          func(childComplexity int, transactionID string, class model.InsightsDeviationClass) int
@@ -2199,6 +2205,8 @@ type MutationResolver interface {
 	PromoteInsightsBaselineClass(ctx context.Context, transactionID string, class model.InsightsDeviationClass) (*model.InsightsPromoteResult, error)
 	ResetInsightsBaselineClass(ctx context.Context, transactionID string, class model.InsightsDeviationClass) (bool, error)
 	ResetInsightsTransactionBaselines(ctx context.Context, transactionID string) (bool, error)
+	PromoteInsightsTransactionBaselines(ctx context.Context, transactionID string) (bool, error)
+	BulkPromoteInsightsTransactions(ctx context.Context, transactionIds []string) (*model.InsightsBulkPromoteResult, error)
 	ForcePromoteInsightsService(ctx context.Context, namespace string, service string) (bool, error)
 	EnableInsightsTransactionGuardrail(ctx context.Context, namespace string, service string) (bool, error)
 	DisableInsightsTransactionGuardrail(ctx context.Context, namespace string, service string) (bool, error)
@@ -5648,6 +5656,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.InsightsBlastRadiusSubgraph.Root(childComplexity), true
+
+	case "InsightsBulkPromoteResult.promoted":
+		if e.complexity.InsightsBulkPromoteResult.Promoted == nil {
+			break
+		}
+
+		return e.complexity.InsightsBulkPromoteResult.Promoted(childComplexity), true
 
 	case "InsightsBulkResolveResult.resolution":
 		if e.complexity.InsightsBulkResolveResult.Resolution == nil {
@@ -9131,6 +9146,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.ApplyRecommendationRemediation(childComplexity, args["recommendationType"].(model.RecommendationType), args["remediationType"].(string)), true
 
+	case "Mutation.bulkPromoteInsightsTransactions":
+		if e.complexity.Mutation.BulkPromoteInsightsTransactions == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_bulkPromoteInsightsTransactions_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.BulkPromoteInsightsTransactions(childComplexity, args["transactionIds"].([]string)), true
+
 	case "Mutation.bulkResolveInsightsAnomalies":
 		if e.complexity.Mutation.BulkResolveInsightsAnomalies == nil {
 			break
@@ -9485,6 +9512,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.PromoteInsightsBaselineClass(childComplexity, args["transactionId"].(string), args["class"].(model.InsightsDeviationClass)), true
+
+	case "Mutation.promoteInsightsTransactionBaselines":
+		if e.complexity.Mutation.PromoteInsightsTransactionBaselines == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_promoteInsightsTransactionBaselines_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.PromoteInsightsTransactionBaselines(childComplexity, args["transactionId"].(string)), true
 
 	case "Mutation.recoverFromRollbackForWorkload":
 		if e.complexity.Mutation.RecoverFromRollbackForWorkload == nil {
@@ -13015,6 +13054,34 @@ func (ec *executionContext) field_Mutation_applyRecommendationRemediation_argsRe
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation_bulkPromoteInsightsTransactions_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_bulkPromoteInsightsTransactions_argsTransactionIds(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["transactionIds"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_bulkPromoteInsightsTransactions_argsTransactionIds(
+	ctx context.Context,
+	rawArgs map[string]any,
+) ([]string, error) {
+	if _, ok := rawArgs["transactionIds"]; !ok {
+		var zeroVal []string
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("transactionIds"))
+	if tmp, ok := rawArgs["transactionIds"]; ok {
+		return ec.unmarshalNID2ᚕstringᚄ(ctx, tmp)
+	}
+
+	var zeroVal []string
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation_bulkResolveInsightsAnomalies_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -14376,6 +14443,34 @@ func (ec *executionContext) field_Mutation_promoteInsightsBaselineClass_argsClas
 	}
 
 	var zeroVal model.InsightsDeviationClass
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_promoteInsightsTransactionBaselines_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_promoteInsightsTransactionBaselines_argsTransactionID(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["transactionId"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_promoteInsightsTransactionBaselines_argsTransactionID(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (string, error) {
+	if _, ok := rawArgs["transactionId"]; !ok {
+		var zeroVal string
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("transactionId"))
+	if tmp, ok := rawArgs["transactionId"]; ok {
+		return ec.unmarshalNID2string(ctx, tmp)
+	}
+
+	var zeroVal string
 	return zeroVal, nil
 }
 
@@ -37708,6 +37803,50 @@ func (ec *executionContext) fieldContext_InsightsBlastRadiusSubgraph_edges(_ con
 				return ec.fieldContext_InsightsBlastRadiusEdge_lastSeen(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type InsightsBlastRadiusEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsBulkPromoteResult_promoted(ctx context.Context, field graphql.CollectedField, obj *model.InsightsBulkPromoteResult) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsBulkPromoteResult_promoted(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Promoted, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsBulkPromoteResult_promoted(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsBulkPromoteResult",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
 		},
 	}
 	return fc, nil
@@ -61278,6 +61417,120 @@ func (ec *executionContext) fieldContext_Mutation_resetInsightsTransactionBaseli
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_resetInsightsTransactionBaselines_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_promoteInsightsTransactionBaselines(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_promoteInsightsTransactionBaselines(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().PromoteInsightsTransactionBaselines(rctx, fc.Args["transactionId"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_promoteInsightsTransactionBaselines(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_promoteInsightsTransactionBaselines_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_bulkPromoteInsightsTransactions(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_bulkPromoteInsightsTransactions(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().BulkPromoteInsightsTransactions(rctx, fc.Args["transactionIds"].([]string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.InsightsBulkPromoteResult)
+	fc.Result = res
+	return ec.marshalNInsightsBulkPromoteResult2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsBulkPromoteResult(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_bulkPromoteInsightsTransactions(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "promoted":
+				return ec.fieldContext_InsightsBulkPromoteResult_promoted(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type InsightsBulkPromoteResult", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_bulkPromoteInsightsTransactions_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -88648,6 +88901,45 @@ func (ec *executionContext) _InsightsBlastRadiusSubgraph(ctx context.Context, se
 	return out
 }
 
+var insightsBulkPromoteResultImplementors = []string{"InsightsBulkPromoteResult"}
+
+func (ec *executionContext) _InsightsBulkPromoteResult(ctx context.Context, sel ast.SelectionSet, obj *model.InsightsBulkPromoteResult) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, insightsBulkPromoteResultImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("InsightsBulkPromoteResult")
+		case "promoted":
+			out.Values[i] = ec._InsightsBulkPromoteResult_promoted(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var insightsBulkResolveResultImplementors = []string{"InsightsBulkResolveResult"}
 
 func (ec *executionContext) _InsightsBulkResolveResult(ctx context.Context, sel ast.SelectionSet, obj *model.InsightsBulkResolveResult) graphql.Marshaler {
@@ -94946,6 +95238,20 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "resetInsightsTransactionBaselines":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_resetInsightsTransactionBaselines(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "promoteInsightsTransactionBaselines":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_promoteInsightsTransactionBaselines(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "bulkPromoteInsightsTransactions":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_bulkPromoteInsightsTransactions(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -101417,6 +101723,36 @@ func (ec *executionContext) marshalNID2string(ctx context.Context, sel ast.Selec
 	return res
 }
 
+func (ec *executionContext) unmarshalNID2ᚕstringᚄ(ctx context.Context, v any) ([]string, error) {
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]string, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNID2string(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNID2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	for i := range v {
+		ret[i] = ec.marshalNID2string(ctx, sel, v[i])
+	}
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) marshalNInsightsAnomalyAttrHighlight2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsAnomalyAttrHighlight(ctx context.Context, sel ast.SelectionSet, v *model.InsightsAnomalyAttrHighlight) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -101809,6 +102145,20 @@ func (ec *executionContext) marshalNInsightsBlastRadiusSubgraph2ᚖgithubᚗcom�
 		return graphql.Null
 	}
 	return ec._InsightsBlastRadiusSubgraph(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNInsightsBulkPromoteResult2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsBulkPromoteResult(ctx context.Context, sel ast.SelectionSet, v model.InsightsBulkPromoteResult) graphql.Marshaler {
+	return ec._InsightsBulkPromoteResult(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNInsightsBulkPromoteResult2ᚖgithubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsBulkPromoteResult(ctx context.Context, sel ast.SelectionSet, v *model.InsightsBulkPromoteResult) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._InsightsBulkPromoteResult(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNInsightsBulkResolution2githubᚗcomᚋodigosᚑioᚋodigosᚋfrontendᚋgraphᚋmodelᚐInsightsBulkResolution(ctx context.Context, v any) (model.InsightsBulkResolution, error) {

--- a/frontend/graph/insights.graphqls
+++ b/frontend/graph/insights.graphqls
@@ -529,6 +529,10 @@ type InsightsBulkPromoteResult {
   promoted: Int!
 }
 
+type InsightsBulkDeleteResult {
+  deleted: Int!
+}
+
 # Guardrails (operator-declared L7 rules, orthogonal to learned baselines)
 
 type InsightsGuardrailRule {
@@ -963,6 +967,13 @@ extend type Mutation {
   Permanently removes a transaction and related state (baselines, samples, issues, txn-scoped policies).
   """
   deleteInsightsTransaction(transactionId: ID!): Boolean!
+  """
+  Permanently removes many transactions and their related state
+  (POST /api/v1/transactions).
+  """
+  bulkDeleteInsightsTransactions(
+    transactionIds: [ID!]!
+  ): InsightsBulkDeleteResult!
   upsertInsightsPolicy(policy: InsightsPolicyInput!): InsightsPolicy!
   deleteInsightsPolicy(scope: InsightsPolicyScope!, scopeKey: String!): Boolean!
   upsertInsightsLearningPolicy(

--- a/frontend/graph/insights.graphqls
+++ b/frontend/graph/insights.graphqls
@@ -180,11 +180,28 @@ type InsightsBlastRadiusSubgraph {
   edges: [InsightsBlastRadiusEdge!]!
 }
 
+"""
+One parsed low-cardinality dimension from the stored operation identity suffix ([key=value]).
+For display only — canonical identity remains in `operation`.
+"""
+type InsightsTransactionIdentityValue {
+  key: String!
+  value: String!
+}
+
 type InsightsTransactionStat {
   id: ID!
   service: String!
   namespace: String!
+  """
+  Full canonical identity string (hashed). Includes [key=value] suffixes when identity dimensions are enabled.
+  """
   operation: String!
+  """
+  Entry-span operation without dimension suffixes.
+  """
+  operationName: String!
+  identityDimensions: [InsightsTransactionIdentityValue!]!
   kind: InsightsTransactionKind!
   volume: Int!
   lastSeen: String!
@@ -196,7 +213,15 @@ type InsightsTransaction {
   id: ID!
   service: String!
   namespace: String!
+  """
+  Full canonical identity string (hashed, guardrails). Includes [key=value] suffixes when identity dimensions are enabled.
+  """
   operation: String!
+  """
+  Human-readable entry-span operation without dimension suffixes.
+  """
+  operationName: String!
+  identityDimensions: [InsightsTransactionIdentityValue!]!
   kind: InsightsTransactionKind!
 }
 
@@ -240,6 +265,17 @@ type InsightsBaselineLearning {
 type InsightsBaselineClass {
   transactionId: ID!
   class: InsightsDeviationClass!
+  """
+  Human-readable name for what this class learns on a transaction
+  (e.g. "Request latency" for D3_latency). Sourced from the risk catalog;
+  UI should display this and keep `class` as the stable id for promote/reset.
+  """
+  classLabel: String!
+  """
+  Tooltip text describing what this class learns for the transaction.
+  Suitable for hover UI; not the finding/anomaly wording.
+  """
+  classDescription: String!
   """
   JSON-encoded baseline data; shape varies per deviation class.
   """
@@ -358,7 +394,22 @@ type InsightsFinding {
   kind: InsightsFindingKind!
   service: String!
   namespace: String!
+  """
+  Human-readable headline. Anomalies use operationName; violations use the guardrail rule label.
+  """
   title: String!
+  """
+  Full canonical transaction operation (anomalies only). Omitted for violations.
+  """
+  operation: String
+  """
+  Entry-span operation without dimension suffixes (anomalies).
+  """
+  operationName: String
+  """
+  Parsed identity dimensions (anomalies only).
+  """
+  identityDimensions: [InsightsTransactionIdentityValue!]
   offending: String
   score: Int!
   severity: InsightsSeverity!
@@ -418,7 +469,15 @@ type InsightsAnomalySummary {
   signature: String!
   service: String!
   namespace: String!
-  operation: String
+  """
+  Full canonical identity string.
+  """
+  operation: String!
+  """
+  Entry-span operation without dimension suffixes.
+  """
+  operationName: String!
+  identityDimensions: [InsightsTransactionIdentityValue!]!
   kind: InsightsTransactionKind
   triggeredClasses: [InsightsDeviationClass!]!
   offending: String
@@ -484,7 +543,15 @@ type InsightsAnomalyIssue {
   signature: String!
   service: String!
   namespace: String!
-  operation: String
+  """
+  Full canonical identity string.
+  """
+  operation: String!
+  """
+  Entry-span operation without dimension suffixes.
+  """
+  operationName: String!
+  identityDimensions: [InsightsTransactionIdentityValue!]!
   kind: InsightsTransactionKind
   triggeredClasses: [InsightsDeviationClass!]!
   offending: String
@@ -618,7 +685,7 @@ input InsightsGuardrailSeedInput {
   scopeKey: String!
   mode: InsightsRuleMode
   """
-  JSON-encoded map[string][]string; keys: allowed_callers | allowed_callees | allowed_egress.
+  JSON-encoded map[string][]string; keys: allowed_callers | allowed_callees | allowed_egress | allowed_transactions.
   """
   items: String!
 }
@@ -629,6 +696,14 @@ type InsightsCatalogClass {
   id: String!
   label: String!
   description: String
+  """
+  Transaction-baseline name for this class (what is learned). Distinct from finding-oriented `label`.
+  """
+  baselineLabel: String!
+  """
+  Tooltip for what this class learns on a transaction baseline.
+  """
+  baselineDescription: String
   category: String!
   categoryLabel: String
   weight: Int!
@@ -722,6 +797,23 @@ type InsightsSystemDetectionSettings {
   autoTransactionGuardrail: Boolean!
 }
 
+"""
+One low-cardinality attribute (or built-in resolver key) folded into transaction identity
+from the sub-transaction entry span only.
+"""
+type InsightsSystemTransactionIdentityDimension {
+  key: String!
+  enabled: Boolean!
+}
+
+"""
+Extra dimensions appended to transaction Operation before hashing.
+Each enabled dimension multiplies cardinality. Use only low-cardinality attributes.
+"""
+type InsightsSystemIdentitySettings {
+  transactionIdentityDimensions: [InsightsSystemTransactionIdentityDimension!]!
+}
+
 type InsightsSystemSettings {
   sampling: InsightsSystemSamplingSettings!
   retention: InsightsSystemRetentionSettings!
@@ -729,6 +821,7 @@ type InsightsSystemSettings {
   capacity: InsightsSystemCapacitySettings!
   writeback: InsightsSystemWritebackSettings!
   detection: InsightsSystemDetectionSettings!
+  identity: InsightsSystemIdentitySettings!
 }
 
 input InsightsSystemSamplingSettingsInput {
@@ -758,6 +851,15 @@ input InsightsSystemDetectionSettingsInput {
   autoTransactionGuardrail: Boolean!
 }
 
+input InsightsSystemTransactionIdentityDimensionInput {
+  key: String!
+  enabled: Boolean!
+}
+
+input InsightsSystemIdentitySettingsInput {
+  transactionIdentityDimensions: [InsightsSystemTransactionIdentityDimensionInput!]!
+}
+
 input InsightsSystemSettingsInput {
   sampling: InsightsSystemSamplingSettingsInput!
   retention: InsightsSystemRetentionSettingsInput!
@@ -765,6 +867,13 @@ input InsightsSystemSettingsInput {
   capacity: InsightsSystemCapacitySettingsInput!
   writeback: InsightsSystemWritebackSettingsInput!
   detection: InsightsSystemDetectionSettingsInput!
+  identity: InsightsSystemIdentitySettingsInput!
+  """
+  Write-only. When true and identity dimensions changed vs stored settings,
+  delete all transactions and related baselines/samples/findings before applying.
+  Never returned by GET.
+  """
+  resetTransactions: Boolean
 }
 
 # Storage health (ClickHouse + writeback snapshot, for the settings/health page)

--- a/frontend/graph/insights.graphqls
+++ b/frontend/graph/insights.graphqls
@@ -691,11 +691,6 @@ type InsightsSystemRetentionSettings {
   observationRetentionDays: Int!
 }
 
-type InsightsSystemFindingsSettings {
-  defaultWindowHours: Int!
-  maxWindowHours: Int!
-}
-
 type InsightsSystemCapacitySettings {
   maxResidentTransactions: Int!
   maxBaselineSetMembers: Int!
@@ -717,7 +712,6 @@ type InsightsSystemDetectionSettings {
 type InsightsSystemSettings {
   sampling: InsightsSystemSamplingSettings!
   retention: InsightsSystemRetentionSettings!
-  findings: InsightsSystemFindingsSettings!
   capacity: InsightsSystemCapacitySettings!
   writeback: InsightsSystemWritebackSettings!
   detection: InsightsSystemDetectionSettings!
@@ -730,11 +724,6 @@ input InsightsSystemSamplingSettingsInput {
 
 input InsightsSystemRetentionSettingsInput {
   observationRetentionDays: Int!
-}
-
-input InsightsSystemFindingsSettingsInput {
-  defaultWindowHours: Int!
-  maxWindowHours: Int!
 }
 
 input InsightsSystemCapacitySettingsInput {
@@ -753,7 +742,6 @@ input InsightsSystemDetectionSettingsInput {
 input InsightsSystemSettingsInput {
   sampling: InsightsSystemSamplingSettingsInput!
   retention: InsightsSystemRetentionSettingsInput!
-  findings: InsightsSystemFindingsSettingsInput!
   capacity: InsightsSystemCapacitySettingsInput!
   writeback: InsightsSystemWritebackSettingsInput!
   detection: InsightsSystemDetectionSettingsInput!

--- a/frontend/graph/insights.graphqls
+++ b/frontend/graph/insights.graphqls
@@ -525,6 +525,10 @@ type InsightsBulkResolveResult {
   resolved: Int!
 }
 
+type InsightsBulkPromoteResult {
+  promoted: Int!
+}
+
 # Guardrails (operator-declared L7 rules, orthogonal to learned baselines)
 
 type InsightsGuardrailRule {
@@ -920,6 +924,19 @@ extend type Mutation {
     class: InsightsDeviationClass!
   ): Boolean!
   resetInsightsTransactionBaselines(transactionId: ID!): Boolean!
+  """
+  Force-promote every scored baseline class of one transaction
+  (POST /api/v1/transactions/{id}/baselines/promote). May auto-enable the
+  transaction guardrail when the global setting is on.
+  """
+  promoteInsightsTransactionBaselines(transactionId: ID!): Boolean!
+  """
+  Force-promote every scored baseline class on each listed transaction
+  (POST /api/v1/transactions/promote).
+  """
+  bulkPromoteInsightsTransactions(
+    transactionIds: [ID!]!
+  ): InsightsBulkPromoteResult!
   """
   Force-promote every scored baseline class on every transaction of a service
   (POST /api/v1/services/transaction-guardrail/force-promote). May auto-enable

--- a/frontend/graph/insights.resolvers.go
+++ b/frontend/graph/insights.resolvers.go
@@ -477,6 +477,27 @@ func (r *mutationResolver) DeleteInsightsTransaction(ctx context.Context, transa
 	return true, nil
 }
 
+// BulkDeleteInsightsTransactions is the resolver for the bulkDeleteInsightsTransactions field.
+func (r *mutationResolver) BulkDeleteInsightsTransactions(ctx context.Context, transactionIds []string) (*model.InsightsBulkDeleteResult, error) {
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]int64, 0, len(transactionIds))
+	for _, raw := range transactionIds {
+		id, err := insights.ParseID(raw)
+		if err != nil {
+			return nil, insights.GraphQLError(ctx, err)
+		}
+		ids = append(ids, id)
+	}
+	result, err := client.BulkDeleteTransactions(ctx, ids)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	return insights.BulkDeleteResultToModel(*result), nil
+}
+
 // UpsertInsightsPolicy is the resolver for the upsertInsightsPolicy field.
 func (r *mutationResolver) UpsertInsightsPolicy(ctx context.Context, policy model.InsightsPolicyInput) (*model.InsightsPolicy, error) {
 	client, err := r.insightsClient(ctx)

--- a/frontend/graph/insights.resolvers.go
+++ b/frontend/graph/insights.resolvers.go
@@ -615,10 +615,15 @@ func (r *mutationResolver) UpdateInsightsSystemSettings(ctx context.Context, set
 	if err != nil {
 		return nil, err
 	}
+	current, err := client.GetSystemSettings(ctx)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
 	request, err := insights.SystemSettingsFromInput(settings)
 	if err != nil {
 		return nil, insights.GraphQLError(ctx, err)
 	}
+	request.Findings = current.Findings
 	stored, err := client.UpdateSystemSettingsAndRead(ctx, request)
 	if err != nil {
 		return nil, insights.GraphQLError(ctx, err)

--- a/frontend/graph/insights.resolvers.go
+++ b/frontend/graph/insights.resolvers.go
@@ -388,6 +388,43 @@ func (r *mutationResolver) ResetInsightsTransactionBaselines(ctx context.Context
 	return true, nil
 }
 
+// PromoteInsightsTransactionBaselines is the resolver for the promoteInsightsTransactionBaselines field.
+func (r *mutationResolver) PromoteInsightsTransactionBaselines(ctx context.Context, transactionID string) (bool, error) {
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return false, err
+	}
+	id, err := insights.ParseID(transactionID)
+	if err != nil {
+		return false, insights.GraphQLError(ctx, err)
+	}
+	if err := client.PromoteTransactionBaselines(ctx, id); err != nil {
+		return false, insights.GraphQLError(ctx, err)
+	}
+	return true, nil
+}
+
+// BulkPromoteInsightsTransactions is the resolver for the bulkPromoteInsightsTransactions field.
+func (r *mutationResolver) BulkPromoteInsightsTransactions(ctx context.Context, transactionIds []string) (*model.InsightsBulkPromoteResult, error) {
+	client, err := r.insightsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]int64, 0, len(transactionIds))
+	for _, raw := range transactionIds {
+		id, err := insights.ParseID(raw)
+		if err != nil {
+			return nil, insights.GraphQLError(ctx, err)
+		}
+		ids = append(ids, id)
+	}
+	result, err := client.BulkPromoteTransactions(ctx, ids)
+	if err != nil {
+		return nil, insights.GraphQLError(ctx, err)
+	}
+	return insights.BulkPromoteResultToModel(*result), nil
+}
+
 // ForcePromoteInsightsService is the resolver for the forcePromoteInsightsService field.
 func (r *mutationResolver) ForcePromoteInsightsService(ctx context.Context, namespace string, service string) (bool, error) {
 	client, err := r.insightsClient(ctx)

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -766,22 +766,26 @@ type InsightsAnomalyClassFinding struct {
 }
 
 type InsightsAnomalyIssue struct {
-	TransactionID    string                   `json:"transactionId"`
-	Signature        string                   `json:"signature"`
-	Service          string                   `json:"service"`
-	Namespace        string                   `json:"namespace"`
-	Operation        *string                  `json:"operation,omitempty"`
-	Kind             *InsightsTransactionKind `json:"kind,omitempty"`
-	TriggeredClasses []InsightsDeviationClass `json:"triggeredClasses"`
-	Offending        *string                  `json:"offending,omitempty"`
-	PolicyID         *string                  `json:"policyId,omitempty"`
-	Occurrences      int                      `json:"occurrences"`
-	MaxScore         int                      `json:"maxScore"`
-	Severity         InsightsSeverity         `json:"severity"`
-	FirstSeen        *string                  `json:"firstSeen,omitempty"`
-	LastSeen         *string                  `json:"lastSeen,omitempty"`
-	LastTraceID      *string                  `json:"lastTraceId,omitempty"`
-	Status           InsightsAnomalyStatus    `json:"status"`
+	TransactionID string `json:"transactionId"`
+	Signature     string `json:"signature"`
+	Service       string `json:"service"`
+	Namespace     string `json:"namespace"`
+	// Full canonical identity string.
+	Operation string `json:"operation"`
+	// Entry-span operation without dimension suffixes.
+	OperationName      string                              `json:"operationName"`
+	IdentityDimensions []*InsightsTransactionIdentityValue `json:"identityDimensions"`
+	Kind               *InsightsTransactionKind            `json:"kind,omitempty"`
+	TriggeredClasses   []InsightsDeviationClass            `json:"triggeredClasses"`
+	Offending          *string                             `json:"offending,omitempty"`
+	PolicyID           *string                             `json:"policyId,omitempty"`
+	Occurrences        int                                 `json:"occurrences"`
+	MaxScore           int                                 `json:"maxScore"`
+	Severity           InsightsSeverity                    `json:"severity"`
+	FirstSeen          *string                             `json:"firstSeen,omitempty"`
+	LastSeen           *string                             `json:"lastSeen,omitempty"`
+	LastTraceID        *string                             `json:"lastTraceId,omitempty"`
+	Status             InsightsAnomalyStatus               `json:"status"`
 	// JSON-encoded evidence keyed by deviation class; only available on the single-anomaly query.
 	Evidence string                  `json:"evidence"`
 	Risk     *InsightsRiskAssessment `json:"risk,omitempty"`
@@ -813,27 +817,38 @@ type InsightsAnomalySpanHighlight struct {
 }
 
 type InsightsAnomalySummary struct {
-	TransactionID    string                   `json:"transactionId"`
-	Signature        string                   `json:"signature"`
-	Service          string                   `json:"service"`
-	Namespace        string                   `json:"namespace"`
-	Operation        *string                  `json:"operation,omitempty"`
-	Kind             *InsightsTransactionKind `json:"kind,omitempty"`
-	TriggeredClasses []InsightsDeviationClass `json:"triggeredClasses"`
-	Offending        *string                  `json:"offending,omitempty"`
-	PolicyID         *string                  `json:"policyId,omitempty"`
-	Occurrences      int                      `json:"occurrences"`
-	MaxScore         int                      `json:"maxScore"`
-	Severity         InsightsSeverity         `json:"severity"`
-	FirstSeen        *string                  `json:"firstSeen,omitempty"`
-	LastSeen         *string                  `json:"lastSeen,omitempty"`
-	LastTraceID      *string                  `json:"lastTraceId,omitempty"`
-	Status           InsightsAnomalyStatus    `json:"status"`
+	TransactionID string `json:"transactionId"`
+	Signature     string `json:"signature"`
+	Service       string `json:"service"`
+	Namespace     string `json:"namespace"`
+	// Full canonical identity string.
+	Operation string `json:"operation"`
+	// Entry-span operation without dimension suffixes.
+	OperationName      string                              `json:"operationName"`
+	IdentityDimensions []*InsightsTransactionIdentityValue `json:"identityDimensions"`
+	Kind               *InsightsTransactionKind            `json:"kind,omitempty"`
+	TriggeredClasses   []InsightsDeviationClass            `json:"triggeredClasses"`
+	Offending          *string                             `json:"offending,omitempty"`
+	PolicyID           *string                             `json:"policyId,omitempty"`
+	Occurrences        int                                 `json:"occurrences"`
+	MaxScore           int                                 `json:"maxScore"`
+	Severity           InsightsSeverity                    `json:"severity"`
+	FirstSeen          *string                             `json:"firstSeen,omitempty"`
+	LastSeen           *string                             `json:"lastSeen,omitempty"`
+	LastTraceID        *string                             `json:"lastTraceId,omitempty"`
+	Status             InsightsAnomalyStatus               `json:"status"`
 }
 
 type InsightsBaselineClass struct {
 	TransactionID string                 `json:"transactionId"`
 	Class         InsightsDeviationClass `json:"class"`
+	// Human-readable name for what this class learns on a transaction
+	// (e.g. "Request latency" for D3_latency). Sourced from the risk catalog;
+	// UI should display this and keep `class` as the stable id for promote/reset.
+	ClassLabel string `json:"classLabel"`
+	// Tooltip text describing what this class learns for the transaction.
+	// Suitable for hover UI; not the finding/anomaly wording.
+	ClassDescription string `json:"classDescription"`
 	// JSON-encoded baseline data; shape varies per deviation class.
 	Data                         *string                   `json:"data,omitempty"`
 	DataSchemaVersion            *int                      `json:"dataSchemaVersion,omitempty"`
@@ -936,14 +951,18 @@ type InsightsCatalogCategory struct {
 }
 
 type InsightsCatalogClass struct {
-	ID            string  `json:"id"`
-	Label         string  `json:"label"`
-	Description   *string `json:"description,omitempty"`
-	Category      string  `json:"category"`
-	CategoryLabel *string `json:"categoryLabel,omitempty"`
-	Weight        int     `json:"weight"`
-	Mitre         *string `json:"mitre,omitempty"`
-	Owasp         *string `json:"owasp,omitempty"`
+	ID          string  `json:"id"`
+	Label       string  `json:"label"`
+	Description *string `json:"description,omitempty"`
+	// Transaction-baseline name for this class (what is learned). Distinct from finding-oriented `label`.
+	BaselineLabel string `json:"baselineLabel"`
+	// Tooltip for what this class learns on a transaction baseline.
+	BaselineDescription *string `json:"baselineDescription,omitempty"`
+	Category            string  `json:"category"`
+	CategoryLabel       *string `json:"categoryLabel,omitempty"`
+	Weight              int     `json:"weight"`
+	Mitre               *string `json:"mitre,omitempty"`
+	Owasp               *string `json:"owasp,omitempty"`
 }
 
 type InsightsCatalogEnricher struct {
@@ -973,15 +992,22 @@ type InsightsEnricherList struct {
 }
 
 type InsightsFinding struct {
-	Kind        InsightsFindingKind `json:"kind"`
-	Service     string              `json:"service"`
-	Namespace   string              `json:"namespace"`
-	Title       string              `json:"title"`
-	Offending   *string             `json:"offending,omitempty"`
-	Score       int                 `json:"score"`
-	Severity    InsightsSeverity    `json:"severity"`
-	Occurrences int                 `json:"occurrences"`
-	LastSeen    string              `json:"lastSeen"`
+	Kind      InsightsFindingKind `json:"kind"`
+	Service   string              `json:"service"`
+	Namespace string              `json:"namespace"`
+	// Human-readable headline. Anomalies use operationName; violations use the guardrail rule label.
+	Title string `json:"title"`
+	// Full canonical transaction operation (anomalies only). Omitted for violations.
+	Operation *string `json:"operation,omitempty"`
+	// Entry-span operation without dimension suffixes (anomalies).
+	OperationName *string `json:"operationName,omitempty"`
+	// Parsed identity dimensions (anomalies only).
+	IdentityDimensions []*InsightsTransactionIdentityValue `json:"identityDimensions,omitempty"`
+	Offending          *string                             `json:"offending,omitempty"`
+	Score              int                                 `json:"score"`
+	Severity           InsightsSeverity                    `json:"severity"`
+	Occurrences        int                                 `json:"occurrences"`
+	LastSeen           string                              `json:"lastSeen"`
 	// Union of anomaly statuses (open|baselined|dismissed) and violation statuses (open|dismissed|allowed).
 	Status string `json:"status"`
 	// Anomaly drill-down key; set when kind is anomaly.
@@ -1299,6 +1325,16 @@ type InsightsSystemFindingsSettingsInput struct {
 	MaxWindowHours     int `json:"maxWindowHours"`
 }
 
+// Extra dimensions appended to transaction Operation before hashing.
+// Each enabled dimension multiplies cardinality. Use only low-cardinality attributes.
+type InsightsSystemIdentitySettings struct {
+	TransactionIdentityDimensions []*InsightsSystemTransactionIdentityDimension `json:"transactionIdentityDimensions"`
+}
+
+type InsightsSystemIdentitySettingsInput struct {
+	TransactionIdentityDimensions []*InsightsSystemTransactionIdentityDimensionInput `json:"transactionIdentityDimensions"`
+}
+
 type InsightsSystemRetentionSettings struct {
 	ObservationRetentionDays int `json:"observationRetentionDays"`
 }
@@ -1324,6 +1360,7 @@ type InsightsSystemSettings struct {
 	Capacity  *InsightsSystemCapacitySettings  `json:"capacity"`
 	Writeback *InsightsSystemWritebackSettings `json:"writeback"`
 	Detection *InsightsSystemDetectionSettings `json:"detection"`
+	Identity  *InsightsSystemIdentitySettings  `json:"identity"`
 }
 
 type InsightsSystemSettingsInput struct {
@@ -1333,6 +1370,23 @@ type InsightsSystemSettingsInput struct {
 	Capacity  *InsightsSystemCapacitySettingsInput  `json:"capacity"`
 	Writeback *InsightsSystemWritebackSettingsInput `json:"writeback"`
 	Detection *InsightsSystemDetectionSettingsInput `json:"detection"`
+	Identity  *InsightsSystemIdentitySettingsInput  `json:"identity"`
+	// Write-only. When true and identity dimensions changed vs stored settings,
+	// delete all transactions and related baselines/samples/findings before applying.
+	// Never returned by GET.
+	ResetTransactions *bool `json:"resetTransactions,omitempty"`
+}
+
+// One low-cardinality attribute (or built-in resolver key) folded into transaction identity
+// from the sub-transaction entry span only.
+type InsightsSystemTransactionIdentityDimension struct {
+	Key     string `json:"key"`
+	Enabled bool   `json:"enabled"`
+}
+
+type InsightsSystemTransactionIdentityDimensionInput struct {
+	Key     string `json:"key"`
+	Enabled bool   `json:"enabled"`
 }
 
 type InsightsSystemWritebackSettings struct {
@@ -1344,23 +1398,38 @@ type InsightsSystemWritebackSettingsInput struct {
 }
 
 type InsightsTransaction struct {
-	ID        string                  `json:"id"`
-	Service   string                  `json:"service"`
-	Namespace string                  `json:"namespace"`
-	Operation string                  `json:"operation"`
-	Kind      InsightsTransactionKind `json:"kind"`
+	ID        string `json:"id"`
+	Service   string `json:"service"`
+	Namespace string `json:"namespace"`
+	// Full canonical identity string (hashed, guardrails). Includes [key=value] suffixes when identity dimensions are enabled.
+	Operation string `json:"operation"`
+	// Human-readable entry-span operation without dimension suffixes.
+	OperationName      string                              `json:"operationName"`
+	IdentityDimensions []*InsightsTransactionIdentityValue `json:"identityDimensions"`
+	Kind               InsightsTransactionKind             `json:"kind"`
+}
+
+// One parsed low-cardinality dimension from the stored operation identity suffix ([key=value]).
+// For display only — canonical identity remains in `operation`.
+type InsightsTransactionIdentityValue struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 type InsightsTransactionStat struct {
-	ID          string                  `json:"id"`
-	Service     string                  `json:"service"`
-	Namespace   string                  `json:"namespace"`
-	Operation   string                  `json:"operation"`
-	Kind        InsightsTransactionKind `json:"kind"`
-	Volume      int                     `json:"volume"`
-	LastSeen    string                  `json:"lastSeen"`
-	HasBaseline *bool                   `json:"hasBaseline,omitempty"`
-	Promoted    *bool                   `json:"promoted,omitempty"`
+	ID        string `json:"id"`
+	Service   string `json:"service"`
+	Namespace string `json:"namespace"`
+	// Full canonical identity string (hashed). Includes [key=value] suffixes when identity dimensions are enabled.
+	Operation string `json:"operation"`
+	// Entry-span operation without dimension suffixes.
+	OperationName      string                              `json:"operationName"`
+	IdentityDimensions []*InsightsTransactionIdentityValue `json:"identityDimensions"`
+	Kind               InsightsTransactionKind             `json:"kind"`
+	Volume             int                                 `json:"volume"`
+	LastSeen           string                              `json:"lastSeen"`
+	HasBaseline        *bool                               `json:"hasBaseline,omitempty"`
+	Promoted           *bool                               `json:"promoted,omitempty"`
 }
 
 type InsightsViolationActionInput struct {

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -903,6 +903,10 @@ type InsightsBlastRadiusSubgraph struct {
 	Edges []*InsightsBlastRadiusEdge `json:"edges"`
 }
 
+type InsightsBulkPromoteResult struct {
+	Promoted int `json:"promoted"`
+}
+
 type InsightsBulkResolveResult struct {
 	Resolution string `json:"resolution"`
 	Resolved   int    `json:"resolved"`

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -903,6 +903,10 @@ type InsightsBlastRadiusSubgraph struct {
 	Edges []*InsightsBlastRadiusEdge `json:"edges"`
 }
 
+type InsightsBulkDeleteResult struct {
+	Deleted int `json:"deleted"`
+}
+
 type InsightsBulkPromoteResult struct {
 	Promoted int `json:"promoted"`
 }

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -1281,16 +1281,6 @@ type InsightsSystemDetectionSettingsInput struct {
 	AutoTransactionGuardrail bool `json:"autoTransactionGuardrail"`
 }
 
-type InsightsSystemFindingsSettings struct {
-	DefaultWindowHours int `json:"defaultWindowHours"`
-	MaxWindowHours     int `json:"maxWindowHours"`
-}
-
-type InsightsSystemFindingsSettingsInput struct {
-	DefaultWindowHours int `json:"defaultWindowHours"`
-	MaxWindowHours     int `json:"maxWindowHours"`
-}
-
 type InsightsSystemRetentionSettings struct {
 	ObservationRetentionDays int `json:"observationRetentionDays"`
 }
@@ -1312,7 +1302,6 @@ type InsightsSystemSamplingSettingsInput struct {
 type InsightsSystemSettings struct {
 	Sampling  *InsightsSystemSamplingSettings  `json:"sampling"`
 	Retention *InsightsSystemRetentionSettings `json:"retention"`
-	Findings  *InsightsSystemFindingsSettings  `json:"findings"`
 	Capacity  *InsightsSystemCapacitySettings  `json:"capacity"`
 	Writeback *InsightsSystemWritebackSettings `json:"writeback"`
 	Detection *InsightsSystemDetectionSettings `json:"detection"`
@@ -1321,7 +1310,6 @@ type InsightsSystemSettings struct {
 type InsightsSystemSettingsInput struct {
 	Sampling  *InsightsSystemSamplingSettingsInput  `json:"sampling"`
 	Retention *InsightsSystemRetentionSettingsInput `json:"retention"`
-	Findings  *InsightsSystemFindingsSettingsInput  `json:"findings"`
 	Capacity  *InsightsSystemCapacitySettingsInput  `json:"capacity"`
 	Writeback *InsightsSystemWritebackSettingsInput `json:"writeback"`
 	Detection *InsightsSystemDetectionSettingsInput `json:"detection"`

--- a/frontend/services/insights/client.go
+++ b/frontend/services/insights/client.go
@@ -99,6 +99,16 @@ func (c *Client) DeleteTransaction(ctx context.Context, transactionID int64) err
 	return c.do(ctx, http.MethodDelete, c.transactionEndpoint(transactionID), nil, nil)
 }
 
+// BulkDeleteTransactions permanently removes many transactions
+// (POST /api/v1/transactions).
+func (c *Client) BulkDeleteTransactions(ctx context.Context, transactionIDs []int64) (*BulkDeleteResult, error) {
+	var result BulkDeleteResult
+	if err := c.do(ctx, http.MethodPost, c.apiEndpoint("transactions"), BulkDeleteRequest{TransactionIDs: transactionIDs}, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 func (c *Client) GetTransactionBaseline(ctx context.Context, transactionID int64) ([]BaselineClass, error) {
 	return doList[BaselineClass](ctx, c, http.MethodGet, c.transactionEndpoint(transactionID, "baseline"), nil)
 }

--- a/frontend/services/insights/client.go
+++ b/frontend/services/insights/client.go
@@ -111,6 +111,22 @@ func (c *Client) PromoteBaselineClass(ctx context.Context, transactionID int64, 
 	return &result, nil
 }
 
+// PromoteTransactionBaselines force-promotes every scored baseline class of one
+// transaction (POST /api/v1/transactions/{id}/baselines/promote).
+func (c *Client) PromoteTransactionBaselines(ctx context.Context, transactionID int64) error {
+	return c.do(ctx, http.MethodPost, c.transactionEndpoint(transactionID, "baselines", "promote"), nil, nil)
+}
+
+// BulkPromoteTransactions force-promotes every scored baseline class on each
+// listed transaction (POST /api/v1/transactions/promote).
+func (c *Client) BulkPromoteTransactions(ctx context.Context, transactionIDs []int64) (*BulkPromoteResult, error) {
+	var result BulkPromoteResult
+	if err := c.do(ctx, http.MethodPost, c.apiEndpoint("transactions", "promote"), BulkPromoteRequest{TransactionIDs: transactionIDs}, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 // ForcePromoteService promotes every scored baseline class on every transaction
 // of the service (POST /api/v1/services/transaction-guardrail/force-promote).
 func (c *Client) ForcePromoteService(ctx context.Context, namespace, service string) error {

--- a/frontend/services/insights/conversions.go
+++ b/frontend/services/insights/conversions.go
@@ -889,10 +889,6 @@ func SystemSettingsToModel(settings SystemSettings) *model.InsightsSystemSetting
 		Retention: &model.InsightsSystemRetentionSettings{
 			ObservationRetentionDays: settings.Retention.ObservationRetentionDays,
 		},
-		Findings: &model.InsightsSystemFindingsSettings{
-			DefaultWindowHours: settings.Findings.DefaultWindowHours,
-			MaxWindowHours:     settings.Findings.MaxWindowHours,
-		},
 		Capacity: &model.InsightsSystemCapacitySettings{
 			MaxResidentTransactions: settings.Capacity.MaxResidentTransactions,
 			MaxBaselineSetMembers:   settings.Capacity.MaxBaselineSetMembers,
@@ -1096,7 +1092,7 @@ func BulkAnomalyRequestFromInput(resolution model.InsightsBulkResolution, items 
 }
 
 func SystemSettingsFromInput(input model.InsightsSystemSettingsInput) (SystemSettings, error) {
-	if input.Sampling == nil || input.Retention == nil || input.Findings == nil || input.Capacity == nil || input.Writeback == nil || input.Detection == nil {
+	if input.Sampling == nil || input.Retention == nil || input.Capacity == nil || input.Writeback == nil || input.Detection == nil {
 		return SystemSettings{}, fmt.Errorf("%w: system settings input is incomplete", ErrBadRequest)
 	}
 	return SystemSettings{
@@ -1106,10 +1102,6 @@ func SystemSettingsFromInput(input model.InsightsSystemSettingsInput) (SystemSet
 		},
 		Retention: SystemRetentionSettings{
 			ObservationRetentionDays: input.Retention.ObservationRetentionDays,
-		},
-		Findings: SystemFindingsSettings{
-			DefaultWindowHours: input.Findings.DefaultWindowHours,
-			MaxWindowHours:     input.Findings.MaxWindowHours,
 		},
 		Capacity: SystemCapacitySettings{
 			MaxResidentTransactions: input.Capacity.MaxResidentTransactions,

--- a/frontend/services/insights/conversions.go
+++ b/frontend/services/insights/conversions.go
@@ -476,6 +476,12 @@ func BulkPromoteResultToModel(result BulkPromoteResult) *model.InsightsBulkPromo
 	}
 }
 
+func BulkDeleteResultToModel(result BulkDeleteResult) *model.InsightsBulkDeleteResult {
+	return &model.InsightsBulkDeleteResult{
+		Deleted: result.Deleted,
+	}
+}
+
 func ObservationSummaryToModel(observation ObservationSummary) *model.InsightsObservationSummary {
 	return &model.InsightsObservationSummary{
 		TraceID:       observation.TraceID,

--- a/frontend/services/insights/conversions.go
+++ b/frontend/services/insights/conversions.go
@@ -388,17 +388,34 @@ func stringSliceOrEmpty(s []string) []string {
 	return s
 }
 
+func TransactionIdentityValueToModel(dim TransactionIdentityValue) *model.InsightsTransactionIdentityValue {
+	return &model.InsightsTransactionIdentityValue{
+		Key:   dim.Key,
+		Value: dim.Value,
+	}
+}
+
+func TransactionIdentityValuesToModel(dims []TransactionIdentityValue) []*model.InsightsTransactionIdentityValue {
+	out := mapSlice(dims, TransactionIdentityValueToModel)
+	if out == nil {
+		return []*model.InsightsTransactionIdentityValue{}
+	}
+	return out
+}
+
 func TransactionStatToModel(stat TransactionStat) *model.InsightsTransactionStat {
 	return &model.InsightsTransactionStat{
-		ID:          FormatID(stat.ID),
-		Service:     stat.Service,
-		Namespace:   stat.Namespace,
-		Operation:   stat.Operation,
-		Kind:        TransactionKindToModel(stat.Kind),
-		Volume:      int64ToInt(stat.Volume),
-		LastSeen:    stat.LastSeen,
-		HasBaseline: stat.HasBaseline,
-		Promoted:    stat.Promoted,
+		ID:                 FormatID(stat.ID),
+		Service:            stat.Service,
+		Namespace:          stat.Namespace,
+		Operation:          stat.Operation,
+		OperationName:      stat.OperationName,
+		IdentityDimensions: TransactionIdentityValuesToModel(stat.IdentityDimensions),
+		Kind:               TransactionKindToModel(stat.Kind),
+		Volume:             int64ToInt(stat.Volume),
+		LastSeen:           stat.LastSeen,
+		HasBaseline:        stat.HasBaseline,
+		Promoted:           stat.Promoted,
 	}
 }
 
@@ -408,11 +425,13 @@ func TransactionStatsToModel(stats []TransactionStat) []*model.InsightsTransacti
 
 func TransactionToModel(transaction Transaction) *model.InsightsTransaction {
 	return &model.InsightsTransaction{
-		ID:        FormatID(transaction.ID),
-		Service:   transaction.Service,
-		Namespace: transaction.Namespace,
-		Operation: transaction.Operation,
-		Kind:      TransactionKindToModel(transaction.Kind),
+		ID:                 FormatID(transaction.ID),
+		Service:            transaction.Service,
+		Namespace:          transaction.Namespace,
+		Operation:          transaction.Operation,
+		OperationName:      transaction.OperationName,
+		IdentityDimensions: TransactionIdentityValuesToModel(transaction.IdentityDimensions),
+		Kind:               TransactionKindToModel(transaction.Kind),
 	}
 }
 
@@ -424,6 +443,8 @@ func BaselineClassToModel(baseline BaselineClass) (*model.InsightsBaselineClass,
 	return &model.InsightsBaselineClass{
 		TransactionID:                FormatID(baseline.TransactionID),
 		Class:                        DeviationClassToModel(baseline.Class),
+		ClassLabel:                   baseline.ClassLabel,
+		ClassDescription:             baseline.ClassDescription,
 		Data:                         data,
 		DataSchemaVersion:            baseline.DataSchemaVersion,
 		ObservationCount:             int64ToInt(baseline.ObservationCount),
@@ -569,21 +590,24 @@ func LearningPoliciesToModel(policies []LearningPolicy) []*model.InsightsLearnin
 
 func FindingToModel(finding Finding) *model.InsightsFinding {
 	return &model.InsightsFinding{
-		Kind:             FindingKindToModel(finding.Kind),
-		Service:          finding.Service,
-		Namespace:        finding.Namespace,
-		Title:            finding.Title,
-		Offending:        finding.Offending,
-		Score:            finding.Score,
-		Severity:         SeverityToModel(finding.Severity),
-		Occurrences:      int64ToInt(finding.Occurrences),
-		LastSeen:         finding.LastSeen,
-		Status:           finding.Status,
-		TransactionID:    formatOptionalID(finding.TransactionID),
-		Signature:        finding.Signature,
-		TriggeredClasses: mapSlice(finding.TriggeredClasses, DeviationClassToModel),
-		ScopeKey:         finding.ScopeKey,
-		RuleKey:          finding.RuleKey,
+		Kind:               FindingKindToModel(finding.Kind),
+		Service:            finding.Service,
+		Namespace:          finding.Namespace,
+		Title:              finding.Title,
+		Operation:          finding.Operation,
+		OperationName:      finding.OperationName,
+		IdentityDimensions: mapSlice(finding.IdentityDimensions, TransactionIdentityValueToModel),
+		Offending:          finding.Offending,
+		Score:              finding.Score,
+		Severity:           SeverityToModel(finding.Severity),
+		Occurrences:        int64ToInt(finding.Occurrences),
+		LastSeen:           finding.LastSeen,
+		Status:             finding.Status,
+		TransactionID:      formatOptionalID(finding.TransactionID),
+		Signature:          finding.Signature,
+		TriggeredClasses:   mapSlice(finding.TriggeredClasses, DeviationClassToModel),
+		ScopeKey:           finding.ScopeKey,
+		RuleKey:            finding.RuleKey,
 	}
 }
 
@@ -618,22 +642,24 @@ func RiskAssessmentToModel(risk RiskAssessment) *model.InsightsRiskAssessment {
 
 func AnomalySummaryToModel(anomaly AnomalySummary) *model.InsightsAnomalySummary {
 	return &model.InsightsAnomalySummary{
-		TransactionID:    FormatID(anomaly.TransactionID),
-		Signature:        anomaly.Signature,
-		Service:          anomaly.Service,
-		Namespace:        anomaly.Namespace,
-		Operation:        anomaly.Operation,
-		Kind:             TransactionKindPtrToModel(anomaly.Kind),
-		TriggeredClasses: mapSlice(anomaly.TriggeredClasses, DeviationClassToModel),
-		Offending:        anomaly.Offending,
-		PolicyID:         formatOptionalID(anomaly.PolicyID),
-		Occurrences:      int64ToInt(anomaly.Occurrences),
-		MaxScore:         anomaly.MaxScore,
-		Severity:         SeverityToModel(anomaly.Severity),
-		FirstSeen:        anomaly.FirstSeen,
-		LastSeen:         anomaly.LastSeen,
-		LastTraceID:      anomaly.LastTraceID,
-		Status:           AnomalyStatusToModel(anomaly.Status),
+		TransactionID:      FormatID(anomaly.TransactionID),
+		Signature:          anomaly.Signature,
+		Service:            anomaly.Service,
+		Namespace:          anomaly.Namespace,
+		Operation:          anomaly.Operation,
+		OperationName:      anomaly.OperationName,
+		IdentityDimensions: TransactionIdentityValuesToModel(anomaly.IdentityDimensions),
+		Kind:               TransactionKindPtrToModel(anomaly.Kind),
+		TriggeredClasses:   mapSlice(anomaly.TriggeredClasses, DeviationClassToModel),
+		Offending:          anomaly.Offending,
+		PolicyID:           formatOptionalID(anomaly.PolicyID),
+		Occurrences:        int64ToInt(anomaly.Occurrences),
+		MaxScore:           anomaly.MaxScore,
+		Severity:           SeverityToModel(anomaly.Severity),
+		FirstSeen:          anomaly.FirstSeen,
+		LastSeen:           anomaly.LastSeen,
+		LastTraceID:        anomaly.LastTraceID,
+		Status:             AnomalyStatusToModel(anomaly.Status),
 	}
 }
 
@@ -711,27 +737,29 @@ func AnomalyIssueToModel(anomaly AnomalyIssue) (*model.InsightsAnomalyIssue, err
 		baselineTrace = ObservationToModel(*anomaly.BaselineTrace)
 	}
 	return &model.InsightsAnomalyIssue{
-		TransactionID:    FormatID(anomaly.TransactionID),
-		Signature:        anomaly.Signature,
-		Service:          anomaly.Service,
-		Namespace:        anomaly.Namespace,
-		Operation:        anomaly.Operation,
-		Kind:             TransactionKindPtrToModel(anomaly.Kind),
-		TriggeredClasses: mapSlice(anomaly.TriggeredClasses, DeviationClassToModel),
-		Offending:        anomaly.Offending,
-		PolicyID:         formatOptionalID(anomaly.PolicyID),
-		Occurrences:      int64ToInt(anomaly.Occurrences),
-		MaxScore:         anomaly.MaxScore,
-		Severity:         SeverityToModel(anomaly.Severity),
-		FirstSeen:        anomaly.FirstSeen,
-		LastSeen:         anomaly.LastSeen,
-		LastTraceID:      anomaly.LastTraceID,
-		Status:           AnomalyStatusToModel(anomaly.Status),
-		Evidence:         evidence,
-		Risk:             risk,
-		ClassFindings:    classFindings,
-		AnomalyTrace:     anomalyTrace,
-		BaselineTrace:    baselineTrace,
+		TransactionID:      FormatID(anomaly.TransactionID),
+		Signature:          anomaly.Signature,
+		Service:            anomaly.Service,
+		Namespace:          anomaly.Namespace,
+		Operation:          anomaly.Operation,
+		OperationName:      anomaly.OperationName,
+		IdentityDimensions: TransactionIdentityValuesToModel(anomaly.IdentityDimensions),
+		Kind:               TransactionKindPtrToModel(anomaly.Kind),
+		TriggeredClasses:   mapSlice(anomaly.TriggeredClasses, DeviationClassToModel),
+		Offending:          anomaly.Offending,
+		PolicyID:           formatOptionalID(anomaly.PolicyID),
+		Occurrences:        int64ToInt(anomaly.Occurrences),
+		MaxScore:           anomaly.MaxScore,
+		Severity:           SeverityToModel(anomaly.Severity),
+		FirstSeen:          anomaly.FirstSeen,
+		LastSeen:           anomaly.LastSeen,
+		LastTraceID:        anomaly.LastTraceID,
+		Status:             AnomalyStatusToModel(anomaly.Status),
+		Evidence:           evidence,
+		Risk:               risk,
+		ClassFindings:      classFindings,
+		AnomalyTrace:       anomalyTrace,
+		BaselineTrace:      baselineTrace,
 	}, nil
 }
 
@@ -808,14 +836,16 @@ func GuardrailViolationDetailToModel(detail GuardrailViolationDetail) *model.Ins
 
 func CatalogClassToModel(class CatalogClass) *model.InsightsCatalogClass {
 	return &model.InsightsCatalogClass{
-		ID:            class.ID,
-		Label:         class.Label,
-		Description:   class.Description,
-		Category:      class.Category,
-		CategoryLabel: class.CategoryLabel,
-		Weight:        class.Weight,
-		Mitre:         class.Mitre,
-		Owasp:         class.Owasp,
+		ID:                  class.ID,
+		Label:               class.Label,
+		Description:         class.Description,
+		BaselineLabel:       class.BaselineLabel,
+		BaselineDescription: class.BaselineDescription,
+		Category:            class.Category,
+		CategoryLabel:       class.CategoryLabel,
+		Weight:              class.Weight,
+		Mitre:               class.Mitre,
+		Owasp:               class.Owasp,
 	}
 }
 
@@ -915,6 +945,24 @@ func SystemSettingsToModel(settings SystemSettings) *model.InsightsSystemSetting
 		Detection: &model.InsightsSystemDetectionSettings{
 			AutoTransactionGuardrail: settings.Detection.AutoTransactionGuardrail,
 		},
+		Identity: SystemIdentitySettingsToModel(settings.Identity),
+	}
+}
+
+func SystemIdentitySettingsToModel(identity SystemIdentitySettings) *model.InsightsSystemIdentitySettings {
+	dims := mapSlice(identity.TransactionIdentityDimensions, SystemTransactionIdentityDimensionToModel)
+	if dims == nil {
+		dims = []*model.InsightsSystemTransactionIdentityDimension{}
+	}
+	return &model.InsightsSystemIdentitySettings{
+		TransactionIdentityDimensions: dims,
+	}
+}
+
+func SystemTransactionIdentityDimensionToModel(dim SystemTransactionIdentityDimension) *model.InsightsSystemTransactionIdentityDimension {
+	return &model.InsightsSystemTransactionIdentityDimension{
+		Key:     dim.Key,
+		Enabled: dim.Enabled,
 	}
 }
 
@@ -1108,7 +1156,7 @@ func BulkAnomalyRequestFromInput(resolution model.InsightsBulkResolution, items 
 }
 
 func SystemSettingsFromInput(input model.InsightsSystemSettingsInput) (SystemSettings, error) {
-	if input.Sampling == nil || input.Retention == nil || input.Findings == nil || input.Capacity == nil || input.Writeback == nil || input.Detection == nil {
+	if input.Sampling == nil || input.Retention == nil || input.Findings == nil || input.Capacity == nil || input.Writeback == nil || input.Detection == nil || input.Identity == nil {
 		return SystemSettings{}, fmt.Errorf("%w: system settings input is incomplete", ErrBadRequest)
 	}
 	return SystemSettings{
@@ -1133,5 +1181,24 @@ func SystemSettingsFromInput(input model.InsightsSystemSettingsInput) (SystemSet
 		Detection: SystemDetectionSettings{
 			AutoTransactionGuardrail: input.Detection.AutoTransactionGuardrail,
 		},
+		Identity:          SystemIdentitySettingsFromInput(input.Identity),
+		ResetTransactions: input.ResetTransactions,
 	}, nil
+}
+
+func SystemIdentitySettingsFromInput(identity *model.InsightsSystemIdentitySettingsInput) SystemIdentitySettings {
+	if identity == nil {
+		return SystemIdentitySettings{TransactionIdentityDimensions: []SystemTransactionIdentityDimension{}}
+	}
+	dims := make([]SystemTransactionIdentityDimension, 0, len(identity.TransactionIdentityDimensions))
+	for _, dim := range identity.TransactionIdentityDimensions {
+		if dim == nil {
+			continue
+		}
+		dims = append(dims, SystemTransactionIdentityDimension{
+			Key:     dim.Key,
+			Enabled: dim.Enabled,
+		})
+	}
+	return SystemIdentitySettings{TransactionIdentityDimensions: dims}
 }

--- a/frontend/services/insights/conversions.go
+++ b/frontend/services/insights/conversions.go
@@ -470,6 +470,12 @@ func PromoteResultToModel(result PromoteResult) *model.InsightsPromoteResult {
 	}
 }
 
+func BulkPromoteResultToModel(result BulkPromoteResult) *model.InsightsBulkPromoteResult {
+	return &model.InsightsBulkPromoteResult{
+		Promoted: result.Promoted,
+	}
+}
+
 func ObservationSummaryToModel(observation ObservationSummary) *model.InsightsObservationSummary {
 	return &model.InsightsObservationSummary{
 		TraceID:       observation.TraceID,

--- a/frontend/services/insights/conversions_test.go
+++ b/frontend/services/insights/conversions_test.go
@@ -238,7 +238,6 @@ func TestSystemSettingsAndGuardrailSeedRoundTrip(t *testing.T) {
 	settings := SystemSettings{
 		Sampling:  SystemSamplingSettings{ExamplesPerTransaction: 3, ExampleSampleIntervalSeconds: 60},
 		Retention: SystemRetentionSettings{ObservationRetentionDays: 14},
-		Findings:  SystemFindingsSettings{DefaultWindowHours: 24, MaxWindowHours: 168},
 		Capacity:  SystemCapacitySettings{MaxResidentTransactions: 1000, MaxBaselineSetMembers: 500},
 		Writeback: SystemWritebackSettings{FlushIntervalSeconds: 30},
 		Detection: SystemDetectionSettings{AutoTransactionGuardrail: true},
@@ -247,7 +246,6 @@ func TestSystemSettingsAndGuardrailSeedRoundTrip(t *testing.T) {
 	back, err := SystemSettingsFromInput(model.InsightsSystemSettingsInput{
 		Sampling:  &model.InsightsSystemSamplingSettingsInput{ExamplesPerTransaction: gql.Sampling.ExamplesPerTransaction, ExampleSampleIntervalSeconds: gql.Sampling.ExampleSampleIntervalSeconds},
 		Retention: &model.InsightsSystemRetentionSettingsInput{ObservationRetentionDays: gql.Retention.ObservationRetentionDays},
-		Findings:  &model.InsightsSystemFindingsSettingsInput{DefaultWindowHours: gql.Findings.DefaultWindowHours, MaxWindowHours: gql.Findings.MaxWindowHours},
 		Capacity:  &model.InsightsSystemCapacitySettingsInput{MaxResidentTransactions: gql.Capacity.MaxResidentTransactions, MaxBaselineSetMembers: gql.Capacity.MaxBaselineSetMembers},
 		Writeback: &model.InsightsSystemWritebackSettingsInput{FlushIntervalSeconds: gql.Writeback.FlushIntervalSeconds},
 		Detection: &model.InsightsSystemDetectionSettingsInput{AutoTransactionGuardrail: gql.Detection.AutoTransactionGuardrail},

--- a/frontend/services/insights/conversions_test.go
+++ b/frontend/services/insights/conversions_test.go
@@ -96,17 +96,25 @@ func TestTransactionIDRoundTrip(t *testing.T) {
 	require.Error(t, err)
 
 	stat := TransactionStat{
-		ID:        4211,
-		Service:   "checkout",
-		Namespace: "prod",
-		Operation: "POST /pay",
-		Kind:      "HTTP",
-		Volume:    12,
-		LastSeen:  "2026-08-05T06:00:00Z",
+		ID:            4211,
+		Service:       "checkout",
+		Namespace:     "prod",
+		Operation:     "POST /pay [http.response.status_code=200]",
+		OperationName: "POST /pay",
+		IdentityDimensions: []TransactionIdentityValue{
+			{Key: "http.response.status_code", Value: "200"},
+		},
+		Kind:     "HTTP",
+		Volume:   12,
+		LastSeen: "2026-08-05T06:00:00Z",
 	}
 	converted := TransactionStatToModel(stat)
 	assert.Equal(t, "4211", converted.ID)
 	assert.Equal(t, model.InsightsTransactionKindHTTP, converted.Kind)
+	assert.Equal(t, "POST /pay", converted.OperationName)
+	require.Len(t, converted.IdentityDimensions, 1)
+	assert.Equal(t, "http.response.status_code", converted.IdentityDimensions[0].Key)
+	assert.Equal(t, "200", converted.IdentityDimensions[0].Value)
 }
 
 func TestPolicyRoundTripEncodesMapsAsJSONStrings(t *testing.T) {
@@ -151,6 +159,8 @@ func TestBaselineAndAnomalyEvidenceStayJSONStrings(t *testing.T) {
 	baseline, err := BaselineClassToModel(BaselineClass{
 		TransactionID:    9,
 		Class:            "D3_latency",
+		ClassLabel:       "Request latency",
+		ClassDescription: "Learns typical request latency for this transaction.",
 		Data:             json.RawMessage(`{"p99_ms":120}`),
 		ObservationCount: 3,
 		Promoted:         true,
@@ -170,6 +180,8 @@ func TestBaselineAndAnomalyEvidenceStayJSONStrings(t *testing.T) {
 	require.NotNil(t, baseline.Data)
 	assert.JSONEq(t, `{"p99_ms":120}`, *baseline.Data)
 	assert.Equal(t, "9", baseline.TransactionID)
+	assert.Equal(t, "Request latency", baseline.ClassLabel)
+	assert.Equal(t, "Learns typical request latency for this transaction.", baseline.ClassDescription)
 	require.NotNil(t, baseline.Learning)
 	assert.Equal(t, model.InsightsBaselineLearningPhasePromoted, baseline.Learning.Phase)
 	assert.Equal(t, 2, baseline.Learning.ObservationsSinceLastChange)
@@ -242,6 +254,12 @@ func TestSystemSettingsAndGuardrailSeedRoundTrip(t *testing.T) {
 		Capacity:  SystemCapacitySettings{MaxResidentTransactions: 1000, MaxBaselineSetMembers: 500},
 		Writeback: SystemWritebackSettings{FlushIntervalSeconds: 30},
 		Detection: SystemDetectionSettings{AutoTransactionGuardrail: true},
+		Identity: SystemIdentitySettings{
+			TransactionIdentityDimensions: []SystemTransactionIdentityDimension{
+				{Key: "http.response.status_code", Enabled: true},
+				{Key: "rpc.grpc.status_code", Enabled: true},
+			},
+		},
 	}
 	gql := SystemSettingsToModel(settings)
 	back, err := SystemSettingsFromInput(model.InsightsSystemSettingsInput{
@@ -251,6 +269,12 @@ func TestSystemSettingsAndGuardrailSeedRoundTrip(t *testing.T) {
 		Capacity:  &model.InsightsSystemCapacitySettingsInput{MaxResidentTransactions: gql.Capacity.MaxResidentTransactions, MaxBaselineSetMembers: gql.Capacity.MaxBaselineSetMembers},
 		Writeback: &model.InsightsSystemWritebackSettingsInput{FlushIntervalSeconds: gql.Writeback.FlushIntervalSeconds},
 		Detection: &model.InsightsSystemDetectionSettingsInput{AutoTransactionGuardrail: gql.Detection.AutoTransactionGuardrail},
+		Identity: &model.InsightsSystemIdentitySettingsInput{
+			TransactionIdentityDimensions: []*model.InsightsSystemTransactionIdentityDimensionInput{
+				{Key: "http.response.status_code", Enabled: true},
+				{Key: "rpc.grpc.status_code", Enabled: true},
+			},
+		},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, settings, back)

--- a/frontend/services/insights/types.go
+++ b/frontend/services/insights/types.go
@@ -172,6 +172,14 @@ type PromoteResult struct {
 	Promoted      bool           `json:"promoted"`
 }
 
+type BulkPromoteRequest struct {
+	TransactionIDs []int64 `json:"transaction_ids"`
+}
+
+type BulkPromoteResult struct {
+	Promoted int `json:"promoted"`
+}
+
 type ObservationSummary struct {
 	TraceID       string       `json:"trace_id"`
 	TransactionID int64        `json:"transaction_id"`

--- a/frontend/services/insights/types.go
+++ b/frontend/services/insights/types.go
@@ -100,29 +100,40 @@ type BlastRadiusSubgraph struct {
 	Edges []BlastRadiusEdge `json:"edges"`
 }
 
+type TransactionIdentityValue struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
 type TransactionStat struct {
-	ID          int64           `json:"id"`
-	Service     string          `json:"service"`
-	Namespace   string          `json:"namespace"`
-	Operation   string          `json:"operation"`
-	Kind        TransactionKind `json:"kind"`
-	Volume      int64           `json:"volume"`
-	LastSeen    string          `json:"last_seen"`
-	HasBaseline *bool           `json:"has_baseline,omitempty"`
-	Promoted    *bool           `json:"promoted,omitempty"`
+	ID                 int64                      `json:"id"`
+	Service            string                     `json:"service"`
+	Namespace          string                     `json:"namespace"`
+	Operation          string                     `json:"operation"`
+	OperationName      string                     `json:"operation_name"`
+	IdentityDimensions []TransactionIdentityValue `json:"identity_dimensions"`
+	Kind               TransactionKind            `json:"kind"`
+	Volume             int64                      `json:"volume"`
+	LastSeen           string                     `json:"last_seen"`
+	HasBaseline        *bool                      `json:"has_baseline,omitempty"`
+	Promoted           *bool                      `json:"promoted,omitempty"`
 }
 
 type Transaction struct {
-	ID        int64           `json:"id"`
-	Service   string          `json:"service"`
-	Namespace string          `json:"namespace"`
-	Operation string          `json:"operation"`
-	Kind      TransactionKind `json:"kind"`
+	ID                 int64                      `json:"id"`
+	Service            string                     `json:"service"`
+	Namespace          string                     `json:"namespace"`
+	Operation          string                     `json:"operation"`
+	OperationName      string                     `json:"operation_name"`
+	IdentityDimensions []TransactionIdentityValue `json:"identity_dimensions"`
+	Kind               TransactionKind            `json:"kind"`
 }
 
 type BaselineClass struct {
 	TransactionID                int64            `json:"transaction_id"`
 	Class                        DeviationClass   `json:"class"`
+	ClassLabel                   string           `json:"class_label"`
+	ClassDescription             string           `json:"class_description"`
 	Data                         json.RawMessage  `json:"data,omitempty"`
 	DataSchemaVersion            *int             `json:"data_schema_version,omitempty"`
 	ObservationCount             int64            `json:"observation_count"`
@@ -237,21 +248,24 @@ type LearningPolicy struct {
 }
 
 type Finding struct {
-	Kind             FindingKind      `json:"kind"`
-	Service          string           `json:"service"`
-	Namespace        string           `json:"namespace"`
-	Title            string           `json:"title"`
-	Offending        *string          `json:"offending,omitempty"`
-	Score            int              `json:"score"`
-	Severity         Severity         `json:"severity"`
-	Occurrences      int64            `json:"occurrences"`
-	LastSeen         string           `json:"last_seen"`
-	Status           string           `json:"status"`
-	TransactionID    *int64           `json:"transaction_id,omitempty"`
-	Signature        *string          `json:"signature,omitempty"`
-	TriggeredClasses []DeviationClass `json:"triggered_classes,omitempty"`
-	ScopeKey         *string          `json:"scope_key,omitempty"`
-	RuleKey          *string          `json:"rule_key,omitempty"`
+	Kind               FindingKind                `json:"kind"`
+	Service            string                     `json:"service"`
+	Namespace          string                     `json:"namespace"`
+	Title              string                     `json:"title"`
+	Operation          *string                    `json:"operation,omitempty"`
+	OperationName      *string                    `json:"operation_name,omitempty"`
+	IdentityDimensions []TransactionIdentityValue `json:"identity_dimensions,omitempty"`
+	Offending          *string                    `json:"offending,omitempty"`
+	Score              int                        `json:"score"`
+	Severity           Severity                   `json:"severity"`
+	Occurrences        int64                      `json:"occurrences"`
+	LastSeen           string                     `json:"last_seen"`
+	Status             string                     `json:"status"`
+	TransactionID      *int64                     `json:"transaction_id,omitempty"`
+	Signature          *string                    `json:"signature,omitempty"`
+	TriggeredClasses   []DeviationClass           `json:"triggered_classes,omitempty"`
+	ScopeKey           *string                    `json:"scope_key,omitempty"`
+	RuleKey            *string                    `json:"rule_key,omitempty"`
 }
 
 type RiskSignal struct {
@@ -276,22 +290,24 @@ type RiskAssessment struct {
 }
 
 type AnomalySummary struct {
-	TransactionID    int64            `json:"transaction_id"`
-	Signature        string           `json:"signature"`
-	Service          string           `json:"service"`
-	Namespace        string           `json:"namespace"`
-	Operation        *string          `json:"operation,omitempty"`
-	Kind             *TransactionKind `json:"kind,omitempty"`
-	TriggeredClasses []DeviationClass `json:"triggered_classes"`
-	Offending        *string          `json:"offending,omitempty"`
-	PolicyID         *int64           `json:"policy_id,omitempty"`
-	Occurrences      int64            `json:"occurrences"`
-	MaxScore         int              `json:"max_score"`
-	Severity         Severity         `json:"severity"`
-	FirstSeen        *string          `json:"first_seen,omitempty"`
-	LastSeen         *string          `json:"last_seen,omitempty"`
-	LastTraceID      *string          `json:"last_trace_id,omitempty"`
-	Status           AnomalyStatus    `json:"status"`
+	TransactionID      int64                      `json:"transaction_id"`
+	Signature          string                     `json:"signature"`
+	Service            string                     `json:"service"`
+	Namespace          string                     `json:"namespace"`
+	Operation          string                     `json:"operation"`
+	OperationName      string                     `json:"operation_name"`
+	IdentityDimensions []TransactionIdentityValue `json:"identity_dimensions"`
+	Kind               *TransactionKind           `json:"kind,omitempty"`
+	TriggeredClasses   []DeviationClass           `json:"triggered_classes"`
+	Offending          *string                    `json:"offending,omitempty"`
+	PolicyID           *int64                     `json:"policy_id,omitempty"`
+	Occurrences        int64                      `json:"occurrences"`
+	MaxScore           int                        `json:"max_score"`
+	Severity           Severity                   `json:"severity"`
+	FirstSeen          *string                    `json:"first_seen,omitempty"`
+	LastSeen           *string                    `json:"last_seen,omitempty"`
+	LastTraceID        *string                    `json:"last_trace_id,omitempty"`
+	Status             AnomalyStatus              `json:"status"`
 }
 
 type AnomalyClassFindingKind string
@@ -326,27 +342,29 @@ type AnomalyClassFinding struct {
 }
 
 type AnomalyIssue struct {
-	TransactionID    int64                 `json:"transaction_id"`
-	Signature        string                `json:"signature"`
-	Service          string                `json:"service"`
-	Namespace        string                `json:"namespace"`
-	Operation        *string               `json:"operation,omitempty"`
-	Kind             *TransactionKind      `json:"kind,omitempty"`
-	TriggeredClasses []DeviationClass      `json:"triggered_classes"`
-	Offending        *string               `json:"offending,omitempty"`
-	Evidence         json.RawMessage       `json:"evidence"`
-	PolicyID         *int64                `json:"policy_id,omitempty"`
-	Occurrences      int64                 `json:"occurrences"`
-	MaxScore         int                   `json:"max_score"`
-	Severity         Severity              `json:"severity"`
-	FirstSeen        *string               `json:"first_seen,omitempty"`
-	LastSeen         *string               `json:"last_seen,omitempty"`
-	LastTraceID      *string               `json:"last_trace_id,omitempty"`
-	Status           AnomalyStatus         `json:"status"`
-	Risk             *RiskAssessment       `json:"risk,omitempty"`
-	ClassFindings    []AnomalyClassFinding `json:"class_findings"`
-	AnomalyTrace     *Observation          `json:"anomaly_trace,omitempty"`
-	BaselineTrace    *Observation          `json:"baseline_trace,omitempty"`
+	TransactionID      int64                      `json:"transaction_id"`
+	Signature          string                     `json:"signature"`
+	Service            string                     `json:"service"`
+	Namespace          string                     `json:"namespace"`
+	Operation          string                     `json:"operation"`
+	OperationName      string                     `json:"operation_name"`
+	IdentityDimensions []TransactionIdentityValue `json:"identity_dimensions"`
+	Kind               *TransactionKind           `json:"kind,omitempty"`
+	TriggeredClasses   []DeviationClass           `json:"triggered_classes"`
+	Offending          *string                    `json:"offending,omitempty"`
+	Evidence           json.RawMessage            `json:"evidence"`
+	PolicyID           *int64                     `json:"policy_id,omitempty"`
+	Occurrences        int64                      `json:"occurrences"`
+	MaxScore           int                        `json:"max_score"`
+	Severity           Severity                   `json:"severity"`
+	FirstSeen          *string                    `json:"first_seen,omitempty"`
+	LastSeen           *string                    `json:"last_seen,omitempty"`
+	LastTraceID        *string                    `json:"last_trace_id,omitempty"`
+	Status             AnomalyStatus              `json:"status"`
+	Risk               *RiskAssessment            `json:"risk,omitempty"`
+	ClassFindings      []AnomalyClassFinding      `json:"class_findings"`
+	AnomalyTrace       *Observation               `json:"anomaly_trace,omitempty"`
+	BaselineTrace      *Observation               `json:"baseline_trace,omitempty"`
 }
 
 type AnomalyRef struct {
@@ -423,14 +441,16 @@ type GuardrailSeedRequest struct {
 }
 
 type CatalogClass struct {
-	ID            string  `json:"id"`
-	Label         string  `json:"label"`
-	Description   *string `json:"description,omitempty"`
-	Category      string  `json:"category"`
-	CategoryLabel *string `json:"category_label,omitempty"`
-	Weight        int     `json:"weight"`
-	Mitre         *string `json:"mitre,omitempty"`
-	Owasp         *string `json:"owasp,omitempty"`
+	ID                  string  `json:"id"`
+	Label               string  `json:"label"`
+	Description         *string `json:"description,omitempty"`
+	BaselineLabel       string  `json:"baseline_label"`
+	BaselineDescription *string `json:"baseline_description,omitempty"`
+	Category            string  `json:"category"`
+	CategoryLabel       *string `json:"category_label,omitempty"`
+	Weight              int     `json:"weight"`
+	Mitre               *string `json:"mitre,omitempty"`
+	Owasp               *string `json:"owasp,omitempty"`
 }
 
 type EnricherList struct {
@@ -509,13 +529,24 @@ type SystemDetectionSettings struct {
 	AutoTransactionGuardrail bool `json:"auto_transaction_guardrail"`
 }
 
+type SystemTransactionIdentityDimension struct {
+	Key     string `json:"key"`
+	Enabled bool   `json:"enabled"`
+}
+
+type SystemIdentitySettings struct {
+	TransactionIdentityDimensions []SystemTransactionIdentityDimension `json:"transaction_identity_dimensions"`
+}
+
 type SystemSettings struct {
-	Sampling  SystemSamplingSettings  `json:"sampling"`
-	Retention SystemRetentionSettings `json:"retention"`
-	Findings  SystemFindingsSettings  `json:"findings"`
-	Capacity  SystemCapacitySettings  `json:"capacity"`
-	Writeback SystemWritebackSettings `json:"writeback"`
-	Detection SystemDetectionSettings `json:"detection"`
+	Sampling          SystemSamplingSettings  `json:"sampling"`
+	Retention         SystemRetentionSettings `json:"retention"`
+	Findings          SystemFindingsSettings  `json:"findings"`
+	Capacity          SystemCapacitySettings  `json:"capacity"`
+	Writeback         SystemWritebackSettings `json:"writeback"`
+	Detection         SystemDetectionSettings `json:"detection"`
+	Identity          SystemIdentitySettings  `json:"identity"`
+	ResetTransactions *bool                   `json:"reset_transactions,omitempty"`
 }
 
 type StorageConnection struct {

--- a/frontend/services/insights/types.go
+++ b/frontend/services/insights/types.go
@@ -180,6 +180,14 @@ type BulkPromoteResult struct {
 	Promoted int `json:"promoted"`
 }
 
+type BulkDeleteRequest struct {
+	TransactionIDs []int64 `json:"transaction_ids"`
+}
+
+type BulkDeleteResult struct {
+	Deleted int `json:"deleted"`
+}
+
 type ObservationSummary struct {
 	TraceID       string       `json:"trace_id"`
 	TransactionID int64        `json:"transaction_id"`

--- a/frontend/services/insights/upsert_test.go
+++ b/frontend/services/insights/upsert_test.go
@@ -150,7 +150,9 @@ func TestUpdateSystemSettingsAndReadReturnsServerDefaults(t *testing.T) {
 			"retention": {"observation_retention_days": 14},
 			"findings": {"default_window_hours": 24, "max_window_hours": 168},
 			"capacity": {"max_resident_transactions": 1000, "max_baseline_set_members": 500},
-			"writeback": {"flush_interval_seconds": 30}
+			"writeback": {"flush_interval_seconds": 30},
+			"detection": {"auto_transaction_guardrail": true},
+			"identity": {"transaction_identity_dimensions": [{"key": "http.response.status_code", "enabled": true}]}
 		}`))
 	}))
 	defer server.Close()
@@ -164,6 +166,9 @@ func TestUpdateSystemSettingsAndReadReturnsServerDefaults(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 168, stored.Findings.MaxWindowHours)
 	assert.Equal(t, 30, stored.Writeback.FlushIntervalSeconds)
+	require.Len(t, stored.Identity.TransactionIdentityDimensions, 1)
+	assert.Equal(t, "http.response.status_code", stored.Identity.TransactionIdentityDimensions[0].Key)
+	assert.True(t, stored.Identity.TransactionIdentityDimensions[0].Enabled)
 }
 
 func TestUpsertPolicyAndReadPropagatesWriteError(t *testing.T) {

--- a/frontend/webapp/graphql/mutations/insights.ts
+++ b/frontend/webapp/graphql/mutations/insights.ts
@@ -121,6 +121,14 @@ export const DELETE_INSIGHTS_TRANSACTION = gql`
   }
 `;
 
+export const BULK_DELETE_INSIGHTS_TRANSACTIONS = gql`
+  mutation BulkDeleteInsightsTransactions($transactionIds: [ID!]!) {
+    bulkDeleteInsightsTransactions(transactionIds: $transactionIds) {
+      deleted
+    }
+  }
+`;
+
 export const UPSERT_INSIGHTS_POLICY = gql`
   mutation UpsertInsightsPolicy($policy: InsightsPolicyInput!) {
     upsertInsightsPolicy(policy: $policy) { ${POLICY_FIELDS} }

--- a/frontend/webapp/graphql/mutations/insights.ts
+++ b/frontend/webapp/graphql/mutations/insights.ts
@@ -59,6 +59,12 @@ const SYSTEM_SETTINGS_FIELDS = `
   detection {
     autoTransactionGuardrail
   }
+  identity {
+    transactionIdentityDimensions {
+      key
+      enabled
+    }
+  }
 `;
 
 export const PROMOTE_INSIGHTS_BASELINE_CLASS = gql`

--- a/frontend/webapp/graphql/mutations/insights.ts
+++ b/frontend/webapp/graphql/mutations/insights.ts
@@ -45,10 +45,6 @@ const SYSTEM_SETTINGS_FIELDS = `
   retention {
     observationRetentionDays
   }
-  findings {
-    defaultWindowHours
-    maxWindowHours
-  }
   capacity {
     maxResidentTransactions
     maxBaselineSetMembers

--- a/frontend/webapp/graphql/mutations/insights.ts
+++ b/frontend/webapp/graphql/mutations/insights.ts
@@ -83,6 +83,20 @@ export const RESET_INSIGHTS_TRANSACTION_BASELINES = gql`
   }
 `;
 
+export const PROMOTE_INSIGHTS_TRANSACTION_BASELINES = gql`
+  mutation PromoteInsightsTransactionBaselines($transactionId: ID!) {
+    promoteInsightsTransactionBaselines(transactionId: $transactionId)
+  }
+`;
+
+export const BULK_PROMOTE_INSIGHTS_TRANSACTIONS = gql`
+  mutation BulkPromoteInsightsTransactions($transactionIds: [ID!]!) {
+    bulkPromoteInsightsTransactions(transactionIds: $transactionIds) {
+      promoted
+    }
+  }
+`;
+
 export const FORCE_PROMOTE_INSIGHTS_SERVICE = gql`
   mutation ForcePromoteInsightsService($namespace: String!, $service: String!) {
     forcePromoteInsightsService(namespace: $namespace, service: $service)

--- a/frontend/webapp/graphql/queries/insights.ts
+++ b/frontend/webapp/graphql/queries/insights.ts
@@ -13,6 +13,11 @@ const TRANSACTION_STAT_FIELDS = `
   service
   namespace
   operation
+  operationName
+  identityDimensions {
+    key
+    value
+  }
   kind
   volume
   lastSeen
@@ -25,12 +30,19 @@ const TRANSACTION_FIELDS = `
   service
   namespace
   operation
+  operationName
+  identityDimensions {
+    key
+    value
+  }
   kind
 `;
 
 const BASELINE_CLASS_FIELDS = `
   transactionId
   class
+  classLabel
+  classDescription
   data
   dataSchemaVersion
   observationCount
@@ -74,6 +86,12 @@ const FINDING_FIELDS = `
   service
   namespace
   title
+  operation
+  operationName
+  identityDimensions {
+    key
+    value
+  }
   offending
   score
   severity
@@ -93,6 +111,11 @@ const ANOMALY_SUMMARY_FIELDS = `
   service
   namespace
   operation
+  operationName
+  identityDimensions {
+    key
+    value
+  }
   kind
   triggeredClasses
   offending
@@ -181,6 +204,8 @@ const CATALOG_FIELDS = `
     id
     label
     description
+    baselineLabel
+    baselineDescription
     category
     categoryLabel
     weight
@@ -245,6 +270,12 @@ const SYSTEM_SETTINGS_FIELDS = `
   }
   detection {
     autoTransactionGuardrail
+  }
+  identity {
+    transactionIdentityDimensions {
+      key
+      enabled
+    }
   }
 `;
 

--- a/frontend/webapp/graphql/queries/insights.ts
+++ b/frontend/webapp/graphql/queries/insights.ts
@@ -232,10 +232,6 @@ const SYSTEM_SETTINGS_FIELDS = `
   retention {
     observationRetentionDays
   }
-  findings {
-    defaultWindowHours
-    maxWindowHours
-  }
   capacity {
     maxResidentTransactions
     maxBaselineSetMembers

--- a/frontend/webapp/lib/odigos-api-adapter.tsx
+++ b/frontend/webapp/lib/odigos-api-adapter.tsx
@@ -44,6 +44,7 @@ import type {
   InsightsAnomalyIssue,
   InsightsAnomalySummary,
   InsightsBaselineClass,
+  InsightsBulkDeleteResult,
   InsightsBulkPromoteResult,
   InsightsBulkResolveResult,
   InsightsCatalog,
@@ -173,6 +174,7 @@ import {
   ENABLE_INSIGHTS_TRANSACTION_GUARDRAIL,
   DISABLE_INSIGHTS_TRANSACTION_GUARDRAIL,
   DELETE_INSIGHTS_TRANSACTION,
+  BULK_DELETE_INSIGHTS_TRANSACTIONS,
   UPSERT_INSIGHTS_POLICY,
   DELETE_INSIGHTS_POLICY,
   UPSERT_INSIGHTS_LEARNING_POLICY,
@@ -579,6 +581,10 @@ const operations: OdigosApiOperations = {
   DELETE_INSIGHTS_TRANSACTION: {
     document: DELETE_INSIGHTS_TRANSACTION,
     transformResult: (raw: unknown) => (raw as { deleteInsightsTransaction?: boolean } | null | undefined)?.deleteInsightsTransaction ?? false,
+  },
+  BULK_DELETE_INSIGHTS_TRANSACTIONS: {
+    document: BULK_DELETE_INSIGHTS_TRANSACTIONS,
+    transformResult: (raw: unknown) => (raw as { bulkDeleteInsightsTransactions?: InsightsBulkDeleteResult } | null | undefined)?.bulkDeleteInsightsTransactions,
   },
   UPSERT_INSIGHTS_POLICY: {
     document: UPSERT_INSIGHTS_POLICY,

--- a/frontend/webapp/lib/odigos-api-adapter.tsx
+++ b/frontend/webapp/lib/odigos-api-adapter.tsx
@@ -44,6 +44,7 @@ import type {
   InsightsAnomalyIssue,
   InsightsAnomalySummary,
   InsightsBaselineClass,
+  InsightsBulkPromoteResult,
   InsightsBulkResolveResult,
   InsightsCatalog,
   InsightsFinding,
@@ -166,6 +167,8 @@ import {
   PROMOTE_INSIGHTS_BASELINE_CLASS,
   RESET_INSIGHTS_BASELINE_CLASS,
   RESET_INSIGHTS_TRANSACTION_BASELINES,
+  PROMOTE_INSIGHTS_TRANSACTION_BASELINES,
+  BULK_PROMOTE_INSIGHTS_TRANSACTIONS,
   FORCE_PROMOTE_INSIGHTS_SERVICE,
   ENABLE_INSIGHTS_TRANSACTION_GUARDRAIL,
   DISABLE_INSIGHTS_TRANSACTION_GUARDRAIL,
@@ -552,6 +555,14 @@ const operations: OdigosApiOperations = {
   RESET_INSIGHTS_TRANSACTION_BASELINES: {
     document: RESET_INSIGHTS_TRANSACTION_BASELINES,
     transformResult: (raw: unknown) => (raw as { resetInsightsTransactionBaselines?: boolean } | null | undefined)?.resetInsightsTransactionBaselines ?? false,
+  },
+  PROMOTE_INSIGHTS_TRANSACTION_BASELINES: {
+    document: PROMOTE_INSIGHTS_TRANSACTION_BASELINES,
+    transformResult: (raw: unknown) => (raw as { promoteInsightsTransactionBaselines?: boolean } | null | undefined)?.promoteInsightsTransactionBaselines ?? false,
+  },
+  BULK_PROMOTE_INSIGHTS_TRANSACTIONS: {
+    document: BULK_PROMOTE_INSIGHTS_TRANSACTIONS,
+    transformResult: (raw: unknown) => (raw as { bulkPromoteInsightsTransactions?: InsightsBulkPromoteResult } | null | undefined)?.bulkPromoteInsightsTransactions,
   },
   FORCE_PROMOTE_INSIGHTS_SERVICE: {
     document: FORCE_PROMOTE_INSIGHTS_SERVICE,


### PR DESCRIPTION
## Summary
- remove `findings.defaultWindowHours/maxWindowHours` from Insights system settings GraphQL schema and generated models
- update webapp system-settings query/mutation selections to match the trimmed contract
- preserve backend `findings` values during system-settings updates by reading current settings and carrying that section forward before write

## TODO
- [ ] Requires kit release with: https://github.com/odigos-io/ui-kit/pull/1236

```release-note
fix: clean up unused findings lookback from Insights system settings GraphQL
```