### PR TITLE
fix(ci): harden Kind E2E against cleanup, apiserver, and load flakes (DEVOPS-83/84/85)

### DIFF
--- a/.github/actions/chaos-tests/action.yml
+++ b/.github/actions/chaos-tests/action.yml
@@ -19,6 +19,8 @@ runs:
         version: 'v0.25.0'
         cluster_name: kind-test-cluster
         config: tests/common/apply/kind-config.yaml
+        # Ephemeral GHA runners: don't fail the job if kind/docker cleanup races.
+        ignore_failed_clean: true
 
     - name: Build Odigos CLI
       uses: ./.github/actions/build/cli

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -260,13 +260,23 @@ jobs:
           echo "LATEST_RELEASE_TAG=$LATEST_RELEASE_TAG" >> $GITHUB_OUTPUT
           echo "Latest release tag for branch $BRANCH: $LATEST_RELEASE_TAG"
 
+      - name: recheck cluster readiness before E2E
+        if: steps.should-run.outputs.skip != 'true'
+        # Image cache restore / kind load can take ~1m; apiserver/etcd may flap in
+        # that window even after the post-create readiness gate passed.
+        run: bash tests/common/wait_for_kind_ready.sh
+
       - name: Run E2E Tests
         if: steps.should-run.outputs.skip != 'true'
         env:
           LATEST_RELEASE_TAG: ${{ steps.get-latest-tag.outputs.LATEST_RELEASE_TAG }}
         run: |
           MINOR_VERSION=$(echo ${{ matrix.kube-version }} | sed -E 's/^1\.([0-9]+).*$/\1/')
-          chainsaw test tests/e2e/${{ matrix.test-scenario }} --values - <<EOF
+          # Default apply timeout is 5s — too short when apiserver briefly flaps
+          # under runner load (context deadline exceeded on early APPLY).
+          chainsaw test tests/e2e/${{ matrix.test-scenario }} \
+            --apply-timeout 30s \
+            --values - <<EOF
           k8sMinorVersion: ${MINOR_VERSION}
           isHelm: ${{ matrix.test-scenario == 'helm-chart' || matrix.test-scenario == 'helm-upgrade' }}
           EOF

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -92,9 +92,9 @@ jobs:
     runs-on: depot-ubuntu-24.04-8
     strategy:
       fail-fast: false
-      # Cap concurrent Kind clusters to reduce runner memory pressure
-      # (chainsaw signal:killed) and control-plane/readiness races under load.
-      max-parallel: 10
+      # No max-parallel: readiness recheck + apply-timeout + install waits absorb
+      # control-plane load better than serializing the matrix (which stretched CI
+      # wall-clock). Reintroduce a cap only if signal:killed / OOM returns.
       matrix:
         kube-version: ["1.32", "1.23", "1.21.12"]
         test-scenario:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -92,6 +92,9 @@ jobs:
     runs-on: depot-ubuntu-24.04-8
     strategy:
       fail-fast: false
+      # Cap concurrent Kind clusters to reduce runner memory pressure
+      # (chainsaw signal:killed) and control-plane/readiness races under load.
+      max-parallel: 10
       matrix:
         kube-version: ["1.32", "1.23", "1.21.12"]
         test-scenario:
@@ -283,6 +286,10 @@ jobs:
               echo "--- describe deploy $ns/$name ---"
               kubectl -n "$ns" describe deploy "$name" || true
           done
+          echo "==== Runner memory ===="; free -h || true
+          echo "==== dmesg OOM / kill hints ===="
+          (sudo dmesg -T 2>/dev/null || dmesg -T 2>/dev/null || true) | \
+            grep -Ei "killed process|out of memory|oom|Memory cgroup" | tail -n 80 || true
 
       ################### Diagnose and collect logs ###################
       - name: Run diagnose command

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,7 +3,7 @@ name: E2E Tests
 on:
   merge_group:
   pull_request:
-    branches: [ main, 'releases/**' ]
+    branches: [main, "releases/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -48,7 +48,6 @@ jobs:
           path: cli/odigos
           key: ${{ github.run_id }}-odigos-cli
 
-
   build-odigos-images:
     runs-on: depot-ubuntu-24.04-8
     steps:
@@ -89,12 +88,12 @@ jobs:
           key: ${{ github.run_id }}-odigos-images
 
   kubernetes-test:
-    needs: [ build-odigos-images, build-cli ]
+    needs: [build-odigos-images, build-cli]
     runs-on: depot-ubuntu-24.04-8
     strategy:
       fail-fast: false
       matrix:
-        kube-version: [ "1.32", "1.23", "1.21.12" ]
+        kube-version: ["1.32", "1.23", "1.21.12"]
         test-scenario:
           - "ui"
           - "helm-chart"
@@ -188,10 +187,7 @@ jobs:
 
       - name: wait for cluster readiness
         if: steps.should-run.outputs.skip != 'true'
-        run: |
-          kubectl wait --for=condition=Ready node --all --timeout=180s
-          kubectl wait -n kube-system --for=condition=Ready pod --all --timeout=300s
-          kubectl rollout status -n kube-system deployment/coredns --timeout=300s
+        run: bash tests/common/wait_for_kind_ready.sh
 
       - name: Restore cached Odigos images
         if: steps.should-run.outputs.skip != 'true'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -183,6 +183,8 @@ jobs:
           version: "v0.25.0"
           cluster_name: kind
           config: tests/common/apply/kind-config.yaml
+          # Ephemeral GHA runners: don't fail the job if kind/docker cleanup races.
+          ignore_failed_clean: true
 
       - name: wait for cluster readiness
         if: steps.should-run.outputs.skip != 'true'

--- a/tests/common/wait_for_kind_ready.sh
+++ b/tests/common/wait_for_kind_ready.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Wait until a Kind cluster is actually usable for E2E APPLY/install steps.
+#
+# Kind/helm-kind-action can report Ready while kube-apiserver/etcd are still
+# flapping under runner load (especially k8s 1.32). Node/pod Ready + CoreDNS
+# rollout is necessary but not sufficient — early kubectl/chainsaw writes then
+# fail with "context deadline exceeded" / "etcdserver: request timed out"
+# (DEVOPS-84).
+set -euo pipefail
+
+READYZ_REQUIRED_SUCCESSES="${READYZ_REQUIRED_SUCCESSES:-5}"
+READYZ_TIMEOUT_SECONDS="${READYZ_TIMEOUT_SECONDS:-180}"
+READYZ_SLEEP_SECONDS="${READYZ_SLEEP_SECONDS:-2}"
+WRITE_PROBE_TIMEOUT_SECONDS="${WRITE_PROBE_TIMEOUT_SECONDS:-60}"
+WRITE_PROBE_NAMESPACE="${WRITE_PROBE_NAMESPACE:-odigos-kind-ready-probe}"
+
+echo "Waiting for nodes, kube-system pods, and CoreDNS..."
+kubectl wait --for=condition=Ready node --all --timeout=180s
+kubectl wait -n kube-system --for=condition=Ready pod --all --timeout=300s
+kubectl rollout status -n kube-system deployment/coredns --timeout=300s
+
+echo "Waiting for kube-apiserver /readyz (${READYZ_REQUIRED_SUCCESSES} consecutive successes, timeout ${READYZ_TIMEOUT_SECONDS}s)..."
+successes=0
+deadline=$((SECONDS + READYZ_TIMEOUT_SECONDS))
+while (( successes < READYZ_REQUIRED_SUCCESSES )); do
+  if (( SECONDS >= deadline )); then
+    echo "ERROR: kube-apiserver /readyz did not stay healthy for ${READYZ_REQUIRED_SUCCESSES} consecutive checks within ${READYZ_TIMEOUT_SECONDS}s"
+    kubectl get --raw='/readyz?verbose' || true
+    kubectl get --raw='/livez?verbose' || true
+    kubectl get nodes -o wide || true
+    kubectl get pods -n kube-system -o wide || true
+    exit 1
+  fi
+
+  if kubectl get --raw='/readyz?verbose' >/tmp/odigos-kind-readyz.out 2>/tmp/odigos-kind-readyz.err; then
+    successes=$((successes + 1))
+    echo "readyz ok (${successes}/${READYZ_REQUIRED_SUCCESSES})"
+  else
+    successes=0
+    echo "readyz not ready; resetting consecutive success counter"
+    cat /tmp/odigos-kind-readyz.err >&2 || true
+  fi
+  sleep "${READYZ_SLEEP_SECONDS}"
+done
+
+echo "Probing API write path (create/delete namespace)..."
+write_deadline=$((SECONDS + WRITE_PROBE_TIMEOUT_SECONDS))
+until kubectl create namespace "${WRITE_PROBE_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f - >/dev/null 2>/tmp/odigos-kind-write-probe.err; do
+  if (( SECONDS >= write_deadline )); then
+    echo "ERROR: API write probe failed within ${WRITE_PROBE_TIMEOUT_SECONDS}s"
+    cat /tmp/odigos-kind-write-probe.err >&2 || true
+    exit 1
+  fi
+  echo "write probe not ready; retrying..."
+  cat /tmp/odigos-kind-write-probe.err >&2 || true
+  sleep "${READYZ_SLEEP_SECONDS}"
+done
+kubectl delete namespace "${WRITE_PROBE_NAMESPACE}" --wait=false >/dev/null 2>&1 || true
+
+echo "Kind control plane is ready for E2E"

--- a/tests/e2e/actions/chainsaw-test.yaml
+++ b/tests/e2e/actions/chainsaw-test.yaml
@@ -26,13 +26,13 @@ spec:
     - name: Install Odigos
       try:
         - script:
-            timeout: 4m
+            timeout: 5m
             content: |
               ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test
               ../../common/verify_odigos_installation.sh odigos-test
               kubectl label namespace odigos-test odigos.io/system-object="true"
         - assert:
-            timeout: 3m
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: Verify Node Odiglet label has been added

--- a/tests/e2e/argo-rollouts/chainsaw-test.yaml
+++ b/tests/e2e/argo-rollouts/chainsaw-test.yaml
@@ -38,13 +38,13 @@ spec:
     - name: Install Odigos
       try:
         - script:
-            timeout: 1m50s
+            timeout: 5m
             content: |
               ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test
               ../../common/verify_odigos_installation.sh odigos-test
               kubectl label namespace odigos-test odigos.io/system-object="true"
         - assert:
-            timeout: 1m10s
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: Verify Node Odiglet label has been added

--- a/tests/e2e/cli-upgrade/chainsaw-test.yaml
+++ b/tests/e2e/cli-upgrade/chainsaw-test.yaml
@@ -19,7 +19,7 @@ spec:
     - name: Install Odigos latest release from GitHub for pre upgrade setup
       try:
         - script:
-            timeout: 1m10s
+            timeout: 2m
             content: |
               #!/bin/bash
 
@@ -76,7 +76,7 @@ spec:
               ./odigos install --ns odigos-test --set imagePrefix=ghcr.io/odigos-io || true
               kubectl label namespace odigos-test odigos.io/system-object="true"
         - assert:
-            timeout: 2m10s
+            timeout: 4m
             file: ../../common/assert/latest-odigos-version-installed.yaml
 
     - name: Assert Trace DB is up
@@ -126,10 +126,10 @@ spec:
       try:
         - script:
             content: ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test --set imagePrefix=docker.io/keyval
-            timeout: 1m10s
+            timeout: 2m
         - assert:
             file: ../../common/assert/odigos-upgraded.yaml
-            timeout: 2m30s
+            timeout: 4m
       catch:
         - get:
             apiVersion: v1

--- a/tests/e2e/data-streams/chainsaw-test.yaml
+++ b/tests/e2e/data-streams/chainsaw-test.yaml
@@ -18,7 +18,7 @@ spec:
     - name: '[1 - Setup] Install Odigos'
       try:
         - script:
-            timeout: 1m50s
+            timeout: 5m
             content: |
               if [ "$MODE" = "cross-cloud-tests" ]; then
                 ../../../cli/odigos install --ns odigos-test --set image.tag="$COMMIT_HASH" --set imagePrefix=public.ecr.aws/y2v0v6s7
@@ -29,6 +29,7 @@ spec:
 
               ../../common/verify_odigos_installation.sh odigos-test
         - assert:
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: '[1 - Setup] Verify Node Odiglet label has been added'

--- a/tests/e2e/env-injection/chainsaw-test.yaml
+++ b/tests/e2e/env-injection/chainsaw-test.yaml
@@ -13,13 +13,13 @@ spec:
     - name: Install Odigos
       try:
         - script:
-            timeout: 1m50s
+            timeout: 5m
             content: |
               ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test
               ../../common/verify_odigos_installation.sh odigos-test
               kubectl label namespace odigos-test odigos.io/system-object="true"
         - assert:
-            timeout: 1m30s
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: Assert config set successfully to default

--- a/tests/e2e/environment-variables/chainsaw-test.yaml
+++ b/tests/e2e/environment-variables/chainsaw-test.yaml
@@ -26,9 +26,9 @@ spec:
               ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test
               ../../common/verify_odigos_installation.sh odigos-test
               kubectl label namespace odigos-test odigos.io/system-object="true"
-            timeout: 1m50s
+            timeout: 5m
         - assert:
-            timeout: 1m10s
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: Verify Node Odiglet label has been added

--- a/tests/e2e/head-sampling-http-java/chainsaw-test.yaml
+++ b/tests/e2e/head-sampling-http-java/chainsaw-test.yaml
@@ -26,7 +26,7 @@ spec:
     - name: Install Odigos
       try:
         - script:
-            timeout: 4m
+            timeout: 5m
             content: |
               # pwd is tests/e2e/head-sampling-http-java — chart lives at repo root helm/odigos
               # Tail sampling enabled (java-community has no agent head sampling). Short aggregation
@@ -40,7 +40,7 @@ spec:
               ../../common/verify_odigos_installation.sh odigos-test
               kubectl label namespace odigos-test odigos.io/system-object="true"
         - assert:
-            timeout: 3m
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: Verify Node Odiglet label has been added

--- a/tests/e2e/head-sampling-http-nodejs/chainsaw-test.yaml
+++ b/tests/e2e/head-sampling-http-nodejs/chainsaw-test.yaml
@@ -23,7 +23,7 @@ spec:
     - name: Install Odigos
       try:
         - script:
-            timeout: 4m
+            timeout: 5m
             content: |
               # pwd is tests/e2e/head-sampling-http-nodejs — chart lives at repo root helm/odigos
               helm upgrade --install odigos ../../../helm/odigos --create-namespace --namespace odigos-test \
@@ -35,7 +35,7 @@ spec:
               ../../common/verify_odigos_installation.sh odigos-test
               kubectl label namespace odigos-test odigos.io/system-object="true"
         - assert:
-            timeout: 3m
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: Verify Node Odiglet label has been added

--- a/tests/e2e/head-sampling-http-python/chainsaw-test.yaml
+++ b/tests/e2e/head-sampling-http-python/chainsaw-test.yaml
@@ -23,7 +23,7 @@ spec:
     - name: Install Odigos
       try:
         - script:
-            timeout: 4m
+            timeout: 5m
             content: |
               # pwd is tests/e2e/head-sampling-http-python — chart lives at repo root helm/odigos
               helm upgrade --install odigos ../../../helm/odigos --create-namespace --namespace odigos-test \
@@ -35,7 +35,7 @@ spec:
               ../../common/verify_odigos_installation.sh odigos-test
               kubectl label namespace odigos-test odigos.io/system-object="true"
         - assert:
-            timeout: 3m
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: Verify Node Odiglet label has been added

--- a/tests/e2e/helm-chart/chainsaw-test.yaml
+++ b/tests/e2e/helm-chart/chainsaw-test.yaml
@@ -32,7 +32,7 @@ spec:
     - name: Install Odigos
       try:
         - script:
-            timeout: 1m10s
+            timeout: 2m
             content: |
               # The pwd is the directory of this file, so we have to walk up to the project root to find the helm chart
               P="../../.."
@@ -77,7 +77,7 @@ spec:
               ../../common/verify_odigos_installation.sh odigos-test
 
         - assert:
-            timeout: 1m10s
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: Verify Backward Compatibility in helm chart fields - Legacy Fields & Mirroring

--- a/tests/e2e/helm-upgrade/chainsaw-test.yaml
+++ b/tests/e2e/helm-upgrade/chainsaw-test.yaml
@@ -19,7 +19,7 @@ spec:
     - name: Install Odigos latest release from GitHub for pre upgrade setup
       try:
         - script:
-            timeout: 1m10s
+            timeout: 2m
             content: |
               #!/bin/bash
 
@@ -58,7 +58,7 @@ spec:
                 --set imagePrefix=ghcr.io/odigos-io
               kubectl label namespace odigos-test odigos.io/system-object="true"
         - assert:
-            timeout: 2m10s
+            timeout: 4m
             file: ../../common/assert/latest-odigos-version-installed.yaml
 
     - name: Assert Trace DB is up
@@ -125,7 +125,7 @@ spec:
             timeout: 1m10s
         - assert:
             file: ../../common/assert/odigos-upgraded.yaml
-            timeout: 2m20s
+            timeout: 4m
       catch:
         - get:
             apiVersion: v1

--- a/tests/e2e/instrumentation-lifecycle/chainsaw-test.yaml
+++ b/tests/e2e/instrumentation-lifecycle/chainsaw-test.yaml
@@ -26,9 +26,9 @@ spec:
               ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test
               ../../common/verify_odigos_installation.sh odigos-test
               kubectl label namespace odigos-test odigos.io/system-object="true"
-            timeout: 2m
+            timeout: 5m
         - assert:
-            timeout: 2m20s
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: Verify Node Odiglet label has been added

--- a/tests/e2e/instrumentation-rollback-stability-window/chainsaw-test.yaml
+++ b/tests/e2e/instrumentation-rollback-stability-window/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
     - name: Install Odigos
       try:
         - script:
-            timeout: 1m10s
+            timeout: 2m
             content: |
               # The pwd is the directory of this file, so we have to walk up to the project root to find the helm chart
               P="../../.."
@@ -28,7 +28,7 @@ spec:
     - name: Verify Odigos Installation
       try:
         - script:
-            timeout: 1m50s
+            timeout: 5m
             content: |
               echo "Starting Odigos version check..."
               export ACTUAL_VERSION=$(../../../cli/odigos version --cluster)
@@ -50,7 +50,7 @@ spec:
 
               ../../common/verify_odigos_installation.sh odigos-test
         - assert:
-            timeout: 1m10s
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
       catch:
         - script:

--- a/tests/e2e/instrumentation-rollback/chainsaw-test.yaml
+++ b/tests/e2e/instrumentation-rollback/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
     - name: Install Odigos
       try:
         - script:
-            timeout: 1m10s
+            timeout: 2m
             content: |
               # The pwd is the directory of this file, so we have to walk up to the project root to find the helm chart
               P="../../.."
@@ -28,7 +28,7 @@ spec:
     - name: Verify Odigos Installation
       try:
         - script:
-            timeout: 1m50s
+            timeout: 5m
             content: |
               echo "Starting Odigos version check..."
               export ACTUAL_VERSION=$(../../../cli/odigos version --cluster)
@@ -50,7 +50,7 @@ spec:
 
               ../../common/verify_odigos_installation.sh odigos-test
         - assert:
-            timeout: 1m10s
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
       catch:
         - script:

--- a/tests/e2e/karpenter-mount-methods/chainsaw-test.yaml
+++ b/tests/e2e/karpenter-mount-methods/chainsaw-test.yaml
@@ -35,7 +35,7 @@ spec:
     - name: '[1 - Virtual Device] Install Odigos (default mount method)'
       try:
         - script:
-            timeout: 2m
+            timeout: 5m
             content: |
               if [ "$MODE" = "cross-cloud-tests" ]; then
                 ../../../cli/odigos install --ns odigos-test \
@@ -47,7 +47,7 @@ spec:
               kubectl label namespace odigos-test odigos.io/system-object="true"
               ../../common/verify_odigos_installation.sh odigos-test
         - assert:
-            timeout: 2m30s
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
         - script:
             timeout: 1m

--- a/tests/e2e/log-collection/chainsaw-test.yaml
+++ b/tests/e2e/log-collection/chainsaw-test.yaml
@@ -22,7 +22,7 @@ spec:
     - name: Install Odigos
       try:
         - script:
-            timeout: 2m
+            timeout: 5m
             content: |
               # The pwd is the directory of this file, so we have to walk up to the project root to find the helm chart
               P="../../.."
@@ -34,7 +34,7 @@ spec:
               kubectl label namespace odigos-test odigos.io/system-object="true"
               ../../common/verify_odigos_installation.sh odigos-test
         - assert:
-            timeout: 1m10s
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: Assert Trace DB is up

--- a/tests/e2e/mount-method/chainsaw-test.yaml
+++ b/tests/e2e/mount-method/chainsaw-test.yaml
@@ -19,7 +19,7 @@ spec:
     - name: '[1 - Setup] Install Odigos'
       try:
         - script:
-            timeout: 1m40s
+            timeout: 5m
             content: |
               if [ "$MODE" = "cross-cloud-tests" ]; then
                 ../../../cli/odigos install --ns odigos-test --set image.tag="$COMMIT_HASH" --set imagePrefix=public.ecr.aws/y2v0v6s7 --set instrumentor.mountMethod=k8s-init-container
@@ -29,7 +29,7 @@ spec:
               kubectl label namespace odigos-test odigos.io/system-object="true"
               ../../common/verify_odigos_installation.sh odigos-test
         - assert:
-            timeout: 1m10s
+            timeout: 4m
             file: ../../common/assert/odigos-installed-no-device-plugin.yaml
 
     - name: '[1 - Setup] Assert - Simple Demo Apps Installed'
@@ -133,7 +133,7 @@ spec:
     - name: '[3 - CSI Driver Test] Upgrade to CSI driver mount method'
       try:
         - script:
-            timeout: 1m10s
+            timeout: 2m
             content: |
               # Upgrade existing installation to CSI driver mount method
               ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test --set instrumentor.mountMethod=k8s-csi-driver

--- a/tests/e2e/runtime-detection/chainsaw-test.yaml
+++ b/tests/e2e/runtime-detection/chainsaw-test.yaml
@@ -24,17 +24,17 @@ spec:
             content: |
               ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test
               kubectl label namespace odigos-test odigos.io/system-object="true"
-            timeout: 1m10s
+            timeout: 2m
 
     - name: Assert Odigos Installed
       try:
         - assert:
-            timeout: 2m
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
         - script:
             content: |
               ../../common/verify_odigos_installation.sh odigos-test
-            timeout: 1m10s
+            timeout: 5m
 
     - name: Verify Node Odiglet label has been added
       try:

--- a/tests/e2e/runtime-detection/chainsaw-test.yaml
+++ b/tests/e2e/runtime-detection/chainsaw-test.yaml
@@ -23,18 +23,12 @@ spec:
         - script:
             content: |
               ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test
+              ../../common/verify_odigos_installation.sh odigos-test
               kubectl label namespace odigos-test odigos.io/system-object="true"
-            timeout: 2m
-
-    - name: Assert Odigos Installed
-      try:
+            timeout: 5m
         - assert:
             timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
-        - script:
-            content: |
-              ../../common/verify_odigos_installation.sh odigos-test
-            timeout: 5m
 
     - name: Verify Node Odiglet label has been added
       try:

--- a/tests/e2e/source/chainsaw-test.yaml
+++ b/tests/e2e/source/chainsaw-test.yaml
@@ -19,7 +19,7 @@ spec:
     - name: '[1 - Setup] Install Odigos'
       try:
         - script:
-            timeout: 4m
+            timeout: 5m
             content: |
               if [ "$MODE" = "cross-cloud-tests" ]; then
                 ../../../cli/odigos install --ns odigos-test --set image.tag="$COMMIT_HASH" --set imagePrefix=public.ecr.aws/y2v0v6s7
@@ -30,7 +30,7 @@ spec:
 
               ../../common/verify_odigos_installation.sh odigos-test
         - assert:
-            timeout: 1m40s
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: '[1 - Setup] Verify Node Odiglet label has been added'

--- a/tests/e2e/tail-sampling-nodejs/chainsaw-test.yaml
+++ b/tests/e2e/tail-sampling-nodejs/chainsaw-test.yaml
@@ -24,7 +24,7 @@ spec:
     - name: Install Odigos
       try:
         - script:
-            timeout: 4m
+            timeout: 5m
             content: |
               # pwd is tests/e2e/tail-sampling-nodejs — chart lives at repo root helm/odigos
               # Gateway tail sampling enabled. Short aggregation wait keeps e2e latency low
@@ -39,7 +39,7 @@ spec:
               ../../common/verify_odigos_installation.sh odigos-test
               kubectl label namespace odigos-test odigos.io/system-object="true"
         - assert:
-            timeout: 3m
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: Verify Node Odiglet label has been added

--- a/tests/e2e/trace-collection/chainsaw-test.yaml
+++ b/tests/e2e/trace-collection/chainsaw-test.yaml
@@ -25,9 +25,9 @@ spec:
               ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test
               ../../common/verify_odigos_installation.sh odigos-test
               kubectl label namespace odigos-test odigos.io/system-object="true"
-            timeout: 2m
+            timeout: 5m
         - assert:
-            timeout: 1m10s
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
 
     - name: Assert Trace DB is up

--- a/tests/e2e/ui/frontend-cypress-tests/chainsaw-test.yaml
+++ b/tests/e2e/ui/frontend-cypress-tests/chainsaw-test.yaml
@@ -19,13 +19,13 @@ spec:
     - name: Install Odigos CLI
       try:
         - script:
-            timeout: 2m40s
+            timeout: 5m
             content: |
               ../../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test
               ../../../common/verify_odigos_installation.sh odigos-test
               kubectl label namespace odigos-test odigos.io/system-object="true"
         - assert:
-            timeout: 1m10s
+            timeout: 4m
             file: ../../../common/assert/odigos-installed.yaml
 
     - name: Verify - Jaeger Installed

--- a/tests/e2e/webhooks/chainsaw-test.yaml
+++ b/tests/e2e/webhooks/chainsaw-test.yaml
@@ -17,9 +17,9 @@ spec:
               fi
               kubectl label namespace odigos-test odigos.io/system-object="true"
               ../../common/verify_odigos_installation.sh odigos-test
-            timeout: 1m50s
+            timeout: 5m
         - assert:
-            timeout: 1m10s
+            timeout: 4m
             file: ../../common/assert/odigos-installed.yaml
     - name: "[Defaulting] - Source without labels has labels added"
       try:


### PR DESCRIPTION
## Summary

Bundles CI flake fixes for OSS Kind E2E:

### [DEVOPS-83](https://linear.app/odigos/issue/DEVOPS-83/ci-kubernetes-jobs-fail-on-kind-post-cleanup-despite-passing-e2e-tests) — Kind post-cleanup
- Set `ignore_failed_clean: true` on `helm/kind-action` in E2E and chaos-tests
- Stops jobs from failing on flaky Docker/Kind teardown after tests already passed

### [DEVOPS-84](https://linear.app/odigos/issue/DEVOPS-84/ci-kind-kube-apiserveretcd-flakes-cause-early-e2e-apply-failures-on) — apiserver/etcd readiness
- After Kind create, wait for consecutive kube-apiserver `/readyz` successes and a namespace write probe (`tests/common/wait_for_kind_ready.sh`)
- Recheck readiness again immediately before chainsaw (after image cache / `kind load`)
- Raise chainsaw `--apply-timeout` to `30s` (default 5s is too short for brief flaps)

### [DEVOPS-85](https://linear.app/odigos/issue/DEVOPS-85/ci-oss-e2e-flakes-chainsaw-signalkilled-and-autoscaler-readiness-races) — load / readiness races
- Raise install/verify/assert timeouts for Odigos component readiness (especially autoscaler webhook certs)
- Align `runtime-detection` with other scenarios: run `verify_odigos_installation.sh` before asserting pods ready
- Add runner memory + dmesg OOM hints to cluster diagnostics on failure
- **No `max-parallel` cap** — the readiness/apply/install waits above absorb load better than serializing the matrix (which stretched CI wall-clock). Reintroduce a cap only if `signal:killed` / OOM returns.

Companion enterprise PR: https://github.com/odigos-io/odigos-enterprise/pull/3647

## Test plan
- [ ] Confirm E2E CI runs on this PR
- [ ] Confirm jobs that pass tests do not fail solely on `Post Create Kind Cluster`
- [ ] Confirm `wait for cluster readiness` / recheck logs show consecutive `readyz ok` + write probe success
- [ ] Spot-check remaining failures (if any) are scenario assertions, not `context deadline exceeded` / `etcdserver: request timed out` / `signal: killed` / autoscaler-not-ready races
- [ ] On any remaining `signal: killed`, check diagnostics for OOM / Memory cgroup lines

```release-note
NONE
```