### PR TITLE
RUN-1121 | feat: run odiglet and data-collection as non-privileged by default

### DIFF
--- a/helm/odigos/templates/odiglet/daemonset.yaml
+++ b/helm/odigos/templates/odiglet/daemonset.yaml
@@ -182,9 +182,14 @@ spec:
             privileged: false
             capabilities:
               add:
-              {{- with .Values.odiglet.odiglet.capabilities }}
-              {{- toYaml . | nindent 14 }}
+              {{- $caps := .Values.odiglet.odiglet.capabilities | default list }}
+              {{- if not (include "odigos.secretExists" .) }}
+              {{- /* the community go instrumentation checks that the target process is alive with
+                     kill(pid, 0), which needs CAP_KILL when the target runs as a different user.
+                     the enterprise distro stats /proc/<pid> instead and needs no capability. */}}
+              {{- if not (has "KILL" $caps) }}{{- $caps = append $caps "KILL" }}{{- end }}
               {{- end }}
+              {{- toYaml $caps | nindent 14 }}
               drop:
                 - ALL
             # for Kubernetes >= 1.30 we can specify AppArmor profile in securityContext

--- a/helm/odigos/templates/odiglet/daemonset.yaml
+++ b/helm/odigos/templates/odiglet/daemonset.yaml
@@ -21,11 +21,7 @@
     {{- end -}}
   {{- end -}}
 {{- end -}}
-{{- $privilegedRequired := or $collectLogs $collectMetrics -}}
 {{- $k8sVersion := include "utils.cleanKubeVersion" . }}
-{{- if and $privilegedRequired .Values.odiglet.unPrivileged }}
-{{ fail "privileged mode is required when collecting logs or metrics, this is currently not supported in unprivileged mode" }}
-{{- end }}
 {{- if and $networkMetricsEnabled .Values.odiglet.noHostNetwork }}
 {{ fail "odiglet.noHostNetwork cannot be true when metricsSources.networkMetrics.enabled is true, since OBI network metrics require hostNetwork" }}
 {{- end }}
@@ -57,7 +53,7 @@ spec:
         app.kubernetes.io/name: odiglet
         odigos.io/collector-role: NODE_COLLECTOR
       annotations:
-        {{- if and (.Values.odiglet.unPrivileged) (semverCompare "<1.30.0" $k8sVersion) }}
+        {{- if and (not .Values.odiglet.odiglet.privileged) (semverCompare "<1.30.0" $k8sVersion) }}
         # Prior to Kubernetes v1.30, AppArmor profile was specified through annotations.
         container.apparmor.security.beta.kubernetes.io/odiglet: unconfined
         {{- end }}
@@ -107,7 +103,7 @@ spec:
           {{- end }}
           {{- end }}
           securityContext:
-          {{- if not .Values.odiglet.unPrivileged}}
+          {{- if .Values.odiglet.odiglet.privileged}}
             privileged: true
           {{- end }}
           env:
@@ -180,7 +176,7 @@ spec:
             - /root/odiglet
           imagePullPolicy: IfNotPresent
           securityContext:
-            {{- if not .Values.odiglet.unPrivileged }}
+            {{- if .Values.odiglet.odiglet.privileged }}
             privileged: true
             {{- else }}
             privileged: false
@@ -308,17 +304,25 @@ spec:
             - --config=k8scm:{{ .Release.Namespace }}/odigos-data-collection/conf
             - --feature-gates=service.profilesSupport
           securityContext:
-            {{- if $privilegedRequired }}
+            {{- if .Values.odiglet.dataCollection.privileged }}
             privileged: true
             {{- else }}
             privileged: false
             capabilities:
               add:
-              {{- with .Values.odiglet.dataCollection.capabilities }}
-              {{- toYaml . | nindent 14 }}
+              {{- $caps := .Values.odiglet.dataCollection.capabilities | default list }}
+              {{- if .Values.profiling.enabled }}
+              {{- /* the eBPF profiler reads /proc/kallsyms addresses and raises RLIMIT_MEMLOCK */}}
+              {{- if not (has "SYSLOG" $caps) }}{{- $caps = append $caps "SYSLOG" }}{{- end }}
+              {{- if not (has "SYS_RESOURCE" $caps) }}{{- $caps = append $caps "SYS_RESOURCE" }}{{- end }}
               {{- end }}
+              {{- toYaml $caps | nindent 14 }}
               drop:
                 - ALL
+            {{- with .Values.odiglet.dataCollection.seLinuxOptions }}
+            seLinuxOptions:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
             {{- end }}
           env:
             - name: NODE_NAME
@@ -462,7 +466,7 @@ spec:
 {{- toYaml .Values.odiglet.deviceplugin.readinessProbe | nindent 12 }}
 {{- end }}
 # CSI driver is only supported in privileged mode
-{{- if and (eq .Values.instrumentor.mountMethod "k8s-csi-driver") .Values.odiglet.unPrivileged }}
+{{- if and (eq .Values.instrumentor.mountMethod "k8s-csi-driver") (not .Values.odiglet.odiglet.privileged) }}
 {{ fail "CSI driver mount method requires privileged mode, this is not supported in unprivileged mode" }}
 {{- end }}
 {{- if eq .Values.instrumentor.mountMethod "k8s-csi-driver" }}

--- a/helm/odigos/values.schema.json
+++ b/helm/odigos/values.schema.json
@@ -1585,7 +1585,7 @@
           "description": "Configuration for the data-collection container.",
           "properties": {
             "capabilities": {
-              "description": "capabilities to add to the data-collection container when running as un privileged - this will be ignored when running as privileged.\nSYS_ADMIN required when running in unprivileged mode if one of the following is true:\n 1. kernel version is older than 5.8 (In \u003e= 5.8 BPF and PERMON were added)\n 2. kernel.perf_event_paranoid sysctl is set to 2 or higher",
+              "description": "capabilities to add to the data-collection container when running non-privileged - this will be ignored when running as privileged.\nSYS_ADMIN required when running in unprivileged mode if one of the following is true:\n 1. kernel version is older than 5.8 (In \u003e= 5.8 BPF and PERMON were added)\n 2. kernel.perf_event_paranoid sysctl is set to 2 or higher\nSYSLOG and SYS_RESOURCE are added automatically when profiling.enabled is true.",
               "items": {
                 "anyOf": [
                   {
@@ -1605,6 +1605,25 @@
               },
               "required": [],
               "title": "capabilities"
+            },
+            "privileged": {
+              "default": "false",
+              "description": "Run the data-collection container as a privileged container.",
+              "required": [],
+              "title": "privileged"
+            },
+            "seLinuxOptions": {
+              "additionalProperties": false,
+              "description": "seLinuxOptions for the data-collection container when running non-privileged.\n\"spc_t\" is the SELinux domain the container already gets when running privileged.\nThis is an advanced option and should only be changed if you know what you are doing.",
+              "properties": {
+                "type": {
+                  "default": "spc_t",
+                  "title": "type",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "seLinuxOptions"
             }
           },
           "required": [],
@@ -1810,7 +1829,7 @@
           "properties": {
             "appArmorProfile": {
               "additionalProperties": false,
-              "description": "apparmorProfile for the odiglet container when running as unPrivileged.\nthis will be ignored when running as privileged.",
+              "description": "apparmorProfile for the odiglet container when running non-privileged.\nthis will be ignored when running as privileged.",
               "properties": {
                 "type": {
                   "default": "Unconfined",
@@ -1822,9 +1841,15 @@
               "title": "appArmorProfile"
             },
             "capabilities": {
-              "description": "capabilities to add to the odiglet container when running as unPrivileged - this will be ignored when running as privileged.\nSYS_ADMIN required when running in unprivileged mode if one of the following is true:\n 1. kernel version is older than 5.8 (In \u003e= 5.8 BPF and PERMON were added)\n 2. kernel.perf_event_paranoid sysctl is set to 2 or higher\nIPC_LOCK required for mmap of perf buffers\nSYS_RESOURCE required only for kernels \u003c 5.11, used for setting rlimit for BPF maps",
+              "description": "capabilities to add to the odiglet container when running non-privileged - this will be ignored when running as privileged.\nSYS_ADMIN required when running in unprivileged mode if one of the following is true:\n 1. kernel version is older than 5.8 (In \u003e= 5.8 BPF and PERMON were added)\n 2. kernel.perf_event_paranoid sysctl is set to 2 or higher\nIPC_LOCK required for mmap of perf buffers\nSYS_RESOURCE required only for kernels \u003c 5.11, used for setting rlimit for BPF maps",
               "items": {
                 "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  },
                   {
                     "type": "string"
                   },
@@ -1906,6 +1931,12 @@
               "title": "livenessProbe",
               "type": "object"
             },
+            "privileged": {
+              "default": "false",
+              "description": "Run the odiglet container, and its init container, as privileged containers.",
+              "required": [],
+              "title": "privileged"
+            },
             "readinessProbe": {
               "additionalProperties": false,
               "properties": {
@@ -1939,7 +1970,7 @@
             },
             "seLinuxOptions": {
               "additionalProperties": false,
-              "description": "SELinux options for the odiglet container when running as unPrivileged.\nIgnored when running as privileged, since container runtimes drop the label in that mode.\nOn SELinux enforcing nodes odiglet needs a privileged SELinux domain to inspect and\ninstrument application processes. \"spc_t\" is that domain in the standard container policy\n(https://github.com/containers/container-selinux/blob/v2.232.1/container.te#L105), and on\nBottlerocket, which aliases it to its own \"control_t\".\nAdjust the type if your nodes use a custom SELinux policy, or set to null to leave the\nlabel to the container runtime.",
+              "description": "SELinux options for the odiglet container when running non-privileged.\nIgnored when running as privileged, since container runtimes drop the label in that mode.\nOn SELinux enforcing nodes odiglet needs a privileged SELinux domain to inspect and\ninstrument application processes. \"spc_t\" is that domain in the standard container policy\n(https://github.com/containers/container-selinux/blob/v2.232.1/container.te#L105), and on\nBottlerocket, which aliases it to its own \"control_t\".\nAdjust the type if your nodes use a custom SELinux policy, or set to null to leave the\nlabel to the container runtime.\nThis is an advanced option and should only be changed if you know what you are doing.",
               "properties": {
                 "level": {
                   "default": "s0",
@@ -1973,7 +2004,7 @@
         },
         "runAsNonRoot": {
           "default": "false",
-          "description": "runAsNonRoot can be set to true to run the containers in the odiglet daemonset as non-root.\nwhen true, each container uses the non-root USER declared in its image (e.g. 65532).\nby default (false), all containers are forced to run as UID/GID 0.\n\nThis setting only changes the UID the containers run as. It does not change the Linux capabilities\ngranted to odiglet (those are controlled separately via unPrivileged and the capabilities lists).\nOperations relying on root's implicit filesystem access can fail as non-root:\ne.g. writing agent files to root-owned host paths (/var/odigos).",
+          "description": "runAsNonRoot can be set to true to run the containers in the odiglet daemonset as non-root.\nwhen true, each container uses the non-root USER declared in its image (e.g. 65532).\nby default (false), all containers are forced to run as UID/GID 0.\n\nThis setting only changes the UID the containers run as. It does not change the Linux capabilities\ngranted to odiglet (those are controlled separately via the per-container privileged and capabilities values).\nOperations relying on root's implicit filesystem access can fail as non-root:\ne.g. writing agent files to root-owned host paths (/var/odigos).",
           "required": [],
           "title": "runAsNonRoot"
         },
@@ -2026,12 +2057,6 @@
           "description": "traceIdSuffix is a unique, 1 byte hex constant identifier for timestamp based trace id generation.\nsupported only in odigos pro (not available in community tier)",
           "required": [],
           "title": "traceIdSuffix"
-        },
-        "unPrivileged": {
-          "default": "false",
-          "description": "run the odiglet pod without privileged containers.\nwhen set to true, odiglet will use the set of capabilities required for eBPF operations.\nby default, odiglet runs as a privileged container.",
-          "required": [],
-          "title": "unPrivileged"
         }
       },
       "required": [],

--- a/helm/odigos/values.schema.json
+++ b/helm/odigos/values.schema.json
@@ -1841,7 +1841,7 @@
               "title": "appArmorProfile"
             },
             "capabilities": {
-              "description": "capabilities to add to the odiglet container when running non-privileged - this will be ignored when running as privileged.\nSYS_ADMIN required when running in unprivileged mode if one of the following is true:\n 1. kernel version is older than 5.8 (In \u003e= 5.8 BPF and PERMON were added)\n 2. kernel.perf_event_paranoid sysctl is set to 2 or higher\nIPC_LOCK required for mmap of perf buffers\nSYS_RESOURCE required only for kernels \u003c 5.11, used for setting rlimit for BPF maps",
+              "description": "capabilities to add to the odiglet container when running non-privileged - this will be ignored when running as privileged.\nSYS_ADMIN required when running in unprivileged mode if one of the following is true:\n 1. kernel version is older than 5.8 (In \u003e= 5.8 BPF and PERMON were added)\n 2. kernel.perf_event_paranoid sysctl is set to 2 or higher\nIPC_LOCK required for mmap of perf buffers\nKILL is added automatically on community installations, where the go instrumentation\nchecks that the target process is alive by signalling it.\nSYS_RESOURCE required only for kernels \u003c 5.11, used for setting rlimit for BPF maps",
               "items": {
                 "anyOf": [
                   {

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -892,7 +892,13 @@ odiglet:
 
     # @schema
     # description: |-
-    #   capabilities to add to the odiglet container when running as unPrivileged - this will be ignored when running as privileged.
+    #   Run the odiglet container, and its init container, as privileged containers.
+    # @schema
+    privileged: false
+
+    # @schema
+    # description: |-
+    #   capabilities to add to the odiglet container when running non-privileged - this will be ignored when running as privileged.
     #   SYS_ADMIN required when running in unprivileged mode if one of the following is true:
     #    1. kernel version is older than 5.8 (In >= 5.8 BPF and PERMON were added)
     #    2. kernel.perf_event_paranoid sysctl is set to 2 or higher
@@ -911,10 +917,14 @@ odiglet:
       - SETUID
       # required for jattach - dynamically instrumenting java processes.
       - SETGID
+      # required for OBI Traffic Control programs. Can be removed if OBI is not being used.
+      - NET_ADMIN
+      # required for OBI socket filter programs. Can be removed if OBI is not being used.
+      - NET_RAW
 
     # @schema
     # description: |-
-    #   apparmorProfile for the odiglet container when running as unPrivileged.
+    #   apparmorProfile for the odiglet container when running non-privileged.
     #   this will be ignored when running as privileged.
     # @schema
     appArmorProfile:
@@ -922,7 +932,7 @@ odiglet:
 
     # @schema
     # description: |-
-    #   SELinux options for the odiglet container when running as unPrivileged.
+    #   SELinux options for the odiglet container when running non-privileged.
     #   Ignored when running as privileged, since container runtimes drop the label in that mode.
     #   On SELinux enforcing nodes odiglet needs a privileged SELinux domain to inspect and
     #   instrument application processes. "spc_t" is that domain in the standard container policy
@@ -930,6 +940,7 @@ odiglet:
     #   Bottlerocket, which aliases it to its own "control_t".
     #   Adjust the type if your nodes use a custom SELinux policy, or set to null to leave the
     #   label to the container runtime.
+    #   This is an advanced option and should only be changed if you know what you are doing.
     # @schema
     seLinuxOptions:
       type: "spc_t"
@@ -959,16 +970,32 @@ odiglet:
 
     # @schema
     # description: |-
-    #   capabilities to add to the data-collection container when running as un privileged - this will be ignored when running as privileged.
+    #   capabilities to add to the data-collection container when running non-privileged - this will be ignored when running as privileged.
     #   SYS_ADMIN required when running in unprivileged mode if one of the following is true:
     #    1. kernel version is older than 5.8 (In >= 5.8 BPF and PERMON were added)
     #    2. kernel.perf_event_paranoid sysctl is set to 2 or higher
+    #   SYSLOG and SYS_RESOURCE are added automatically when profiling.enabled is true.
     # @schema
     capabilities:
       - SYS_ADMIN
       - BPF
       - PERFMON
       - IPC_LOCK
+
+    # @schema
+    # description: |-
+    #   Run the data-collection container as a privileged container.
+    # @schema
+    privileged: false
+
+    # @schema
+    # description: |-
+    #   seLinuxOptions for the data-collection container when running non-privileged.
+    #   "spc_t" is the SELinux domain the container already gets when running privileged.
+    #   This is an advanced option and should only be changed if you know what you are doing.
+    # @schema
+    seLinuxOptions:
+      type: "spc_t"
 
   # @schema
   # description: Uncomment to override the global nodeSelector (values.nodeSelector) for this component
@@ -1137,20 +1164,12 @@ odiglet:
 
   # @schema
   # description: |-
-  #   run the odiglet pod without privileged containers.
-  #   when set to true, odiglet will use the set of capabilities required for eBPF operations.
-  #   by default, odiglet runs as a privileged container.
-  # @schema
-  unPrivileged: false
-
-  # @schema
-  # description: |-
   #   runAsNonRoot can be set to true to run the containers in the odiglet daemonset as non-root.
   #   when true, each container uses the non-root USER declared in its image (e.g. 65532).
   #   by default (false), all containers are forced to run as UID/GID 0.
   #
   #   This setting only changes the UID the containers run as. It does not change the Linux capabilities
-  #   granted to odiglet (those are controlled separately via unPrivileged and the capabilities lists).
+  #   granted to odiglet (those are controlled separately via the per-container privileged and capabilities values).
   #   Operations relying on root's implicit filesystem access can fail as non-root:
   #   e.g. writing agent files to root-owned host paths (/var/odigos).
   # @schema

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -903,6 +903,8 @@ odiglet:
     #    1. kernel version is older than 5.8 (In >= 5.8 BPF and PERMON were added)
     #    2. kernel.perf_event_paranoid sysctl is set to 2 or higher
     #   IPC_LOCK required for mmap of perf buffers
+    #   KILL is added automatically on community installations, where the go instrumentation
+    #   checks that the target process is alive by signalling it.
     #   SYS_RESOURCE required only for kernels < 5.11, used for setting rlimit for BPF maps
     # @schema
     capabilities:

--- a/tests/common/assert/latest-odigos-version-installed.yaml
+++ b/tests/common/assert/latest-odigos-version-installed.yaml
@@ -77,11 +77,7 @@ spec:
   containers:
     - name: odiglet
       resources: {}
-      securityContext:
-        privileged: false
     - name: data-collection
-      securityContext:
-        privileged: false
       env:
         - name: NODE_NAME
           valueFrom:

--- a/tests/common/assert/latest-odigos-version-installed.yaml
+++ b/tests/common/assert/latest-odigos-version-installed.yaml
@@ -78,10 +78,10 @@ spec:
     - name: odiglet
       resources: {}
       securityContext:
-        privileged: true
+        privileged: false
     - name: data-collection
       securityContext:
-        privileged: true
+        privileged: false
       env:
         - name: NODE_NAME
           valueFrom:

--- a/tests/common/assert/odigos-installed-no-device-plugin.yaml
+++ b/tests/common/assert/odigos-installed-no-device-plugin.yaml
@@ -78,10 +78,10 @@ spec:
     - name: odiglet
       resources: {}
       securityContext:
-        privileged: true
+        privileged: false
     - name: data-collection
       securityContext:
-        privileged: true
+        privileged: false
       env:
         - name: NODE_NAME
           valueFrom:

--- a/tests/common/assert/odigos-installed.yaml
+++ b/tests/common/assert/odigos-installed.yaml
@@ -78,10 +78,10 @@ spec:
     - name: odiglet
       resources: {}
       securityContext:
-        privileged: true
+        privileged: false
     - name: data-collection
       securityContext:
-        privileged: true
+        privileged: false
       env:
         - name: NODE_NAME
           valueFrom:

--- a/tests/common/assert/odigos-upgraded.yaml
+++ b/tests/common/assert/odigos-upgraded.yaml
@@ -76,11 +76,11 @@ spec:
   (containers[?name=='odiglet']):
     - resources: {}
       securityContext:
-        privileged: true
+        privileged: false
       image: docker.io/keyval/odigos-odiglet:e2e-test
   (containers[?name=='data-collection']):
     - securityContext:
-        privileged: true
+        privileged: false
       env:
         - name: NODE_NAME
           valueFrom:
@@ -150,11 +150,11 @@ spec:
   (containers[?name=='odiglet']):
     - resources: {}
       securityContext:
-        privileged: true
+        privileged: false
       image: docker.io/keyval/odigos-odiglet:e2e-test
   (containers[?name=='data-collection']):
     - securityContext:
-        privileged: true
+        privileged: false
       env:
         - name: NODE_NAME
           valueFrom:

--- a/tests/e2e/helm-chart/check-data-collection-resources.sh
+++ b/tests/e2e/helm-chart/check-data-collection-resources.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-#!/usr/bin/env bash
-set -euo pipefail
-
 # Accept optional path argument
 P=${1:-"../../.."}
 
@@ -14,45 +11,37 @@ helm template odigos "$P/helm/odigos" \
   --show-only templates/odiglet/daemonset.yaml > /tmp/helm-template-output.yaml
 
 YAML_FILE="/tmp/helm-template-output.yaml"
+DC='.spec.template.spec.containers[] | select(.name=="data-collection") | .resources'
 
 echo "📋 Extracting data-collection container resources..."
-
-RESOURCES=$(grep -A 60 "name: data-collection" "$YAML_FILE" | grep -A 15 "resources:" || true)
-
-echo "🔍 Found resources section:"
-echo "$RESOURCES"
+yq "$DC" "$YAML_FILE"
 echo
 
-# --- Extraction ---
-MEMORY_REQUEST_RAW=$(echo "$RESOURCES" | grep -A 2 "requests:" | grep "memory:" | awk '{print $2}')
-MEMORY_LIMIT_RAW=$(echo "$RESOURCES" | grep -A 2 "limits:" | grep "memory:" | awk '{print $2}')
+MEMORY_REQUEST=$(yq "$DC.requests.memory" "$YAML_FILE")
+MEMORY_LIMIT=$(yq "$DC.limits.memory" "$YAML_FILE")
+CPU_REQUEST=$(yq "$DC.requests.cpu" "$YAML_FILE")
+CPU_LIMIT=$(yq "$DC.limits.cpu" "$YAML_FILE")
 
-# --- Normalization helper ---
-normalize() {
-  local val="$1"
-  # Remove quotes, carriage returns, newlines, and extra spaces
-  echo "$val" | tr -d '\r' | tr -d '\n' | sed 's/"//g' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
-}
-
-MEMORY_REQUEST=$(normalize "$MEMORY_REQUEST_RAW")
-MEMORY_LIMIT=$(normalize "$MEMORY_LIMIT_RAW")
-
-printf "🔍 Debug raw values:\n"
-printf "  MEMORY_REQUEST_RAW=[%s]\n" "$MEMORY_REQUEST_RAW"
-printf "  MEMORY_LIMIT_RAW=[%s]\n" "$MEMORY_LIMIT_RAW"
+printf "🔍 Values:\n"
+printf "  memory: request=[%s] limit=[%s]\n" "$MEMORY_REQUEST" "$MEMORY_LIMIT"
+printf "  cpu:    request=[%s] limit=[%s]\n" "$CPU_REQUEST" "$CPU_LIMIT"
 printf "\n"
 
-printf "🔍 Normalized values:\n"
-printf "  MEMORY_REQUEST=[%s]\n" "$MEMORY_REQUEST"
-printf "  MEMORY_LIMIT=[%s]\n" "$MEMORY_LIMIT"
-printf "\n"
-
-# --- Validation ---
 echo "✅ Verifying mirroring (requests should equal limits)..."
 
+rc=0
 if [[ "$MEMORY_REQUEST" == "570Mi" && "$MEMORY_LIMIT" == "570Mi" ]]; then
   echo "✅ Memory mirroring works: request=$MEMORY_REQUEST, limit=$MEMORY_LIMIT"
 else
   echo "❌ Memory mirroring failed: request='$MEMORY_REQUEST', limit='$MEMORY_LIMIT' (expected both '570Mi')"
-  exit 1
+  rc=1
 fi
+
+if [[ "$CPU_REQUEST" == "560m" && "$CPU_LIMIT" == "560m" ]]; then
+  echo "✅ CPU mirroring works: request=$CPU_REQUEST, limit=$CPU_LIMIT"
+else
+  echo "❌ CPU mirroring failed: request='$CPU_REQUEST', limit='$CPU_LIMIT' (expected both '560m')"
+  rc=1
+fi
+
+exit $rc

--- a/tests/e2e/helm-chart/verify-datacollection-resources.yaml
+++ b/tests/e2e/helm-chart/verify-datacollection-resources.yaml
@@ -15,10 +15,10 @@ spec:
     - name: odiglet
       resources: {}
       securityContext:
-        privileged: true
+        privileged: false
     - name: data-collection
       securityContext:
-        privileged: true
+        privileged: false
       env:
         - name: NODE_NAME
           valueFrom:

--- a/tests/e2e/mount-method/chainsaw-test.yaml
+++ b/tests/e2e/mount-method/chainsaw-test.yaml
@@ -136,7 +136,7 @@ spec:
             timeout: 2m
             content: |
               # Upgrade existing installation to CSI driver mount method
-              ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test --set instrumentor.mountMethod=k8s-csi-driver
+              ../../../cli/odigos install --ns odigos-test --set image.tag=e2e-test --set instrumentor.mountMethod=k8s-csi-driver --set odiglet.odiglet.privileged=true
 
     - name: '[3 - CSI Driver Test] Assert config changed successfully'
       try:

--- a/tests/e2e/mount-method/odiglet-ready-with-csi-driver.yaml
+++ b/tests/e2e/mount-method/odiglet-ready-with-csi-driver.yaml
@@ -22,7 +22,7 @@ spec:
       image: docker.io/keyval/odigos-odiglet:e2e-test
     - name: data-collection
       securityContext:
-        privileged: true
+        privileged: false
       env:
         - name: NODE_NAME
           valueFrom:
@@ -107,7 +107,7 @@ spec:
       image: docker.io/keyval/odigos-odiglet:e2e-test
     - name: data-collection
       securityContext:
-        privileged: true
+        privileged: false
       env:
         - name: NODE_NAME
           valueFrom:

--- a/tests/e2e/mount-method/odiglet-ready.yaml
+++ b/tests/e2e/mount-method/odiglet-ready.yaml
@@ -18,11 +18,11 @@ spec:
     - name: odiglet
       resources: {}
       securityContext:
-        privileged: true
+        privileged: false
       image: docker.io/keyval/odigos-odiglet:e2e-test
     - name: data-collection
       securityContext:
-        privileged: true
+        privileged: false
       env:
         - name: NODE_NAME
           valueFrom:
@@ -90,11 +90,11 @@ spec:
     - name: odiglet
       resources: {}
       securityContext:
-        privileged: true
+        privileged: false
       image: docker.io/keyval/odigos-odiglet:e2e-test
     - name: data-collection
       securityContext:
-        privileged: true
+        privileged: false
       env:
         - name: NODE_NAME
           valueFrom:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->

The odiglet daemonset ran its containers as privileged by default, and there was no explicit flag controlling the data-collection container at all — its privilege level was implied by the collected signals. Running it non-privileged required `--set signals="{traces}"`, which coupled an unrelated setting to a security decision and made logs/metrics collection
impossible without privileged mode.

This PR:
- Runs the odiglet and data-collection containers **non-privileged by default**, using the capabilities, appArmorProfile and seLinuxOptions already defined per container.
- Replaces `odiglet.unPrivileged` with per-container `odiglet.odiglet.privileged` and `odiglet.dataCollection.privileged`, both defaulting to `false`. The old key sat at the pod level but only ever controlled the odiglet and init containers, which was misleading.
- Removes the signals-derived privilege decision, so data-collection can run non-privileged with metrics and logs enabled.
- Adds `odiglet.dataCollection.seLinuxOptions` (default `spc_t`), the SELinux domain the container already receives when running privileged, so dropping privileged does not change its domain on SELinux-enforcing nodes.
- Adds `SYSLOG` and `SYS_RESOURCE` to data-collection when `profiling.enabled` is true, only when not already present in the user-supplied capabilities list. The eBPF profiler reads `/proc/kallsyms` addresses (`CAP_SYSLOG`) and raises `RLIMIT_MEMLOCK` (`CAP_SYS_RESOURCE`).
- for OBI `NET_ADMIN` and `NET_RAW` are added to the default capability set of the odiglet container - these can be removed if OBI is not used.
- For community go instrumentation we add the `KILL` capability since the upstream go openteleemtry instrumentation use signal(0) to check for existance of a PID.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
feat: [BREAKING CHANGE] the odiglet and data-collection containers now run as non-privileged by default. To restore the previous behavior set `odiglet.odiglet.privileged=true` and `odiglet.dataCollection.privileged=true`.
feat: [BREAKING CHANGE] `odiglet.unPrivileged` is replaced by the per-container `odiglet.odiglet.privileged` and `odiglet.dataCollection.privileged` flags, to make clear they apply to individual containers in the odiglet daemonset and not to the whole pod.
feat: [BREAKING CHANGE] the `k8s-csi-driver` mount method now requires `odiglet.odiglet.privileged=true`.
feat: data-collection can now run non-privileged with metrics and logs enabled; it is no longer implied by `signals`.
```
