### PR TITLE
CORE-1637: schedule odiglet only on nodes with instrumented pods

### DIFF
--- a/api/k8sconsts/node.go
+++ b/api/k8sconsts/node.go
@@ -9,18 +9,27 @@ const (
 	// GKEManagedNodeNamePrefix is the prefix for node names on GKE Autopilot clusters.
 	GKEManagedNodeNamePrefix = "gk3-"
 
-	// InstrumentedPodsNodeLabel is set on a Node by the instrumentor when at least
-	// one Odigos-instrumented pod is running on that node.
-	// When odiglet.scheduleOnlyOnInstrumentedNodes is enabled, odiglet DaemonSet
-	// pods are scheduled only onto Nodes that carry this label.
-	InstrumentedPodsNodeLabel = "odigos.io/instrumented-pods"
+	// FirstInstrumentedPodAtNodeLabel is set on a Node by the instrumentor when the
+	// first Odigos-instrumented pod is discovered on that node.
+	// The value is the UTC time of that first discovery
+	// (compact form 20060102T150405Z; colons are not valid in label values).
+	// The label is removed only after no instrumented pods remain and the label is
+	// at least FirstInstrumentedPodAtNodeLabelRetentionEnvVar old.
+	// When odiglet.scheduleOnlyOnInstrumentedNodes.enabled is true, odiglet DaemonSet
+	// pods are scheduled only onto Nodes that carry this label (Exists match).
+	FirstInstrumentedPodAtNodeLabel = "odigos.io/first-instrumented-pod-at"
 
-	// InstrumentedPodsNodeLabelValue is the value written for InstrumentedPodsNodeLabel
-	// when instrumented pods are present on the node. The label is removed when none remain.
-	InstrumentedPodsNodeLabelValue = "true"
+	// FirstInstrumentedPodAtNodeLabelTimeFormat is the label-safe UTC timestamp layout
+	// used as the value of FirstInstrumentedPodAtNodeLabel.
+	FirstInstrumentedPodAtNodeLabelTimeFormat = "20060102T150405Z"
 
 	// OdigletScheduleOnlyOnInstrumentedNodesEnvVar is set on the instrumentor from
-	// odiglet.scheduleOnlyOnInstrumentedNodes. Changing it rolls the instrumentor and
-	// controls whether the instrumented-nodes controllers are registered.
+	// odiglet.scheduleOnlyOnInstrumentedNodes.enabled. Changing it rolls the instrumentor
+	// and controls whether the instrumented-nodes controllers are registered.
 	OdigletScheduleOnlyOnInstrumentedNodesEnvVar = "ODIGOS_ODIGLET_SCHEDULE_ONLY_ON_INSTRUMENTED_NODES"
+
+	// FirstInstrumentedPodAtNodeLabelRetentionEnvVar is a Go duration (e.g. "5m") set on the
+	// instrumentor from odiglet.scheduleOnlyOnInstrumentedNodes.nodeLabelRetention.
+	// FirstInstrumentedPodAtNodeLabel is not removed until it has existed at least this long.
+	FirstInstrumentedPodAtNodeLabelRetentionEnvVar = "ODIGOS_INSTRUMENTED_PODS_NODE_LABEL_RETENTION"
 )

--- a/api/k8sconsts/node.go
+++ b/api/k8sconsts/node.go
@@ -14,22 +14,20 @@ const (
 	// The value is the UTC time of that first discovery
 	// (compact form 20060102T150405Z; colons are not valid in label values).
 	// The label is removed only after no instrumented pods remain and the label is
-	// at least FirstInstrumentedPodAtNodeLabelRetentionEnvVar old.
-	// When odiglet.scheduleOnlyOnInstrumentedNodes.enabled is true, odiglet DaemonSet
-	// pods are scheduled only onto Nodes that carry this label (Exists match).
+	// at least as old as FirstInstrumentedPodAtNodeLabelRetentionEnvVar.
+	// When that env var is set, odiglet DaemonSet pods are scheduled only onto
+	// Nodes that carry this label (Exists match).
 	FirstInstrumentedPodAtNodeLabel = "odigos.io/first-instrumented-pod-at"
 
 	// FirstInstrumentedPodAtNodeLabelTimeFormat is the label-safe UTC timestamp layout
 	// used as the value of FirstInstrumentedPodAtNodeLabel.
 	FirstInstrumentedPodAtNodeLabelTimeFormat = "20060102T150405Z"
 
-	// OdigletScheduleOnlyOnInstrumentedNodesEnvVar is set on the instrumentor from
-	// odiglet.scheduleOnlyOnInstrumentedNodes.enabled. Changing it rolls the instrumentor
-	// and controls whether the instrumented-nodes controllers are registered.
-	OdigletScheduleOnlyOnInstrumentedNodesEnvVar = "ODIGOS_ODIGLET_SCHEDULE_ONLY_ON_INSTRUMENTED_NODES"
-
-	// FirstInstrumentedPodAtNodeLabelRetentionEnvVar is a Go duration (e.g. "5m") set on the
-	// instrumentor from odiglet.scheduleOnlyOnInstrumentedNodes.nodeLabelRetention.
-	// FirstInstrumentedPodAtNodeLabel is not removed until it has existed at least this long.
+	// FirstInstrumentedPodAtNodeLabelRetentionEnvVar is a Go duration (e.g. "5m") set on
+	// the instrumentor from odiglet.scheduleOnlyOnInstrumentedNodes when enabled.
+	// Presence of this env var enables scheduling odiglet only on instrumented nodes
+	// and registers the instrumented-nodes controllers. The value is how long to keep
+	// FirstInstrumentedPodAtNodeLabel after the last instrumented pod leaves (use "0s"
+	// to remove immediately).
 	FirstInstrumentedPodAtNodeLabelRetentionEnvVar = "ODIGOS_INSTRUMENTED_PODS_NODE_LABEL_RETENTION"
 )

--- a/api/k8sconsts/node.go
+++ b/api/k8sconsts/node.go
@@ -8,4 +8,19 @@ const (
 
 	// GKEManagedNodeNamePrefix is the prefix for node names on GKE Autopilot clusters.
 	GKEManagedNodeNamePrefix = "gk3-"
+
+	// InstrumentedPodsNodeLabel is set on a Node by the instrumentor when at least
+	// one Odigos-instrumented pod is running on that node.
+	// When odiglet.scheduleOnlyOnInstrumentedNodes is enabled, odiglet DaemonSet
+	// pods are scheduled only onto Nodes that carry this label.
+	InstrumentedPodsNodeLabel = "odigos.io/instrumented-pods"
+
+	// InstrumentedPodsNodeLabelValue is the value written for InstrumentedPodsNodeLabel
+	// when instrumented pods are present on the node. The label is removed when none remain.
+	InstrumentedPodsNodeLabelValue = "true"
+
+	// OdigletScheduleOnlyOnInstrumentedNodesEnvVar is set on the instrumentor from
+	// odiglet.scheduleOnlyOnInstrumentedNodes. Changing it rolls the instrumentor and
+	// controls whether the instrumented-nodes controllers are registered.
+	OdigletScheduleOnlyOnInstrumentedNodesEnvVar = "ODIGOS_ODIGLET_SCHEDULE_ONLY_ON_INSTRUMENTED_NODES"
 )

--- a/cli/cmd/uninstall-dep.go
+++ b/cli/cmd/uninstall-dep.go
@@ -543,26 +543,21 @@ func uninstallRBAC(ctx context.Context, client *kube.Client, ns, _ string) error
 func cleanupNodeOdigosLabels(ctx context.Context, client *kube.Client, ns, _ string) error {
 	nodeSet := make(map[string]struct{})
 
-	// Step 1: Get OSS nodes
-	ossNodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{
-		LabelSelector: k8sconsts.OdigletOSSInstalledLabel,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to list nodes with %s: %w", k8sconsts.OdigletOSSInstalledLabel, err)
+	labelSelectors := []string{
+		k8sconsts.OdigletOSSInstalledLabel,
+		k8sconsts.OdigletEnterpriseInstalledLabel,
+		k8sconsts.FirstInstrumentedPodAtNodeLabel,
 	}
-	for _, node := range ossNodes.Items {
-		nodeSet[node.Name] = struct{}{}
-	}
-
-	// Step 2: Get Enterprise nodes
-	enterpriseNodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{
-		LabelSelector: k8sconsts.OdigletEnterpriseInstalledLabel,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to list nodes with %s: %w", k8sconsts.OdigletEnterpriseInstalledLabel, err)
-	}
-	for _, node := range enterpriseNodes.Items {
-		nodeSet[node.Name] = struct{}{}
+	for _, label := range labelSelectors {
+		nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+			LabelSelector: label,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to list nodes with %s: %w", label, err)
+		}
+		for _, node := range nodes.Items {
+			nodeSet[node.Name] = struct{}{}
+		}
 	}
 
 	for nodeName := range nodeSet {
@@ -572,6 +567,7 @@ func cleanupNodeOdigosLabels(ctx context.Context, client *kube.Client, ns, _ str
 					// Setting to `nil` removes the labels if exists, otherwise will ignore
 					k8sconsts.OdigletOSSInstalledLabel:        nil,
 					k8sconsts.OdigletEnterpriseInstalledLabel: nil,
+					k8sconsts.FirstInstrumentedPodAtNodeLabel: nil,
 				},
 			},
 		}

--- a/helm/odigos/templates/instrumentor/clusterrole.yaml
+++ b/helm/odigos/templates/instrumentor/clusterrole.yaml
@@ -13,6 +13,8 @@ rules:
       - list
       - watch
       - get
+      - patch
+      - update
   - apiGroups:
       - ''
     resources:

--- a/helm/odigos/templates/instrumentor/clusterrole.yaml
+++ b/helm/odigos/templates/instrumentor/clusterrole.yaml
@@ -13,8 +13,10 @@ rules:
       - list
       - watch
       - get
+      {{- if dig "scheduleOnlyOnInstrumentedNodes" "enabled" false (.Values.odiglet | default dict) }}
       - patch
       - update
+      {{- end }}
   - apiGroups:
       - ''
     resources:

--- a/helm/odigos/templates/instrumentor/deployment.yaml
+++ b/helm/odigos/templates/instrumentor/deployment.yaml
@@ -108,6 +108,10 @@ spec:
             {{- else }}
             value: {{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "agents" "Tag" $imageTag) }}
             {{- end }}
+          {{- if .Values.odiglet.scheduleOnlyOnInstrumentedNodes }}
+          - name: ODIGOS_ODIGLET_SCHEDULE_ONLY_ON_INSTRUMENTED_NODES
+            value: "true"
+          {{- end }}
           - name: GOMEMLIMIT
             value: {{ include "odigos.gomemlimitFromResources" (dict "Resources" .Values.instrumentor.resources) }}
         volumeMounts:

--- a/helm/odigos/templates/instrumentor/deployment.yaml
+++ b/helm/odigos/templates/instrumentor/deployment.yaml
@@ -108,9 +108,11 @@ spec:
             {{- else }}
             value: {{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "agents" "Tag" $imageTag) }}
             {{- end }}
-          {{- if .Values.odiglet.scheduleOnlyOnInstrumentedNodes }}
+          {{- if dig "scheduleOnlyOnInstrumentedNodes" "enabled" false (.Values.odiglet | default dict) }}
           - name: ODIGOS_ODIGLET_SCHEDULE_ONLY_ON_INSTRUMENTED_NODES
             value: "true"
+          - name: ODIGOS_INSTRUMENTED_PODS_NODE_LABEL_RETENTION
+            value: {{ dig "scheduleOnlyOnInstrumentedNodes" "nodeLabelRetention" "5m" (.Values.odiglet | default dict) | quote }}
           {{- end }}
           - name: GOMEMLIMIT
             value: {{ include "odigos.gomemlimitFromResources" (dict "Resources" .Values.instrumentor.resources) }}

--- a/helm/odigos/templates/instrumentor/deployment.yaml
+++ b/helm/odigos/templates/instrumentor/deployment.yaml
@@ -109,8 +109,6 @@ spec:
             value: {{ template "utils.imageName" (dict "Values" .Values "Release" .Release "Component" "agents" "Tag" $imageTag) }}
             {{- end }}
           {{- if dig "scheduleOnlyOnInstrumentedNodes" "enabled" false (.Values.odiglet | default dict) }}
-          - name: ODIGOS_ODIGLET_SCHEDULE_ONLY_ON_INSTRUMENTED_NODES
-            value: "true"
           - name: ODIGOS_INSTRUMENTED_PODS_NODE_LABEL_RETENTION
             value: {{ dig "scheduleOnlyOnInstrumentedNodes" "nodeLabelRetention" "5m" (.Values.odiglet | default dict) | quote }}
           {{- end }}

--- a/helm/odigos/templates/odiglet/daemonset.yaml
+++ b/helm/odigos/templates/odiglet/daemonset.yaml
@@ -29,8 +29,8 @@
 {{- if and $networkMetricsEnabled .Values.odiglet.noHostNetwork }}
 {{ fail "odiglet.noHostNetwork cannot be true when metricsSources.networkMetrics.enabled is true, since OBI network metrics require hostNetwork" }}
 {{- end }}
-{{- if and .Values.odiglet.scheduleOnlyOnInstrumentedNodes (ne .Values.instrumentor.mountMethod "k8s-init-container") }}
-{{ fail "odiglet.scheduleOnlyOnInstrumentedNodes requires instrumentor.mountMethod=k8s-init-container" }}
+{{- if and (dig "scheduleOnlyOnInstrumentedNodes" "enabled" false (.Values.odiglet | default dict)) (ne .Values.instrumentor.mountMethod "k8s-init-container") }}
+{{ fail "odiglet.scheduleOnlyOnInstrumentedNodes.enabled requires instrumentor.mountMethod=k8s-init-container" }}
 {{- end }}
 apiVersion: apps/v1
 kind: DaemonSet
@@ -72,9 +72,6 @@ spec:
       {{- range $k, $v := .Values.nodeSelector }}
       {{- $_ := set $nodeSelector $k $v }}
       {{- end }}
-      {{- end }}
-      {{- if .Values.odiglet.scheduleOnlyOnInstrumentedNodes }}
-      {{- $_ := set $nodeSelector "odigos.io/instrumented-pods" "true" }}
       {{- end }}
       {{- if $nodeSelector }}
       nodeSelector:
@@ -613,9 +610,21 @@ spec:
   {{- if .tolerations }}
       tolerations: {{ toYaml .tolerations | nindent 8 }}
   {{- end }}
-  {{- if .affinity }}
-      affinity: {{ toYaml .affinity | nindent 8 }}
-  {{- end }}
+{{- end }}
+{{- /* Exists match: label value is a discovery timestamp, not a fixed "true". */}}
+{{- if or (and .Values.odiglet.affinity (not (empty .Values.odiglet.affinity))) (dig "scheduleOnlyOnInstrumentedNodes" "enabled" false (.Values.odiglet | default dict)) }}
+      affinity:
+{{- if and .Values.odiglet.affinity (not (empty .Values.odiglet.affinity)) }}
+{{ toYaml .Values.odiglet.affinity | nindent 8 }}
+{{- end }}
+{{- if dig "scheduleOnlyOnInstrumentedNodes" "enabled" false (.Values.odiglet | default dict) }}
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: odigos.io/first-instrumented-pod-at
+                    operator: Exists
+{{- end }}
 {{- end }}
       # Force UID 0 unless runAsNonRoot is opted in; otherwise image USER (non-zero) is used.
       securityContext:

--- a/helm/odigos/templates/odiglet/daemonset.yaml
+++ b/helm/odigos/templates/odiglet/daemonset.yaml
@@ -29,6 +29,9 @@
 {{- if and $networkMetricsEnabled .Values.odiglet.noHostNetwork }}
 {{ fail "odiglet.noHostNetwork cannot be true when metricsSources.networkMetrics.enabled is true, since OBI network metrics require hostNetwork" }}
 {{- end }}
+{{- if and .Values.odiglet.scheduleOnlyOnInstrumentedNodes (ne .Values.instrumentor.mountMethod "k8s-init-container") }}
+{{ fail "odiglet.scheduleOnlyOnInstrumentedNodes requires instrumentor.mountMethod=k8s-init-container" }}
+{{- end }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -60,14 +63,22 @@ spec:
         {{- end }}
         kubectl.kubernetes.io/default-container: odiglet
     spec:
+      {{- $nodeSelector := dict }}
       {{- if .Values.odiglet.nodeSelector }}
-      # Component-specific nodeSelector (overrides global values.yaml nodeSelector)
-      nodeSelector:
-      {{- toYaml .Values.odiglet.nodeSelector | nindent 8 }}
+      {{- range $k, $v := .Values.odiglet.nodeSelector }}
+      {{- $_ := set $nodeSelector $k $v }}
+      {{- end }}
       {{- else if .Values.nodeSelector }}
-      # Global nodeSelector from values.yaml
+      {{- range $k, $v := .Values.nodeSelector }}
+      {{- $_ := set $nodeSelector $k $v }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.odiglet.scheduleOnlyOnInstrumentedNodes }}
+      {{- $_ := set $nodeSelector "odigos.io/instrumented-pods" "true" }}
+      {{- end }}
+      {{- if $nodeSelector }}
       nodeSelector:
-      {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- toYaml $nodeSelector | nindent 8 }}
       {{- end }}
       # we will always have at least one init container
       # if the mountMethod is k8s-init-container, we will pre-pull the agents image here as an init container

--- a/helm/odigos/values.schema.json
+++ b/helm/odigos/values.schema.json
@@ -1960,8 +1960,22 @@
           "title": "runAsNonRoot"
         },
         "scheduleOnlyOnInstrumentedNodes": {
-          "default": "false",
-          "description": "When true, odiglet DaemonSet pods are only scheduled on nodes that already\nhave at least one instrumented pod. By default (false), odiglet runs on all\nnodes (subject to nodeSelector, affinity, and tolerations).",
+          "additionalProperties": false,
+          "description": "Schedule odiglet only on nodes that already have at least one instrumented\npod. Reduces the resources Odigos uses on the cluster, which is useful when\nthere are many nodes and few instrumented pods.\nRequires instrumentor.mountMethod to be set to k8s-init-container.\nCons: the first time an instrumented pod starts on a node there is a period\nwithout telemetry until odiglet starts on that node; assumes additional RBAC\npermissions to patch and update node labels.",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "When true, odiglet runs only on nodes that already have instrumented pods.\nBy default (false), odiglet runs on all nodes (subject to nodeSelector,\naffinity, and tolerations).",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "nodeLabelRetention": {
+              "default": "5m",
+              "description": "How long to keep odiglet scheduled on a node after its last instrumented\npod leaves. Acts as a rate limit so odiglet is not started and stopped\ntoo frequently. Go duration string (e.g. 5m, 1h). Set to 0s to stop\nimmediately. Default is 5m.",
+              "title": "nodeLabelRetention",
+              "type": "string"
+            }
+          },
           "required": [],
           "title": "scheduleOnlyOnInstrumentedNodes"
         },

--- a/helm/odigos/values.schema.json
+++ b/helm/odigos/values.schema.json
@@ -1959,6 +1959,12 @@
           "required": [],
           "title": "runAsNonRoot"
         },
+        "scheduleOnlyOnInstrumentedNodes": {
+          "default": "false",
+          "description": "When true, odiglet DaemonSet pods are only scheduled on nodes that already\nhave at least one instrumented pod. By default (false), odiglet runs on all\nnodes (subject to nodeSelector, affinity, and tolerations).",
+          "required": [],
+          "title": "scheduleOnlyOnInstrumentedNodes"
+        },
         "tolerations": {
           "description": "This toleration with 'Exists' operator and no key/effect specified\nwill match ALL taints, allowing pods to be scheduled on any node\nregardless of its taints (including master/control-plane nodes)",
           "items": {

--- a/helm/odigos/values.schema.json
+++ b/helm/odigos/values.schema.json
@@ -1983,7 +1983,7 @@
           "properties": {
             "enabled": {
               "default": "false",
-              "description": "When true, odiglet runs only on nodes that already have instrumented pods.\nBy default (false), odiglet runs on all nodes (subject to nodeSelector,\naffinity, and tolerations).",
+              "description": "When true, odiglet runs only on nodes that already have instrumented pods.\nBy default (false), odiglet runs on all nodes (subject to nodeSelector,\naffinity, and tolerations).\nWhen enabled together with a non-default nodeSelector, affinity, or\ntolerations, those settings still apply: odiglet is scheduled only on\nnodes that both carry the instrumented-pod label and satisfy the other\nconstraints (they are combined, not replaced).",
               "required": [],
               "title": "enabled"
             },

--- a/helm/odigos/values.schema.json
+++ b/helm/odigos/values.schema.json
@@ -1982,10 +1982,10 @@
           "description": "Schedule odiglet only on nodes that already have at least one instrumented\npod. Reduces the resources Odigos uses on the cluster, which is useful when\nthere are many nodes and few instrumented pods.\nRequires instrumentor.mountMethod to be set to k8s-init-container.\nCons: the first time an instrumented pod starts on a node there is a period\nwithout telemetry until odiglet starts on that node; assumes additional RBAC\npermissions to patch and update node labels.",
           "properties": {
             "enabled": {
-              "default": false,
+              "default": "false",
               "description": "When true, odiglet runs only on nodes that already have instrumented pods.\nBy default (false), odiglet runs on all nodes (subject to nodeSelector,\naffinity, and tolerations).",
-              "title": "enabled",
-              "type": "boolean"
+              "required": [],
+              "title": "enabled"
             },
             "nodeLabelRetention": {
               "default": "5m",

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -1020,6 +1020,10 @@ odiglet:
     #   When true, odiglet runs only on nodes that already have instrumented pods.
     #   By default (false), odiglet runs on all nodes (subject to nodeSelector,
     #   affinity, and tolerations).
+    #   When enabled together with a non-default nodeSelector, affinity, or
+    #   tolerations, those settings still apply: odiglet is scheduled only on
+    #   nodes that both carry the instrumented-pod label and satisfy the other
+    #   constraints (they are combined, not replaced).
     # @schema
     enabled: false
 

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -991,14 +991,32 @@ odiglet:
 
   # @schema
   # description: |-
-  #   When true, odiglet DaemonSet pods are only scheduled on nodes that already
-  #   have at least one instrumented pod. By default (false), odiglet runs on all
-  #   nodes (subject to nodeSelector, affinity, and tolerations).
+  #   Schedule odiglet only on nodes that already have at least one instrumented
+  #   pod. Reduces the resources Odigos uses on the cluster, which is useful when
+  #   there are many nodes and few instrumented pods.
   #   Requires instrumentor.mountMethod to be set to k8s-init-container.
-  #   Also set as an env var on the instrumentor so toggling this value restarts
-  #   it and enables/disables the node-label controllers.
+  #   Cons: the first time an instrumented pod starts on a node there is a period
+  #   without telemetry until odiglet starts on that node; assumes additional RBAC
+  #   permissions to patch and update node labels.
   # @schema
-  scheduleOnlyOnInstrumentedNodes: false
+  scheduleOnlyOnInstrumentedNodes:
+    # @schema
+    # description: |-
+    #   When true, odiglet runs only on nodes that already have instrumented pods.
+    #   By default (false), odiglet runs on all nodes (subject to nodeSelector,
+    #   affinity, and tolerations).
+    # @schema
+    enabled: false
+
+    # @schema
+    # description: |-
+    #   How long to keep odiglet scheduled on a node after its last instrumented
+    #   pod leaves. Acts as a rate limit so odiglet is not started and stopped
+    #   too frequently. Go duration string (e.g. 5m, 1h). Set to 0s to stop
+    #   immediately. Default is 5m.
+    # type: string
+    # @schema
+    # nodeLabelRetention: "5m"
 
   # @schema
   # description: Priority class name. Set to empty string to disable.

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -990,6 +990,17 @@ odiglet:
   affinity: {}
 
   # @schema
+  # description: |-
+  #   When true, odiglet DaemonSet pods are only scheduled on nodes that already
+  #   have at least one instrumented pod. By default (false), odiglet runs on all
+  #   nodes (subject to nodeSelector, affinity, and tolerations).
+  #   Requires instrumentor.mountMethod to be set to k8s-init-container.
+  #   Also set as an env var on the instrumentor so toggling this value restarts
+  #   it and enables/disables the node-label controllers.
+  # @schema
+  scheduleOnlyOnInstrumentedNodes: false
+
+  # @schema
   # description: Priority class name. Set to empty string to disable.
   # @schema
   priorityClassName: 'system-node-critical'

--- a/instrumentor/controllers/agentenabled/pods_webhook.go
+++ b/instrumentor/controllers/agentenabled/pods_webhook.go
@@ -216,7 +216,7 @@ func (p *PodsWebhook) injectOdigos(ctx context.Context, pod *corev1.Pod, req adm
 		podswebhook.MountPodVolumeToHostPath(pod)
 	}
 
-	if odigosConfiguration.MountMethod != nil && *odigosConfiguration.MountMethod == common.K8sInitContainerMountMethod && volumeMounted {
+	if mountMethod == common.K8sInitContainerMountMethod && volumeMounted {
 		// only mount the volume if at least one container has a volume to mount
 		podswebhook.MountPodVolumeToEmptyDir(pod)
 		if len(dirsToCopy) > 0 {

--- a/instrumentor/controllers/instrumentednodes/instrumentationconfig_controller.go
+++ b/instrumentor/controllers/instrumentednodes/instrumentationconfig_controller.go
@@ -1,0 +1,108 @@
+package instrumentednodes
+
+import (
+	"context"
+	"errors"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/odigos-io/odigos/api/k8sconsts"
+	commonlogger "github.com/odigos-io/odigos/common/logger"
+	"github.com/odigos-io/odigos/k8sutils/pkg/utils"
+	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
+)
+
+// InstrumentationConfigReconciler syncs instrumented-pods node labels for nodes
+// that run pods belonging to the workload of the reconciled InstrumentationConfig.
+type InstrumentationConfigReconciler struct {
+	client.Client
+}
+
+func (r *InstrumentationConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := commonlogger.FromContext(ctx)
+
+	pw, err := workload.ExtractWorkloadInfoFromRuntimeObjectName(req.Name, req.Namespace)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	nodeNames, err := r.nodeNamesForWorkload(ctx, pw)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	var syncErrs []error
+	nodesReconciler := &NodesReconciler{Client: r.Client}
+	for nodeName := range nodeNames {
+		if err := nodesReconciler.syncNode(ctx, nodeName); err != nil {
+			syncErrs = append(syncErrs, err)
+		}
+	}
+
+	logger.Info("synced instrumented pods node labels for instrumentation config",
+		"instrumentationConfig", req.NamespacedName, "nodes", len(nodeNames))
+	return utils.K8SUpdateErrorHandler(errors.Join(syncErrs...))
+}
+
+func (r *InstrumentationConfigReconciler) nodeNamesForWorkload(ctx context.Context, pw k8sconsts.PodWorkload) (map[string]struct{}, error) {
+	nodes := map[string]struct{}{}
+
+	workloadObj := workload.ClientObjectFromWorkloadKind(pw.Kind)
+	if workloadObj == nil {
+		return nodes, nil
+	}
+
+	err := r.Get(ctx, client.ObjectKey{Namespace: pw.Namespace, Name: pw.Name}, workloadObj)
+	if err != nil {
+		return nodes, client.IgnoreNotFound(err)
+	}
+
+	switch pw.Kind {
+	case k8sconsts.WorkloadKindStaticPod:
+		pod := workloadObj.(*corev1.Pod)
+		if pod.Spec.NodeName != "" {
+			nodes[pod.Spec.NodeName] = struct{}{}
+		}
+		return nodes, nil
+	case k8sconsts.WorkloadKindCronJob:
+		var pods corev1.PodList
+		err = r.List(ctx, &pods, client.InNamespace(pw.Namespace))
+		if err != nil {
+			return nil, err
+		}
+		for i := range pods.Items {
+			pod := &pods.Items[i]
+			podWorkload, err := workload.PodWorkloadObject(pod)
+			if err != nil || podWorkload == nil {
+				continue
+			}
+			if podWorkload.Name == pw.Name && podWorkload.Kind == pw.Kind && pod.Spec.NodeName != "" {
+				nodes[pod.Spec.NodeName] = struct{}{}
+			}
+		}
+		return nodes, nil
+	}
+
+	genericWorkload, err := workload.ObjectToWorkload(workloadObj)
+	if err != nil {
+		return nil, err
+	}
+	labelSelector := genericWorkload.LabelSelector()
+	if labelSelector == nil {
+		return nodes, nil
+	}
+
+	var pods corev1.PodList
+	err = r.List(ctx, &pods, client.InNamespace(pw.Namespace), client.MatchingLabels(labelSelector.MatchLabels))
+	if err != nil {
+		return nil, err
+	}
+	for i := range pods.Items {
+		if pods.Items[i].Spec.NodeName != "" {
+			nodes[pods.Items[i].Spec.NodeName] = struct{}{}
+		}
+	}
+	return nodes, nil
+}

--- a/instrumentor/controllers/instrumentednodes/instrumentationconfig_controller.go
+++ b/instrumentor/controllers/instrumentednodes/instrumentationconfig_controller.go
@@ -3,13 +3,13 @@ package instrumentednodes
 import (
 	"context"
 	"errors"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/odigos-io/odigos/api/k8sconsts"
-	commonlogger "github.com/odigos-io/odigos/common/logger"
 	"github.com/odigos-io/odigos/k8sutils/pkg/utils"
 	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
 )
@@ -18,11 +18,10 @@ import (
 // that run pods belonging to the workload of the reconciled InstrumentationConfig.
 type InstrumentationConfigReconciler struct {
 	client.Client
+	NodeLabelRetention time.Duration
 }
 
 func (r *InstrumentationConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := commonlogger.FromContext(ctx)
-
 	pw, err := workload.ExtractWorkloadInfoFromRuntimeObjectName(req.Name, req.Namespace)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -34,16 +33,26 @@ func (r *InstrumentationConfigReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	var syncErrs []error
-	nodesReconciler := &NodesReconciler{Client: r.Client}
+	var requeueAfter time.Duration
 	for nodeName := range nodeNames {
-		if err := nodesReconciler.syncNode(ctx, nodeName); err != nil {
+		ra, err := syncNode(ctx, r.Client, nodeName, r.NodeLabelRetention)
+		if err != nil {
 			syncErrs = append(syncErrs, err)
+			continue
+		}
+		if ra > 0 && (requeueAfter == 0 || ra < requeueAfter) {
+			requeueAfter = ra
 		}
 	}
 
-	logger.Info("synced instrumented pods node labels for instrumentation config",
-		"instrumentationConfig", req.NamespacedName, "nodes", len(nodeNames))
-	return utils.K8SUpdateErrorHandler(errors.Join(syncErrs...))
+	res, err := utils.K8SUpdateErrorHandler(errors.Join(syncErrs...))
+	if err != nil {
+		return res, err
+	}
+	if requeueAfter > 0 {
+		return ctrl.Result{RequeueAfter: requeueAfter}, nil
+	}
+	return res, nil
 }
 
 func (r *InstrumentationConfigReconciler) nodeNamesForWorkload(ctx context.Context, pw k8sconsts.PodWorkload) (map[string]struct{}, error) {

--- a/instrumentor/controllers/instrumentednodes/instrumentationconfig_controller.go
+++ b/instrumentor/controllers/instrumentednodes/instrumentationconfig_controller.go
@@ -92,26 +92,26 @@ func (r *InstrumentationConfigReconciler) nodeNamesForWorkload(ctx context.Conte
 			}
 		}
 		return nodes, nil
-	}
+	default:
+		genericWorkload, err := workload.ObjectToWorkload(workloadObj)
+		if err != nil {
+			return nil, err
+		}
+		labelSelector := genericWorkload.LabelSelector()
+		if labelSelector == nil {
+			return nodes, nil
+		}
 
-	genericWorkload, err := workload.ObjectToWorkload(workloadObj)
-	if err != nil {
-		return nil, err
-	}
-	labelSelector := genericWorkload.LabelSelector()
-	if labelSelector == nil {
+		var pods corev1.PodList
+		err = r.List(ctx, &pods, client.InNamespace(pw.Namespace), client.MatchingLabels(labelSelector.MatchLabels))
+		if err != nil {
+			return nil, err
+		}
+		for i := range pods.Items {
+			if pods.Items[i].Spec.NodeName != "" {
+				nodes[pods.Items[i].Spec.NodeName] = struct{}{}
+			}
+		}
 		return nodes, nil
 	}
-
-	var pods corev1.PodList
-	err = r.List(ctx, &pods, client.InNamespace(pw.Namespace), client.MatchingLabels(labelSelector.MatchLabels))
-	if err != nil {
-		return nil, err
-	}
-	for i := range pods.Items {
-		if pods.Items[i].Spec.NodeName != "" {
-			nodes[pods.Items[i].Spec.NodeName] = struct{}{}
-		}
-	}
-	return nodes, nil
 }

--- a/instrumentor/controllers/instrumentednodes/manager.go
+++ b/instrumentor/controllers/instrumentednodes/manager.go
@@ -1,0 +1,79 @@
+package instrumentednodes
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	odigospredicate "github.com/odigos-io/odigos/k8sutils/pkg/predicate"
+)
+
+func mapPodToNode(ctx context.Context, obj client.Object) []reconcile.Request {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok || pod.Spec.NodeName == "" {
+		return nil
+	}
+	return []reconcile.Request{{
+		NamespacedName: client.ObjectKey{Name: pod.Spec.NodeName},
+	}}
+}
+
+func SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+	err := mgr.GetFieldIndexer().IndexField(
+		ctx,
+		&corev1.Pod{},
+		podNodeNameIndex,
+		func(obj client.Object) []string {
+			pod, ok := obj.(*corev1.Pod)
+			if !ok || pod.Spec.NodeName == "" {
+				return nil
+			}
+			return []string{pod.Spec.NodeName}
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	err = builder.
+		ControllerManagedBy(mgr).
+		Named("instrumentednodes-nodes").
+		For(&corev1.Node{}).
+		Watches(
+			&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(mapPodToNode),
+			builder.WithPredicates(odigospredicate.ExistencePredicate{}),
+		).
+		Complete(&NodesReconciler{
+			Client: mgr.GetClient(),
+		})
+	if err != nil {
+		return err
+	}
+
+	err = builder.
+		ControllerManagedBy(mgr).
+		Named("instrumentednodes-instrumentationconfig").
+		For(&odigosv1.InstrumentationConfig{}).
+		WithEventFilter(odigospredicate.ExistencePredicate{}).
+		Complete(&InstrumentationConfigReconciler{
+			Client: mgr.GetClient(),
+		})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func SetupLabelCleanupWithManager(mgr ctrl.Manager) error {
+	return mgr.Add(&removeInstrumentedPodsNodeLabelsRunnable{
+		Client: mgr.GetClient(),
+	})
+}

--- a/instrumentor/controllers/instrumentednodes/manager.go
+++ b/instrumentor/controllers/instrumentednodes/manager.go
@@ -32,7 +32,7 @@ func SetupWithManager(ctx context.Context, mgr ctrl.Manager, nodeLabelRetention 
 		return err
 	}
 
-	// check if label should be set or removed when pods are created/deleted on node
+	// check if label should be set when pods are created/scheduled on a node
 	err = builder.
 		ControllerManagedBy(mgr).
 		Named("instrumentednodes-pods").
@@ -40,7 +40,6 @@ func SetupWithManager(ctx context.Context, mgr ctrl.Manager, nodeLabelRetention 
 		WithEventFilter(&podNodeNamePredicate{}).
 		Complete(&PodsReconciler{
 			Client:             mgr.GetClient(),
-			PodNodes:           newPodNodeTracker(),
 			NodeLabelRetention: nodeLabelRetention,
 		})
 	if err != nil {

--- a/instrumentor/controllers/instrumentednodes/manager.go
+++ b/instrumentor/controllers/instrumentednodes/manager.go
@@ -2,29 +2,20 @@ package instrumentednodes
 
 import (
 	"context"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
 	odigospredicate "github.com/odigos-io/odigos/k8sutils/pkg/predicate"
 )
 
-func mapPodToNode(ctx context.Context, obj client.Object) []reconcile.Request {
-	pod, ok := obj.(*corev1.Pod)
-	if !ok || pod.Spec.NodeName == "" {
-		return nil
-	}
-	return []reconcile.Request{{
-		NamespacedName: client.ObjectKey{Name: pod.Spec.NodeName},
-	}}
-}
-
-func SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+func SetupWithManager(ctx context.Context, mgr ctrl.Manager, nodeLabelRetention time.Duration) error {
+	// Index pods by Spec.NodeName so sync can list only pods on a given node
+	// (MatchingFields) instead of scanning the full pod cache.
 	err := mgr.GetFieldIndexer().IndexField(
 		ctx,
 		&corev1.Pod{},
@@ -41,39 +32,52 @@ func SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 		return err
 	}
 
+	// check if label should be set or removed when pods are created/deleted on node
 	err = builder.
 		ControllerManagedBy(mgr).
-		Named("instrumentednodes-nodes").
-		For(&corev1.Node{}).
-		Watches(
-			&corev1.Pod{},
-			handler.EnqueueRequestsFromMapFunc(mapPodToNode),
-			builder.WithPredicates(odigospredicate.ExistencePredicate{}),
-		).
-		Complete(&NodesReconciler{
-			Client: mgr.GetClient(),
+		Named("instrumentednodes-pods").
+		For(&corev1.Pod{}).
+		WithEventFilter(&podNodeNamePredicate{}).
+		Complete(&PodsReconciler{
+			Client:             mgr.GetClient(),
+			PodNodes:           newPodNodeTracker(),
+			NodeLabelRetention: nodeLabelRetention,
 		})
 	if err != nil {
 		return err
 	}
 
+	// Reconcile on node create (pod may already be in cache before the node is)
+	// and when FirstInstrumentedPodAtNodeLabel changes. Label-change reconciles are
+	// usually a no-op, but cover cache update races so the label value stays correct.
+	err = builder.
+		ControllerManagedBy(mgr).
+		Named("instrumentednodes-nodes").
+		For(&corev1.Node{}).
+		WithEventFilter(&nodeInstrumentedPodsLabelPredicate{}).
+		Complete(&NodesReconciler{
+			Client:             mgr.GetClient(),
+			NodeLabelRetention: nodeLabelRetention,
+		})
+	if err != nil {
+		return err
+	}
+
+	// we need to update the label when something becomes "marked for instrumentation",
+	// to allow odiglet to do runtime detection prior to pods with agents injectedm,
+	// and also need to react to instrumented pods with no label ("optional pod manifest injection" a.k.a "no restart")
 	err = builder.
 		ControllerManagedBy(mgr).
 		Named("instrumentednodes-instrumentationconfig").
 		For(&odigosv1.InstrumentationConfig{}).
 		WithEventFilter(odigospredicate.ExistencePredicate{}).
 		Complete(&InstrumentationConfigReconciler{
-			Client: mgr.GetClient(),
+			Client:             mgr.GetClient(),
+			NodeLabelRetention: nodeLabelRetention,
 		})
 	if err != nil {
 		return err
 	}
 
 	return nil
-}
-
-func SetupLabelCleanupWithManager(mgr ctrl.Manager) error {
-	return mgr.Add(&removeInstrumentedPodsNodeLabelsRunnable{
-		Client: mgr.GetClient(),
-	})
 }

--- a/instrumentor/controllers/instrumentednodes/nodes_controller.go
+++ b/instrumentor/controllers/instrumentednodes/nodes_controller.go
@@ -2,148 +2,54 @@ package instrumentednodes
 
 import (
 	"context"
-	"encoding/json"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	"github.com/odigos-io/odigos/api/k8sconsts"
-	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
-	commonlogger "github.com/odigos-io/odigos/common/logger"
 	"github.com/odigos-io/odigos/k8sutils/pkg/utils"
-	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
 )
 
-const podNodeNameIndex = "spec.nodeName"
+// nodeInstrumentedPodsLabelPredicate triggers on node create and when
+// FirstInstrumentedPodAtNodeLabel is added, removed, or changed.
+type nodeInstrumentedPodsLabelPredicate struct{}
 
-// NodesReconciler keeps k8sconsts.InstrumentedPodsNodeLabel on each Node to
-// indicate whether the node currently runs any instrumented pods.
-type NodesReconciler struct {
-	client.Client
-}
-
-func (r *NodesReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := commonlogger.FromContext(ctx)
-
-	err := r.syncNode(ctx, req.Name)
-	if err != nil {
-		return utils.K8SUpdateErrorHandler(err)
-	}
-
-	logger.Info("synced instrumented pods node label", "node", req.Name)
-	return ctrl.Result{}, nil
-}
-
-func (r *NodesReconciler) syncNode(ctx context.Context, nodeName string) error {
-	var node corev1.Node
-	err := r.Get(ctx, client.ObjectKey{Name: nodeName}, &node)
-	if err != nil {
-		return client.IgnoreNotFound(err)
-	}
-
-	hasInstrumented, err := r.hasInstrumentedPod(ctx, node.Name)
-	if err != nil {
-		return err
-	}
-
-	return r.syncInstrumentedPodsNodeLabel(ctx, &node, hasInstrumented)
-}
-
-func (r *NodesReconciler) hasInstrumentedPod(ctx context.Context, nodeName string) (bool, error) {
-	var pods corev1.PodList
-	err := r.List(ctx, &pods, client.MatchingFields{podNodeNameIndex: nodeName})
-	if err != nil {
-		return false, err
-	}
-
-	for i := range pods.Items {
-		pod := &pods.Items[i]
-		if _, ok := pod.Labels[k8sconsts.OdigosAgentsMetaHashLabel]; ok {
-			return true, nil
-		}
-	}
-
-	for i := range pods.Items {
-		pod := &pods.Items[i]
-		hasIC, err := r.podHasInstrumentationConfig(ctx, pod)
-		if err != nil {
-			return false, err
-		}
-		if hasIC {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
-func (r *NodesReconciler) podHasInstrumentationConfig(ctx context.Context, pod *corev1.Pod) (bool, error) {
-	pw, err := workload.PodWorkloadObject(pod)
-	if err != nil || pw == nil {
-		return false, err
-	}
-
-	icName := workload.CalculateWorkloadRuntimeObjectName(pw.Name, pw.Kind)
-	var ic odigosv1.InstrumentationConfig
-	err = r.Get(ctx, client.ObjectKey{Namespace: pw.Namespace, Name: icName}, &ic)
-	if err != nil {
-		return false, client.IgnoreNotFound(err)
-	}
-	return true, nil
-}
-
-func (r *NodesReconciler) syncInstrumentedPodsNodeLabel(ctx context.Context, node *corev1.Node, hasInstrumented bool) error {
-	_, hasLabel := node.Labels[k8sconsts.InstrumentedPodsNodeLabel]
-	if hasInstrumented == hasLabel {
-		return nil
-	}
-
-	original := node.DeepCopy()
-	if node.Labels == nil {
-		node.Labels = map[string]string{}
-	}
-	if hasInstrumented {
-		node.Labels[k8sconsts.InstrumentedPodsNodeLabel] = k8sconsts.InstrumentedPodsNodeLabelValue
-	} else {
-		delete(node.Labels, k8sconsts.InstrumentedPodsNodeLabel)
-	}
-
-	return r.Patch(ctx, node, client.MergeFrom(original))
-}
-
-// removeInstrumentedPodsNodeLabelsRunnable strips leftover InstrumentedPodsNodeLabel
-// from all nodes when schedule-only-on-instrumented-nodes is disabled.
-type removeInstrumentedPodsNodeLabelsRunnable struct {
-	Client client.Client
-}
-
-func (r *removeInstrumentedPodsNodeLabelsRunnable) NeedLeaderElection() bool {
+func (p nodeInstrumentedPodsLabelPredicate) Create(e event.CreateEvent) bool {
 	return true
 }
 
-func (r *removeInstrumentedPodsNodeLabelsRunnable) Start(ctx context.Context) error {
-	var nodes corev1.NodeList
-	if err := r.Client.List(ctx, &nodes, client.HasLabels{k8sconsts.InstrumentedPodsNodeLabel}); err != nil {
-		return err
+func (p nodeInstrumentedPodsLabelPredicate) Update(e event.UpdateEvent) bool {
+	oldNode, okOld := e.ObjectOld.(*corev1.Node)
+	newNode, okNew := e.ObjectNew.(*corev1.Node)
+	if !okOld || !okNew {
+		return false
 	}
+	return oldNode.Labels[k8sconsts.FirstInstrumentedPodAtNodeLabel] != newNode.Labels[k8sconsts.FirstInstrumentedPodAtNodeLabel]
+}
 
-	patch, err := json.Marshal(map[string]any{
-		"metadata": map[string]any{
-			"labels": map[string]any{
-				k8sconsts.InstrumentedPodsNodeLabel: nil,
-			},
-		},
-	})
+func (p nodeInstrumentedPodsLabelPredicate) Delete(e event.DeleteEvent) bool {
+	return false
+}
+
+func (p nodeInstrumentedPodsLabelPredicate) Generic(e event.GenericEvent) bool {
+	return false
+}
+
+type NodesReconciler struct {
+	client.Client
+	NodeLabelRetention time.Duration
+}
+
+func (r *NodesReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	requeueAfter, err := syncNode(ctx, r.Client, req.Name, r.NodeLabelRetention)
 	if err != nil {
-		return err
+		return utils.K8SUpdateErrorHandler(err)
 	}
-
-	for i := range nodes.Items {
-		if err := r.Client.Patch(ctx, &nodes.Items[i], client.RawPatch(types.MergePatchType, patch)); err != nil {
-			return err
-		}
+	if requeueAfter > 0 {
+		return ctrl.Result{RequeueAfter: requeueAfter}, nil
 	}
-	return nil
+	return ctrl.Result{}, nil
 }

--- a/instrumentor/controllers/instrumentednodes/nodes_controller.go
+++ b/instrumentor/controllers/instrumentednodes/nodes_controller.go
@@ -48,8 +48,13 @@ func (r *NodesReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	if err != nil {
 		return utils.K8SUpdateErrorHandler(err)
 	}
-	if requeueAfter > 0 {
-		return ctrl.Result{RequeueAfter: requeueAfter}, nil
+	// Periodically re-sync so the label is cleared after instrumented pods are
+	// deleted. The pods controller cannot handle deletes (node name is unknown
+	// once the pod is gone), so this is the path that eventually removes the label.
+	// it means new pods are handled right away, but pods being deleted are handled at most 1 minute after they are deleted.
+	const periodicRequeue = time.Minute
+	if requeueAfter == 0 || requeueAfter > periodicRequeue {
+		requeueAfter = periodicRequeue
 	}
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: requeueAfter}, nil
 }

--- a/instrumentor/controllers/instrumentednodes/nodes_controller.go
+++ b/instrumentor/controllers/instrumentednodes/nodes_controller.go
@@ -1,0 +1,149 @@
+package instrumentednodes
+
+import (
+	"context"
+	"encoding/json"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/odigos-io/odigos/api/k8sconsts"
+	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	commonlogger "github.com/odigos-io/odigos/common/logger"
+	"github.com/odigos-io/odigos/k8sutils/pkg/utils"
+	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
+)
+
+const podNodeNameIndex = "spec.nodeName"
+
+// NodesReconciler keeps k8sconsts.InstrumentedPodsNodeLabel on each Node to
+// indicate whether the node currently runs any instrumented pods.
+type NodesReconciler struct {
+	client.Client
+}
+
+func (r *NodesReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := commonlogger.FromContext(ctx)
+
+	err := r.syncNode(ctx, req.Name)
+	if err != nil {
+		return utils.K8SUpdateErrorHandler(err)
+	}
+
+	logger.Info("synced instrumented pods node label", "node", req.Name)
+	return ctrl.Result{}, nil
+}
+
+func (r *NodesReconciler) syncNode(ctx context.Context, nodeName string) error {
+	var node corev1.Node
+	err := r.Get(ctx, client.ObjectKey{Name: nodeName}, &node)
+	if err != nil {
+		return client.IgnoreNotFound(err)
+	}
+
+	hasInstrumented, err := r.hasInstrumentedPod(ctx, node.Name)
+	if err != nil {
+		return err
+	}
+
+	return r.syncInstrumentedPodsNodeLabel(ctx, &node, hasInstrumented)
+}
+
+func (r *NodesReconciler) hasInstrumentedPod(ctx context.Context, nodeName string) (bool, error) {
+	var pods corev1.PodList
+	err := r.List(ctx, &pods, client.MatchingFields{podNodeNameIndex: nodeName})
+	if err != nil {
+		return false, err
+	}
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if _, ok := pod.Labels[k8sconsts.OdigosAgentsMetaHashLabel]; ok {
+			return true, nil
+		}
+	}
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		hasIC, err := r.podHasInstrumentationConfig(ctx, pod)
+		if err != nil {
+			return false, err
+		}
+		if hasIC {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (r *NodesReconciler) podHasInstrumentationConfig(ctx context.Context, pod *corev1.Pod) (bool, error) {
+	pw, err := workload.PodWorkloadObject(pod)
+	if err != nil || pw == nil {
+		return false, err
+	}
+
+	icName := workload.CalculateWorkloadRuntimeObjectName(pw.Name, pw.Kind)
+	var ic odigosv1.InstrumentationConfig
+	err = r.Get(ctx, client.ObjectKey{Namespace: pw.Namespace, Name: icName}, &ic)
+	if err != nil {
+		return false, client.IgnoreNotFound(err)
+	}
+	return true, nil
+}
+
+func (r *NodesReconciler) syncInstrumentedPodsNodeLabel(ctx context.Context, node *corev1.Node, hasInstrumented bool) error {
+	_, hasLabel := node.Labels[k8sconsts.InstrumentedPodsNodeLabel]
+	if hasInstrumented == hasLabel {
+		return nil
+	}
+
+	original := node.DeepCopy()
+	if node.Labels == nil {
+		node.Labels = map[string]string{}
+	}
+	if hasInstrumented {
+		node.Labels[k8sconsts.InstrumentedPodsNodeLabel] = k8sconsts.InstrumentedPodsNodeLabelValue
+	} else {
+		delete(node.Labels, k8sconsts.InstrumentedPodsNodeLabel)
+	}
+
+	return r.Patch(ctx, node, client.MergeFrom(original))
+}
+
+// removeInstrumentedPodsNodeLabelsRunnable strips leftover InstrumentedPodsNodeLabel
+// from all nodes when schedule-only-on-instrumented-nodes is disabled.
+type removeInstrumentedPodsNodeLabelsRunnable struct {
+	Client client.Client
+}
+
+func (r *removeInstrumentedPodsNodeLabelsRunnable) NeedLeaderElection() bool {
+	return true
+}
+
+func (r *removeInstrumentedPodsNodeLabelsRunnable) Start(ctx context.Context) error {
+	var nodes corev1.NodeList
+	if err := r.Client.List(ctx, &nodes, client.HasLabels{k8sconsts.InstrumentedPodsNodeLabel}); err != nil {
+		return err
+	}
+
+	patch, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"labels": map[string]any{
+				k8sconsts.InstrumentedPodsNodeLabel: nil,
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	for i := range nodes.Items {
+		if err := r.Client.Patch(ctx, &nodes.Items[i], client.RawPatch(types.MergePatchType, patch)); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/instrumentor/controllers/instrumentednodes/pods_controller.go
+++ b/instrumentor/controllers/instrumentednodes/pods_controller.go
@@ -1,0 +1,190 @@
+package instrumentednodes
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	"github.com/odigos-io/odigos/api/k8sconsts"
+	commonlogger "github.com/odigos-io/odigos/common/logger"
+	"github.com/odigos-io/odigos/k8sutils/pkg/utils"
+)
+
+const maxPodNodeTrackerSize = 10000
+
+// podNodeNamePredicate triggers on pod create/delete and when Spec.NodeName changes.
+type podNodeNamePredicate struct{}
+
+func (p podNodeNamePredicate) Create(e event.CreateEvent) bool {
+	return true
+}
+
+func (p podNodeNamePredicate) Update(e event.UpdateEvent) bool {
+	oldPod, okOld := e.ObjectOld.(*corev1.Pod)
+	newPod, okNew := e.ObjectNew.(*corev1.Pod)
+	if !okOld || !okNew {
+		return false
+	}
+	// NodeName only transitions from empty to set when the pod is scheduled;
+	// Kubernetes never reassigns an existing pod to a different node.
+	return oldPod.Spec.NodeName != newPod.Spec.NodeName
+}
+
+func (p podNodeNamePredicate) Delete(e event.DeleteEvent) bool {
+	return true
+}
+
+func (p podNodeNamePredicate) Generic(e event.GenericEvent) bool {
+	return false
+}
+
+// podNodeTracker maps pod name+namespace to its node so deletes can still sync the node.
+// when a pod is deleted, we cannot "Get" it and discover the node it was running on,
+// thus we need to maintain our track to be able to sync the node when a pod is deleted
+type podNodeTracker struct {
+	mu       sync.Mutex
+	podNodes map[ctrl.Request]string
+}
+
+func newPodNodeTracker() *podNodeTracker {
+	return &podNodeTracker{
+		podNodes: make(map[ctrl.Request]string),
+	}
+}
+
+func (t *podNodeTracker) Get(req ctrl.Request) (string, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	node, ok := t.podNodes[req]
+	return node, ok
+}
+
+func (t *podNodeTracker) Set(req ctrl.Request, nodeName string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.podNodes) >= maxPodNodeTrackerSize {
+		return fmt.Errorf("pod node tracker is at max size: %d, skipping set", maxPodNodeTrackerSize)
+	}
+	t.podNodes[req] = nodeName
+	return nil
+}
+
+func (t *podNodeTracker) Delete(req ctrl.Request) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.podNodes, req)
+}
+
+// PodsReconciler syncs the instrumented-pods node label when pods are created,
+// scheduled, or deleted.
+type PodsReconciler struct {
+	client.Client
+	PodNodes           *podNodeTracker
+	NodeLabelRetention time.Duration
+}
+
+func (r *PodsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := commonlogger.FromContext(ctx)
+
+	var pod corev1.Pod
+	err := r.Get(ctx, req.NamespacedName, &pod)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return r.handleDeletedPod(ctx, req)
+		}
+		return ctrl.Result{}, err
+	}
+
+	_, hasOdigosAgentsMetaHashLabel := pod.Labels[k8sconsts.OdigosAgentsMetaHashLabel]
+	if !hasOdigosAgentsMetaHashLabel {
+		// for live pods, the pod reconcile only cares about them if they have the label,
+		// e.g. - to set the node label when the first pod with agents is scheduled on the node.
+		// "new sources" and "no restart" cases are handled by different reconcilers
+		return ctrl.Result{}, nil
+	}
+
+	previousNode, _ := r.PodNodes.Get(req)
+	nodeName := pod.Spec.NodeName
+	if nodeName != "" {
+		if err := r.PodNodes.Set(req, nodeName); err != nil {
+			logger.Error(err, "error setting pod to node mapping", "pod", req.NamespacedName)
+		}
+	}
+
+	var requeueAfter time.Duration
+	if nodeName != "" {
+		ra, err := syncNode(ctx, r.Client, nodeName, r.NodeLabelRetention)
+		if err != nil {
+			return utils.K8SUpdateErrorHandler(err)
+		}
+		requeueAfter = ra
+		logger.Info("synced instrumented pods node label", "node", nodeName, "pod", req.NamespacedName)
+	}
+
+	if previousNode != "" && previousNode != nodeName {
+		// node name should not change after the pod is scheduled,
+		// so this case is not actually expected to happen,
+		// but it's here for completeness, robustness practices,
+		// so if for any reason it does, the controller keeps the states consistent
+		logger.Info("pod node name changed after scheduling, syncing previous node", "pod", req.NamespacedName, "previousNode", previousNode, "nodeName", nodeName)
+		ra, err := syncNode(ctx, r.Client, previousNode, r.NodeLabelRetention)
+		if err != nil {
+			return utils.K8SUpdateErrorHandler(err)
+		}
+		if ra > 0 && (requeueAfter == 0 || ra < requeueAfter) {
+			requeueAfter = ra
+		}
+	}
+
+	if requeueAfter > 0 {
+		return ctrl.Result{RequeueAfter: requeueAfter}, nil
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *PodsReconciler) handleDeletedPod(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// deleted pod cannot be used to find it's node name, so we use our cache to sync the node
+	// we need to do it for all pods (both with and without the label)
+	// to correctly account for when a "no restart" pod is deleted and the label should be removed
+	nodeName, ok := r.PodNodes.Get(req)
+	if !ok || nodeName == "" {
+		return ctrl.Result{}, nil
+	}
+
+	// shortcut - deleted pods can only remove the label, so if it's not here already we can return early
+	n := &corev1.Node{}
+	err := r.Client.Get(ctx, client.ObjectKey{Name: nodeName}, n)
+	if err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			r.PodNodes.Delete(req)
+			return ctrl.Result{}, nil
+		}
+		return utils.K8SUpdateErrorHandler(err)
+	}
+	_, nodeHasInstrumentedPodsLabel := n.Labels[k8sconsts.FirstInstrumentedPodAtNodeLabel]
+	if !nodeHasInstrumentedPodsLabel {
+		// already has no label, so nothing to do
+		r.PodNodes.Delete(req)
+		return ctrl.Result{}, nil
+	}
+
+	requeueAfter, err := syncNode(ctx, r.Client, nodeName, r.NodeLabelRetention)
+	if err != nil {
+		return utils.K8SUpdateErrorHandler(err)
+	}
+	if requeueAfter > 0 {
+		// keep the tracker entry so a requeue can still resolve the node name
+		return ctrl.Result{RequeueAfter: requeueAfter}, nil
+	}
+
+	// delete only after sync, since we need this record in cache if we are going to retry
+	r.PodNodes.Delete(req)
+	return ctrl.Result{}, nil
+}

--- a/instrumentor/controllers/instrumentednodes/pods_controller.go
+++ b/instrumentor/controllers/instrumentednodes/pods_controller.go
@@ -2,8 +2,6 @@ package instrumentednodes
 
 import (
 	"context"
-	"fmt"
-	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -17,13 +15,13 @@ import (
 	"github.com/odigos-io/odigos/k8sutils/pkg/utils"
 )
 
-const maxPodNodeTrackerSize = 10000
-
-// podNodeNamePredicate triggers on pod create/delete and when Spec.NodeName changes.
+// podNodeNamePredicate triggers on pod create and when Spec.NodeName changes.
+// Deletes are ignored: once a pod is gone we cannot discover its node name.
 type podNodeNamePredicate struct{}
 
 func (p podNodeNamePredicate) Create(e event.CreateEvent) bool {
-	return true
+	pod, ok := e.Object.(*corev1.Pod)
+	return ok && pod.Spec.NodeName != ""
 }
 
 func (p podNodeNamePredicate) Update(e event.UpdateEvent) bool {
@@ -38,55 +36,17 @@ func (p podNodeNamePredicate) Update(e event.UpdateEvent) bool {
 }
 
 func (p podNodeNamePredicate) Delete(e event.DeleteEvent) bool {
-	return true
+	return false
 }
 
 func (p podNodeNamePredicate) Generic(e event.GenericEvent) bool {
 	return false
 }
 
-// podNodeTracker maps pod name+namespace to its node so deletes can still sync the node.
-// when a pod is deleted, we cannot "Get" it and discover the node it was running on,
-// thus we need to maintain our track to be able to sync the node when a pod is deleted
-type podNodeTracker struct {
-	mu       sync.Mutex
-	podNodes map[ctrl.Request]string
-}
-
-func newPodNodeTracker() *podNodeTracker {
-	return &podNodeTracker{
-		podNodes: make(map[ctrl.Request]string),
-	}
-}
-
-func (t *podNodeTracker) Get(req ctrl.Request) (string, bool) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	node, ok := t.podNodes[req]
-	return node, ok
-}
-
-func (t *podNodeTracker) Set(req ctrl.Request, nodeName string) error {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if len(t.podNodes) >= maxPodNodeTrackerSize {
-		return fmt.Errorf("pod node tracker is at max size: %d, skipping set", maxPodNodeTrackerSize)
-	}
-	t.podNodes[req] = nodeName
-	return nil
-}
-
-func (t *podNodeTracker) Delete(req ctrl.Request) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	delete(t.podNodes, req)
-}
-
-// PodsReconciler syncs the instrumented-pods node label when pods are created,
-// scheduled, or deleted.
+// PodsReconciler syncs the instrumented-pods node label when pods are created
+// or scheduled. Deleted pods are not handled here (node name is unknown).
 type PodsReconciler struct {
 	client.Client
-	PodNodes           *podNodeTracker
 	NodeLabelRetention time.Duration
 }
 
@@ -97,7 +57,7 @@ func (r *PodsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	err := r.Get(ctx, req.NamespacedName, &pod)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return r.handleDeletedPod(ctx, req)
+			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
 	}
@@ -110,68 +70,8 @@ func (r *PodsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, nil
 	}
 
-	previousNode, _ := r.PodNodes.Get(req)
 	nodeName := pod.Spec.NodeName
-	if nodeName != "" {
-		if err := r.PodNodes.Set(req, nodeName); err != nil {
-			logger.Error(err, "error setting pod to node mapping", "pod", req.NamespacedName)
-		}
-	}
-
-	var requeueAfter time.Duration
-	if nodeName != "" {
-		ra, err := syncNode(ctx, r.Client, nodeName, r.NodeLabelRetention)
-		if err != nil {
-			return utils.K8SUpdateErrorHandler(err)
-		}
-		requeueAfter = ra
-		logger.Info("synced instrumented pods node label", "node", nodeName, "pod", req.NamespacedName)
-	}
-
-	if previousNode != "" && previousNode != nodeName {
-		// node name should not change after the pod is scheduled,
-		// so this case is not actually expected to happen,
-		// but it's here for completeness, robustness practices,
-		// so if for any reason it does, the controller keeps the states consistent
-		logger.Info("pod node name changed after scheduling, syncing previous node", "pod", req.NamespacedName, "previousNode", previousNode, "nodeName", nodeName)
-		ra, err := syncNode(ctx, r.Client, previousNode, r.NodeLabelRetention)
-		if err != nil {
-			return utils.K8SUpdateErrorHandler(err)
-		}
-		if ra > 0 && (requeueAfter == 0 || ra < requeueAfter) {
-			requeueAfter = ra
-		}
-	}
-
-	if requeueAfter > 0 {
-		return ctrl.Result{RequeueAfter: requeueAfter}, nil
-	}
-	return ctrl.Result{}, nil
-}
-
-func (r *PodsReconciler) handleDeletedPod(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	// deleted pod cannot be used to find it's node name, so we use our cache to sync the node
-	// we need to do it for all pods (both with and without the label)
-	// to correctly account for when a "no restart" pod is deleted and the label should be removed
-	nodeName, ok := r.PodNodes.Get(req)
-	if !ok || nodeName == "" {
-		return ctrl.Result{}, nil
-	}
-
-	// shortcut - deleted pods can only remove the label, so if it's not here already we can return early
-	n := &corev1.Node{}
-	err := r.Client.Get(ctx, client.ObjectKey{Name: nodeName}, n)
-	if err != nil {
-		if client.IgnoreNotFound(err) == nil {
-			r.PodNodes.Delete(req)
-			return ctrl.Result{}, nil
-		}
-		return utils.K8SUpdateErrorHandler(err)
-	}
-	_, nodeHasInstrumentedPodsLabel := n.Labels[k8sconsts.FirstInstrumentedPodAtNodeLabel]
-	if !nodeHasInstrumentedPodsLabel {
-		// already has no label, so nothing to do
-		r.PodNodes.Delete(req)
+	if nodeName == "" {
 		return ctrl.Result{}, nil
 	}
 
@@ -179,12 +79,10 @@ func (r *PodsReconciler) handleDeletedPod(ctx context.Context, req ctrl.Request)
 	if err != nil {
 		return utils.K8SUpdateErrorHandler(err)
 	}
+	logger.Info("synced instrumented pods node label", "node", nodeName, "pod", req.NamespacedName)
+
 	if requeueAfter > 0 {
-		// keep the tracker entry so a requeue can still resolve the node name
 		return ctrl.Result{RequeueAfter: requeueAfter}, nil
 	}
-
-	// delete only after sync, since we need this record in cache if we are going to retry
-	r.PodNodes.Delete(req)
 	return ctrl.Result{}, nil
 }

--- a/instrumentor/controllers/instrumentednodes/sync.go
+++ b/instrumentor/controllers/instrumentednodes/sync.go
@@ -1,0 +1,151 @@
+package instrumentednodes
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/odigos-io/odigos/api/k8sconsts"
+	odigosv1 "github.com/odigos-io/odigos/api/odigos/v1alpha1"
+	"github.com/odigos-io/odigos/k8sutils/pkg/workload"
+)
+
+const podNodeNameIndex = "spec.nodeName"
+
+func syncNode(ctx context.Context, c client.Client, nodeName string, nodeLabelRetention time.Duration) (time.Duration, error) {
+	var node corev1.Node
+	err := c.Get(ctx, client.ObjectKey{Name: nodeName}, &node)
+	if err != nil {
+		return 0, client.IgnoreNotFound(err)
+	}
+
+	hasInstrumented, err := hasInstrumentedPod(ctx, c, node.Name)
+	if err != nil {
+		return 0, err
+	}
+
+	return syncFirstInstrumentedPodAtNodeLabel(ctx, c, &node, hasInstrumented, nodeLabelRetention)
+}
+
+func hasInstrumentedPod(ctx context.Context, c client.Client, nodeName string) (bool, error) {
+	var pods corev1.PodList
+	err := c.List(ctx, &pods, client.MatchingFields{podNodeNameIndex: nodeName})
+	if err != nil {
+		return false, err
+	}
+
+	// first do a quick and cheap check for the OdigosAgentsMetaHashLabel
+	// if found, we don't need to check for pods instrumented with "no restart"
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if _, ok := pod.Labels[k8sconsts.OdigosAgentsMetaHashLabel]; ok {
+			return true, nil
+		}
+	}
+
+	// this check requires us to list the instrumentation configs,
+	// so we do it only when neccecary
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		hasIC, err := podHasInstrumentationConfig(ctx, c, pod)
+		if err != nil {
+			return false, err
+		}
+		if hasIC {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func podHasInstrumentationConfig(ctx context.Context, c client.Client, pod *corev1.Pod) (bool, error) {
+	pw, err := workload.PodWorkloadObject(pod)
+	if err != nil || pw == nil {
+		return false, err
+	}
+
+	icName := workload.CalculateWorkloadRuntimeObjectName(pw.Name, pw.Kind)
+	var ic odigosv1.InstrumentationConfig
+	err = c.Get(ctx, client.ObjectKey{Namespace: pw.Namespace, Name: icName}, &ic)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func syncFirstInstrumentedPodAtNodeLabel(ctx context.Context, c client.Client, node *corev1.Node, hasInstrumented bool, nodeLabelRetention time.Duration) (time.Duration, error) {
+	labelValue, hasLabel := node.Labels[k8sconsts.FirstInstrumentedPodAtNodeLabel]
+
+	if hasInstrumented {
+
+		if hasLabel {
+			// already has label, nothing to do
+			return 0, nil
+		}
+		// set the label
+		now := time.Now().UTC().Format(k8sconsts.FirstInstrumentedPodAtNodeLabelTimeFormat)
+		err := patchFirstInstrumentedPodAtNodeLabel(ctx, c, node, now)
+		if err != nil {
+			return 0, err
+		}
+		return 0, nil
+
+	} else {
+
+		if !hasLabel {
+			// already has no label, nothing to do
+			return 0, nil
+		}
+		// check for rate limiting
+		requeueAfter, delayRemoval := retentionRemaining(labelValue, nodeLabelRetention)
+		if delayRemoval {
+			return requeueAfter, nil
+		}
+		// remove the label
+		err := patchFirstInstrumentedPodAtNodeLabel(ctx, c, node, nil)
+		if err != nil {
+			return 0, err
+		}
+		return 0, nil
+	}
+}
+
+func patchFirstInstrumentedPodAtNodeLabel(ctx context.Context, c client.Client, node *corev1.Node, value any) error {
+	patch, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"labels": map[string]any{
+				k8sconsts.FirstInstrumentedPodAtNodeLabel: value,
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	return c.Patch(ctx, node, client.RawPatch(types.MergePatchType, patch))
+}
+
+// retentionRemaining reports whether removal should wait, and for how long.
+// Unparseable label values (e.g. legacy "true") are treated as eligible for immediate removal.
+func retentionRemaining(labelValue string, nodeLabelRetention time.Duration) (time.Duration, bool) {
+	if nodeLabelRetention <= 0 {
+		return 0, false
+	}
+	discoveredAt, err := time.Parse(k8sconsts.FirstInstrumentedPodAtNodeLabelTimeFormat, labelValue)
+	if err != nil {
+		return 0, false
+	}
+	remaining := discoveredAt.UTC().Add(nodeLabelRetention).Sub(time.Now().UTC())
+	if remaining <= 0 {
+		return 0, false
+	}
+	return remaining, true
+}

--- a/instrumentor/controllers/instrumentednodes/sync.go
+++ b/instrumentor/controllers/instrumentednodes/sync.go
@@ -85,37 +85,24 @@ func podHasInstrumentationConfig(ctx context.Context, c client.Client, pod *core
 func syncFirstInstrumentedPodAtNodeLabel(ctx context.Context, c client.Client, node *corev1.Node, hasInstrumented bool, nodeLabelRetention time.Duration) (time.Duration, error) {
 	labelValue, hasLabel := node.Labels[k8sconsts.FirstInstrumentedPodAtNodeLabel]
 
-	if hasInstrumented {
+	// label already reflects the desired state
+	if hasInstrumented == hasLabel {
+		return 0, nil
+	}
 
-		if hasLabel {
-			// already has label, nothing to do
-			return 0, nil
-		}
-		// set the label
+	if hasInstrumented {
+		// node just got it's first instrumented pod: sttamp it with the current time
 		now := time.Now().UTC().Format(k8sconsts.FirstInstrumentedPodAtNodeLabelTimeFormat)
 		err := patchFirstInstrumentedPodAtNodeLabel(ctx, c, node, now)
-		if err != nil {
-			return 0, err
-		}
-		return 0, nil
-
+		return 0, err
 	} else {
-
-		if !hasLabel {
-			// already has no label, nothing to do
-			return 0, nil
-		}
-		// check for rate limiting
+		// no instrumented pods left: remove the label but only after the retention period
 		requeueAfter, delayRemoval := retentionRemaining(labelValue, nodeLabelRetention)
 		if delayRemoval {
 			return requeueAfter, nil
 		}
-		// remove the label
 		err := patchFirstInstrumentedPodAtNodeLabel(ctx, c, node, nil)
-		if err != nil {
-			return 0, err
-		}
-		return 0, nil
+		return 0, err
 	}
 }
 

--- a/instrumentor/controllers/manager.go
+++ b/instrumentor/controllers/manager.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/odigos-io/odigos/common"
 	"github.com/odigos-io/odigos/distros"
 	"github.com/odigos-io/odigos/instrumentor/controllers/agentenabled"
+	"github.com/odigos-io/odigos/instrumentor/controllers/instrumentednodes"
 	"github.com/odigos-io/odigos/instrumentor/controllers/podsmanifestinjectionstatus"
 	"github.com/odigos-io/odigos/instrumentor/controllers/sourceinstrumentation"
 
@@ -169,7 +171,7 @@ func durationPointer(d time.Duration) *time.Duration {
 	return &d
 }
 
-func SetupWithManager(mgr manager.Manager, dp *distros.Provider, k8sVersion *version.Version) error {
+func SetupWithManager(ctx context.Context, mgr manager.Manager, dp *distros.Provider, k8sVersion *version.Version, scheduleOdigletOnlyOnInstrumentedNodes bool) error {
 	err := agentenabled.SetupWithManager(mgr, dp)
 	if err != nil {
 		return fmt.Errorf("failed to create controller for agent enabled: %w", err)
@@ -183,6 +185,18 @@ func SetupWithManager(mgr manager.Manager, dp *distros.Provider, k8sVersion *ver
 	err = podsmanifestinjectionstatus.SetupWithManager(mgr)
 	if err != nil {
 		return fmt.Errorf("failed to create controller for pod injection: %w", err)
+	}
+
+	if scheduleOdigletOnlyOnInstrumentedNodes {
+		err = instrumentednodes.SetupWithManager(ctx, mgr)
+		if err != nil {
+			return fmt.Errorf("failed to create controller for instrumented nodes: %w", err)
+		}
+	} else {
+		err = instrumentednodes.SetupLabelCleanupWithManager(mgr)
+		if err != nil {
+			return fmt.Errorf("failed to register instrumented pods node labels cleanup: %w", err)
+		}
 	}
 
 	return nil
@@ -248,6 +262,10 @@ func podTransformFunc(obj interface{}) (interface{}, error) {
 	strippedPod := corev1.Pod{
 		ObjectMeta: pod.ObjectMeta,
 		Status:     stripedStatus,
+		// Keep NodeName so pods can be listed by node via a field index.
+		Spec: corev1.PodSpec{
+			NodeName: pod.Spec.NodeName,
+		},
 	}
 	if workload.IsStaticPod(pod) {
 		strippedPod.Spec = pod.Spec

--- a/instrumentor/controllers/manager.go
+++ b/instrumentor/controllers/manager.go
@@ -171,7 +171,7 @@ func durationPointer(d time.Duration) *time.Duration {
 	return &d
 }
 
-func SetupWithManager(ctx context.Context, mgr manager.Manager, dp *distros.Provider, k8sVersion *version.Version, scheduleOdigletOnlyOnInstrumentedNodes bool) error {
+func SetupWithManager(ctx context.Context, mgr manager.Manager, dp *distros.Provider, k8sVersion *version.Version, scheduleOdigletOnlyOnInstrumentedNodes bool, instrumentedPodsNodeLabelRetention time.Duration) error {
 	err := agentenabled.SetupWithManager(mgr, dp)
 	if err != nil {
 		return fmt.Errorf("failed to create controller for agent enabled: %w", err)
@@ -188,14 +188,9 @@ func SetupWithManager(ctx context.Context, mgr manager.Manager, dp *distros.Prov
 	}
 
 	if scheduleOdigletOnlyOnInstrumentedNodes {
-		err = instrumentednodes.SetupWithManager(ctx, mgr)
+		err = instrumentednodes.SetupWithManager(ctx, mgr, instrumentedPodsNodeLabelRetention)
 		if err != nil {
 			return fmt.Errorf("failed to create controller for instrumented nodes: %w", err)
-		}
-	} else {
-		err = instrumentednodes.SetupLabelCleanupWithManager(mgr)
-		if err != nil {
-			return fmt.Errorf("failed to register instrumented pods node labels cleanup: %w", err)
 		}
 	}
 

--- a/instrumentor/instrumentor.go
+++ b/instrumentor/instrumentor.go
@@ -99,8 +99,7 @@ func New(opts controllers.KubeManagerOptions, dp *distros.Provider, waspMutator 
 	}
 
 	// wire up the controllers and webhooks
-	scheduleOdigletOnlyOnInstrumentedNodes := os.Getenv(k8sconsts.OdigletScheduleOnlyOnInstrumentedNodesEnvVar) == "true"
-	instrumentedPodsNodeLabelRetention := parseFirstInstrumentedPodAtNodeLabelRetention()
+	scheduleOdigletOnlyOnInstrumentedNodes, instrumentedPodsNodeLabelRetention := parseFirstInstrumentedPodAtNodeLabelRetention()
 	err = controllers.SetupWithManager(context.Background(), mgr, dp, k8sVersion, scheduleOdigletOnlyOnInstrumentedNodes, instrumentedPodsNodeLabelRetention)
 	if err != nil {
 		return nil, err
@@ -199,19 +198,19 @@ func (i *Instrumentor) Run(ctx context.Context, odigosTelemetryDisabled bool) {
 	}
 }
 
-func parseFirstInstrumentedPodAtNodeLabelRetention() time.Duration {
+func parseFirstInstrumentedPodAtNodeLabelRetention() (enabled bool, retention time.Duration) {
 	raw := os.Getenv(k8sconsts.FirstInstrumentedPodAtNodeLabelRetentionEnvVar)
 	if raw == "" {
-		return 0
+		return false, 0
 	}
 	d, err := time.ParseDuration(raw)
 	if err != nil {
-		commonlogger.LoggerCompat().Error("invalid instrumented pods node label retention, using 0",
+		commonlogger.LoggerCompat().Error("invalid instrumented pods node label retention, using 5m",
 			"env", k8sconsts.FirstInstrumentedPodAtNodeLabelRetentionEnvVar, "value", raw, "err", err)
-		return 0
+		return true, 5 * time.Minute
 	}
 	if d < 0 {
-		return 0
+		d = 0
 	}
-	return d
+	return true, d
 }

--- a/instrumentor/instrumentor.go
+++ b/instrumentor/instrumentor.go
@@ -100,7 +100,8 @@ func New(opts controllers.KubeManagerOptions, dp *distros.Provider, waspMutator 
 
 	// wire up the controllers and webhooks
 	scheduleOdigletOnlyOnInstrumentedNodes := os.Getenv(k8sconsts.OdigletScheduleOnlyOnInstrumentedNodesEnvVar) == "true"
-	err = controllers.SetupWithManager(context.Background(), mgr, dp, k8sVersion, scheduleOdigletOnlyOnInstrumentedNodes)
+	instrumentedPodsNodeLabelRetention := parseFirstInstrumentedPodAtNodeLabelRetention()
+	err = controllers.SetupWithManager(context.Background(), mgr, dp, k8sVersion, scheduleOdigletOnlyOnInstrumentedNodes, instrumentedPodsNodeLabelRetention)
 	if err != nil {
 		return nil, err
 	}
@@ -196,4 +197,21 @@ func (i *Instrumentor) Run(ctx context.Context, odigosTelemetryDisabled bool) {
 	if err != nil {
 		logger.Error("Instrumentor exited with error", "err", err)
 	}
+}
+
+func parseFirstInstrumentedPodAtNodeLabelRetention() time.Duration {
+	raw := os.Getenv(k8sconsts.FirstInstrumentedPodAtNodeLabelRetentionEnvVar)
+	if raw == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		commonlogger.LoggerCompat().Error("invalid instrumented pods node label retention, using 0",
+			"env", k8sconsts.FirstInstrumentedPodAtNodeLabelRetentionEnvVar, "value", raw, "err", err)
+		return 0
+	}
+	if d < 0 {
+		return 0
+	}
+	return d
 }

--- a/instrumentor/instrumentor.go
+++ b/instrumentor/instrumentor.go
@@ -99,7 +99,8 @@ func New(opts controllers.KubeManagerOptions, dp *distros.Provider, waspMutator 
 	}
 
 	// wire up the controllers and webhooks
-	err = controllers.SetupWithManager(mgr, dp, k8sVersion)
+	scheduleOdigletOnlyOnInstrumentedNodes := os.Getenv(k8sconsts.OdigletScheduleOnlyOnInstrumentedNodesEnvVar) == "true"
+	err = controllers.SetupWithManager(context.Background(), mgr, dp, k8sVersion, scheduleOdigletOnlyOnInstrumentedNodes)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds an opt-in Helm setting `odiglet.scheduleOnlyOnInstrumentedNodes` so odiglet DaemonSet pods are scheduled only on nodes that already run instrumented workloads. This is intended for the `k8s-init-container` mount method, where agents do not need odiglet present on every node.

When enabled:
- the instrumentor maintains the `odigos.io/instrumented-pods` node label from instrumented pods / InstrumentationConfigs
- the odiglet DaemonSet gets a matching `nodeSelector`
- toggling the flag sets/clears an instrumentor env var so the controllers (or a one-shot label cleanup runnable) are registered on restart

When disabled, leftover node labels are cleaned up by a leader-elected runnable.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
```release-note
Add odiglet.scheduleOnlyOnInstrumentedNodes to schedule odiglet only on nodes that already have instrumented pods (requires instrumentor.mountMethod=k8s-init-container).
```

Linear: https://linear.app/odigos/issue/CORE-1637