### PR TITLE
fix: bump UI Docker/CI Node to Active LTS 24

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -309,7 +309,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - name: Install webapp dependencies
         run: yarn install --frozen-lockfile
         working-directory: frontend/webapp

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM node:20.19.0 AS deps
+FROM --platform=$BUILDPLATFORM node:24 AS deps
 WORKDIR /app
 COPY frontend/webapp/package.json frontend/webapp/yarn.lock ./
 COPY frontend/webapp/.yalc* ./.yalc/
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/usr/local/share/.cache/yarn \
       yarn install --frozen-lockfile; \
     fi
 
-FROM --platform=$BUILDPLATFORM node:20.19.0 AS builder
+FROM --platform=$BUILDPLATFORM node:24 AS builder
 WORKDIR /webapp
 COPY --from=deps /app/node_modules ./node_modules
 COPY frontend/webapp .


### PR DESCRIPTION
## Summary
- Bump `frontend/Dockerfile` build stages from EOL `node:20.19.0` to Active LTS `node:24`
- Bump frontend webapp CI in `.github/workflows/build.yaml` from Node 20 to Node 24

Related: [CORE-1555](https://linear.app/odigos/issue/CORE-1555/update-deprecated-node-versions-for-ui-dockerimages)

```release-note
fix: bump UI Docker/CI Node to Active LTS 24
```