### PR TITLE
RUN-1104 | feat(odiglet): source eBPF map memory from load-time accounting

### DIFF
--- a/odiglet/odiglet.go
+++ b/odiglet/odiglet.go
@@ -54,6 +54,7 @@ type Odiglet struct {
 	criClient               *criwrapper.CriClient
 	obiManager              *obisdk.Manager
 	runnables               []Runnable
+	metricsCollector        *ebpfMetrics.EBPFMetricsCollector
 }
 
 // AddRunnable registers a task to run inside Odiglet.Run's errgroup. Call before Run; safe to
@@ -148,7 +149,7 @@ func New(clientset *kubernetes.Clientset, instrumentationMgrOpts ebpf.Instrument
 
 	ebpfLogger := commonlogger.LoggerCompat().With("subsystem", "ebpfmanager")
 	metricsLogger := commonlogger.LoggerCompat().With("subsystem", "ebpfmetrics")
-	collector := ebpfMetrics.NewEBPFMetricsCollector(env.Current.NodeName, metricsLogger)
+	collector := ebpfMetrics.NewEBPFMetricsCollector(env.Current.NodeName, metricsLogger, instrumentationMgrOpts.MapMemoryReporter)
 	if err := collector.RegisterMetrics(); err != nil {
 		metricsLogger.Error("failed to register metrics", "err", err)
 	}
@@ -191,12 +192,21 @@ func New(clientset *kubernetes.Clientset, instrumentationMgrOpts ebpf.Instrument
 		instrumentationRequests: instrumentationRequests,
 		criClient:               &criWrapper,
 		obiManager:              obiManager,
+		metricsCollector:        collector,
 	}, nil
 }
 
 func (o *Odiglet) builtInRunnables(ebpfDone chan struct{}, logger *commonlogger.OdigosLogger) []Runnable {
 	odigosNs := env.GetCurrentNamespace()
 	runnables := []Runnable{
+		Runnable{
+			Name: "eBPF metrics reconciler",
+			// Refreshing metrics is never worth taking odiglet down for.
+			PropagateErr: false,
+			Run: func(ctx context.Context) error {
+				return o.metricsCollector.Reconcile(ctx)
+			},
+		},
 		Runnable{
 			Name: "pprof server",
 			// if we fail to start the pprof server, don't return an error as it is not critical

--- a/odiglet/pkg/ebpf/common.go
+++ b/odiglet/pkg/ebpf/common.go
@@ -14,6 +14,7 @@ import (
 	"github.com/odigos-io/odigos/distros/distro"
 	"github.com/odigos-io/odigos/instrumentation"
 	"github.com/odigos-io/odigos/odiglet/pkg/detector"
+	"github.com/odigos-io/odigos/odiglet/pkg/metrics"
 
 	processdetector "github.com/odigos-io/runtime-detector"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,6 +37,15 @@ type InstrumentationManagerOptions struct {
 	MetricsMap           *cilumebpf.Map
 	MetricsAttributesMap *cilumebpf.Map
 	LogsMap              *cilumebpf.Map
+
+	// MapMemoryReporter supplies eBPF map memory accounting recorded when
+	// each map was loaded, so the metrics collector can report it without
+	// rediscovering it from /proc on every scrape. The accounting lives in
+	// a module OSS cannot import, so like the shared maps above this is
+	// enterprise-only: OSS leaves it nil and the collector falls back to
+	// walking /proc, which is the only source it has for maps loaded
+	// outside that accounting regardless.
+	MapMemoryReporter metrics.MapMemoryReporter
 }
 
 // NewManager creates a new instrumentation manager for eBPF which is configured to work with Kubernetes.

--- a/odiglet/pkg/metrics/metrics.go
+++ b/odiglet/pkg/metrics/metrics.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/cilium/ebpf"
 	commonlogger "github.com/odigos-io/odigos/common/logger"
@@ -24,6 +25,14 @@ import (
 const (
 	perfEvent = "perf_event"
 	rss       = "Rss:"
+
+	// allPerfBuffersName and allPerfBuffersType label the synthetic entry
+	// that carries the summed userspace mmap cost of every perf buffer.
+	// It is not a real map — there is no single kernel object behind it —
+	// which is why it is aggregated under one fabricated name rather than
+	// attributed per map.
+	allPerfBuffersName = "PerfBuffersMemoryUsage"
+	allPerfBuffersType = "AllPerfBuffers"
 )
 
 var (
@@ -45,6 +54,10 @@ type EBPFMetricsCollector struct {
 	mu                 sync.RWMutex
 	nodeName           string
 	logger             *commonlogger.OdigosLogger
+
+	// reporter, when non-nil, supplies map memory recorded at load time and
+	// moves the /proc walk off the scrape path. See Reconcile.
+	reporter MapMemoryReporter
 }
 
 // Returns true of the map allocation size should be fetched from the map's memlock
@@ -67,7 +80,10 @@ func isMemlockMap(mapType ebpf.MapType) bool {
 // NewEBPFMetricsCollector creates an eBPF metrics collector. Pass a logger from the caller (e.g. odiglet main)
 // so the same logger and level are used; use commonlogger.LoggerCompat().With("subsystem", "ebpfmetrics").
 // If logger is nil, a new subsystem logger is used.
-func NewEBPFMetricsCollector(nodeName string, logger *commonlogger.OdigosLogger) *EBPFMetricsCollector {
+//
+// reporter may be nil, in which case map memory is discovered by walking
+// /proc on every scrape as before.
+func NewEBPFMetricsCollector(nodeName string, logger *commonlogger.OdigosLogger, reporter MapMemoryReporter) *EBPFMetricsCollector {
 	if logger == nil {
 		logger = commonlogger.LoggerCompat().With("subsystem", "ebpfmetrics")
 	}
@@ -76,6 +92,48 @@ func NewEBPFMetricsCollector(nodeName string, logger *commonlogger.OdigosLogger)
 		eBPFTotalProgCnt:   0,
 		nodeName:           nodeName,
 		logger:             logger,
+		reporter:           reporter,
+	}
+}
+
+// ReconcileInterval is how often Reconcile re-walks /proc when a
+// MapMemoryReporter is supplying map memory. The walk then only feeds
+// numbers the reporter cannot know (program count, and the userspace
+// mmaps behind perf buffers), none of which move quickly, so a
+// coarse interval costs nothing in fidelity and keeps an O(open fds)
+// scan off the scrape path entirely.
+const ReconcileInterval = 2 * time.Minute
+
+// Reconcile periodically refreshes the /proc-derived figures until ctx is
+// cancelled. Without a MapMemoryReporter the walk already runs per scrape
+// and this is a no-op, so callers may start it unconditionally.
+//
+// The walk also sees BPF objects the reporter cannot: maps loaded outside
+// the accounting entirely, such as OBI's. RegisterMetrics reports the
+// difference.
+func (mc *EBPFMetricsCollector) Reconcile(ctx context.Context) error {
+	if mc.reporter == nil {
+		<-ctx.Done()
+		return nil
+	}
+
+	// Populate once up front so the first scrape after startup has real
+	// numbers rather than zeros.
+	if err := mc.collectSelfTotalBPFMemlock(); err != nil {
+		mc.logger.Error("failed initial eBPF /proc reconcile", "err", err)
+	}
+
+	ticker := time.NewTicker(ReconcileInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := mc.collectSelfTotalBPFMemlock(); err != nil {
+				mc.logger.Error("failed to reconcile eBPF metrics from /proc", "err", err)
+			}
+		}
 	}
 }
 
@@ -254,8 +312,8 @@ func (mc *EBPFMetricsCollector) collectSelfTotalBPFMemlock() error {
 	// Insert a fabricated eBPFMapMetrics in order to track all perf buffer memory usage
 	uniqueID := getUniqueID(BPFMapsMetrics)
 	BPFMapsMetrics[uniqueID] = eBPFMapMetrics{
-		name:        "PerfBuffersMemoryUsage",
-		mapType:     "AllPerfBuffers",
+		name:        allPerfBuffersName,
+		mapType:     allPerfBuffersType,
 		memoryUsage: totalPerfBuffersMemUsage,
 		refCnt:      uint32(totalPerfBuffers),
 	}
@@ -312,40 +370,135 @@ func (mc *EBPFMetricsCollector) RegisterMetrics() error {
 	if err != nil {
 		return err
 	}
+	untrackedGauge, err := meter.Int64ObservableGauge(
+		"bpf_maps_untracked_count",
+		metric.WithDescription("BPF maps found by walking /proc that load-time accounting did not record. Zero means the accounting sees every map this process holds; a positive value is the number loaded outside it (e.g. by OBI or another agent)"),
+		metric.WithUnit("{maps}"),
+	)
+	if err != nil {
+		return err
+	}
+
 	// The callback that runs everytime /metrics is scraped from odiglet, collects data and refreshes gauges
 	_, err = meter.RegisterCallback(
 		func(ctx context.Context, observer metric.Observer) error {
-			if err := mc.collectSelfTotalBPFMemlock(); err != nil {
-				mc.logger.Error("failed to collect eBPF metrics during scrape", "err", err)
-			}
-
-			var totalMapsMemory int64
-			mapCount := len(mc.eBPFMapsMetricsMap)
-
-			for mapId, eBPFMapMetrics := range mc.eBPFMapsMetricsMap {
-				totalMapsMemory += eBPFMapMetrics.memoryUsage
-
-				observer.ObserveInt64(eBPFMapMemoryGauge, eBPFMapMetrics.memoryUsage,
-					metric.WithAttributes(
-						attribute.String("name", eBPFMapMetrics.name),
-						attribute.Int("map_id", int(mapId)),
-						attribute.String("map_type", eBPFMapMetrics.mapType),
-						semconv.K8SNodeName(mc.nodeName),
-					),
-				)
-				observer.ObserveInt64(refCountGauge, int64(eBPFMapMetrics.refCnt),
-					metric.WithAttributes(
-						attribute.String("name", eBPFMapMetrics.name),
-					),
-				)
-			}
-
 			nodeAttrs := metric.WithAttributes(
 				semconv.K8SNodeName(mc.nodeName),
 			)
+
+			// Without a reporter the walk is the only source, so it runs
+			// here. With one it runs on Reconcile's interval and this
+			// callback does no I/O.
+			if mc.reporter == nil {
+				if err := mc.collectSelfTotalBPFMemlock(); err != nil {
+					mc.logger.Error("failed to collect eBPF metrics during scrape", "err", err)
+				}
+			}
+
+			mc.mu.RLock()
+			walkedMaps := mc.eBPFMapsMetricsMap
+			walkedProgCount := mc.eBPFTotalProgCnt
+			mc.mu.RUnlock()
+
+			var (
+				totalMapsMemory int64
+				mapCount        int
+			)
+
+			if mc.reporter != nil {
+				report := mc.reporter.MapMemorySnapshot()
+				mapCount = len(report)
+
+				// Several allocations can share a (name, type) — the same
+				// map declared by a probe loaded into many processes. OTel
+				// takes one value per attribute set per callback, so these
+				// must be summed rather than observed separately.
+				type mapKey struct{ name, mapType string }
+				byMap := make(map[mapKey]struct {
+					bytes int64
+					refs  int
+				}, len(report))
+				for _, e := range report {
+					totalMapsMemory += e.Bytes
+					k := mapKey{name: e.MapName, mapType: e.MapType}
+					agg := byMap[k]
+					agg.bytes += e.Bytes
+					agg.refs += e.Refs
+					byMap[k] = agg
+				}
+
+				for k, agg := range byMap {
+					observer.ObserveInt64(eBPFMapMemoryGauge, agg.bytes,
+						metric.WithAttributes(
+							attribute.String("name", k.name),
+							attribute.String("map_type", k.mapType),
+							semconv.K8SNodeName(mc.nodeName),
+						),
+					)
+					observer.ObserveInt64(refCountGauge, int64(agg.refs),
+						metric.WithAttributes(
+							attribute.String("name", k.name),
+						),
+					)
+				}
+
+				// Perf buffers are the one thing the reporter cannot
+				// price: the map is a few per-CPU fd slots while the cost
+				// is the reader's userspace mmap, which only the walk
+				// sees. Ring buffers are priced by the reporter.
+				for _, walked := range walkedMaps {
+					if walked.mapType != allPerfBuffersType {
+						continue
+					}
+					totalMapsMemory += walked.memoryUsage
+					mapCount++
+					observer.ObserveInt64(eBPFMapMemoryGauge, walked.memoryUsage,
+						metric.WithAttributes(
+							attribute.String("name", walked.name),
+							attribute.String("map_type", walked.mapType),
+							semconv.K8SNodeName(mc.nodeName),
+						),
+					)
+				}
+
+				// Maps the walk found that accounting never recorded. A
+				// steady zero is the evidence that load-time accounting
+				// is complete; anything else names the gap in one number
+				// instead of leaving it invisible.
+				if untracked := len(walkedMaps) - mapCount; untracked > 0 {
+					observer.ObserveInt64(untrackedGauge, int64(untracked), nodeAttrs)
+				} else {
+					observer.ObserveInt64(untrackedGauge, 0, nodeAttrs)
+				}
+			} else {
+				mapCount = len(walkedMaps)
+				for mapId, eBPFMapMetrics := range walkedMaps {
+					totalMapsMemory += eBPFMapMetrics.memoryUsage
+
+					observer.ObserveInt64(eBPFMapMemoryGauge, eBPFMapMetrics.memoryUsage,
+						metric.WithAttributes(
+							attribute.String("name", eBPFMapMetrics.name),
+							attribute.Int("map_id", int(mapId)),
+							attribute.String("map_type", eBPFMapMetrics.mapType),
+							semconv.K8SNodeName(mc.nodeName),
+						),
+					)
+					observer.ObserveInt64(refCountGauge, int64(eBPFMapMetrics.refCnt),
+						metric.WithAttributes(
+							attribute.String("name", eBPFMapMetrics.name),
+						),
+					)
+				}
+			}
+
 			observer.ObserveInt64(totalMapsMemGauge, totalMapsMemory, nodeAttrs)
 			observer.ObserveInt64(mapCountGauge, int64(mapCount), nodeAttrs)
-			observer.ObserveInt64(programCountGauge, mc.eBPFTotalProgCnt, nodeAttrs)
+			// Program count stays on the walk in both modes. Load-time
+			// accounting only sees programs loaded through it, so a
+			// static count would silently under-report every loader not
+			// yet routed that way; the walk counts every bpf-prog
+			// descriptor the process holds regardless of origin.
+			observer.ObserveInt64(programCountGauge, walkedProgCount, nodeAttrs)
 
 			return nil
 		},
@@ -354,6 +507,7 @@ func (mc *EBPFMetricsCollector) RegisterMetrics() error {
 		mapCountGauge,
 		programCountGauge,
 		refCountGauge,
+		untrackedGauge,
 	)
 
 	return err

--- a/odiglet/pkg/metrics/reporter.go
+++ b/odiglet/pkg/metrics/reporter.go
@@ -1,0 +1,32 @@
+package metrics
+
+// MapMemoryEntry is one accounted eBPF map allocation, however many probes
+// or processes reference it. Plain types on purpose: the implementation
+// lives in a module OSS odigos does not depend on.
+type MapMemoryEntry struct {
+	MapName string
+	// MapType is the stringified cilium/ebpf type, e.g. "Hash".
+	MapType   string
+	Component string
+	// ProbeID is empty when the map is shared more widely than one probe,
+	// and PID is nil when it is not scoped to a single process. Both are
+	// normal values for node-wide and probe-wide shared maps.
+	ProbeID string
+	PID     *int
+	// Bytes is what the kernel commits for the map once full, fixed at load.
+	Bytes int64
+	// Refs is how many registrations hold this allocation — the sharing
+	// structure, not a count of open file descriptors.
+	Refs int
+}
+
+// MapMemoryReporter supplies map memory recorded when each map was loaded,
+// rather than rediscovered from the kernel on every read. Builds without an
+// implementation leave it nil and fall back to reading /proc, which is the
+// only option for maps loaded outside that accounting anyway.
+//
+// MapMemorySnapshot is called from a metrics scrape callback: it must be
+// safe for concurrent use and must not block.
+type MapMemoryReporter interface {
+	MapMemorySnapshot() []MapMemoryEntry
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

The eBPF map metrics are recomputed from scratch inside the OTel scrape callback: readlink every entry in `/proc/self/fd`, dup each `bpf-map` fd, build an `ebpf.Map`, call `Info()` (an `OBJ_GET_INFO_BY_FD` plus an open/read of `fdinfo`), close it, then line-scan all of `/proc/self/smaps`. On a busy node that is `O(open fds)` syscalls per scrape to recover a number the kernel fixes at map creation.

- Adds `MapMemoryReporter`, so a build can supply accounting recorded when each map was loaded. Defined in plain types because the implementation lives in a module OSS cannot import; enterprise supplies one through `InstrumentationManagerOptions`, alongside the shared maps already there for the same reason.
- With a reporter the scrape callback does no I/O at all. The `/proc` walk moves to `Reconcile`, a `Runnable` on a coarse interval, since it still covers what the reporter cannot see — maps loaded outside the accounting entirely, such as OBI's.
- Without a reporter nothing changes: the walk still runs per scrape, which is the only source a build with no load-time accounting has.
- Fixes a pre-existing data race: the scrape callback read `eBPFMapsMetricsMap` without holding `mu`, which `collectSelfTotalBPFMemlock` writes under it.

Metric names are unchanged so existing dashboards keep resolving, but two of them now mean something different and that is worth knowing before the graphs move:

- `bpf_map_memory_usage` is now worst case — what the kernel commits once a map is full — rather than currently resident, and is correct for map types the old path could only guess at (ring buffers never reached the memlock branch and reported `MaxEntries` as if it were a byte count).
- `bpf_maps_ref_count` is now how many probes and processes share a map, not how many file descriptors happen to be open onto it.
- The `map_id` label is gone. It came from `Info()`, the syscall being removed, and was never a byproduct of loading — name plus type replaces it, at lower cardinality.
- New `bpf_maps_untracked_count`: maps the walk finds that load-time accounting did not record. A steady zero is the evidence the accounting is complete.

`bpf_programs_count` deliberately stays on the walk — counting only what the accounting sees would silently under-report every loader not yet routed through it.

Second of three. Needs odigos-io/ebpf-core#59 released and pinned in enterprise; this PR itself has no new dependency.

```release-note
odiglet's eBPF map memory metrics are now recorded when each map is loaded instead of being rediscovered from /proc on every scrape. `bpf_map_memory_usage` now reports worst-case rather than currently-resident bytes, `bpf_maps_ref_count` now reports how many probes share a map, and the `map_id` label has been replaced by map name and type.
```
