### PR TITLE
fix(ci): ignore Kind post-cleanup failures (DEVOPS-83)

### DIFF
--- a/.github/actions/chaos-tests/action.yml
+++ b/.github/actions/chaos-tests/action.yml
@@ -19,6 +19,8 @@ runs:
         version: 'v0.25.0'
         cluster_name: kind-test-cluster
         config: tests/common/apply/kind-config.yaml
+        # Ephemeral GHA runners: don't fail the job if kind/docker cleanup races.
+        ignore_failed_clean: true
 
     - name: Build Odigos CLI
       uses: ./.github/actions/build/cli

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -183,6 +183,8 @@ jobs:
           version: "v0.25.0"
           cluster_name: kind
           config: tests/common/apply/kind-config.yaml
+          # Ephemeral GHA runners: don't fail the job if kind/docker cleanup races.
+          ignore_failed_clean: true
 
       - name: wait for cluster readiness
         if: steps.should-run.outputs.skip != 'true'


### PR DESCRIPTION
## Summary
- Set `ignore_failed_clean: true` on `helm/kind-action` in E2E and chaos-tests so flaky Kind/Docker teardown no longer fails the workflow after tests pass
- Companion to the enterprise fix for [DEVOPS-83](https://linear.app/odigos/issue/DEVOPS-83/ci-kubernetes-jobs-fail-on-kind-post-cleanup-despite-passing-e2e-tests)

## Test plan
- [x] Confirm E2E CI runs on this PR
- [x] Confirm no job fails solely on `Post Create Kind Cluster` when tests pass

```release-note
NONE
```