### PR TITLE
CORE-1548 | fix: stop double-counting auto-rollback in workload health

### DIFF
--- a/frontend/graph/workload.resolvers.go
+++ b/frontend/graph/workload.resolvers.go
@@ -125,11 +125,8 @@ func (r *k8sWorkloadResolver) WorkloadOdigosHealthStatus(ctx context.Context, ob
 
 	conditions := []*model.DesiredConditionStatus{}
 	if ic != nil {
-		autoRollbackConfig := l.GetAutoRollbackConfig()
-
 		conditions = append(conditions, status.CalculateRuntimeInspectionStatus(ic))
 		conditions = append(conditions, status.CalculateAgentInjectionEnabledStatus(ic))
-		conditions = append(conditions, status.CalculateAutoRollbackStatus(ic, autoRollbackConfig))
 	} else {
 		reasonStr := string(status.WorkloadOdigosHealthStatusReasonDisabled)
 		conditions = append(conditions, &model.DesiredConditionStatus{


### PR DESCRIPTION
#### What this PR does / why we need it:
`workloadOdigosHealthStatus` was aggregating `CalculateAutoRollbackStatus` separately, even though auto-rollback is already reflected in agent injection enabled when relevant. That double-counted rollback severity on the lazy GraphQL resolver path. Remove the redundant aggregation so overall workload health matches the intended signals (and aligns with the eager populate path, which did not include auto-rollback).

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
```release-note
Fix overall workload Odigos health status double-counting auto-rollback when agent injection enabled already reflects it.
```

Linear: https://linear.app/odigos/issue/CORE-1548/stop-double-counting-auto-rollback-in-workloadodigoshealthstatus

Made with [Cursor](https://cursor.com)