### PR TITLE
CORE-1557 | fix: enable traces pipeline when insights has no destinations

### DIFF
--- a/common/config/root_test.go
+++ b/common/config/root_test.go
@@ -353,6 +353,43 @@ func TestServiceGraphInsights(t *testing.T) {
 	assert.Equal(t, []string{"prometheus/servicegraph", consts.ServiceGraphInsightsExporterName}, pipe.Exporters)
 }
 
+// TestInsightsEnablesTracesWithoutDestinations verifies that insights alone
+// forces the traces root pipeline and ReceiverSignals, so agents export spans
+// even when no destination is configured.
+func TestInsightsEnablesTracesWithoutDestinations(t *testing.T) {
+	on := true
+	gatewayOptions := pipelinegen.GatewayConfigOptions{
+		OdigosNamespace:      "odigos-system",
+		Insights:             &common.InsightsConfiguration{Enabled: &on},
+		InsightsOtlpEndpoint: "dns:///odigos-insights-headless.odigos-system:4317",
+	}
+	cfg, err, _, signals := pipelinegen.CalculateGatewayConfig(
+		nil,
+		nil,
+		selfMetricsReceiver(), nil, &gatewayOptions,
+	)
+	require.NoError(t, err)
+	require.Contains(t, signals, common.TracesObservabilitySignal)
+	require.NotContains(t, signals, common.MetricsObservabilitySignal)
+	require.NotContains(t, signals, common.LogsObservabilitySignal)
+
+	_, hasTracesIn := cfg.Service.Pipelines["traces/in"]
+	assert.True(t, hasTracesIn, "insights must create the root traces pipeline with no destinations")
+	_, hasServiceGraph := cfg.Service.Pipelines["metrics/servicegraph"]
+	assert.True(t, hasServiceGraph, "service graph should still be wired when insights enables traces")
+
+	_, hasForward := cfg.Connectors[consts.TracesPostGroupByForwardConnectorName]
+	assert.False(t, hasForward, "post-groupby forward must be skipped when there is no traces destination")
+	_, hasExporting := cfg.Service.Pipelines[consts.TracesExportingPipelineName]
+	assert.False(t, hasExporting, "traces/exporting must be skipped when there is no traces destination")
+	_, hasRouter := cfg.Connectors["odigosrouterconnector/traces"]
+	assert.False(t, hasRouter, "router must not be wired when there is no traces destination")
+
+	tracesIn := cfg.Service.Pipelines["traces/in"]
+	assert.Contains(t, tracesIn.Exporters, consts.ServiceGraphConnectorName)
+	assert.Contains(t, tracesIn.Processors, consts.GroupByTraceProcessor)
+}
+
 // TestServiceGraphInsightsDisabled verifies the insights exporter is absent
 // when insights is not active, so the default service-graph path is unchanged.
 func TestServiceGraphInsightsDisabled(t *testing.T) {

--- a/common/pipelinegen/config_builder.go
+++ b/common/pipelinegen/config_builder.go
@@ -267,7 +267,8 @@ func insertRootPipelinesToConfig(currentConfig *config.Config,
 	signals []common.ObservabilitySignal, hasTracesDestination bool, gatewayOptions *GatewayConfigOptions) {
 	if slices.Contains(signals, common.TracesObservabilitySignal) {
 		if traceAggregationNeeded(gatewayOptions) {
-			applySplitTracesRootPipelines(currentConfig, tracesProcessors, tracesPostForwardProcessors, gatewayOptions.OdigosConfigExtensionName, hasTracesDestination)
+			applySplitTracesRootPipelines(currentConfig, tracesProcessors, tracesPostForwardProcessors,
+				gatewayOptions.OdigosConfigExtensionName, hasTracesDestination)
 		} else {
 			allTracesProcessors := append(slices.Clone(tracesProcessors), tracesPostForwardProcessors...)
 			applyRootPipelineForSignal(currentConfig, common.TracesObservabilitySignal, allTracesProcessors, gatewayOptions.OdigosConfigExtensionName)

--- a/common/pipelinegen/config_builder.go
+++ b/common/pipelinegen/config_builder.go
@@ -103,6 +103,7 @@ func CalculateGatewayConfig(
 	destForwardConnectors := make(map[string][]string)
 
 	tracesEnabled := false
+	hasTracesDestination := false // traces can be enabled without a destination (insights case)
 	metricsEnabled := false
 	logsEnabled := false
 	profilesEnabled := false
@@ -167,6 +168,7 @@ func CalculateGatewayConfig(
 			switch {
 			case strings.HasPrefix(pipelineName, "traces/"):
 				tracesEnabled = true
+				hasTracesDestination = true
 			case strings.HasPrefix(pipelineName, "metrics/"):
 				metricsEnabled = true
 			case strings.HasPrefix(pipelineName, "logs/"):
@@ -180,6 +182,12 @@ func CalculateGatewayConfig(
 		}
 
 		status.Destination[dest.GetID()] = nil // mark this destination as success
+	}
+
+	// Insights taps the root traces pipeline; force traces on even with no destinations
+	// so the gateway receives spans and ReceiverSignals advertises traces to agents.
+	if common.InsightsPipelineActive(gatewayOptions.Insights) {
+		tracesEnabled = true
 	}
 
 	// track which signals are enabled
@@ -220,6 +228,7 @@ func CalculateGatewayConfig(
 		processorsResults.LogsProcessors,
 		processorsResults.ProfilesProcessors,
 		enabledSignals,
+		hasTracesDestination,
 		gatewayOptions)
 
 	// Optional: Add collector self-observability
@@ -255,10 +264,10 @@ func CalculateGatewayConfig(
 
 func insertRootPipelinesToConfig(currentConfig *config.Config,
 	tracesProcessors, tracesPostForwardProcessors, metricsProcessors, logsProcessors, profilesProcessors []string,
-	signals []common.ObservabilitySignal, gatewayOptions *GatewayConfigOptions) {
+	signals []common.ObservabilitySignal, hasTracesDestination bool, gatewayOptions *GatewayConfigOptions) {
 	if slices.Contains(signals, common.TracesObservabilitySignal) {
 		if traceAggregationNeeded(gatewayOptions) {
-			applySplitTracesRootPipelines(currentConfig, tracesProcessors, tracesPostForwardProcessors, gatewayOptions.OdigosConfigExtensionName)
+			applySplitTracesRootPipelines(currentConfig, tracesProcessors, tracesPostForwardProcessors, gatewayOptions.OdigosConfigExtensionName, hasTracesDestination)
 		} else {
 			allTracesProcessors := append(slices.Clone(tracesProcessors), tracesPostForwardProcessors...)
 			applyRootPipelineForSignal(currentConfig, common.TracesObservabilitySignal, allTracesProcessors, gatewayOptions.OdigosConfigExtensionName)
@@ -281,17 +290,30 @@ func insertRootPipelinesToConfig(currentConfig *config.Config,
 // applySplitTracesRootPipelines forks traces after enrichment processors so complete trace batches
 // are templated before tail sampling. traces/in aggregates and forwards; traces/exporting tail-samples,
 // batches, and routes to destinations.
+// When there is no traces destination (e.g. insights-only), skip the forward/exporting/router split
+// and keep a single traces/in pipeline — downstream taps (insights, servicegraph) attach there.
 func applySplitTracesRootPipelines(
 	currentConfig *config.Config,
 	tracesProcessors, tracesPostForwardProcessors []string,
 	odigosConfigExtensionName *string,
+	hasTracesDestination bool,
 ) {
+	tracesInProcessors, tracesExportingProcessors := splitTracesProcessorsForPipelines(tracesProcessors, tracesPostForwardProcessors)
+	rootPipelineName := GetTelemetryRootPipelineName(common.TracesObservabilitySignal)
+
+	// shortcut - for example when only insights are enabled, no need to export traces to destinations
+	if !hasTracesDestination {
+		currentConfig.Service.Pipelines[rootPipelineName] = config.Pipeline{
+			Receivers:  []string{"otlp"},
+			Processors: append([]string{"resource/odigos-version"}, tracesInProcessors...),
+			Exporters:  []string{},
+		}
+		return
+	}
+
 	forwardConnectorName := consts.TracesPostGroupByForwardConnectorName
 	currentConfig.Connectors[forwardConnectorName] = config.GenericMap{}
 
-	tracesInProcessors, tracesExportingProcessors := splitTracesProcessorsForPipelines(tracesProcessors, tracesPostForwardProcessors)
-
-	rootPipelineName := GetTelemetryRootPipelineName(common.TracesObservabilitySignal)
 	currentConfig.Service.Pipelines[rootPipelineName] = config.Pipeline{
 		Receivers:  []string{"otlp"},
 		Processors: append([]string{"resource/odigos-version"}, tracesInProcessors...),


### PR DESCRIPTION
#### What this PR does / why we need it:
When Insights is enabled without any traces destination, the gateway never turned on the root traces pipeline, so `ReceiverSignals` omitted traces and agents did not export spans to Insights.

This forces traces on when Insights is active, and skips the post-groupby forward / `traces/exporting` / router split when there is no traces destination so insights and servicegraph can still attach to a single `traces/in` pipeline.

Linear: https://linear.app/odigos/issue/CORE-1557/enable-gateway-traces-pipeline-when-insights-is-active-without

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
```release-note
Fix Insights receiving no traces when no traces destination is configured by enabling the gateway traces pipeline for Insights-only setups.
```