### PR TITLE
fix(ci): reduce OSS E2E flakes from Kind load and readiness races (DEVOPS-85)

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -92,6 +92,9 @@ jobs:
     runs-on: depot-ubuntu-24.04-8
     strategy:
       fail-fast: false
+      # Cap concurrent Kind clusters to reduce runner memory pressure
+      # (chainsaw signal:killed) and control-plane/readiness races under load.
+      max-parallel: 10
       matrix:
         kube-version: ["1.32", "1.23", "1.21.12"]
         test-scenario:
@@ -283,6 +286,10 @@ jobs:
               echo "--- describe deploy $ns/$name ---"
               kubectl -n "$ns" describe deploy "$name" || true
           done
+          echo "==== Runner memory ===="; free -h || true
+          echo "==== dmesg OOM / kill hints ===="
+          (sudo dmesg -T 2>/dev/null || dmesg -T 2>/dev/null || true) | \
+            grep -Ei "killed process|out of memory|oom|Memory cgroup" | tail -n 80 || true
 
       ################### Diagnose and collect logs ###################
       - name: Run diagnose command

--- a/tests/e2e/actions/chainsaw-test.yaml
+++ b/tests/e2e/actions/chainsaw-test.yaml
@@ -26,13 +26,13 @@ spec:
     - name: Install Odigos
       try:
         - script:
-            timeout: 4m
+            timeout: 5m
             content: |
               ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test
               ../../common/verify_odigos_installation.sh odigos-test
               kubectl label namespace odigos-test odigos.io/system-object="true"
         - assert:
-            timeout: 3m
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: Verify Node Odiglet label has been added

--- a/tests/e2e/argo-rollouts/chainsaw-test.yaml
+++ b/tests/e2e/argo-rollouts/chainsaw-test.yaml
@@ -38,13 +38,13 @@ spec:
     - name: Install Odigos
       try:
         - script:
-            timeout: 1m50s
+            timeout: 5m
             content: |
               ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test
               ../../common/verify_odigos_installation.sh odigos-test
               kubectl label namespace odigos-test odigos.io/system-object="true"
         - assert:
-            timeout: 1m10s
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: Verify Node Odiglet label has been added

--- a/tests/e2e/cli-upgrade/chainsaw-test.yaml
+++ b/tests/e2e/cli-upgrade/chainsaw-test.yaml
@@ -19,7 +19,7 @@ spec:
     - name: Install Odigos latest release from GitHub for pre upgrade setup
       try:
         - script:
-            timeout: 1m10s
+            timeout: 2m
             content: |
               #!/bin/bash
 
@@ -76,7 +76,7 @@ spec:
               ./odigos install --ns odigos-test --set imagePrefix=ghcr.io/odigos-io || true
               kubectl label namespace odigos-test odigos.io/system-object="true"
         - assert:
-            timeout: 2m10s
+            timeout: 4m
             file: ../../common/assert/latest-odigos-version-installed.yaml
 
     - name: Assert Trace DB is up
@@ -126,10 +126,10 @@ spec:
       try:
         - script:
             content: ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test --set imagePrefix=docker.io/keyval
-            timeout: 1m10s
+            timeout: 2m
         - assert:
             file: ../../common/assert/odigos-upgraded.yaml
-            timeout: 2m30s
+            timeout: 4m
       catch:
         - get:
             apiVersion: v1

--- a/tests/e2e/data-streams/chainsaw-test.yaml
+++ b/tests/e2e/data-streams/chainsaw-test.yaml
@@ -18,7 +18,7 @@ spec:
     - name: '[1 - Setup] Install Odigos'
       try:
         - script:
-            timeout: 1m50s
+            timeout: 5m
             content: |
               if [ "$MODE" = "cross-cloud-tests" ]; then
                 ../../../cli/odigos install --ns odigos-test --set image.tag="$COMMIT_HASH" --set imagePrefix=public.ecr.aws/y2v0v6s7
@@ -29,6 +29,7 @@ spec:
 
               ../../common/verify_odigos_installation.sh odigos-test
         - assert:
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: '[1 - Setup] Verify Node Odiglet label has been added'

--- a/tests/e2e/env-injection/chainsaw-test.yaml
+++ b/tests/e2e/env-injection/chainsaw-test.yaml
@@ -13,13 +13,13 @@ spec:
     - name: Install Odigos
       try:
         - script:
-            timeout: 1m50s
+            timeout: 5m
             content: |
               ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test
               ../../common/verify_odigos_installation.sh odigos-test
               kubectl label namespace odigos-test odigos.io/system-object="true"
         - assert:
-            timeout: 1m30s
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: Assert config set successfully to default

--- a/tests/e2e/environment-variables/chainsaw-test.yaml
+++ b/tests/e2e/environment-variables/chainsaw-test.yaml
@@ -26,9 +26,9 @@ spec:
               ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test
               ../../common/verify_odigos_installation.sh odigos-test
               kubectl label namespace odigos-test odigos.io/system-object="true"
-            timeout: 1m50s
+            timeout: 5m
         - assert:
-            timeout: 1m10s
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: Verify Node Odiglet label has been added

--- a/tests/e2e/head-sampling-http-java/chainsaw-test.yaml
+++ b/tests/e2e/head-sampling-http-java/chainsaw-test.yaml
@@ -26,7 +26,7 @@ spec:
     - name: Install Odigos
       try:
         - script:
-            timeout: 4m
+            timeout: 5m
             content: |
               # pwd is tests/e2e/head-sampling-http-java — chart lives at repo root helm/odigos
               # Tail sampling enabled (java-community has no agent head sampling). Short aggregation
@@ -40,7 +40,7 @@ spec:
               ../../common/verify_odigos_installation.sh odigos-test
               kubectl label namespace odigos-test odigos.io/system-object="true"
         - assert:
-            timeout: 3m
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: Verify Node Odiglet label has been added

--- a/tests/e2e/head-sampling-http-nodejs/chainsaw-test.yaml
+++ b/tests/e2e/head-sampling-http-nodejs/chainsaw-test.yaml
@@ -23,7 +23,7 @@ spec:
     - name: Install Odigos
       try:
         - script:
-            timeout: 4m
+            timeout: 5m
             content: |
               # pwd is tests/e2e/head-sampling-http-nodejs — chart lives at repo root helm/odigos
               helm upgrade --install odigos ../../../helm/odigos --create-namespace --namespace odigos-test \
@@ -35,7 +35,7 @@ spec:
               ../../common/verify_odigos_installation.sh odigos-test
               kubectl label namespace odigos-test odigos.io/system-object="true"
         - assert:
-            timeout: 3m
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: Verify Node Odiglet label has been added

--- a/tests/e2e/head-sampling-http-python/chainsaw-test.yaml
+++ b/tests/e2e/head-sampling-http-python/chainsaw-test.yaml
@@ -23,7 +23,7 @@ spec:
     - name: Install Odigos
       try:
         - script:
-            timeout: 4m
+            timeout: 5m
             content: |
               # pwd is tests/e2e/head-sampling-http-python — chart lives at repo root helm/odigos
               helm upgrade --install odigos ../../../helm/odigos --create-namespace --namespace odigos-test \
@@ -35,7 +35,7 @@ spec:
               ../../common/verify_odigos_installation.sh odigos-test
               kubectl label namespace odigos-test odigos.io/system-object="true"
         - assert:
-            timeout: 3m
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: Verify Node Odiglet label has been added

--- a/tests/e2e/helm-chart/chainsaw-test.yaml
+++ b/tests/e2e/helm-chart/chainsaw-test.yaml
@@ -32,7 +32,7 @@ spec:
     - name: Install Odigos
       try:
         - script:
-            timeout: 1m10s
+            timeout: 2m
             content: |
               # The pwd is the directory of this file, so we have to walk up to the project root to find the helm chart
               P="../../.."
@@ -77,7 +77,7 @@ spec:
               ../../common/verify_odigos_installation.sh odigos-test
 
         - assert:
-            timeout: 1m10s
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: Verify Backward Compatibility in helm chart fields - Legacy Fields & Mirroring

--- a/tests/e2e/helm-upgrade/chainsaw-test.yaml
+++ b/tests/e2e/helm-upgrade/chainsaw-test.yaml
@@ -19,7 +19,7 @@ spec:
     - name: Install Odigos latest release from GitHub for pre upgrade setup
       try:
         - script:
-            timeout: 1m10s
+            timeout: 2m
             content: |
               #!/bin/bash
 
@@ -58,7 +58,7 @@ spec:
                 --set imagePrefix=ghcr.io/odigos-io
               kubectl label namespace odigos-test odigos.io/system-object="true"
         - assert:
-            timeout: 2m10s
+            timeout: 4m
             file: ../../common/assert/latest-odigos-version-installed.yaml
 
     - name: Assert Trace DB is up
@@ -125,7 +125,7 @@ spec:
             timeout: 1m10s
         - assert:
             file: ../../common/assert/odigos-upgraded.yaml
-            timeout: 2m20s
+            timeout: 4m
       catch:
         - get:
             apiVersion: v1

--- a/tests/e2e/instrumentation-lifecycle/chainsaw-test.yaml
+++ b/tests/e2e/instrumentation-lifecycle/chainsaw-test.yaml
@@ -26,9 +26,9 @@ spec:
               ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test
               ../../common/verify_odigos_installation.sh odigos-test
               kubectl label namespace odigos-test odigos.io/system-object="true"
-            timeout: 2m
+            timeout: 5m
         - assert:
-            timeout: 2m20s
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: Verify Node Odiglet label has been added

--- a/tests/e2e/instrumentation-rollback-stability-window/chainsaw-test.yaml
+++ b/tests/e2e/instrumentation-rollback-stability-window/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
     - name: Install Odigos
       try:
         - script:
-            timeout: 1m10s
+            timeout: 2m
             content: |
               # The pwd is the directory of this file, so we have to walk up to the project root to find the helm chart
               P="../../.."
@@ -28,7 +28,7 @@ spec:
     - name: Verify Odigos Installation
       try:
         - script:
-            timeout: 1m50s
+            timeout: 5m
             content: |
               echo "Starting Odigos version check..."
               export ACTUAL_VERSION=$(../../../cli/odigos version --cluster)
@@ -50,7 +50,7 @@ spec:
 
               ../../common/verify_odigos_installation.sh odigos-test
         - assert:
-            timeout: 1m10s
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
       catch:
         - script:

--- a/tests/e2e/instrumentation-rollback/chainsaw-test.yaml
+++ b/tests/e2e/instrumentation-rollback/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
     - name: Install Odigos
       try:
         - script:
-            timeout: 1m10s
+            timeout: 2m
             content: |
               # The pwd is the directory of this file, so we have to walk up to the project root to find the helm chart
               P="../../.."
@@ -28,7 +28,7 @@ spec:
     - name: Verify Odigos Installation
       try:
         - script:
-            timeout: 1m50s
+            timeout: 5m
             content: |
               echo "Starting Odigos version check..."
               export ACTUAL_VERSION=$(../../../cli/odigos version --cluster)
@@ -50,7 +50,7 @@ spec:
 
               ../../common/verify_odigos_installation.sh odigos-test
         - assert:
-            timeout: 1m10s
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
       catch:
         - script:

--- a/tests/e2e/karpenter-mount-methods/chainsaw-test.yaml
+++ b/tests/e2e/karpenter-mount-methods/chainsaw-test.yaml
@@ -35,7 +35,7 @@ spec:
     - name: '[1 - Virtual Device] Install Odigos (default mount method)'
       try:
         - script:
-            timeout: 2m
+            timeout: 5m
             content: |
               if [ "$MODE" = "cross-cloud-tests" ]; then
                 ../../../cli/odigos install --ns odigos-test \
@@ -47,7 +47,7 @@ spec:
               kubectl label namespace odigos-test odigos.io/system-object="true"
               ../../common/verify_odigos_installation.sh odigos-test
         - assert:
-            timeout: 2m30s
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
         - script:
             timeout: 1m

--- a/tests/e2e/log-collection/chainsaw-test.yaml
+++ b/tests/e2e/log-collection/chainsaw-test.yaml
@@ -22,7 +22,7 @@ spec:
     - name: Install Odigos
       try:
         - script:
-            timeout: 2m
+            timeout: 5m
             content: |
               # The pwd is the directory of this file, so we have to walk up to the project root to find the helm chart
               P="../../.."
@@ -34,7 +34,7 @@ spec:
               kubectl label namespace odigos-test odigos.io/system-object="true"
               ../../common/verify_odigos_installation.sh odigos-test
         - assert:
-            timeout: 1m10s
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: Assert Trace DB is up

--- a/tests/e2e/mount-method/chainsaw-test.yaml
+++ b/tests/e2e/mount-method/chainsaw-test.yaml
@@ -19,7 +19,7 @@ spec:
     - name: '[1 - Setup] Install Odigos'
       try:
         - script:
-            timeout: 1m40s
+            timeout: 5m
             content: |
               if [ "$MODE" = "cross-cloud-tests" ]; then
                 ../../../cli/odigos install --ns odigos-test --set image.tag="$COMMIT_HASH" --set imagePrefix=public.ecr.aws/y2v0v6s7 --set instrumentor.mountMethod=k8s-init-container
@@ -29,7 +29,7 @@ spec:
               kubectl label namespace odigos-test odigos.io/system-object="true"
               ../../common/verify_odigos_installation.sh odigos-test
         - assert:
-            timeout: 1m10s
+            timeout: 4m
             file: ../../common/assert/odigos-installed-no-device-plugin.yaml
 
     - name: '[1 - Setup] Assert - Simple Demo Apps Installed'
@@ -133,7 +133,7 @@ spec:
     - name: '[3 - CSI Driver Test] Upgrade to CSI driver mount method'
       try:
         - script:
-            timeout: 1m10s
+            timeout: 2m
             content: |
               # Upgrade existing installation to CSI driver mount method
               ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test --set instrumentor.mountMethod=k8s-csi-driver

--- a/tests/e2e/runtime-detection/chainsaw-test.yaml
+++ b/tests/e2e/runtime-detection/chainsaw-test.yaml
@@ -24,17 +24,17 @@ spec:
             content: |
               ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test
               kubectl label namespace odigos-test odigos.io/system-object="true"
-            timeout: 1m10s
+            timeout: 2m
 
     - name: Assert Odigos Installed
       try:
         - assert:
-            timeout: 2m
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
         - script:
             content: |
               ../../common/verify_odigos_installation.sh odigos-test
-            timeout: 1m10s
+            timeout: 5m
 
     - name: Verify Node Odiglet label has been added
       try:

--- a/tests/e2e/source/chainsaw-test.yaml
+++ b/tests/e2e/source/chainsaw-test.yaml
@@ -19,7 +19,7 @@ spec:
     - name: '[1 - Setup] Install Odigos'
       try:
         - script:
-            timeout: 4m
+            timeout: 5m
             content: |
               if [ "$MODE" = "cross-cloud-tests" ]; then
                 ../../../cli/odigos install --ns odigos-test --set image.tag="$COMMIT_HASH" --set imagePrefix=public.ecr.aws/y2v0v6s7
@@ -30,7 +30,7 @@ spec:
 
               ../../common/verify_odigos_installation.sh odigos-test
         - assert:
-            timeout: 1m40s
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: '[1 - Setup] Verify Node Odiglet label has been added'

--- a/tests/e2e/tail-sampling-nodejs/chainsaw-test.yaml
+++ b/tests/e2e/tail-sampling-nodejs/chainsaw-test.yaml
@@ -24,7 +24,7 @@ spec:
     - name: Install Odigos
       try:
         - script:
-            timeout: 4m
+            timeout: 5m
             content: |
               # pwd is tests/e2e/tail-sampling-nodejs — chart lives at repo root helm/odigos
               # Gateway tail sampling enabled. Short aggregation wait keeps e2e latency low
@@ -39,7 +39,7 @@ spec:
               ../../common/verify_odigos_installation.sh odigos-test
               kubectl label namespace odigos-test odigos.io/system-object="true"
         - assert:
-            timeout: 3m
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: Verify Node Odiglet label has been added

--- a/tests/e2e/trace-collection/chainsaw-test.yaml
+++ b/tests/e2e/trace-collection/chainsaw-test.yaml
@@ -25,9 +25,9 @@ spec:
               ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test
               ../../common/verify_odigos_installation.sh odigos-test
               kubectl label namespace odigos-test odigos.io/system-object="true"
-            timeout: 2m
+            timeout: 5m
         - assert:
-            timeout: 1m10s
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: Assert Trace DB is up

--- a/tests/e2e/ui/frontend-cypress-tests/chainsaw-test.yaml
+++ b/tests/e2e/ui/frontend-cypress-tests/chainsaw-test.yaml
@@ -19,13 +19,13 @@ spec:
     - name: Install Odigos CLI
       try:
         - script:
-            timeout: 2m40s
+            timeout: 5m
             content: |
               ../../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test
               ../../../common/verify_odigos_installation.sh odigos-test
               kubectl label namespace odigos-test odigos.io/system-object="true"
         - assert:
-            timeout: 1m10s
+            timeout: 4m
             file: ../../../common/assert/odigos-installed.yaml
 
     - name: Verify - Jaeger Installed

--- a/tests/e2e/webhooks/chainsaw-test.yaml
+++ b/tests/e2e/webhooks/chainsaw-test.yaml
@@ -17,9 +17,9 @@ spec:
               fi
               kubectl label namespace odigos-test odigos.io/system-object="true"
               ../../common/verify_odigos_installation.sh odigos-test
-            timeout: 1m50s
+            timeout: 5m
         - assert:
-            timeout: 1m10s
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
     - name: "[Defaulting] - Source without labels has labels added"
       try:


### PR DESCRIPTION
## Summary
- Cap `kubernetes-test` at `max-parallel: 10` to reduce concurrent Kind clusters (memory pressure → chainsaw `signal: killed`)
- Raise install/verify/assert timeouts for Odigos readiness (especially autoscaler webhook cert readiness under load)
- Add runner memory + dmesg OOM hints to cluster diagnostics on failure

Stacked on [#5746](https://github.com/odigos-io/odigos/pull/5746) (DEVOPS-84 → DEVOPS-83). Does **not** reintroduce Kind cleanup or `/readyz` changes.

## Test plan
- [ ] Confirm E2E CI runs on this PR
- [ ] Compare flake rate vs [run 34025710775](https://github.com/odigos-io/odigos/actions/runs/34025710775) for `signal: killed` vs autoscaler-not-ready
- [ ] On any remaining `signal: killed`, check diagnostics for OOM / Memory cgroup lines

```release-note
NONE
```