### PR TITLE
CORE-1645 | feat: replace original path in HTTP span names during URL templatization

### DIFF
--- a/collector/processors/odigosurltemplateprocessor/README.md
+++ b/collector/processors/odigosurltemplateprocessor/README.md
@@ -35,7 +35,7 @@ For spans that match the above constraints, the processor will calculate the tem
 
 ### Span Name
 
-If the span name equals the method (e.g. "GET"), and the processor is able to calculate a templated route, the span name will be set to `{method} {target}`. Otherwise, the span name will not be modified.
+If the span name equals the method (e.g. "GET"), and the processor is able to calculate a templated route, the span name will be set to `{method} {target}`. If the span name already contains the original URL path, that path is replaced with the templated target. Otherwise, the span name will not be modified.
 
 When `target` is empty string, for example `http://example.com`, the target will be set to `"/"` for enhanced usability (differentiate root path from missing target).
 

--- a/collector/processors/odigosurltemplateprocessor/processor.go
+++ b/collector/processors/odigosurltemplateprocessor/processor.go
@@ -372,25 +372,40 @@ func (p *urlTemplateProcessor) calculateTemplatedUrlFromAttrWithRules(attr pcomm
 	return urlPath, odigosattributes.UrlTemplatizationResultStaticPath.Ptr()
 }
 
-func updateHttpSpanName(span ptrace.Span, httpMethod string, templatedUrl string) {
-	currentName := span.Name()
-	if currentName != httpMethod {
-		// be conservative and only update the name for the use case "GET" => "GET /user/{id}"
-		// if the span name is set to something else, keep it and don't override it.
-		// we might want to revisit this in the future based on real world feedback.
-		return
-	}
-
+func updateHttpSpanName(span ptrace.Span, httpMethod string, originalPath string, templatedUrl string) {
 	// if the templated url is not available, we keep the span name as is.
 	if templatedUrl == "" {
 		return
 	}
 
-	// generate span name based on semantic conventions:
-	// HTTP span names SHOULD be {method} {target} if there is a (low-cardinality) target available.
-	// the "target" in our case is the templated url (which is either http.route or url.template attributes).
-	newSpanName := fmt.Sprintf("%s %s", httpMethod, templatedUrl)
-	span.SetName(newSpanName)
+	currentName := span.Name()
+	if currentName == httpMethod {
+		// generate span name based on semantic conventions:
+		// HTTP span names SHOULD be {method} {target} if there is a (low-cardinality) target available.
+		// the "target" in our case is the templated url (which is either http.route or url.template attributes).
+		span.SetName(fmt.Sprintf("%s %s", httpMethod, templatedUrl))
+		return
+	}
+
+	// if the original path appears in the span name, replace it with the templated path.
+	// skip "/" to avoid matching arbitrary slashes in unrelated names.
+	if originalPath == "" || originalPath == "/" || originalPath == templatedUrl {
+		return
+	}
+	idx := strings.Index(currentName, originalPath)
+	if idx < 0 {
+		return
+	}
+	end := idx + len(originalPath)
+	// only replace when the path is a complete match (end of name, or followed by a non-path char).
+	// avoids treating "/user/1234" as a match inside "/user/12345".
+	if end < len(currentName) {
+		next := currentName[end]
+		if next != ' ' && next != '?' && next != '#' {
+			return
+		}
+	}
+	span.SetName(currentName[:idx] + templatedUrl + currentName[end:])
 }
 
 func (p *urlTemplateProcessor) enhanceSpanWithRules(span ptrace.Span, httpMethod string, targetAttribute string, config workloadUrlTemplatizationConfig) {
@@ -404,7 +419,7 @@ func (p *urlTemplateProcessor) enhanceSpanWithRules(span ptrace.Span, httpMethod
 			return
 		}
 		if val.Str() == "" {
-			updateHttpSpanName(span, httpMethod, "/")
+			updateHttpSpanName(span, httpMethod, "", "/")
 		}
 		// avoid overriding the attribute if it is already set
 		return
@@ -415,10 +430,12 @@ func (p *urlTemplateProcessor) enhanceSpanWithRules(span ptrace.Span, httpMethod
 		return
 	}
 
+	originalPath, _ := resolveUrlPath(attr)
+
 	// set the templated url in the target attribute and update the span name if needed
 	attr.PutStr(targetAttribute, templatedUrl)
 	attr.PutStr(odigosattributes.UrlTemplatizationResultAttribute, string(*templatizationResult))
-	updateHttpSpanName(span, httpMethod, templatedUrl)
+	updateHttpSpanName(span, httpMethod, originalPath, templatedUrl)
 }
 
 // processSpanWithRules enhances an HTTP span with templated URL using the given rules.

--- a/collector/processors/odigosurltemplateprocessor/processor_test.go
+++ b/collector/processors/odigosurltemplateprocessor/processor_test.go
@@ -201,6 +201,30 @@ func TestProcessor_Traces(t *testing.T) {
 			expectedAttrValue: "/user/{id}", // should exist
 		},
 		{
+			name:          "span name contains original path",
+			spanKind:      ptrace.SpanKindServer,
+			inputSpanName: "GET /user/1234",
+			inputSpanAttrs: map[string]any{
+				"http.request.method": "GET",
+				"url.path":            "/user/1234",
+			},
+			expectedSpanName:  "GET /user/{id}",
+			expectedAttrKey:   "http.route",
+			expectedAttrValue: "/user/{id}",
+		},
+		{
+			name:          "span name contains original path as prefix of longer path",
+			spanKind:      ptrace.SpanKindServer,
+			inputSpanName: "GET /user/12345",
+			inputSpanAttrs: map[string]any{
+				"http.request.method": "GET",
+				"url.path":            "/user/1234",
+			},
+			expectedSpanName:  "GET /user/12345", // do not replace partial path match
+			expectedAttrKey:   "http.route",
+			expectedAttrValue: "/user/{id}",
+		},
+		{
 			name:          "ignore internal span",
 			spanKind:      ptrace.SpanKindInternal,
 			inputSpanName: "GET",


### PR DESCRIPTION
#### What this PR does / why we need it:
When URL templatization succeeds, the processor already sets low-cardinality `http.route` / `url.template`. Span names that already include the concrete path (e.g. `GET /user/1234`) were left unchanged and stayed high-cardinality.

This updates `updateHttpSpanName` so that if the original URL path appears in the span name, it is replaced with the templated path. The existing behavior for method-only names (`GET` → `GET /user/{id}`) is unchanged. Replacement requires a complete path match to avoid partial prefix false positives (e.g. `/user/1234` inside `/user/12345`).

Linear: https://linear.app/odigos/issue/CORE-1645/replace-original-url-path-in-http-span-names-during-url-templatization

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
```release-note
URL templatization now replaces the original path inside HTTP span names when present, not only when the name equals the method.
```

Made with [Cursor](https://cursor.com)