### PR TITLE
RUN-1119 | feat: add odiglet seLinuxOptions helm values and a default for non-privileged mode

### DIFF
--- a/helm/odigos/templates/odiglet/daemonset.yaml
+++ b/helm/odigos/templates/odiglet/daemonset.yaml
@@ -190,6 +190,10 @@ spec:
               {{ toYaml . | nindent 14 }}
             {{- end }}
             {{- end }}
+            {{- with .Values.odiglet.odiglet.seLinuxOptions }}
+            seLinuxOptions:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
             {{- end }} # end of securityContext
           livenessProbe:
 {{ toYaml .Values.odiglet.odiglet.livenessProbe | indent 12 }}

--- a/helm/odigos/values.schema.json
+++ b/helm/odigos/values.schema.json
@@ -1936,6 +1936,24 @@
               "required": [],
               "title": "readinessProbe",
               "type": "object"
+            },
+            "seLinuxOptions": {
+              "additionalProperties": false,
+              "description": "SELinux options for the odiglet container when running as unPrivileged.\nIgnored when running as privileged, since container runtimes drop the label in that mode.\nOn SELinux enforcing nodes odiglet needs a privileged SELinux domain to inspect and\ninstrument application processes. \"spc_t\" is that domain in the standard container policy\n(https://github.com/containers/container-selinux/blob/v2.232.1/container.te#L105), and on\nBottlerocket, which aliases it to its own \"control_t\".\nAdjust the type if your nodes use a custom SELinux policy, or set to null to leave the\nlabel to the container runtime.",
+              "properties": {
+                "level": {
+                  "default": "s0",
+                  "title": "level",
+                  "type": "string"
+                },
+                "type": {
+                  "default": "spc_t",
+                  "title": "type",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "seLinuxOptions"
             }
           },
           "required": [],

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -922,6 +922,21 @@ odiglet:
 
     # @schema
     # description: |-
+    #   SELinux options for the odiglet container when running as unPrivileged.
+    #   Ignored when running as privileged, since container runtimes drop the label in that mode.
+    #   On SELinux enforcing nodes odiglet needs a privileged SELinux domain to inspect and
+    #   instrument application processes. "spc_t" is that domain in the standard container policy
+    #   (https://github.com/containers/container-selinux/blob/v2.232.1/container.te#L105), and on
+    #   Bottlerocket, which aliases it to its own "control_t".
+    #   Adjust the type if your nodes use a custom SELinux policy, or set to null to leave the
+    #   label to the container runtime.
+    # @schema
+    seLinuxOptions:
+      type: "spc_t"
+      level: "s0"
+
+    # @schema
+    # description: |-
     #   Percentage of the memory limit to use for GOMEMLIMIT when the odiglet
     #   memory limit is >= 500Mi. Below 500Mi the default 80% is used.
     #   Odiglet allocates significant memory for eBPF maps which live outside


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
feat: add odiglet seLinuxOptions helm values and a default for non-privileged mode
```
