### PR TITLE
perf(procdiscovery): cut per-PID environ and maps scan allocations

### DIFF
--- a/common/otheragent/otheragent.go
+++ b/common/otheragent/otheragent.go
@@ -5,6 +5,7 @@ package otheragent
 
 import (
 	"bufio"
+	"bytes"
 	"io"
 	"strings"
 
@@ -120,9 +121,10 @@ func agentMatchesProcess(p Process, agent *KnownAgent) bool {
 
 // mapsContains reports whether any line of a process maps reader contains name.
 func mapsContains(r io.Reader, name string) bool {
+	needle := []byte(name)
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
-		if strings.Contains(scanner.Text(), name) {
+		if bytes.Contains(scanner.Bytes(), needle) {
 			return true
 		}
 	}

--- a/procdiscovery/pkg/inspectors/utils/inspectUtils.go
+++ b/procdiscovery/pkg/inspectors/utils/inspectUtils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bufio"
+	"bytes"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -39,13 +40,21 @@ func IsProcessEqualProcessNamesWithVersion(pcx *process.ProcessContext, processN
 }
 
 func IsMapsFileContainsBinary(mapsFile process.ProcessFile, binaries []string) bool {
+	if len(binaries) == 0 {
+		return false
+	}
+
+	// Convert once; []byte(string) inside the per-line loop would re-allocate.
+	binaryBytes := make([][]byte, len(binaries))
+	for i, binary := range binaries {
+		binaryBytes[i] = []byte(binary)
+	}
+
 	scanner := bufio.NewScanner(mapsFile)
-
 	for scanner.Scan() {
-		line := scanner.Text()
-
-		for _, binary := range binaries {
-			if strings.Contains(line, binary) {
+		line := scanner.Bytes()
+		for _, binary := range binaryBytes {
+			if bytes.Contains(line, binary) {
 				return true
 			}
 		}

--- a/procdiscovery/pkg/inspectors/utils/maps_bench_test.go
+++ b/procdiscovery/pkg/inspectors/utils/maps_bench_test.go
@@ -1,0 +1,56 @@
+package utils
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+type memProcessFile struct {
+	*bytes.Reader
+}
+
+func (m memProcessFile) Close() error { return nil }
+
+func buildSyntheticMaps(lines int, hitBinary string, hitAt int) []byte {
+	var b strings.Builder
+	for i := 0; i < lines; i++ {
+		if i == hitAt && hitBinary != "" {
+			b.WriteString("7f8a1c000000-7f8a1c200000 r-xp 00000000 08:01 123456 /usr/lib/")
+			b.WriteString(hitBinary)
+			b.WriteString("\n")
+			continue
+		}
+		b.WriteString("7f8a1c000000-7f8a1c200000 r-xp 00000000 08:01 123456 /usr/lib/x86_64-linux-gnu/libc.so.6\n")
+	}
+	return []byte(b.String())
+}
+
+func BenchmarkIsMapsFileContainsBinary(b *testing.B) {
+	cases := []struct {
+		name     string
+		lines    int
+		hitAt    int
+		binaries []string
+	}{
+		{"miss_200", 200, -1, []string{"libpython", "libjvm.so", "libruby.so"}},
+		{"hit_early_200", 200, 5, []string{"libpython", "libjvm.so", "libruby.so"}},
+		{"miss_2000", 2000, -1, []string{"libpython", "libjvm.so", "libruby.so"}},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			data := buildSyntheticMaps(tc.lines, "libpython3.11.so.1.0", tc.hitAt)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				f := memProcessFile{bytes.NewReader(data)}
+				_ = IsMapsFileContainsBinary(f, tc.binaries)
+			}
+		})
+	}
+}
+
+// Ensure memProcessFile satisfies the small interface used by the helper.
+var _ io.ReadSeekCloser = memProcessFile{}
+var _ io.ReaderAt = memProcessFile{}

--- a/procdiscovery/pkg/inspectors/utils/maps_test.go
+++ b/procdiscovery/pkg/inspectors/utils/maps_test.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestIsMapsFileContainsBinary(t *testing.T) {
+	data := buildSyntheticMaps(20, "libpython3.11.so.1.0", 7)
+
+	t.Run("hit", func(t *testing.T) {
+		f := memProcessFile{bytes.NewReader(data)}
+		if !IsMapsFileContainsBinary(f, []string{"libjvm.so", "libpython"}) {
+			t.Fatal("expected hit for libpython")
+		}
+	})
+
+	t.Run("miss", func(t *testing.T) {
+		f := memProcessFile{bytes.NewReader(data)}
+		if IsMapsFileContainsBinary(f, []string{"libjvm.so", "libruby.so"}) {
+			t.Fatal("expected miss")
+		}
+	})
+
+	t.Run("empty_binaries", func(t *testing.T) {
+		f := memProcessFile{bytes.NewReader(data)}
+		if IsMapsFileContainsBinary(f, nil) {
+			t.Fatal("expected false for empty binaries")
+		}
+	})
+}

--- a/procdiscovery/pkg/process/environ_bench_test.go
+++ b/procdiscovery/pkg/process/environ_bench_test.go
@@ -1,0 +1,75 @@
+package process
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func buildSyntheticEnviron(numVars int) []byte {
+	var b strings.Builder
+	for i := 0; i < numVars; i++ {
+		switch i % 20 {
+		case 0:
+			fmt.Fprintf(&b, "NODE_VERSION=v%d.0.0\x00", i)
+		case 1:
+			fmt.Fprintf(&b, "PYTHON_VERSION=%d.11\x00", i)
+		case 2:
+			fmt.Fprintf(&b, "PATH=/usr/local/bin:/usr/bin:/bin%d\x00", i)
+		case 3:
+			fmt.Fprintf(&b, "HOME=/home/user%d\x00", i)
+		default:
+			fmt.Fprintf(&b, "ENV_VAR_%d=value_%d_with_some_payload_data\x00", i, i)
+		}
+	}
+	return []byte(b.String())
+}
+
+func setupFakeProcEnviron(b *testing.B, pid int, environ []byte) (restore func()) {
+	b.Helper()
+	tmp := b.TempDir()
+	pidDir := filepath.Join(tmp, fmt.Sprintf("%d", pid))
+	if err := os.MkdirAll(pidDir, 0o755); err != nil {
+		b.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pidDir, "environ"), environ, 0o644); err != nil {
+		b.Fatal(err)
+	}
+	old := procDir
+	procDir = tmp
+	return func() { procDir = old }
+}
+
+func BenchmarkGetRelevantEnvVars(b *testing.B) {
+	cases := []struct {
+		name    string
+		numVars int
+	}{
+		{"50vars", 50},
+		{"200vars", 200},
+		{"500vars", 500},
+	}
+	runtimeDetectionEnvs := map[string]struct{}{
+		"ODIGOS_SERVICE_NAME": {},
+		"OTEL_SERVICE_NAME":   {},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			environ := buildSyntheticEnviron(tc.numVars)
+			restore := setupFakeProcEnviron(b, 42, environ)
+			defer restore()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			var sink ProcessEnvs
+			for i := 0; i < b.N; i++ {
+				sink = getRelevantEnvVars(42, runtimeDetectionEnvs)
+			}
+			if sink.DetailedEnvs == nil && sink.OverwriteEnvs == nil && len(environ) == 0 {
+				b.Fatal("unexpected empty result for empty environ")
+			}
+		})
+	}
+}

--- a/procdiscovery/pkg/process/environ_test.go
+++ b/procdiscovery/pkg/process/environ_test.go
@@ -1,0 +1,77 @@
+package process
+
+import (
+	"maps"
+	"testing"
+)
+
+func TestParseRelevantEnvVars(t *testing.T) {
+	runtimeDetectionEnvs := map[string]struct{}{
+		"ODIGOS_SERVICE_NAME": {},
+		"OTEL_SERVICE_NAME":   {},
+	}
+
+	t.Run("empty", func(t *testing.T) {
+		envs := parseRelevantEnvVars(nil, runtimeDetectionEnvs)
+		if len(envs.OverwriteEnvs) != 0 || len(envs.DetailedEnvs) != 0 {
+			t.Fatalf("expected empty maps, got overwrite=%v detailed=%v", envs.OverwriteEnvs, envs.DetailedEnvs)
+		}
+	})
+
+	t.Run("filters_to_watched_keys", func(t *testing.T) {
+		payload := []byte(
+			"PATH=/usr/bin\x00" +
+				"NODE_VERSION=v20.11.0\x00" +
+				"ODIGOS_SERVICE_NAME=checkout\x00" +
+				"JAVA_TOOL_OPTIONS=-javaagent:/opt/dd.jar\x00" +
+				"HOME=/home/app\x00" +
+				"PYTHON_VERSION=3.11.6\x00",
+		)
+		envs := parseRelevantEnvVars(payload, runtimeDetectionEnvs)
+		wantOverwrite := map[string]string{
+			"ODIGOS_SERVICE_NAME": "checkout",
+		}
+		wantDetailed := map[string]string{
+			"NODE_VERSION":      "v20.11.0",
+			"JAVA_TOOL_OPTIONS": "-javaagent:/opt/dd.jar",
+			"PYTHON_VERSION":    "3.11.6",
+		}
+		if !maps.Equal(envs.OverwriteEnvs, wantOverwrite) {
+			t.Fatalf("OverwriteEnvs = %#v, want %#v", envs.OverwriteEnvs, wantOverwrite)
+		}
+		if !maps.Equal(envs.DetailedEnvs, wantDetailed) {
+			t.Fatalf("DetailedEnvs = %#v, want %#v", envs.DetailedEnvs, wantDetailed)
+		}
+	})
+
+	t.Run("handles_missing_trailing_nul_and_malformed", func(t *testing.T) {
+		payload := []byte(
+			"NODE_VERSION=v18.0.0\x00" +
+				"NOT_A_PAIR\x00" +
+				"=novalue\x00" +
+				"JAVA_HOME=/usr/lib/jvm",
+		)
+		envs := parseRelevantEnvVars(payload, nil)
+		if envs.OverwriteEnvs != nil {
+			t.Fatalf("expected nil OverwriteEnvs, got %#v", envs.OverwriteEnvs)
+		}
+		wantDetailed := map[string]string{
+			"NODE_VERSION": "v18.0.0",
+			"JAVA_HOME":    "/usr/lib/jvm",
+		}
+		if !maps.Equal(envs.DetailedEnvs, wantDetailed) {
+			t.Fatalf("DetailedEnvs = %#v, want %#v", envs.DetailedEnvs, wantDetailed)
+		}
+	})
+
+	t.Run("value_may_contain_equals", func(t *testing.T) {
+		payload := []byte("NODE_OPTIONS=--require=/a=b.js\x00")
+		envs := parseRelevantEnvVars(payload, nil)
+		wantDetailed := map[string]string{
+			"NODE_OPTIONS": "--require=/a=b.js",
+		}
+		if !maps.Equal(envs.DetailedEnvs, wantDetailed) {
+			t.Fatalf("DetailedEnvs = %#v, want %#v", envs.DetailedEnvs, wantDetailed)
+		}
+	})
+}

--- a/procdiscovery/pkg/process/process.go
+++ b/procdiscovery/pkg/process/process.go
@@ -1,13 +1,12 @@
 package process
 
 import (
-	"bufio"
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
 	"os"
-	"strings"
 
 	"github.com/odigos-io/odigos/common/otheragent"
 )
@@ -292,53 +291,70 @@ func getRelevantEnvVars(pid int, runtimeDetectionEnvs map[string]struct{}) Proce
 		return ProcessEnvs{}
 	}
 
-	r := bufio.NewReader(strings.NewReader(string(fileContent)))
+	return parseRelevantEnvVars(fileContent, runtimeDetectionEnvs)
+}
 
-	overWriteEnvsResult := make(map[string]string)
-	detailedEnvsResult := make(map[string]string)
+// parseRelevantEnvVars extracts the small subset of environment variables that
+// Odigos needs for runtime detection and other-agent detection.
+//
+// It scans the NUL-separated /proc/<pid>/environ payload in place and only
+// allocates strings for entries that match one of the watched key sets.
+func parseRelevantEnvVars(fileContent []byte, runtimeDetectionEnvs map[string]struct{}) ProcessEnvs {
+	var overWriteEnvsResult map[string]string
+	var detailedEnvsResult map[string]string
 
-	for {
-		// The entries are  separated  by
-		// null bytes ('\0'), and there may be a null byte at the end.
-		str, err := r.ReadString(0)
-		if err == io.EOF {
-			break
-		} else if err != nil {
-			return ProcessEnvs{}
+	for len(fileContent) > 0 {
+		entry := fileContent
+		if i := bytes.IndexByte(fileContent, 0); i >= 0 {
+			entry = fileContent[:i]
+			fileContent = fileContent[i+1:]
+		} else {
+			fileContent = nil
 		}
-
-		str = strings.TrimRight(str, "\x00")
-		envParts := strings.SplitN(str, "=", 2)
-		if len(envParts) != 2 {
+		if len(entry) == 0 {
 			continue
 		}
 
-		envName := envParts[0]
-		envDetectionValue := envParts[1]
+		eq := bytes.IndexByte(entry, '=')
+		if eq <= 0 {
+			continue
+		}
+
+		// m[string(b)] map lookups do not allocate; only matched keys/values are copied.
+		name := entry[:eq]
+		value := entry[eq+1:]
 
 		if runtimeDetectionEnvs != nil {
-			if _, ok := runtimeDetectionEnvs[envName]; ok {
-				overWriteEnvsResult[envName] = envDetectionValue
+			if _, ok := runtimeDetectionEnvs[string(name)]; ok {
+				if overWriteEnvsResult == nil {
+					overWriteEnvsResult = make(map[string]string)
+				}
+				overWriteEnvsResult[string(name)] = string(value)
 			}
 		}
 
-		if _, ok := LangsVersionEnvs[envName]; ok {
-			detailedEnvsResult[envName] = envDetectionValue
+		if _, ok := LangsVersionEnvs[string(name)]; ok {
+			if detailedEnvsResult == nil {
+				detailedEnvsResult = make(map[string]string)
+			}
+			detailedEnvsResult[string(name)] = string(value)
+			continue
 		}
 
 		// Collect the keys the shared other-agent detector inspects, so detection
 		// can read them off the process env without any caller wiring.
-		if _, ok := otheragent.AgentDetectionEnvKeys[envName]; ok {
-			detailedEnvsResult[envName] = envDetectionValue
+		if _, ok := otheragent.AgentDetectionEnvKeys[string(name)]; ok {
+			if detailedEnvsResult == nil {
+				detailedEnvsResult = make(map[string]string)
+			}
+			detailedEnvsResult[string(name)] = string(value)
 		}
 	}
 
-	envs := ProcessEnvs{
+	return ProcessEnvs{
 		OverwriteEnvs: overWriteEnvsResult,
 		DetailedEnvs:  detailedEnvsResult,
 	}
-
-	return envs
 }
 
 func isSecureExecutionMode(pid int) (bool, error) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### What this PR does / why we need it:

Odiglet process discovery calls `GetPidDetails` (and therefore `/proc/<pid>/environ` parsing) for every PID it inspects, and language DeepScan walks `/proc/<pid>/maps` for several runtimes. Both paths were allocation-heavy in tight per-process loops.

**What was slow (verified with `go test -bench` + pprof, not speculation):**

1. **`getRelevantEnvVars`** converted the whole environ blob to a `string`, wrapped it in `strings.NewReader`/`bufio.Reader`, then `ReadString(0)` + `strings.SplitN` per entry — ~2 allocs per env var even when the var is discarded.
2. **`IsMapsFileContainsBinary`** (and otheragent `mapsContains`) called `scanner.Text()` per maps line — 1 string alloc per line on full-file misses (common for non-matching languages).

**How measured**

```bash
cd procdiscovery
go test ./pkg/process/ -bench=BenchmarkGetRelevantEnvVars -benchmem -count=5
go test ./pkg/inspectors/utils/ -bench=BenchmarkIsMapsFileContainsBinary -benchmem -count=5

# alloc profiles (paired before/after on same machine)
go test ./pkg/process/ -bench=BenchmarkGetRelevantEnvVars/200vars -benchmem -benchtime=2s -memprofile=environ_mem.pprof
go tool pprof -alloc_objects -text environ_mem.pprof
go test ./pkg/inspectors/utils/ -bench=BenchmarkIsMapsFileContainsBinary/miss_2000 -benchmem -benchtime=2s -memprofile=maps_mem.pprof
go tool pprof -alloc_objects -text maps_mem.pprof
```

Machine: Linux amd64, Intel Xeon, Go 1.26.2.

**Before → after (median of count=5)**

| Benchmark | before | after | delta |
|-----------|-------:|------:|------:|
| `GetRelevantEnvVars/50vars` | 10674 ns, **113 allocs**, 12850 B | 5897 ns, **21 allocs**, 2984 B | −45% ns, **−81% allocs** |
| `GetRelevantEnvVars/200vars` | 27799 ns, **413 allocs**, 36655 B | 12447 ns, **49 allocs**, 9465 B | −55% ns, **−88% allocs** |
| `GetRelevantEnvVars/500vars` | 59261 ns, **1013 allocs**, 84160 B | 25414 ns, **109 allocs**, 22492 B | −57% ns, **−89% allocs** |
| `IsMapsFileContainsBinary/miss_200` | 20123 ns, **202 allocs**, 23344 B | 15595 ns, **6 allocs**, 4272 B | −22% ns, **−97% allocs** |
| `IsMapsFileContainsBinary/miss_2000` | 184195 ns, **2002 allocs**, 196144 B | 147485 ns, **6 allocs**, 4272 B | −20% ns, **−99.7% allocs** |

**pprof evidence**

- Environ **before** alloc_objects: ~49% `strings.SplitN` / `strings.genSplit`, ~48% `bufio.Reader.ReadString` (`bytealg.MakeNoZero`).
- Environ **after**: those sites gone; remaining cost is matched key/value string copies + `os.ReadFile`.
- Maps **before** alloc_objects: **99.85%** `bufio.(*Scanner).Text`.
- Maps **after**: constant overhead (needle `[]byte` conversion once + scanner buffer); no per-line strings.

[Environ allocs before/after](https://cursor.com/agents/bc-fffe90b6-f058-4991-8cd1-9cacfa65187e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbench_allocs_environ.svg)
[Maps allocs before/after](https://cursor.com/agents/bc-fffe90b6-f058-4991-8cd1-9cacfa65187e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbench_allocs_maps.svg)
[Environ latency before/after](https://cursor.com/agents/bc-fffe90b6-f058-4991-8cd1-9cacfa65187e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbench_latency_environ.svg)
[Maps latency before/after](https://cursor.com/agents/bc-fffe90b6-f058-4991-8cd1-9cacfa65187e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbench_latency_maps.svg)

**Fix (why safe)**

- Parse NUL-separated environ bytes in place; use non-allocating `m[string(b)]` lookups; only `string()`-copy keys/values that match `runtimeDetectionEnvs`, `LangsVersionEnvs`, or `otheragent.AgentDetectionEnvKeys`.
- Scan maps with `scanner.Bytes()` + `bytes.Contains` (needles converted once).
- Behavior preserved: same watched keys, values may still contain `=`, malformed entries skipped, trailing NUL optional. Empty results may return nil maps (equivalent for `len`/range/index). Unit tests cover the environ parser and maps helper.

**Also profiled but not changed:** `odigosurltemplateprocessor` default templatize path (~0–4 allocs/op already). Left alone — no shippable win there without riskier regex rewrites.

**CI notes (current run)**

- `build`, `golangci-lint`, `go mod tidy`, `build-and-test-odiglet`, and **92/94** checks passed.
- `require-linear`: needs a Linear issue id in title/body/branch (e.g. `CORE-123`). Please add one — this agent had no Linear issue to attach.
- `kubernetes-test (1.32, head-sampling-http-java)`: unrelated flake — `expected 20 got 21/22` on `queries/http-server-exact.yaml` span counts. Same suite passed on k8s 1.21.12 and 1.23; this change does not touch sampling.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
NONE
```


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fffe90b6-f058-4991-8cd1-9cacfa65187e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fffe90b6-f058-4991-8cd1-9cacfa65187e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

