### PR TITLE
Cherry-pick: CORE-1562: allow replacing default ignored containers and namespaces via Helm (backport to v1.35)

### DIFF
--- a/api/k8sconsts/consts.go
+++ b/api/k8sconsts/consts.go
@@ -26,14 +26,6 @@ const (
 var MinK8SVersionForInstallation = version.MustParse("v1.20.15-0")
 
 var (
-	// Default ignored namespaces
-	DefaultIgnoredNamespaces = []string{
-		"local-path-storage",
-		"istio-system",
-		"linkerd",
-		"kube-node-lease",
-	}
-
 	// Openshift namespaces
 	OpenshiftIgnoredNamespaces = []string{
 		"openshift",
@@ -97,9 +89,6 @@ var (
 		"openshift-user-workload-monitoring",
 		"openshift-vsphere-infra",
 	}
-
-	// Default ignored container names
-	DefaultIgnoredContainers = []string{"istio-proxy", "vault-agent", "filebeat", "linkerd-proxy", "fluentd", "akeyless-init"}
 )
 
 const (

--- a/cli/cmd/sources_cluster.go
+++ b/cli/cmd/sources_cluster.go
@@ -146,12 +146,17 @@ func enableClusterSource(cmd *cobra.Command) {
 }
 
 func instrumentCluster(ctx context.Context, client *kube.Client, excludeNamespaces map[string]struct{}, excludeApps map[string]struct{}, dryRun bool, isRemote bool, onlyNamespace string, onlyDeployment string) {
-	systemNs := sliceToMap(k8sconsts.DefaultIgnoredNamespaces)
 	odigosNs, err := resources.GetOdigosNamespace(client, ctx)
 	if err != nil {
 		fmt.Printf("\033[31mERROR\033[0m Cannot get odigos namespace: %s\n", err)
 		os.Exit(1)
 	}
+	config, err := resources.GetCurrentConfig(ctx, client, odigosNs)
+	if err != nil {
+		fmt.Printf("\033[31mERROR\033[0m Cannot get odigos configuration: %s\n", err)
+		os.Exit(1)
+	}
+	systemNs := sliceToMap(config.IgnoredNamespaces)
 	systemNs[odigosNs] = struct{}{}
 
 	orchestrator, err := lifecycle.NewOrchestrator(client, ctx, isRemote)

--- a/helm/odigos/values.schema.json
+++ b/helm/odigos/values.schema.json
@@ -590,14 +590,52 @@
       "title": "ignoreOdigosNamespace"
     },
     "ignoredContainers": {
-      "default": "",
-      "description": "container names to never instrument\nuseful for sidecars which are not interesting to be instrumented\nset by default: istio-proxy, vault-agent, filebeat, linkerd-proxy, fluentd, akeyless-init\nyou can add additional container names to ignore by adding them to the list",
+      "description": "container names to never instrument\nuseful for sidecars which are not interesting to be instrumented",
+      "items": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "required": []
+      },
       "required": [],
       "title": "ignoredContainers"
     },
     "ignoredNamespaces": {
-      "default": "",
-      "description": "namespaces list not to show in odigos ui\nset by default: odigos-system, kube-system, local-path-storage, istio-system, linkerd, kube-node-lease\nyou can add additional namespaces to ignore by adding them to the list",
+      "description": "Namespaces excluded from the Odigos UI so system and infrastructure namespaces\n(service meshes, local storage, lease holders, etc.) do not clutter the sources list.\nThe Odigos install namespace is ignored by default; set ignoreOdigosNamespace to false to show it.\nWhen openshift.enabled is true, OpenShift system namespaces are also ignored automatically.",
+      "items": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "required": []
+      },
       "required": [],
       "title": "ignoredNamespaces"
     },

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -35,11 +35,16 @@ images: {}
 
 # @schema
 # description: |-
-#   namespaces list not to show in odigos ui
-#   set by default: odigos-system, kube-system, local-path-storage, istio-system, linkerd, kube-node-lease
-#   you can add additional namespaces to ignore by adding them to the list
+#   Namespaces excluded from the Odigos UI so system and infrastructure namespaces
+#   (service meshes, local storage, lease holders, etc.) do not clutter the sources list.
+#   The Odigos install namespace is ignored by default; set ignoreOdigosNamespace to false to show it.
+#   When openshift.enabled is true, OpenShift system namespaces are also ignored automatically.
 # @schema
 ignoredNamespaces:
+  - local-path-storage
+  - istio-system
+  - linkerd
+  - kube-node-lease
 
 # @schema
 # description: |-
@@ -54,10 +59,14 @@ ignoreOdigosNamespace: true
 # description: |-
 #   container names to never instrument
 #   useful for sidecars which are not interesting to be instrumented
-#   set by default: istio-proxy, vault-agent, filebeat, linkerd-proxy, fluentd, akeyless-init
-#   you can add additional container names to ignore by adding them to the list
 # @schema
 ignoredContainers:
+  - istio-proxy
+  - vault-agent
+  - filebeat
+  - linkerd-proxy
+  - fluentd
+  - akeyless-init
 
 # @schema
 # description: Name of the cluster, will be used to identify this cluster in the centralized backend

--- a/scheduler/controllers/odigosconfiguration/odigosconfiguration_controller.go
+++ b/scheduler/controllers/odigosconfiguration/odigosconfiguration_controller.go
@@ -102,12 +102,12 @@ func (r *odigosConfigurationController) Reconcile(ctx context.Context, _ ctrl.Re
 		return ctrl.Result{}, err
 	}
 
-	// make sure the default ignored namespaces are always present
-	defaultIgnoredNamespaces := k8sconsts.DefaultIgnoredNamespaces
+	// OpenShift system namespaces are always merged when openshift is enabled.
+	// Other defaults come from Helm ignoredNamespaces and are not re-merged here,
+	// so users can replace that list entirely.
 	if odigosConfiguration.OpenshiftEnabled {
-		defaultIgnoredNamespaces = append(defaultIgnoredNamespaces, k8sconsts.OpenshiftIgnoredNamespaces...)
+		odigosConfiguration.IgnoredNamespaces = mergeIgnoredItemLists(odigosConfiguration.IgnoredNamespaces, k8sconsts.OpenshiftIgnoredNamespaces)
 	}
-	odigosConfiguration.IgnoredNamespaces = mergeIgnoredItemLists(odigosConfiguration.IgnoredNamespaces, defaultIgnoredNamespaces)
 
 	currentNamespace := env.GetCurrentNamespace()
 	// Only add the current namespace to ignored namespaces if ignoreOdigosNamespace is not explicitly set to false
@@ -117,9 +117,6 @@ func (r *odigosConfigurationController) Reconcile(ctx context.Context, _ ctrl.Re
 		// Remove the namespace from the list if ignoreOdigosNamespace is explicitly set to false
 		odigosConfiguration.IgnoredNamespaces = removeItemFromList(odigosConfiguration.IgnoredNamespaces, currentNamespace)
 	}
-
-	// make sure the default ignored containers are always present
-	odigosConfiguration.IgnoredContainers = mergeIgnoredItemLists(odigosConfiguration.IgnoredContainers, k8sconsts.DefaultIgnoredContainers)
 
 	modifyConfigWithEffectiveProfiles(effectiveProfiles, &odigosConfiguration)
 	odigosConfiguration.Profiles = effectiveProfiles


### PR DESCRIPTION
#### What this PR does / why we need it:
Cherry-pick of https://github.com/odigos-io/odigos/pull/5716 onto `releases/v1.35.0`.

Today the default ignored containers and namespaces are hardcoded in Go and always merged into the effective config. Users cannot remove entries from those lists, so they cannot instrument previously always-ignored sidecars or work with namespaces that were permanently filtered out.

This PR moves those defaults into Helm `values.yaml` and stops the scheduler from re-merging them. Setting `ignoredContainers` or `ignoredNamespaces` now **replaces** the entire list.

Still unchanged on purpose:
- OpenShift system namespaces continue to be merged when `openshift.enabled` is true
- The Odigos install namespace continues to be controlled by `ignoreOdigosNamespace`

The CLI cluster-instrument path now reads ignored namespaces from the installed Odigos configuration instead of the removed Go constant.

Linear: https://linear.app/odigos/issue/CORE-1562/allow-opting-out-of-default-ignored-containers

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
```release-note
ignoredContainers and ignoredNamespaces set via Helm or config now replace their default lists instead of merging with them, so users can opt in to instrumenting previously always-ignored sidecars and namespaces. OpenShift system namespaces and the Odigos install namespace are still handled separately.
```

Made with [Cursor](https://cursor.com)