### PR TITLE
DEVOPS-73: Add OBI sdk tag to fix release

### DIFF
--- a/.github/actions/tag-modules/action.yml
+++ b/.github/actions/tag-modules/action.yml
@@ -47,6 +47,7 @@ runs:
         git tag instrumentor/${{ inputs.tag }}
         git tag k8sutils/${{ inputs.tag }}
         git tag odiglet/${{ inputs.tag }}
+        git tag odiglet/pkg/ebpf/sdks/obi/${{ inputs.tag }}
         git tag odigosauth/${{ inputs.tag }}
         git tag opampserver/${{ inputs.tag }}
         git tag procdiscovery/${{ inputs.tag }}


### PR DESCRIPTION
#### What this PR does / why we need it:
https://github.com/odigos-io/odigos-enterprise/pull/3521 updated how enterprise tags are resolved, but this broke because we don't currently tag the OBI sdk here, so the latest release tag failed on enterprise with

```
go: github.com/odigos-io/odigos-enterprise/odiglet/cmd/enterprise imports
        github.com/odigos-io/odigos/odiglet/pkg/ebpf imports
        github.com/odigos-io/odigos/k8sutils/pkg/workload imports
        github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1 imports
        k8s.io/kube-openapi/pkg/validation/spec imports
        github.com/go-openapi/swag imports
        github.com/go-openapi/swag/loading tested by
        github.com/go-openapi/swag/loading.test imports
        github.com/go-openapi/testify/enable/yaml/v2: github.com/odigos-io/odigos/odiglet/pkg/ebpf/sdks/obi@v1.36.0-pre6: reading github.com/odigos-io/odigos/odiglet/pkg/ebpf/sdks/obi/go.mod at revision odiglet/pkg/ebpf/sdks/obi/v1.36.0-pre6: unknown revision odiglet/pkg/ebpf/sdks/obi/v1.36.0-pre6
```

for reference, the OBI SDK exists as its own module to separate it from the Go OSS sdk.

We import the OBI SDK into our enterprise odiglet, which has its own Enterprise Go SDK. When the OBI package was in the same `sdks` package as OSS Go, it created an ambiguous import conflict in Enterprise. So that's why it's its own module

cherry-pick:v1.35

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
