### PR TITLE
RUN-1115 | feat(instrumentation): set telemetry.distro.name for eBPF distributions

### DIFF
--- a/instrumentation/manager.go
+++ b/instrumentation/manager.go
@@ -446,6 +446,19 @@ func (m *manager[ProcessGroup, ConfigGroup, ProcessDetails]) metricsAttributeSet
 	)
 }
 
+// withTelemetryDistroName returns attrs with telemetry.distro.name set to distroName.
+// An existing value (for example from OTEL_RESOURCE_ATTRIBUTES) is kept. attrs is not modified.
+func withTelemetryDistroName(attrs []attribute.KeyValue, distroName string) []attribute.KeyValue {
+	for _, attr := range attrs {
+		if attr.Key == semconv.TelemetryDistroNameKey {
+			return attrs
+		}
+	}
+	out := make([]attribute.KeyValue, 0, len(attrs)+1)
+	out = append(out, attrs...)
+	return append(out, semconv.TelemetryDistroName(distroName))
+}
+
 func (m *manager[ProcessGroup, ConfigGroup, ProcessDetails]) cleanInstrumentation(ctx context.Context, pid int) {
 	details, found := m.detailsByPid[pid]
 	if !found {
@@ -604,6 +617,9 @@ func (m *manager[ProcessGroup, ConfigGroup, ProcessDetails]) tryInstrument(ctx c
 	// Distro factory: the process's own instrumentation and the main instrumentation path - report
 	// init/load, track even on failure (so the reporter is notified on exit and a failed distro can
 	// be retried), and run.
+	// The distribution is reported as telemetry.distro.name. Generic factories do not get it, as they
+	// are not the distribution instrumenting the process.
+	settings.ResourceAttributes = withTelemetryDistroName(settings.ResourceAttributes, otelDistro.Name)
 	inst, initErr := factory.CreateInstrumentation(ctx, pid, settings)
 	reporterErr := m.handler.Reporter.OnInit(ctx, pid, initErr, pd)
 	if reporterErr != nil {

--- a/tests/common/queries/resource-attributes.yaml
+++ b/tests/common/queries/resource-attributes.yaml
@@ -4,6 +4,7 @@ description: |
   This test check the following resource attributes:
   A. odigos.version attribute exists on all spans
   B. Kubernetes attributes are correctly set on all spans
+  C. telemetry.distro.name is the Odigos distribution name on spans from eBPF instrumentations
 query: |
   length([?(
     !span.resourceAttributes."odigos.version" ||
@@ -11,6 +12,7 @@ query: |
     !span.resourceAttributes."k8s.pod.name" ||
     !span.resourceAttributes."k8s.namespace.name" ||
     !span.resourceAttributes."k8s.container.name" ||
+    (span.resourceAttributes."telemetry.sdk.language" == 'go' && !starts_with(span.resourceAttributes."telemetry.distro.name", 'golang-')) ||
     !(
       starts_with(span.resourceAttributes."k8s.node.name", 'kind-') ||
       starts_with(span.resourceAttributes."k8s.node.name", 'aks-') ||


### PR DESCRIPTION
#### What this PR does / why we need it:
Each eBPF agent decides on its own whether to report `telemetry.distro.name`, and the Java agent does not report it at all. This sets it in the instrumentation manager from the process's distribution, so every eBPF distribution reports the Odigos distribution name. Generic factories do not get it. An existing value, for example from `OTEL_RESOURCE_ATTRIBUTES`, is kept.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
eBPF instrumentations now report `telemetry.distro.name` with the Odigos distribution name (for example `java-ebpf-instrumentations`, `golang-enterprise`).
```

cherry-pick: v1.36
