### PR TITLE
CORE-1631 | fix(helm): stop Insights install from hanging when ClickHouse storage cannot bind

### DIFF
--- a/helm/odigos/templates/NOTES.txt
+++ b/helm/odigos/templates/NOTES.txt
@@ -8,3 +8,23 @@ brew install odigos-io/odigos-cli/odigos
 odigos ui
 
 Then, go to: http://localhost:3000
+
+{{ if and .Values.insights.enabled (eq .Values.insights.clickhouse.storage.persistence false) }}
+{{- $existingPVC := lookup "v1" "PersistentVolumeClaim" .Release.Namespace "odigos-insights-clickhouse" }}
+
+WARNING: Insights persistence is disabled.
+
+ClickHouse is using emptyDir. Insights data will be lost when the
+ClickHouse pod is recreated or rescheduled.
+
+You can enable persistent storage by setting:
+
+  insights.clickhouse.storage.persistence=true
+
+{{ if $existingPVC }}
+A previous ClickHouse PVC named "odigos-insights-clickhouse" still exists.
+
+The PVC was intentionally retained to protect existing Insights data and is
+not used while persistence is disabled.
+{{ end }}
+{{ end }}

--- a/helm/odigos/templates/insights/clickhouse/deployment.yaml
+++ b/helm/odigos/templates/insights/clickhouse/deployment.yaml
@@ -107,8 +107,12 @@ spec:
       {{- end }}
       volumes:
         - name: data
+          {{- if ne .Values.insights.clickhouse.storage.persistence false }}
           persistentVolumeClaim:
             claimName: odigos-insights-clickhouse
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
         - name: config
           configMap:
             name: odigos-insights-clickhouse

--- a/helm/odigos/templates/insights/clickhouse/migrate-job.yaml
+++ b/helm/odigos/templates/insights/clickhouse/migrate-job.yaml
@@ -1,48 +1,120 @@
 {{- if and .Values.insights.enabled (include "odigos.secretExists" .) }}
 {{- /*
-Schema migrations run exactly once per release from this Job (never from the
-serving replicas), so replicas scale without racing on DDL. The `migrate`
-entrypoint retries until ClickHouse is reachable, so it tolerates the bundled
-DB still starting up.
+Schema migrations run from this Job rather than from serving replicas, so
+multiple Insights replicas never race on DDL.
 
-The hook phase is chosen adaptively, because ClickHouse (its Secret, Service,
-Deployment and PVC) are ordinary resources that Helm applies only during the
-main release phase -- AFTER pre-* hooks and BEFORE post-* hooks:
-  - ClickHouse already exists (steady-state upgrade): run pre-upgrade, so the
-    schema is migrated BEFORE the new odigos-insights replicas roll out in the
-    main phase and new code never serves against an old schema.
-  - ClickHouse does NOT exist yet (fresh install, or the first upgrade that
-    enables insights): a pre-upgrade migration would run before the main phase
-    that creates ClickHouse, so it would have no Secret to mount and no DB to
-    reach -- this is the "secret odigos-insights-clickhouse not found"
-    CreateContainerConfigError. Fall back to post-install/post-upgrade so the
-    migration runs AFTER ClickHouse has been created.
-We deliberately keep ClickHouse as ordinary (non-hook) resources: turning the
-PVC into a hook would delete it via Helm's default before-hook-creation policy
-on every upgrade, wiping all insights data.
+There are three lifecycle cases:
 
-Either way the insights pods gate their own readiness on the schema
-(waitForSchemaReady in insights/cmd/main.go keeps /readyz at 503 until this Job
-has applied the schema), so no replica serves a missing/stale schema regardless
-of the phase chosen here.
+1. Bootstrap
+   Fresh install, or first upgrade that enables Insights.
+
+   There is no existing ClickHouse Deployment, so migration is rendered as a
+   regular Kubernetes Job. Helm does not block waiting for it.
+
+   ClickHouse and the migration Job can start asynchronously. The migrate
+   command retries until ClickHouse is reachable, and Insights replicas remain
+   unready through waitForSchemaReady until the schema is ready.
+
+2. Normal Insights upgrade
+   An existing ClickHouse Deployment is present and the requested storage mode
+   is unchanged.
+
+   Migration runs as a pre-upgrade Helm hook. Helm waits for it before applying
+   the new release, ensuring new Insights code never runs against an old schema.
+
+   A failed migration intentionally fails the Helm upgrade.
+
+3. Storage-mode transition
+   persistence=true -> false
+   persistence=false -> true
+
+   Migration must NOT run as a pre-upgrade hook.
+
+   For example, when switching true -> false because the PVC is Pending, a
+   pre-upgrade migration would wait for the old PVC-backed ClickHouse before
+   Helm is allowed to update ClickHouse to emptyDir. That creates a deadlock.
+
+   During a storage transition, migration therefore runs as a regular Job.
+   Helm first applies the desired ClickHouse storage configuration, the migrate
+   process retries until that ClickHouse is reachable, and Insights remains
+   unready until the schema exists.
+
+Regular bootstrap/transition Jobs include the Helm release revision in their
+name. This prevents immutable completed Jobs from colliding with future
+bootstrap or storage-transition Jobs.
+
+ClickHouse Secret, Service, Deployment and PVC remain ordinary Helm resources.
+The PVC has helm.sh/resource-policy: keep so Insights data is not automatically
+deleted on uninstall or when persistence is temporarily disabled.
 */}}
-{{- $clickhouseExists := lookup "v1" "Secret" .Release.Namespace "odigos-insights-clickhouse" }}
+
+{{- /*
+Inspect the ClickHouse Deployment that exists BEFORE this Helm operation.
+
+lookup intentionally reflects live cluster state. During helm template and
+client-only dry-runs it may return empty, which safely falls back to the
+non-blocking bootstrap behavior.
+*/}}
+{{- $existingClickHouse := lookup "apps/v1" "Deployment" .Release.Namespace "odigos-insights-clickhouse" }}
+{{- $clickhouseExists := not (empty $existingClickHouse) }}
+
+{{- /*
+Determine the storage mode requested by the new release.
+*/}}
+{{- $desiredPersistent := ne .Values.insights.clickhouse.storage.persistence false }}
+
+{{- /*
+Determine the storage mode used by the currently installed ClickHouse
+Deployment.
+
+Default false is intentional: if there is no existing Deployment there is no
+previous persistent mode to preserve and this is treated as bootstrap.
+*/}}
+{{- $currentlyPersistent := false }}
+
+{{- if $clickhouseExists }}
+  {{- range $volume := $existingClickHouse.spec.template.spec.volumes }}
+    {{- if eq $volume.name "data" }}
+      {{- if hasKey $volume "persistentVolumeClaim" }}
+        {{- $currentlyPersistent = true }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- /*
+A storage transition must be non-blocking so Helm can first update ClickHouse
+to the requested storage backend.
+*/}}
+{{- $storageModeChanging := and .Release.IsUpgrade $clickhouseExists (ne $currentlyPersistent $desiredPersistent) }}
+
+{{- /*
+Only an actual upgrade of an already-existing ClickHouse installation with an
+unchanged storage mode requires synchronous pre-upgrade migration.
+*/}}
+{{- $usePreUpgradeHook := and .Release.IsUpgrade $clickhouseExists (not $storageModeChanging) }}
+
 apiVersion: batch/v1
 kind: Job
 metadata:
+  {{- if $usePreUpgradeHook }}
   name: odigos-insights-migrate
+  {{- else if $storageModeChanging }}
+  name: odigos-insights-migrate-storage-transition-{{ .Release.Revision }}
+  {{- else }}
+  name: odigos-insights-migrate-bootstrap-{{ .Release.Revision }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: odigos-insights-migrate
     odigos.io/system-object: "true"
+  {{- if $usePreUpgradeHook }}
   annotations:
-    {{- if $clickhouseExists }}
-    "helm.sh/hook": pre-upgrade,post-install
-    {{- else }}
-    "helm.sh/hook": post-install,post-upgrade
-    {{- end }}
+    "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  {{- end }}
+
 spec:
   # The process retries connecting internally; this bounds a genuinely stuck run
   # (e.g. a broken migration) instead of retrying forever.
@@ -82,7 +154,10 @@ spec:
             limits:
               cpu: 500m
               memory: 256Mi
+
       {{- with .Values.insights.tolerations }}
-      tolerations: {{ toYaml . | nindent 8 }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
+
 {{- end }}

--- a/helm/odigos/templates/insights/clickhouse/pvc.yaml
+++ b/helm/odigos/templates/insights/clickhouse/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.insights.enabled (include "odigos.secretExists" .) }}
+{{- if and .Values.insights.enabled (include "odigos.secretExists" .) (ne .Values.insights.clickhouse.storage.persistence false) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/helm/odigos/values.schema.json
+++ b/helm/odigos/values.schema.json
@@ -712,7 +712,7 @@
         },
         "clickhouse": {
           "additionalProperties": false,
-          "description": "Bundled ClickHouse for the insights service. Single replica, single PVC,\nno replication, no backups. Scale insights pods for HA of ingestion;\nkeep ClickHouse at one replica. User and database name stay hardcoded\n(odigos_insights); image, resources, scheduling, and storage are tunable.",
+          "description": "Bundled ClickHouse for the insights service. Single replica, no\nreplication, no backups. Data is on a PVC by default\n(insights.clickhouse.storage.persistence); set that to false for\nemptyDir. Scale insights pods for HA of ingestion; keep ClickHouse at\none replica. User and database name stay hardcoded (odigos_insights);\nimage, resources, scheduling, and storage are tunable.",
           "properties": {
             "affinity": {
               "additionalProperties": true,
@@ -845,15 +845,21 @@
             "storage": {
               "additionalProperties": false,
               "properties": {
+                "persistence": {
+                  "default": "true",
+                  "description": "When true (default), ClickHouse keeps Insights data on a persistent\nvolume so it survives pod restarts. Set to false only for\ndevelopment or testing: ClickHouse then uses emptyDir, and all\nInsights data is lost when the pod is recreated or rescheduled.",
+                  "required": [],
+                  "title": "persistence"
+                },
                 "size": {
                   "default": "8Gi",
-                  "description": "PVC size for the ClickHouse data volume. Growth is driven mainly by\ntransaction cardinality and trace_observations retention (TTL).\nExpand only if the StorageClass supports volume expansion.",
+                  "description": "PVC size for the ClickHouse data volume. Growth is driven mainly by\ntransaction cardinality and trace_observations retention (TTL).\nExpand only if the StorageClass supports volume expansion.\nIgnored when persistence is false.",
                   "required": [],
                   "title": "size"
                 },
                 "storageClassName": {
                   "default": "",
-                  "description": "StorageClass for the ClickHouse PVC. Empty string uses the cluster\ndefault. Prefer a class backed by fast local/SSD block storage;\navoid slow shared NFS for MergeTree. The class is fixed at PVC\ncreation — changing this value after install does not migrate an\nexisting volume. The PVC is kept across helm uninstall\n(helm.sh/resource-policy: keep).",
+                  "description": "StorageClass for the ClickHouse PVC. Empty string uses the cluster\ndefault. Prefer a class backed by fast local/SSD block storage;\navoid slow shared NFS for MergeTree. The class is fixed at PVC\ncreation — changing this value after install does not migrate an\nexisting volume. The PVC is kept across helm uninstall\n(helm.sh/resource-policy: keep). Ignored when persistence is false.",
                   "required": [],
                   "title": "storageClassName"
                 }

--- a/helm/odigos/values.schema.json
+++ b/helm/odigos/values.schema.json
@@ -853,13 +853,13 @@
                 },
                 "size": {
                   "default": "8Gi",
-                  "description": "PVC size for the ClickHouse data volume. Growth is driven mainly by\ntransaction cardinality and trace_observations retention (TTL).\nExpand only if the StorageClass supports volume expansion.\nIgnored when persistence is false.",
+                  "description": "PVC size for the ClickHouse data volume. Growth is driven mainly by\ntransaction cardinality and trace_observations retention (TTL).\nExpand only if the StorageClass supports volume expansion.",
                   "required": [],
                   "title": "size"
                 },
                 "storageClassName": {
                   "default": "",
-                  "description": "StorageClass for the ClickHouse PVC. Empty string uses the cluster\ndefault. Prefer a class backed by fast local/SSD block storage;\navoid slow shared NFS for MergeTree. The class is fixed at PVC\ncreation — changing this value after install does not migrate an\nexisting volume. The PVC is kept across helm uninstall\n(helm.sh/resource-policy: keep). Ignored when persistence is false.",
+                  "description": "StorageClass for the ClickHouse PVC. Empty string uses the cluster\ndefault. Prefer a class backed by fast local/SSD block storage;\navoid slow shared NFS for MergeTree. The class is fixed at PVC\ncreation — changing this value after install does not migrate an\nexisting volume. The PVC is kept across helm uninstall\n(helm.sh/resource-policy: keep).",
                   "required": [],
                   "title": "storageClassName"
                 }

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -1314,10 +1314,12 @@ insights:
 
   # @schema
   # description: |-
-  #   Bundled ClickHouse for the insights service. Single replica, single PVC,
-  #   no replication, no backups. Scale insights pods for HA of ingestion;
-  #   keep ClickHouse at one replica. User and database name stay hardcoded
-  #   (odigos_insights); image, resources, scheduling, and storage are tunable.
+  #   Bundled ClickHouse for the insights service. Single replica, no
+  #   replication, no backups. Data is on a PVC by default
+  #   (insights.clickhouse.storage.persistence); set that to false for
+  #   emptyDir. Scale insights pods for HA of ingestion; keep ClickHouse at
+  #   one replica. User and database name stay hardcoded (odigos_insights);
+  #   image, resources, scheduling, and storage are tunable.
   # @schema
   clickhouse:
     # @schema
@@ -1437,6 +1439,14 @@ insights:
       extraConfig: ""
 
     storage:
+      # @schema
+      # description: |-
+      #   When true (default), ClickHouse keeps Insights data on a persistent
+      #   volume so it survives pod restarts. Set to false only for
+      #   development or testing: ClickHouse then uses emptyDir, and all
+      #   Insights data is lost when the pod is recreated or rescheduled.
+      # @schema
+      persistence: true
       # @schema
       # description: |-
       #   PVC size for the ClickHouse data volume. Growth is driven mainly by


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->

First-time Insights install no longer blocks Helm on the schema migrate hook, so a Pending ClickHouse PVC cannot stall `helm upgrade --install`. Existing Insights upgrades still run migrate as a pre-upgrade hook, and `insights.clickhouse.storage.persistence=false` is an explicit emptyDir option for development or testing.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
fix(helm): stop Insights install from hanging when ClickHouse storage cannot bind
```

cherry-pick: v1.36