### PR TITLE
fix(ci): wait for Kind apiserver /readyz before E2E (DEVOPS-84)

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,7 +3,7 @@ name: E2E Tests
 on:
   merge_group:
   pull_request:
-    branches: [ main, 'releases/**' ]
+    branches: [main, "releases/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -48,7 +48,6 @@ jobs:
           path: cli/odigos
           key: ${{ github.run_id }}-odigos-cli
 
-
   build-odigos-images:
     runs-on: depot-ubuntu-24.04-8
     steps:
@@ -89,12 +88,12 @@ jobs:
           key: ${{ github.run_id }}-odigos-images
 
   kubernetes-test:
-    needs: [ build-odigos-images, build-cli ]
+    needs: [build-odigos-images, build-cli]
     runs-on: depot-ubuntu-24.04-8
     strategy:
       fail-fast: false
       matrix:
-        kube-version: [ "1.32", "1.23", "1.21.12" ]
+        kube-version: ["1.32", "1.23", "1.21.12"]
         test-scenario:
           - "ui"
           - "helm-chart"
@@ -188,10 +187,7 @@ jobs:
 
       - name: wait for cluster readiness
         if: steps.should-run.outputs.skip != 'true'
-        run: |
-          kubectl wait --for=condition=Ready node --all --timeout=180s
-          kubectl wait -n kube-system --for=condition=Ready pod --all --timeout=300s
-          kubectl rollout status -n kube-system deployment/coredns --timeout=300s
+        run: bash tests/common/wait_for_kind_ready.sh
 
       - name: Restore cached Odigos images
         if: steps.should-run.outputs.skip != 'true'

--- a/tests/common/wait_for_kind_ready.sh
+++ b/tests/common/wait_for_kind_ready.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Wait until a Kind cluster is actually usable for E2E APPLY/install steps.
+#
+# Kind/helm-kind-action can report Ready while kube-apiserver/etcd are still
+# flapping under runner load (especially k8s 1.32). Node/pod Ready + CoreDNS
+# rollout is necessary but not sufficient — early kubectl/chainsaw writes then
+# fail with "context deadline exceeded" / "etcdserver: request timed out"
+# (DEVOPS-84).
+set -euo pipefail
+
+READYZ_REQUIRED_SUCCESSES="${READYZ_REQUIRED_SUCCESSES:-5}"
+READYZ_TIMEOUT_SECONDS="${READYZ_TIMEOUT_SECONDS:-180}"
+READYZ_SLEEP_SECONDS="${READYZ_SLEEP_SECONDS:-2}"
+WRITE_PROBE_TIMEOUT_SECONDS="${WRITE_PROBE_TIMEOUT_SECONDS:-60}"
+WRITE_PROBE_NAMESPACE="${WRITE_PROBE_NAMESPACE:-odigos-kind-ready-probe}"
+
+echo "Waiting for nodes, kube-system pods, and CoreDNS..."
+kubectl wait --for=condition=Ready node --all --timeout=180s
+kubectl wait -n kube-system --for=condition=Ready pod --all --timeout=300s
+kubectl rollout status -n kube-system deployment/coredns --timeout=300s
+
+echo "Waiting for kube-apiserver /readyz (${READYZ_REQUIRED_SUCCESSES} consecutive successes, timeout ${READYZ_TIMEOUT_SECONDS}s)..."
+successes=0
+deadline=$((SECONDS + READYZ_TIMEOUT_SECONDS))
+while (( successes < READYZ_REQUIRED_SUCCESSES )); do
+  if (( SECONDS >= deadline )); then
+    echo "ERROR: kube-apiserver /readyz did not stay healthy for ${READYZ_REQUIRED_SUCCESSES} consecutive checks within ${READYZ_TIMEOUT_SECONDS}s"
+    kubectl get --raw='/readyz?verbose' || true
+    kubectl get --raw='/livez?verbose' || true
+    kubectl get nodes -o wide || true
+    kubectl get pods -n kube-system -o wide || true
+    exit 1
+  fi
+
+  if kubectl get --raw='/readyz?verbose' >/tmp/odigos-kind-readyz.out 2>/tmp/odigos-kind-readyz.err; then
+    successes=$((successes + 1))
+    echo "readyz ok (${successes}/${READYZ_REQUIRED_SUCCESSES})"
+  else
+    successes=0
+    echo "readyz not ready; resetting consecutive success counter"
+    cat /tmp/odigos-kind-readyz.err >&2 || true
+  fi
+  sleep "${READYZ_SLEEP_SECONDS}"
+done
+
+echo "Probing API write path (create/delete namespace)..."
+write_deadline=$((SECONDS + WRITE_PROBE_TIMEOUT_SECONDS))
+until kubectl create namespace "${WRITE_PROBE_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f - >/dev/null 2>/tmp/odigos-kind-write-probe.err; do
+  if (( SECONDS >= write_deadline )); then
+    echo "ERROR: API write probe failed within ${WRITE_PROBE_TIMEOUT_SECONDS}s"
+    cat /tmp/odigos-kind-write-probe.err >&2 || true
+    exit 1
+  fi
+  echo "write probe not ready; retrying..."
+  cat /tmp/odigos-kind-write-probe.err >&2 || true
+  sleep "${READYZ_SLEEP_SECONDS}"
+done
+kubectl delete namespace "${WRITE_PROBE_NAMESPACE}" --wait=false >/dev/null 2>&1 || true
+
+echo "Kind control plane is ready for E2E"


### PR DESCRIPTION
## Summary
- After Kind create, wait for consecutive kube-apiserver `/readyz` successes and a namespace write probe before E2E starts
- Prevents early APPLY failures when nodes/pods look Ready but apiserver/etcd are still flapping under runner load
- Companion to the enterprise fix for [DEVOPS-84](https://linear.app/odigos/issue/DEVOPS-84/ci-kind-kube-apiserveretcd-flakes-cause-early-e2e-apply-failures-on)

## Test plan
- [ ] Confirm E2E CI runs on this PR
- [ ] Confirm `wait for cluster readiness` logs show consecutive `readyz ok` + write probe success
- [ ] Spot-check that remaining failures (if any) are scenario assertions, not `context deadline exceeded` / `etcdserver: request timed out` during early APPLY

```release-note
NONE
```

Made with [Cursor](https://cursor.com)