### PR TITLE
CORE-1567: (insights) pass transaction window time through graphql

### DIFF
--- a/frontend/graph/generated.go
+++ b/frontend/graph/generated.go
@@ -620,7 +620,7 @@ type ComplexityRoot struct {
 		StorageHealth       func(childComplexity int) int
 		SystemSettings      func(childComplexity int) int
 		Transaction         func(childComplexity int, id string) int
-		Transactions        func(childComplexity int, namespace *string, service *string, kind *model.InsightsTransactionKind) int
+		Transactions        func(childComplexity int, namespace *string, service *string, kind *model.InsightsTransactionKind, windowHours *int) int
 	}
 
 	InsightsAnomalyAttrHighlight struct {
@@ -2182,7 +2182,7 @@ type InsightsResolver interface {
 	ServiceNames(ctx context.Context, obj *model.Insights) ([]string, error)
 	ServiceProfile(ctx context.Context, obj *model.Insights, namespace *string, service string) (*model.InsightsServiceProfile, error)
 	BlastRadius(ctx context.Context, obj *model.Insights, namespace *string, service string, depth *int) (*model.InsightsBlastRadiusSubgraph, error)
-	Transactions(ctx context.Context, obj *model.Insights, namespace *string, service *string, kind *model.InsightsTransactionKind) ([]*model.InsightsTransactionStat, error)
+	Transactions(ctx context.Context, obj *model.Insights, namespace *string, service *string, kind *model.InsightsTransactionKind, windowHours *int) ([]*model.InsightsTransactionStat, error)
 	Transaction(ctx context.Context, obj *model.Insights, id string) (*model.InsightsTransaction, error)
 	Baseline(ctx context.Context, obj *model.Insights, transactionID string) ([]*model.InsightsBaselineClass, error)
 	Observations(ctx context.Context, obj *model.Insights, transactionID string, sampleReason *model.InsightsSampleReason) ([]*model.InsightsObservationSummary, error)
@@ -5087,7 +5087,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Insights.Transactions(childComplexity, args["namespace"].(*string), args["service"].(*string), args["kind"].(*model.InsightsTransactionKind)), true
+		return e.complexity.Insights.Transactions(childComplexity, args["namespace"].(*string), args["service"].(*string), args["kind"].(*model.InsightsTransactionKind), args["windowHours"].(*int)), true
 
 	case "InsightsAnomalyAttrHighlight.key":
 		if e.complexity.InsightsAnomalyAttrHighlight.Key == nil {
@@ -13225,6 +13225,11 @@ func (ec *executionContext) field_Insights_transactions_args(ctx context.Context
 		return nil, err
 	}
 	args["kind"] = arg2
+	arg3, err := ec.field_Insights_transactions_argsWindowHours(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["windowHours"] = arg3
 	return args, nil
 }
 func (ec *executionContext) field_Insights_transactions_argsNamespace(
@@ -13278,6 +13283,24 @@ func (ec *executionContext) field_Insights_transactions_argsKind(
 	}
 
 	var zeroVal *model.InsightsTransactionKind
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Insights_transactions_argsWindowHours(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*int, error) {
+	if _, ok := rawArgs["windowHours"]; !ok {
+		var zeroVal *int
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("windowHours"))
+	if tmp, ok := rawArgs["windowHours"]; ok {
+		return ec.unmarshalOInt2ᚖint(ctx, tmp)
+	}
+
+	var zeroVal *int
 	return zeroVal, nil
 }
 
@@ -33024,7 +33047,7 @@ func (ec *executionContext) _Insights_transactions(ctx context.Context, field gr
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Insights().Transactions(rctx, obj, fc.Args["namespace"].(*string), fc.Args["service"].(*string), fc.Args["kind"].(*model.InsightsTransactionKind))
+		return ec.resolvers.Insights().Transactions(rctx, obj, fc.Args["namespace"].(*string), fc.Args["service"].(*string), fc.Args["kind"].(*model.InsightsTransactionKind), fc.Args["windowHours"].(*int))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/frontend/graph/insights.graphqls
+++ b/frontend/graph/insights.graphqls
@@ -1013,6 +1013,7 @@ type Insights {
     namespace: String
     service: String
     kind: InsightsTransactionKind
+    windowHours: Int
   ): [InsightsTransactionStat!]!
   transaction(id: ID!): InsightsTransaction
   baseline(transactionId: ID!): [InsightsBaselineClass!]!

--- a/frontend/graph/insights.resolvers.go
+++ b/frontend/graph/insights.resolvers.go
@@ -76,15 +76,16 @@ func (r *insightsResolver) BlastRadius(ctx context.Context, obj *model.Insights,
 }
 
 // Transactions is the resolver for the transactions field.
-func (r *insightsResolver) Transactions(ctx context.Context, obj *model.Insights, namespace *string, service *string, kind *model.InsightsTransactionKind) ([]*model.InsightsTransactionStat, error) {
+func (r *insightsResolver) Transactions(ctx context.Context, obj *model.Insights, namespace *string, service *string, kind *model.InsightsTransactionKind, windowHours *int) ([]*model.InsightsTransactionStat, error) {
 	client, err := r.insightsClient(ctx)
 	if err != nil {
 		return nil, err
 	}
 	stats, err := client.ListTransactions(ctx, insights.ListTransactionsParams{
-		Namespace: namespace,
-		Service:   service,
-		Kind:      insights.TransactionKindPtrFromModel(kind),
+		Namespace:   namespace,
+		Service:     service,
+		Kind:        insights.TransactionKindPtrFromModel(kind),
+		WindowHours: windowHours,
 	})
 	if err != nil {
 		return nil, insights.GraphQLError(ctx, err)

--- a/frontend/services/insights/client.go
+++ b/frontend/services/insights/client.go
@@ -87,6 +87,7 @@ func (c *Client) ListTransactions(ctx context.Context, params ListTransactionsPa
 	if params.Kind != nil {
 		query.Set("kind", string(*params.Kind))
 	}
+	addWindowHoursFilter(query, params.WindowHours)
 	endpoint.RawQuery = query.Encode()
 	return doList[TransactionStat](ctx, c, http.MethodGet, endpoint, nil)
 }
@@ -508,11 +509,15 @@ func addOptionalString(query url.Values, key string, value *string) {
 	}
 }
 
-func addFindingFilters(endpoint *url.URL, windowHours *int, service, namespace, status *string) {
-	query := endpoint.Query()
+func addWindowHoursFilter(query url.Values, windowHours *int) {
 	if windowHours != nil {
 		query.Set("window_hours", strconv.Itoa(*windowHours))
 	}
+}
+
+func addFindingFilters(endpoint *url.URL, windowHours *int, service, namespace, status *string) {
+	query := endpoint.Query()
+	addWindowHoursFilter(query, windowHours)
 	addOptionalString(query, "service", service)
 	addOptionalString(query, "namespace", namespace)
 	addOptionalString(query, "status", status)

--- a/frontend/services/insights/client_test.go
+++ b/frontend/services/insights/client_test.go
@@ -142,6 +142,26 @@ func TestClientEncodesQueryParameters(t *testing.T) {
 	assert.Empty(t, items)
 }
 
+func TestClientListTransactionsWindowHours(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/transactions", r.URL.Path)
+		assert.Equal(t, "168", r.URL.Query().Get("window_hours"))
+		_, _ = w.Write([]byte(`{"count":0,"items":[]}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	require.NoError(t, err)
+	windowHours := 168
+
+	items, err := client.ListTransactions(context.Background(), ListTransactionsParams{
+		WindowHours: &windowHours,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, items)
+}
+
 func TestClientDecodesCollectionEnvelope(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)

--- a/frontend/services/insights/types.go
+++ b/frontend/services/insights/types.go
@@ -30,9 +30,10 @@ func AnomalyEvidenceSampleReason(signature string) SampleReason {
 }
 
 type ListTransactionsParams struct {
-	Namespace *string
-	Service   *string
-	Kind      *TransactionKind
+	Namespace   *string
+	Service     *string
+	Kind        *TransactionKind
+	WindowHours *int
 }
 
 type ListObservationsParams struct {

--- a/frontend/webapp/graphql/queries/insights.ts
+++ b/frontend/webapp/graphql/queries/insights.ts
@@ -421,9 +421,9 @@ export const GET_INSIGHTS_BLAST_RADIUS = gql`
 `;
 
 export const GET_INSIGHTS_TRANSACTIONS = gql`
-  query GetInsightsTransactions($namespace: String, $service: String, $kind: InsightsTransactionKind) {
+  query GetInsightsTransactions($namespace: String, $service: String, $kind: InsightsTransactionKind, $windowHours: Int) {
     insights {
-      transactions(namespace: $namespace, service: $service, kind: $kind) { ${TRANSACTION_STAT_FIELDS} }
+      transactions(namespace: $namespace, service: $service, kind: $kind, windowHours: $windowHours) { ${TRANSACTION_STAT_FIELDS} }
     }
   }
 `;


### PR DESCRIPTION
#### What this PR does / why we need it:
This exposes the time selection parameters through the ui graphql for insights transactions

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
