### PR TITLE
fix(datastreams): copy OTLP profiles dictionary when splitting batches for destination

### DIFF
--- a/collector/connectors/odigosrouterconnector/connector.go
+++ b/collector/connectors/odigosrouterconnector/connector.go
@@ -364,10 +364,23 @@ func (r *routerConnector) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	return errs
 }
 
+// newProfilesWithDictionary returns an empty Profiles whose dictionary is a copy
+// of src's. Unlike traces/metrics/logs, OTLP profiles keep strings, functions,
+// locations, and stacks in a top-level dictionary; each ResourceProfiles only
+// stores indexes into that table. NewProfiles() has an empty dictionary, so a
+// ResourceProfiles CopyTo onto it produces a valid payload with unresolvable
+// samples. ConsumeProfiles fans out to a default batch and per-consumer batches;
+// both must start from this so appended resources keep resolvable indexes.
+func newProfilesWithDictionary(src pprofile.Profiles) pprofile.Profiles {
+	out := pprofile.NewProfiles()
+	src.Dictionary().CopyTo(out.Dictionary())
+	return out
+}
+
 func (r *routerConnector) ConsumeProfiles(ctx context.Context, pd pprofile.Profiles) error {
 	cfg := r.profilesConfig
 	profilesByConsumer := make(map[xconsumer.Profiles]pprofile.Profiles)
-	defaultProfiles := pprofile.NewProfiles()
+	defaultProfiles := newProfilesWithDictionary(pd)
 	var errs error
 
 	rProfiles := pd.ResourceProfiles()
@@ -389,7 +402,7 @@ func (r *routerConnector) ConsumeProfiles(ctx context.Context, pd pprofile.Profi
 
 			batch, ok := profilesByConsumer[consumer]
 			if !ok {
-				batch = pprofile.NewProfiles()
+				batch = newProfilesWithDictionary(pd)
 			}
 			rp.CopyTo(batch.ResourceProfiles().AppendEmpty())
 			profilesByConsumer[consumer] = batch


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Copy profiles dictionary when routing datastreams so destinations receive samples

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
fix: copy profiles dictionary on datastream fan-out so destination export works
```
