### PR TITLE
CORE-1552 | expose findings firstSeen in GraphQL and bump ui-kit

### DIFF
--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -849,6 +849,7 @@ type ComplexityRoot struct {
 	}
 
 	InsightsFinding struct {
+		FirstSeen          func(childComplexity int) int
 		IdentityDimensions func(childComplexity int) int
 		Kind               func(childComplexity int) int
 		LastSeen           func(childComplexity int) int
@@ -6137,6 +6138,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.InsightsEnricherList.Label(childComplexity), true
+
+	case "InsightsFinding.firstSeen":
+		if e.complexity.InsightsFinding.FirstSeen == nil {
+			break
+		}
+
+		return e.complexity.InsightsFinding.FirstSeen(childComplexity), true
 
 	case "InsightsFinding.identityDimensions":
 		if e.complexity.InsightsFinding.IdentityDimensions == nil {
@@ -33426,6 +33434,8 @@ func (ec *executionContext) fieldContext_Insights_findings(ctx context.Context, 
 				return ec.fieldContext_InsightsFinding_severity(ctx, field)
 			case "occurrences":
 				return ec.fieldContext_InsightsFinding_occurrences(ctx, field)
+			case "firstSeen":
+				return ec.fieldContext_InsightsFinding_firstSeen(ctx, field)
 			case "lastSeen":
 				return ec.fieldContext_InsightsFinding_lastSeen(ctx, field)
 			case "status":
@@ -41400,6 +41410,47 @@ func (ec *executionContext) fieldContext_InsightsFinding_occurrences(_ context.C
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InsightsFinding_firstSeen(ctx context.Context, field graphql.CollectedField, obj *model.InsightsFinding) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InsightsFinding_firstSeen(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FirstSeen, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InsightsFinding_firstSeen(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InsightsFinding",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -91621,6 +91672,8 @@ func (ec *executionContext) _InsightsFinding(ctx context.Context, sel ast.Select
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "firstSeen":
+			out.Values[i] = ec._InsightsFinding_firstSeen(ctx, field, obj)
 		case "lastSeen":
 			out.Values[i] = ec._InsightsFinding_lastSeen(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/frontend/graph/insights.graphqls
+++ b/frontend/graph/insights.graphqls
@@ -447,6 +447,10 @@ type InsightsFinding {
   score: Int!
   severity: InsightsSeverity!
   occurrences: Int!
+  """
+  Earliest occurrence of this finding (anomaly or guardrail violation).
+  """
+  firstSeen: String
   lastSeen: String!
   """
   Union of anomaly statuses (open|accepted|dismissed) and violation statuses (open|dismissed|accepted).

--- a/frontend/graph/model/models_gen.go
+++ b/frontend/graph/model/models_gen.go
@@ -1033,7 +1033,9 @@ type InsightsFinding struct {
 	Score              int                                 `json:"score"`
 	Severity           InsightsSeverity                    `json:"severity"`
 	Occurrences        int                                 `json:"occurrences"`
-	LastSeen           string                              `json:"lastSeen"`
+	// Earliest occurrence of this finding (anomaly or guardrail violation).
+	FirstSeen *string `json:"firstSeen,omitempty"`
+	LastSeen  string  `json:"lastSeen"`
 	// Union of anomaly statuses (open|accepted|dismissed) and violation statuses (open|dismissed|accepted).
 	Status string `json:"status"`
 	// Anomaly drill-down key; set when kind is anomaly.

--- a/frontend/services/insights/conversions.go
+++ b/frontend/services/insights/conversions.go
@@ -634,6 +634,7 @@ func FindingToModel(finding Finding) *model.InsightsFinding {
 		Score:              finding.Score,
 		Severity:           SeverityToModel(finding.Severity),
 		Occurrences:        int64ToInt(finding.Occurrences),
+		FirstSeen:          finding.FirstSeen,
 		LastSeen:           finding.LastSeen,
 		Status:             finding.Status,
 		TransactionID:      formatOptionalID(finding.TransactionID),

--- a/frontend/services/insights/types.go
+++ b/frontend/services/insights/types.go
@@ -288,6 +288,7 @@ type Finding struct {
 	Score              int                        `json:"score"`
 	Severity           Severity                   `json:"severity"`
 	Occurrences        int64                      `json:"occurrences"`
+	FirstSeen          *string                    `json:"first_seen,omitempty"`
 	LastSeen           string                     `json:"last_seen"`
 	Status             string                     `json:"status"`
 	TransactionID      *int64                     `json:"transaction_id,omitempty"`

--- a/frontend/webapp/graphql/queries/insights.ts
+++ b/frontend/webapp/graphql/queries/insights.ts
@@ -110,6 +110,7 @@ const FINDING_FIELDS = `
   score
   severity
   occurrences
+  firstSeen
   lastSeen
   status
   transactionId

--- a/frontend/webapp/package.json
+++ b/frontend/webapp/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@apollo/client": "^4.2.12",
-    "@odigos/ui-kit": "0.0.291",
+    "@odigos/ui-kit": "0.0.292",
     "graphql": "^16.14.2",
     "next": "15.5.21",
     "react": "19.2.8",

--- a/frontend/webapp/yarn.lock
+++ b/frontend/webapp/yarn.lock
@@ -579,10 +579,10 @@
   resolved "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
 
-"@odigos/ui-kit@0.0.291":
-  version "0.0.291"
-  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.291.tgz#507e991381bf60db4d1c2030fb8ea146e8682f56"
-  integrity sha512-63Byn3wplKEtJoz6Rp8xvlq2M8UPRAIdmRuRkxL3efx6tA8EO4tx1V8H7GbcolhjuI9E88Jd2hrcrAjJ0sjQ1A==
+"@odigos/ui-kit@0.0.292":
+  version "0.0.292"
+  resolved "https://registry.yarnpkg.com/@odigos/ui-kit/-/ui-kit-0.0.292.tgz#d95118aebc3dd9d8566844449ff658a443b4787b"
+  integrity sha512-yPy5MontDclUgAQdgUl+mSC5/G4xGA+M/uVpy/CJr0oDx40pTZqvVMCjDpurImW00nUIM+BReBGA2UZiw/GGww==
   dependencies:
     "@xyflow/react" "^12.11.5"
     elkjs "^0.12.0"


### PR DESCRIPTION
#### What this PR does / why we need it:
Expose `firstSeen` on the unified Insights findings GraphQL type and wire it through the BFF so the UI can group related findings (including guardrail violations) by earliest occurrence. Also bumps `@odigos/ui-kit` to `0.0.292` for the Related findings grouping UI.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
```release-note
Insights findings now include firstSeen (including guardrail violations) so related findings can be grouped by time in the UI.
```

Made with [Cursor](https://cursor.com)