### PR TITLE
PLAT-1458 | fix(helm): allow UI to update recommendations

### DIFF
--- a/docs/snippets/shared/permissions.mdx
+++ b/docs/snippets/shared/permissions.mdx
@@ -215,6 +215,7 @@ Below are the Roles used by Odigos components. These Roles are only scoped to th
 | autoscaling | horizontalpodautoscalers | \* | get |
 | odigos.io | \* | \* | get<br />list<br />watch |
 | odigos.io | instrumentationrules<br />destinations<br />actions<br />samplings | \* | create<br />patch<br />update<br />delete |
+| odigos.io | recommendations | \* | update<br />patch |
 | odigos.io | collectorsgroups | \* | get<br />list<br />watch |
 | actions.odigos.io | \* | \* | get<br />list<br />watch<br />create<br />patch<br />update<br />delete |
 | operator.odigos.io | odigos | \* | get<br />list<br />watch |

--- a/helm/odigos/templates/ui/role.yaml
+++ b/helm/odigos/templates/ui/role.yaml
@@ -66,6 +66,13 @@ rules:
       - patch
       - update
       - delete
+  - apiGroups:
+      - odigos.io
+    resources:
+      - 'recommendations'
+    verbs:
+      - update
+      - patch
   {{- end }}
   - apiGroups:
       - odigos.io


### PR DESCRIPTION
#### What this PR does / why we need it:
The Odigos UI service account could not update `recommendations` (e.g. dismiss `infer-db-attributes`), which failed with an RBAC forbidden error.

This adds `update`/`patch` for `recommendations` on the `odigos-ui` Role, without granting create or delete.

Linear: https://linear.app/odigos/issue/PLAT-1458/ui-cannot-update-recommendation-dismissed-state-due-to-missing-rbac

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
```release-note
Fix UI RBAC so recommendation dismiss/update works.
```

Made with [Cursor](https://cursor.com)