### PR TITLE
Move the entire kubernetes-test behind an action

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,12 @@
 Please add a meaningful description for future maintainers on what this change does and why we need it.
 -->
 
+#### Additional Kubernetes versions to test:
+<!--
+The Kubernetes E2E suite runs against 1.32 by default. Apply one or more
+`test-k8s/<version>` labels (for example, `test-k8s/1.29`) to add versions.
+-->
+
 #### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
 <!--
 This section will go in the release notes for this version. Is this something users should be able to find easily?

--- a/.github/actions/kubernetes-tests/action.yml
+++ b/.github/actions/kubernetes-tests/action.yml
@@ -8,9 +8,6 @@ inputs:
   test-scenario:
     description: "Name of the test scenario under tests/e2e"
     required: true
-  cache-key-suffix:
-    description: "Suffix used to isolate workflow build caches"
-    default: pr
   supported-versions:
     description: >-
       JSON map of every supported Kubernetes version to its kind node image and minor version.
@@ -105,7 +102,7 @@ runs:
           cli-image.tar
           victoria-metrics-image.tar
         fail-on-cache-miss: true
-        key: ${{ github.run_id }}-${{ inputs.cache-key-suffix }}-odigos-images
+        key: ${{ github.run_id }}-odigos-images
 
     - name: Load Odigos images into kind cluster
       shell: bash
@@ -119,7 +116,7 @@ runs:
       with:
         path: cli/odigos
         fail-on-cache-miss: true
-        key: ${{ github.run_id }}-${{ inputs.cache-key-suffix }}-odigos-cli
+        key: ${{ github.run_id }}-odigos-cli
 
     - name: Make CLI binary executable
       shell: bash

--- a/.github/actions/kubernetes-tests/action.yml
+++ b/.github/actions/kubernetes-tests/action.yml
@@ -1,0 +1,223 @@
+name: "Kubernetes Tests"
+description: "Run an Odigos end-to-end test on a kind cluster"
+
+inputs:
+  kubernetes-version:
+    description: "Kubernetes version to test"
+    required: true
+  test-scenario:
+    description: "Name of the test scenario under tests/e2e"
+    required: true
+  supported-versions:
+    description: >-
+      JSON map of every supported Kubernetes version to its kind node image and minor version.
+      Add an entry here to test against a new version.
+    # 1.21.12 is pinned because it is the first 1.21 patch with the systemd cgroups
+    # compatibility changes required by kind.
+    default: >-
+      {
+        "1.21.12": { "nodeImage": "kindest/node:v1.21.12@sha256:ae05d44cc636ee961068399ea5123ae421790f472c309900c151a44ee35c3e3e", "minorVersion": 21 },
+        "1.22":    { "nodeImage": "kindest/node:v1.22.17@sha256:f5b2e5698c6c9d6d0adc419c0deae21a425c07d81bbf3b6a6834042f25d4fba2", "minorVersion": 22 },
+        "1.23":    { "nodeImage": "kindest/node:v1.23.17@sha256:14d0a9a892b943866d7e6be119a06871291c517d279aedb816a4b4bc0ec0a5b3", "minorVersion": 23 },
+        "1.24":    { "nodeImage": "kindest/node:v1.24.17@sha256:bad10f9b98d54586cba05a7eaa1b61c6b90bfc4ee174fdc43a7b75ca75c95e51", "minorVersion": 24 },
+        "1.25":    { "nodeImage": "kindest/node:v1.25.16@sha256:6110314339b3b44d10da7d27881849a87e092124afab5956f2e10ecdb463b025", "minorVersion": 25 },
+        "1.26":    { "nodeImage": "kindest/node:v1.26.15@sha256:c79602a44b4056d7e48dc20f7504350f1e87530fe953428b792def00bc1076dd", "minorVersion": 26 },
+        "1.27":    { "nodeImage": "kindest/node:v1.27.16@sha256:2d21a61643eafc439905e18705b8186f3296384750a835ad7a005dceb9546d20", "minorVersion": 27 },
+        "1.28":    { "nodeImage": "kindest/node:v1.28.15@sha256:a7c05c7ae043a0b8c818f5a06188bc2c4098f6cb59ca7d1856df00375d839251", "minorVersion": 28 },
+        "1.29":    { "nodeImage": "kindest/node:v1.29.14@sha256:8703bd94ee24e51b778d5556ae310c6c0fa67d761fae6379c8e0bb480e6fea29", "minorVersion": 29 },
+        "1.30":    { "nodeImage": "kindest/node:v1.30.13@sha256:397209b3d947d154f6641f2d0ce8d473732bd91c87d9575ade99049aa33cd648", "minorVersion": 30 },
+        "1.31":    { "nodeImage": "kindest/node:v1.31.14@sha256:6f86cf509dbb42767b6e79debc3f2c32e4ee01386f0489b3b2be24b0a55aac2b", "minorVersion": 31 },
+        "1.32":    { "nodeImage": "kindest/node:v1.32.11@sha256:5fc52d52a7b9574015299724bd68f183702956aa4a2116ae75a63cb574b35af8", "minorVersion": 32 },
+        "1.33":    { "nodeImage": "kindest/node:v1.33.12@sha256:3f5c8443c620245e4d355cfe09e96a91ead32ceaa569d3f1ca9edf0cb2fe2ff4", "minorVersion": 33 },
+        "1.34":    { "nodeImage": "kindest/node:v1.34.11@sha256:44e222ee2132dab25ff87301682f89eb82c7880ea3a1bf543bfe9708fd08d67d", "minorVersion": 34 },
+        "1.35":    { "nodeImage": "kindest/node:v1.35.8@sha256:07b2536e30b803ed61d1677a79df6115f798ce64c80f9e22f6ed45afd09323c0", "minorVersion": 35 },
+        "1.36":    { "nodeImage": "kindest/node:v1.36.4@sha256:099e049362a1526b2db71494e1947aae99bd16290d7c895f2b7ea312e3cbfaed", "minorVersion": 36 },
+        "1.37":    { "nodeImage": "kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5", "minorVersion": 37 }
+      }
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate inputs
+      shell: bash
+      env:
+        KUBERNETES_VERSION: ${{ inputs.kubernetes-version }}
+        NODE_IMAGE: ${{ fromJSON(inputs.supported-versions)[inputs.kubernetes-version].nodeImage }}
+        TEST_SCENARIO: ${{ inputs.test-scenario }}
+      run: |
+        if [[ -z "$NODE_IMAGE" ]]; then
+          echo "::error::Unsupported Kubernetes version '$KUBERNETES_VERSION'. Add it to the 'supported-versions' input of .github/actions/kubernetes-tests"
+          exit 1
+        fi
+
+        if [[ ! -d "tests/e2e/$TEST_SCENARIO" ]]; then
+          echo "::error::Unknown test scenario '$TEST_SCENARIO': tests/e2e/$TEST_SCENARIO does not exist"
+          exit 1
+        fi
+
+    - name: Set up Go
+      if: inputs.test-scenario == 'karpenter-mount-methods'
+      uses: actions/setup-go@v7
+      with:
+        go-version: "~1.26.6"
+        check-latest: true
+        cache: true
+
+    - name: Install ko
+      if: inputs.test-scenario == 'karpenter-mount-methods'
+      uses: ko-build/setup-ko@v0.9
+
+    - name: Install jq
+      if: inputs.test-scenario == 'karpenter-mount-methods'
+      shell: bash
+      run: sudo apt-get update && sudo apt-get install -y jq
+
+    - name: Set up Helm
+      uses: azure/setup-helm@v4
+      with:
+        version: v3.9.0
+
+    - name: Install chainsaw
+      uses: kyverno/action-install-chainsaw@v0.2.13
+
+    - name: Create kind cluster
+      uses: helm/kind-action@v1.12.0
+      with:
+        node_image: ${{ fromJSON(inputs.supported-versions)[inputs.kubernetes-version].nodeImage }}
+        version: "v0.33.0"
+        cluster_name: kind
+        config: tests/common/apply/kind-config.yaml
+        # Ephemeral GHA runners: don't fail the job if kind/docker cleanup races.
+        ignore_failed_clean: true
+
+    - name: Wait for cluster readiness
+      shell: bash
+      run: bash tests/common/wait_for_kind_ready.sh
+
+    - name: Restore cached Odigos images
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          odigos-images.tar
+          cli-image.tar
+          victoria-metrics-image.tar
+        fail-on-cache-miss: true
+        key: ${{ github.run_id }}-odigos-images
+
+    - name: Load Odigos images into kind cluster
+      shell: bash
+      run: |
+        kind load image-archive odigos-images.tar
+        kind load image-archive cli-image.tar
+        kind load image-archive victoria-metrics-image.tar
+
+    - name: Restore cached CLI binary
+      uses: actions/cache/restore@v4
+      with:
+        path: cli/odigos
+        fail-on-cache-miss: true
+        key: ${{ github.run_id }}-odigos-cli
+
+    - name: Make CLI binary executable
+      shell: bash
+      run: chmod +x cli/odigos
+
+    - name: Get latest release tag for branch from Helm
+      id: get-latest-tag
+      shell: bash
+      env:
+        BRANCH: ${{ github.base_ref || github.ref_name }}
+      run: |
+        echo "📦 Updating Helm repositories..."
+        helm repo add odigos https://odigos-io.github.io/odigos/ || true
+        helm repo update
+
+        if [[ "$BRANCH" == releases/* ]]; then
+          VERSION_PREFIX=$(echo "$BRANCH" | sed -E 's|releases/v([0-9]+\.[0-9]+)\..*|\1|')
+          echo "Release branch detected, looking for v${VERSION_PREFIX}.* in Helm"
+          LATEST_RELEASE_TAG=$(helm search repo odigos/odigos --versions | awk -v prefix="^v${VERSION_PREFIX}\\." '$1 == "odigos/odigos" && $3 ~ prefix {print $3; exit}')
+        else
+          echo "Non-release branch, using latest Helm chart version"
+          LATEST_RELEASE_TAG=$(helm search repo odigos/odigos | awk '$1 == "odigos/odigos" {print $3}')
+        fi
+        echo "LATEST_RELEASE_TAG=$LATEST_RELEASE_TAG" >> "$GITHUB_OUTPUT"
+        echo "Latest release tag for branch $BRANCH: $LATEST_RELEASE_TAG"
+
+    - name: Recheck cluster readiness before E2E
+      shell: bash
+      run: bash tests/common/wait_for_kind_ready.sh
+
+    - name: Run E2E tests
+      shell: bash
+      env:
+        LATEST_RELEASE_TAG: ${{ steps.get-latest-tag.outputs.LATEST_RELEASE_TAG }}
+        TEST_SCENARIO: ${{ inputs.test-scenario }}
+        KUBERNETES_MINOR_VERSION: ${{ fromJSON(inputs.supported-versions)[inputs.kubernetes-version].minorVersion }}
+        IS_HELM: ${{ inputs.test-scenario == 'helm-chart' || inputs.test-scenario == 'helm-upgrade' }}
+      run: |
+        chainsaw test "tests/e2e/$TEST_SCENARIO" \
+          --apply-timeout 30s \
+          --values - <<EOF
+        k8sMinorVersion: ${KUBERNETES_MINOR_VERSION}
+        isHelm: ${IS_HELM}
+        EOF
+
+    - name: Cluster diagnostics
+      if: failure()
+      shell: bash
+      run: |
+        echo "==== Nodes ===="; kubectl get nodes -o wide
+        echo "==== Pods (all namespaces) ===="; kubectl get pods -A -o wide
+        echo "==== Events (last 10m) ===="; kubectl get events -A --sort-by=.lastTimestamp | tail -n 200
+        echo "==== Deployments not ready ===="
+        kubectl get deploy -A -o json | \
+          jq -r '.items[]
+            | select((.status.readyReplicas // 0) != (.status.replicas // 0))
+            | "\(.metadata.namespace) \(.metadata.name)"' \
+          | while read ns name; do
+            echo "--- describe deploy $ns/$name ---"
+            kubectl -n "$ns" describe deploy "$name" || true
+          done
+        echo "==== Runner memory ===="; free -h || true
+        echo "==== dmesg OOM / kill hints ===="
+        (sudo dmesg -T 2>/dev/null || dmesg -T 2>/dev/null || true) | \
+          grep -Ei "killed process|out of memory|oom|Memory cgroup" | tail -n 80 || true
+
+    - name: Run diagnose command
+      if: failure() && inputs.test-scenario != 'ui'
+      shell: bash
+      run: ./cli/odigos diagnose
+      continue-on-error: true
+
+    - name: Upload diagnose artifact
+      if: failure() && inputs.test-scenario != 'ui'
+      uses: actions/upload-artifact@v4
+      with:
+        name: run-details-${{ inputs.test-scenario }}-${{ inputs.kubernetes-version }}
+        path: odigos_debug*.tar.gz
+      continue-on-error: true
+
+    - name: Upload UI screenshots artifact
+      if: failure() && inputs.test-scenario == 'ui'
+      uses: actions/upload-artifact@v4
+      with:
+        name: ui-screenshots-${{ inputs.test-scenario }}-${{ inputs.kubernetes-version }}
+        path: frontend/webapp/cypress/screenshots
+      continue-on-error: true
+
+    - name: Upload UI videos artifact
+      if: failure() && inputs.test-scenario == 'ui'
+      uses: actions/upload-artifact@v4
+      with:
+        name: ui-videos-${{ inputs.test-scenario }}-${{ inputs.kubernetes-version }}
+        path: frontend/webapp/cypress/videos
+      continue-on-error: true
+
+    - name: Delete pipeline build caches on success
+      if: success()
+      shell: bash
+      run: |
+        gh extension install actions/gh-actions-cache || true
+        gh actions-cache delete odigos-build-${{ inputs.test-scenario }}-${{ inputs.kubernetes-version }} --confirm || true
+        gh actions-cache delete odigos-deps-${{ inputs.test-scenario }}-${{ inputs.kubernetes-version }} --confirm || true
+      continue-on-error: true

--- a/.github/actions/kubernetes-tests/action.yml
+++ b/.github/actions/kubernetes-tests/action.yml
@@ -8,6 +8,9 @@ inputs:
   test-scenario:
     description: "Name of the test scenario under tests/e2e"
     required: true
+  cache-key-suffix:
+    description: "Suffix used to isolate workflow build caches"
+    default: pr
   supported-versions:
     description: >-
       JSON map of every supported Kubernetes version to its kind node image and minor version.
@@ -102,7 +105,7 @@ runs:
           cli-image.tar
           victoria-metrics-image.tar
         fail-on-cache-miss: true
-        key: ${{ github.run_id }}-odigos-images
+        key: ${{ github.run_id }}-${{ inputs.cache-key-suffix }}-odigos-images
 
     - name: Load Odigos images into kind cluster
       shell: bash
@@ -116,7 +119,7 @@ runs:
       with:
         path: cli/odigos
         fail-on-cache-miss: true
-        key: ${{ github.run_id }}-odigos-cli
+        key: ${{ github.run_id }}-${{ inputs.cache-key-suffix }}-odigos-cli
 
     - name: Make CLI binary executable
       shell: bash

--- a/.github/actions/nightly/report/action.yml
+++ b/.github/actions/nightly/report/action.yml
@@ -24,9 +24,14 @@ runs:
   steps:
     - name: Send Slack Notification
       shell: bash
+      env:
+        STATUS: ${{ inputs.status }}
+        SUITE_NAME: ${{ inputs.suite_name }}
+        SUITE_PARAMETERS: ${{ inputs.suite_parameters }}
+        SLACK_WEBHOOK_URL: ${{ inputs.slack_webhook_url }}
       run: |
         # Decide if status is SUCCESS or FAILURE.
-        if [[ "${{ inputs.status }}" == "success" ]]; then
+        if [[ "$STATUS" == "success" ]]; then
           STATUS_MSG="*SUCCESS*"
           EMOJI="✅"
         else
@@ -40,8 +45,8 @@ runs:
         # Construct Slack payload with jq so that special characters in suite_parameters are properly escaped.
         SLACK_JSON=$(jq -n \
           --arg status_msg  "$STATUS_MSG" \
-          --arg suite_name  "${{ inputs.suite_name }}" \
-          --arg suite_params "${{ inputs.suite_parameters }}" \
+          --arg suite_name  "$SUITE_NAME" \
+          --arg suite_params "$SUITE_PARAMETERS" \
           --arg link        "$GITHUB_LINK" \
           --arg emoji       "$EMOJI" \
           '{
@@ -72,4 +77,4 @@ runs:
         # Send the JSON to Slack via the webhook
         curl -X POST -H 'Content-type: application/json' \
           --data "$SLACK_JSON" \
-          "${{ inputs.slack_webhook_url }}"
+          "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -5,24 +5,13 @@ on:
   pull_request:
     branches: [main, "releases/**"]
     types: [opened, synchronize, reopened, labeled, unlabeled]
-  workflow_call:
-    inputs:
-      kubernetes-version:
-        description: "Kubernetes version to test"
-        type: string
-        required: true
-    secrets:
-      slack_webhook_url:
-        description: "Slack webhook used for nightly Kubernetes test reports"
-        required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-${{ inputs.kubernetes-version || 'pr' }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   prepare-additional-kubernetes-versions:
-    if: inputs.kubernetes-version == ''
     runs-on: ubuntu-latest
     outputs:
       versions: ${{ steps.versions.outputs.versions }}
@@ -86,7 +75,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: cli/odigos
-          key: ${{ github.run_id }}-${{ inputs.kubernetes-version || 'pr' }}-odigos-cli
+          key: ${{ github.run_id }}-odigos-cli
 
   build-odigos-images:
     runs-on: depot-ubuntu-24.04-8
@@ -125,11 +114,10 @@ jobs:
             odigos-images.tar
             cli-image.tar
             victoria-metrics-image.tar
-          key: ${{ github.run_id }}-${{ inputs.kubernetes-version || 'pr' }}-odigos-images
+          key: ${{ github.run_id }}-odigos-images
 
   kubernetes-test:
     needs: [build-odigos-images, build-cli]
-    if: inputs.kubernetes-version == ''
     runs-on: depot-ubuntu-24.04-8
     strategy:
       fail-fast: false
@@ -193,7 +181,7 @@ jobs:
 
   additional-kubernetes-tests:
     needs: [prepare-additional-kubernetes-versions, build-odigos-images, build-cli]
-    if: inputs.kubernetes-version == '' && needs.prepare-additional-kubernetes-versions.outputs.has_versions == 'true'
+    if: needs.prepare-additional-kubernetes-versions.outputs.has_versions == 'true'
     runs-on: depot-ubuntu-24.04-8
     strategy:
       fail-fast: false
@@ -231,61 +219,3 @@ jobs:
         with:
           kubernetes-version: ${{ matrix.kube-version }}
           test-scenario: ${{ matrix.test-scenario }}
-
-  nightly-kubernetes-tests:
-    needs: [build-odigos-images, build-cli]
-    if: inputs.kubernetes-version != ''
-    runs-on: depot-ubuntu-24.04-8
-    strategy:
-      fail-fast: false
-      matrix:
-        kube-version: ["${{ inputs.kubernetes-version }}"]
-        test-scenario:
-          - "ui"
-          - "helm-chart"
-          - "cli-upgrade"
-          - "helm-upgrade"
-          - "runtime-detection"
-          - "instrumentation-lifecycle"
-          - "instrumentation-rollback"
-          - "instrumentation-rollback-stability-window"
-          - "environment-variables"
-          - "trace-collection"
-          - "log-collection"
-          - "source"
-          - "webhooks"
-          - "env-injection"
-          - "data-streams"
-          - "mount-method"
-          - "argo-rollouts"
-          - "head-sampling-http-nodejs"
-          - "head-sampling-http-python"
-          - "head-sampling-http-java"
-          - "tail-sampling-nodejs"
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Run Kubernetes test
-        uses: ./.github/actions/kubernetes-tests
-        with:
-          kubernetes-version: ${{ matrix.kube-version }}
-          test-scenario: ${{ matrix.test-scenario }}
-          cache-key-suffix: ${{ inputs.kubernetes-version }}
-
-  nightly-kubernetes-tests-report:
-    if: always() && inputs.kubernetes-version != ''
-    needs: nightly-kubernetes-tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Report Kubernetes version test outcome
-        uses: ./.github/actions/nightly/report
-        with:
-          status: ${{ needs.nightly-kubernetes-tests.result }}
-          suite_name: kubernetes-tests-${{ inputs.kubernetes-version }}
-          suite_parameters: '{"kubernetes_version": "${{ inputs.kubernetes-version }}"}'
-          slack_webhook_url: ${{ secrets.slack_webhook_url }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -96,39 +96,31 @@ jobs:
       # control-plane load better than serializing the matrix (which stretched CI
       # wall-clock). Reintroduce a cap only if signal:killed / OOM returns.
       matrix:
-        kube-version: ["1.32", "1.23", "1.21.12"]
+        kube-version: ["1.21.12", "1.22", "1.23", "1.24", "1.25", "1.26", "1.27", "1.28", "1.29", "1.30", "1.31", "1.32", "1.33", "1.34", "1.35", "1.36", "1.37"]
         test-scenario:
-          - "ui"
+          # - "ui"
           - "helm-chart"
-          - "cli-upgrade"
-          - "helm-upgrade"
-          - "runtime-detection"
-          - "instrumentation-lifecycle"
-          - "instrumentation-rollback"
-          - "instrumentation-rollback-stability-window"
-          - "environment-variables"
-          - "trace-collection"
-          - "log-collection"
-          - "source"
-          - "webhooks"
-          - "env-injection"
-          - "data-streams"
-          - "mount-method"
-          - "argo-rollouts"
-          - "head-sampling-http-nodejs"
-          - "head-sampling-http-python"
-          - "head-sampling-http-java"
-          - "tail-sampling-nodejs"
+          # - "cli-upgrade"
+          # - "helm-upgrade"
+          # - "runtime-detection"
+          # - "instrumentation-lifecycle"
+          # - "instrumentation-rollback"
+          # - "instrumentation-rollback-stability-window"
+          # - "environment-variables"
+          # - "trace-collection"
+          # - "log-collection"
+          # - "source"
+          # - "webhooks"
+          # - "env-injection"
+          # - "data-streams"
+          # - "mount-method"
+          # - "argo-rollouts"
+          # - "head-sampling-http-nodejs"
+          # - "head-sampling-http-python"
+          # - "head-sampling-http-java"
+          # - "tail-sampling-nodejs"
         include:
-          - kube-version: "1.21.12"
-            # use 1.21.12 for systemd cgroups compatibility changes in kind 0.13 https://github.com/kubernetes-sigs/kind/releases/tag/v0.13.0
-            kind-image: "kindest/node:v1.21.12@sha256:ae05d44cc636ee961068399ea5123ae421790f472c309900c151a44ee35c3e3e"
-          - kube-version: "1.23"
-            kind-image: "kindest/node:v1.23.17@sha256:14d0a9a892b943866d7e6be119a06871291c517d279aedb816a4b4bc0ec0a5b3"
           - kube-version: "1.32"
-            kind-image: "kindest/node:v1.32.0@sha256:2458b423d635d7b01637cac2d6de7e1c1dca1148a2ba2e90975e214ca849e7cb"
-          - kube-version: "1.32"
-            kind-image: "kindest/node:v1.32.0@sha256:2458b423d635d7b01637cac2d6de7e1c1dca1148a2ba2e90975e214ca849e7cb"
             test-scenario: "karpenter-mount-methods"
 
     steps:
@@ -151,192 +143,9 @@ jobs:
         if: steps.should-run.outputs.skip != 'true'
         uses: actions/checkout@v5
 
-      - name: Set up Go
-        if: steps.should-run.outputs.skip != 'true' && matrix.test-scenario == 'karpenter-mount-methods'
-        uses: actions/setup-go@v7
+      - name: Run Kubernetes test
+        if: steps.should-run.outputs.skip != 'true'
+        uses: ./.github/actions/kubernetes-tests
         with:
-          go-version: "~1.26.6"
-          check-latest: true
-          cache: true
-
-      - name: Install ko
-        if: steps.should-run.outputs.skip != 'true' && matrix.test-scenario == 'karpenter-mount-methods'
-        uses: ko-build/setup-ko@v0.9
-
-      - name: Install jq
-        if: steps.should-run.outputs.skip != 'true' && matrix.test-scenario == 'karpenter-mount-methods'
-        run: sudo apt-get update && sudo apt-get install -y jq
-
-      - name: Set up Helm
-        if: steps.should-run.outputs.skip != 'true'
-        uses: azure/setup-helm@v4
-        with:
-          version: v3.9.0
-
-      - name: Install chainsaw
-        if: steps.should-run.outputs.skip != 'true'
-        uses: kyverno/action-install-chainsaw@v0.2.13
-
-      - name: Create Kind Cluster
-        if: steps.should-run.outputs.skip != 'true'
-        uses: helm/kind-action@v1.12.0
-        with:
-          node_image: ${{ matrix.kind-image }}
-          version: "v0.25.0"
-          cluster_name: kind
-          config: tests/common/apply/kind-config.yaml
-          # Ephemeral GHA runners: don't fail the job if kind/docker cleanup races.
-          ignore_failed_clean: true
-
-      - name: wait for cluster readiness
-        if: steps.should-run.outputs.skip != 'true'
-        run: bash tests/common/wait_for_kind_ready.sh
-
-      - name: Restore cached Odigos images
-        if: steps.should-run.outputs.skip != 'true'
-        id: restore-images-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            odigos-images.tar
-            cli-image.tar
-            victoria-metrics-image.tar
-          fail-on-cache-miss: true
-          key: ${{ github.run_id }}-odigos-images
-
-      - name: Check if images cache was restored
-        if: steps.should-run.outputs.skip != 'true' && steps.restore-images-cache.outputs.cache-hit != 'true'
-        run: |
-          echo "❌ Cache miss for Odigos images - this should not happen!"
-          echo "Expected cache key: ${{ github.run_id }}-odigos-images"
-          exit 1
-
-      - name: Load Odigos Images to Kind Cluster
-        if: steps.should-run.outputs.skip != 'true'
-        run: |
-          kind load image-archive odigos-images.tar
-          kind load image-archive cli-image.tar
-          kind load image-archive victoria-metrics-image.tar
-
-      - name: Restore cached CLI binary
-        if: steps.should-run.outputs.skip != 'true'
-        id: restore-cli-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: cli/odigos
-          fail-on-cache-miss: true
-          key: ${{ github.run_id }}-odigos-cli
-
-      - name: Check if CLI cache was restored
-        if: steps.should-run.outputs.skip != 'true' && steps.restore-cli-cache.outputs.cache-hit != 'true'
-        run: |
-          echo "❌ Cache miss for CLI binary - this should not happen!"
-          echo "Expected cache key: ${{ github.run_id }}-odigos-cli"
-          exit 1
-
-      - name: Move CLI binary & set permissions
-        if: steps.should-run.outputs.skip != 'true'
-        run: chmod +x cli/odigos
-
-      - name: Get latest release tag for branch from Helm
-        if: steps.should-run.outputs.skip != 'true'
-        id: get-latest-tag
-        run: |
-          echo "📦 Updating Helm repositories..."
-          helm repo add odigos https://odigos-io.github.io/odigos/ || true
-          helm repo update
-
-          BRANCH="${{ github.base_ref || github.ref_name }}"
-          # If on a release branch (e.g., releases/v1.14.0), get latest Helm version for that version line
-          # Otherwise (main), get the latest overall Helm chart version
-          if [[ "$BRANCH" == releases/* ]]; then
-            VERSION_PREFIX=$(echo "$BRANCH" | sed -E 's|releases/v([0-9]+\.[0-9]+)\..*|\1|')
-            echo "Release branch detected, looking for v${VERSION_PREFIX}.* in Helm"
-            LATEST_RELEASE_TAG=$(helm search repo odigos/odigos --versions | awk -v prefix="^v${VERSION_PREFIX}\\\\." '$1 == "odigos/odigos" && $3 ~ prefix {print $3; exit}')
-          else
-            echo "Non-release branch, using latest Helm chart version"
-            LATEST_RELEASE_TAG=$(helm search repo odigos/odigos | awk '$1 == "odigos/odigos" {print $3}')
-          fi
-          echo "LATEST_RELEASE_TAG=$LATEST_RELEASE_TAG" >> $GITHUB_OUTPUT
-          echo "Latest release tag for branch $BRANCH: $LATEST_RELEASE_TAG"
-
-      - name: recheck cluster readiness before E2E
-        if: steps.should-run.outputs.skip != 'true'
-        # Image cache restore / kind load can take ~1m; apiserver/etcd may flap in
-        # that window even after the post-create readiness gate passed.
-        run: bash tests/common/wait_for_kind_ready.sh
-
-      - name: Run E2E Tests
-        if: steps.should-run.outputs.skip != 'true'
-        env:
-          LATEST_RELEASE_TAG: ${{ steps.get-latest-tag.outputs.LATEST_RELEASE_TAG }}
-        run: |
-          MINOR_VERSION=$(echo ${{ matrix.kube-version }} | sed -E 's/^1\.([0-9]+).*$/\1/')
-          # Default apply timeout is 5s — too short when apiserver briefly flaps
-          # under runner load (context deadline exceeded on early APPLY).
-          chainsaw test tests/e2e/${{ matrix.test-scenario }} \
-            --apply-timeout 30s \
-            --values - <<EOF
-          k8sMinorVersion: ${MINOR_VERSION}
-          isHelm: ${{ matrix.test-scenario == 'helm-chart' || matrix.test-scenario == 'helm-upgrade' }}
-          EOF
-
-      - name: Cluster diagnostics
-        if: failure() && steps.should-run.outputs.skip != 'true'
-        run: |
-          echo "==== Nodes ===="; kubectl get nodes -o wide
-          echo "==== Pods (all namespaces) ===="; kubectl get pods -A -o wide
-          echo "==== Events (last 10m) ===="; kubectl get events -A --sort-by=.lastTimestamp | tail -n 200
-          echo "==== Deployments not ready ===="
-            kubectl get deploy -A -o json | \
-            jq -r '.items[]
-              | select((.status.readyReplicas // 0) != (.status.replicas // 0))
-              | "\(.metadata.namespace) \(.metadata.name)"' \
-            | while read ns name; do
-              echo "--- describe deploy $ns/$name ---"
-              kubectl -n "$ns" describe deploy "$name" || true
-          done
-          echo "==== Runner memory ===="; free -h || true
-          echo "==== dmesg OOM / kill hints ===="
-          (sudo dmesg -T 2>/dev/null || dmesg -T 2>/dev/null || true) | \
-            grep -Ei "killed process|out of memory|oom|Memory cgroup" | tail -n 80 || true
-
-      ################### Diagnose and collect logs ###################
-      - name: Run diagnose command
-        if: ${{ failure() && steps.should-run.outputs.skip != 'true' && matrix.test-scenario != 'ui' }}
-        run: ./cli/odigos diagnose
-        continue-on-error: true
-
-      - name: Upload diagnose artifact
-        if: ${{ failure() && steps.should-run.outputs.skip != 'true' && matrix.test-scenario != 'ui' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: run-details-${{ matrix.test-scenario }}-${{ matrix.kube-version }}
-          path: odigos_debug*.tar.gz
-        continue-on-error: true
-
-      - name: Upload UI screenshots artifact
-        if: ${{ failure() && steps.should-run.outputs.skip != 'true' && matrix.test-scenario == 'ui' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: ui-screenshots-${{ matrix.test-scenario }}-${{ matrix.kube-version }}
-          path: frontend/webapp/cypress/screenshots
-        continue-on-error: true
-
-      - name: Upload UI videos artifact
-        if: ${{ failure() && steps.should-run.outputs.skip != 'true' && matrix.test-scenario == 'ui' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: ui-videos-${{ matrix.test-scenario }}-${{ matrix.kube-version }}
-          path: frontend/webapp/cypress/videos
-        continue-on-error: true
-
-      - name: Delete pipeline build caches on success
-        if: ${{ success() && steps.should-run.outputs.skip != 'true' }}
-        run: |
-          echo "Deleting pipeline build caches..."
-          gh extension install actions/gh-actions-cache || true
-          # Only delete caches created by this workflow run
-          gh actions-cache delete odigos-build-${{ matrix.test-scenario }}-${{ matrix.kube-version }} --confirm || true
-          gh actions-cache delete odigos-deps-${{ matrix.test-scenario }}-${{ matrix.kube-version }} --confirm || true
-        continue-on-error: true
+          kubernetes-version: ${{ matrix.kube-version }}
+          test-scenario: ${{ matrix.test-scenario }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -7,17 +7,22 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_call:
     inputs:
-      profile:
-        description: "Kubernetes version selection profile"
+      kubernetes-version:
+        description: "Kubernetes version to test"
         type: string
-        default: pr
+        required: true
+    secrets:
+      slack_webhook_url:
+        description: "Slack webhook used for nightly Kubernetes test reports"
+        required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-${{ inputs.kubernetes-version || 'pr' }}
   cancel-in-progress: true
 
 jobs:
   prepare-additional-kubernetes-versions:
+    if: inputs.kubernetes-version == ''
     runs-on: ubuntu-latest
     outputs:
       versions: ${{ steps.versions.outputs.versions }}
@@ -27,27 +32,18 @@ jobs:
         id: versions
         shell: bash
         env:
-          PROFILE: ${{ inputs.profile }}
           PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: |
           PR_VERSION="1.32"
-          LOWEST_VERSION="1.21.12"
-
-          if [[ "$PROFILE" == "nightly" ]]; then
-            VERSIONS=$(jq -cn \
-              --arg lowest "$LOWEST_VERSION" \
-              '[$lowest]')
-          else
-            VERSIONS=$(jq -cn \
-              --arg pr "$PR_VERSION" \
-              --argjson labels "${PR_LABELS:-null}" \
-              '[
-                ($labels // [])[]
-                | select(startswith("test-k8s/"))
-                | sub("^test-k8s/"; "")
-                | select(. != $pr)
-              ] | unique')
-          fi
+          VERSIONS=$(jq -cn \
+            --arg pr "$PR_VERSION" \
+            --argjson labels "${PR_LABELS:-null}" \
+            '[
+              ($labels // [])[]
+              | select(startswith("test-k8s/"))
+              | sub("^test-k8s/"; "")
+              | select(. != $pr)
+            ] | unique')
 
           HAS_VERSIONS=$(jq -r 'length > 0' <<< "$VERSIONS")
           echo "Selected additional Kubernetes versions: $VERSIONS"
@@ -90,7 +86,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: cli/odigos
-          key: ${{ github.run_id }}-odigos-cli
+          key: ${{ github.run_id }}-${{ inputs.kubernetes-version || 'pr' }}-odigos-cli
 
   build-odigos-images:
     runs-on: depot-ubuntu-24.04-8
@@ -129,10 +125,11 @@ jobs:
             odigos-images.tar
             cli-image.tar
             victoria-metrics-image.tar
-          key: ${{ github.run_id }}-odigos-images
+          key: ${{ github.run_id }}-${{ inputs.kubernetes-version || 'pr' }}-odigos-images
 
   kubernetes-test:
     needs: [build-odigos-images, build-cli]
+    if: inputs.kubernetes-version == ''
     runs-on: depot-ubuntu-24.04-8
     strategy:
       fail-fast: false
@@ -196,7 +193,7 @@ jobs:
 
   additional-kubernetes-tests:
     needs: [prepare-additional-kubernetes-versions, build-odigos-images, build-cli]
-    if: needs.prepare-additional-kubernetes-versions.outputs.has_versions == 'true'
+    if: inputs.kubernetes-version == '' && needs.prepare-additional-kubernetes-versions.outputs.has_versions == 'true'
     runs-on: depot-ubuntu-24.04-8
     strategy:
       fail-fast: false
@@ -234,3 +231,61 @@ jobs:
         with:
           kubernetes-version: ${{ matrix.kube-version }}
           test-scenario: ${{ matrix.test-scenario }}
+
+  nightly-kubernetes-tests:
+    needs: [build-odigos-images, build-cli]
+    if: inputs.kubernetes-version != ''
+    runs-on: depot-ubuntu-24.04-8
+    strategy:
+      fail-fast: false
+      matrix:
+        kube-version: ["${{ inputs.kubernetes-version }}"]
+        test-scenario:
+          - "ui"
+          - "helm-chart"
+          - "cli-upgrade"
+          - "helm-upgrade"
+          - "runtime-detection"
+          - "instrumentation-lifecycle"
+          - "instrumentation-rollback"
+          - "instrumentation-rollback-stability-window"
+          - "environment-variables"
+          - "trace-collection"
+          - "log-collection"
+          - "source"
+          - "webhooks"
+          - "env-injection"
+          - "data-streams"
+          - "mount-method"
+          - "argo-rollouts"
+          - "head-sampling-http-nodejs"
+          - "head-sampling-http-python"
+          - "head-sampling-http-java"
+          - "tail-sampling-nodejs"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Run Kubernetes test
+        uses: ./.github/actions/kubernetes-tests
+        with:
+          kubernetes-version: ${{ matrix.kube-version }}
+          test-scenario: ${{ matrix.test-scenario }}
+          cache-key-suffix: ${{ inputs.kubernetes-version }}
+
+  nightly-kubernetes-tests-report:
+    if: always() && inputs.kubernetes-version != ''
+    needs: nightly-kubernetes-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Report Kubernetes version test outcome
+        uses: ./.github/actions/nightly/report
+        with:
+          status: ${{ needs.nightly-kubernetes-tests.result }}
+          suite_name: kubernetes-tests-${{ inputs.kubernetes-version }}
+          suite_parameters: '{"kubernetes_version": "${{ inputs.kubernetes-version }}"}'
+          slack_webhook_url: ${{ secrets.slack_webhook_url }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4,12 +4,56 @@ on:
   merge_group:
   pull_request:
     branches: [main, "releases/**"]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  workflow_call:
+    inputs:
+      profile:
+        description: "Kubernetes version selection profile"
+        type: string
+        default: pr
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
+  prepare-additional-kubernetes-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.versions.outputs.versions }}
+      has_versions: ${{ steps.versions.outputs.has_versions }}
+    steps:
+      - name: Select Kubernetes versions
+        id: versions
+        shell: bash
+        env:
+          PROFILE: ${{ inputs.profile }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          PR_VERSION="1.32"
+          LOWEST_VERSION="1.21.12"
+
+          if [[ "$PROFILE" == "nightly" ]]; then
+            VERSIONS=$(jq -cn \
+              --arg lowest "$LOWEST_VERSION" \
+              '[$lowest]')
+          else
+            VERSIONS=$(jq -cn \
+              --arg pr "$PR_VERSION" \
+              --argjson labels "${PR_LABELS:-null}" \
+              '[
+                ($labels // [])[]
+                | select(startswith("test-k8s/"))
+                | sub("^test-k8s/"; "")
+                | select(. != $pr)
+              ] | unique')
+          fi
+
+          HAS_VERSIONS=$(jq -r 'length > 0' <<< "$VERSIONS")
+          echo "Selected additional Kubernetes versions: $VERSIONS"
+          echo "versions=$VERSIONS" >> "$GITHUB_OUTPUT"
+          echo "has_versions=$HAS_VERSIONS" >> "$GITHUB_OUTPUT"
+
   build-cli:
     runs-on: depot-ubuntu-24.04
     steps:
@@ -96,29 +140,29 @@ jobs:
       # control-plane load better than serializing the matrix (which stretched CI
       # wall-clock). Reintroduce a cap only if signal:killed / OOM returns.
       matrix:
-        kube-version: ["1.21.12", "1.22", "1.23", "1.24", "1.25", "1.26", "1.27", "1.28", "1.29", "1.30", "1.31", "1.32", "1.33", "1.34", "1.35", "1.36", "1.37"]
+        kube-version: ["1.32"]
         test-scenario:
-          # - "ui"
+          - "ui"
           - "helm-chart"
-          # - "cli-upgrade"
-          # - "helm-upgrade"
-          # - "runtime-detection"
-          # - "instrumentation-lifecycle"
-          # - "instrumentation-rollback"
-          # - "instrumentation-rollback-stability-window"
-          # - "environment-variables"
-          # - "trace-collection"
-          # - "log-collection"
-          # - "source"
-          # - "webhooks"
-          # - "env-injection"
-          # - "data-streams"
-          # - "mount-method"
-          # - "argo-rollouts"
-          # - "head-sampling-http-nodejs"
-          # - "head-sampling-http-python"
-          # - "head-sampling-http-java"
-          # - "tail-sampling-nodejs"
+          - "cli-upgrade"
+          - "helm-upgrade"
+          - "runtime-detection"
+          - "instrumentation-lifecycle"
+          - "instrumentation-rollback"
+          - "instrumentation-rollback-stability-window"
+          - "environment-variables"
+          - "trace-collection"
+          - "log-collection"
+          - "source"
+          - "webhooks"
+          - "env-injection"
+          - "data-streams"
+          - "mount-method"
+          - "argo-rollouts"
+          - "head-sampling-http-nodejs"
+          - "head-sampling-http-python"
+          - "head-sampling-http-java"
+          - "tail-sampling-nodejs"
         include:
           - kube-version: "1.32"
             test-scenario: "karpenter-mount-methods"
@@ -145,6 +189,47 @@ jobs:
 
       - name: Run Kubernetes test
         if: steps.should-run.outputs.skip != 'true'
+        uses: ./.github/actions/kubernetes-tests
+        with:
+          kubernetes-version: ${{ matrix.kube-version }}
+          test-scenario: ${{ matrix.test-scenario }}
+
+  additional-kubernetes-tests:
+    needs: [prepare-additional-kubernetes-versions, build-odigos-images, build-cli]
+    if: needs.prepare-additional-kubernetes-versions.outputs.has_versions == 'true'
+    runs-on: depot-ubuntu-24.04-8
+    strategy:
+      fail-fast: false
+      matrix:
+        kube-version: ${{ fromJSON(needs.prepare-additional-kubernetes-versions.outputs.versions) }}
+        test-scenario:
+          - "ui"
+          - "helm-chart"
+          - "cli-upgrade"
+          - "helm-upgrade"
+          - "runtime-detection"
+          - "instrumentation-lifecycle"
+          - "instrumentation-rollback"
+          - "instrumentation-rollback-stability-window"
+          - "environment-variables"
+          - "trace-collection"
+          - "log-collection"
+          - "source"
+          - "webhooks"
+          - "env-injection"
+          - "data-streams"
+          - "mount-method"
+          - "argo-rollouts"
+          - "head-sampling-http-nodejs"
+          - "head-sampling-http-python"
+          - "head-sampling-http-java"
+          - "tail-sampling-nodejs"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Run Kubernetes test
         uses: ./.github/actions/kubernetes-tests
         with:
           kubernetes-version: ${{ matrix.kube-version }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,16 +39,138 @@ jobs:
   build-images:
     uses: ./.github/workflows/build-dev-images.yml
 
+  build-cli:
+    runs-on: depot-ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: "~1.26.6"
+          check-latest: true
+          cache: true
+          cache-dependency-path: |
+            **/go.sum
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.15.2
+
+      - name: Build CLI
+        run: |
+          cd cli
+          TAG=0.0.0-e2e-test
+          sed -i -E 's/0.0.0/'"${TAG#v}"'/' ../helm/odigos/Chart.yaml
+          sed -i -E 's/0.0.0/'"${TAG#v}"'/' ../helm/odigos-central/Chart.yaml
+          helm package ../helm/odigos -d pkg/helm/embedded
+          helm package ../helm/odigos-central -d pkg/helm/embedded
+          go build -tags=embed_manifests \
+            -ldflags "-X github.com/odigos-io/odigos/cli/pkg/helm.OdigosChartVersion=${TAG#v}" \
+            -o odigos
+
+      - name: Save CLI binary to cache
+        uses: actions/cache/save@v4
+        with:
+          path: cli/odigos
+          key: ${{ github.run_id }}-odigos-cli
+
+  build-odigos-images:
+    runs-on: depot-ubuntu-24.04-8
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Build Odigos Images
+        run: |
+          TAG=e2e-test make build-images
+          docker save -o odigos-images.tar $(docker images --format "{{.Repository}}:{{.Tag}}" | grep "odigos")
+
+      - uses: ko-build/setup-ko@v0.9
+
+      - name: Build CLI Image
+        run: |
+          TAG=e2e-test make build-cli-image
+          docker save docker.io/keyval/odigos-cli:e2e-test -o cli-image.tar
+
+      # Victoria Metrics is published, not built in this repo. Materialize a single-platform
+      # image (buildx --load) so kind load does not fail on multi-arch manifests.
+      - name: Prepare Victoria Metrics Image
+        run: |
+          printf 'FROM docker.io/keyval/odigos-victoria-metrics:latest\n' | docker buildx build \
+            --platform=linux/$(docker version -f '{{.Server.Arch}}') \
+            --pull \
+            -t docker.io/keyval/odigos-victoria-metrics:e2e-test \
+            --load \
+            -
+          docker save docker.io/keyval/odigos-victoria-metrics:e2e-test -o victoria-metrics-image.tar
+
+      - name: Save Odigos images to cache
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            odigos-images.tar
+            cli-image.tar
+            victoria-metrics-image.tar
+          key: ${{ github.run_id }}-odigos-images
+
   kubernetes-tests:
+    needs: [build-cli, build-odigos-images]
+    runs-on: depot-ubuntu-24.04-8
     strategy:
       fail-fast: false
       matrix:
         kubernetes-version: ["1.21.12", "1.37"]
-    uses: ./.github/workflows/e2e.yaml
-    with:
-      kubernetes-version: ${{ matrix.kubernetes-version }}
-    secrets:
-      slack_webhook_url: ${{ secrets.CLOUD_PROVIDERS_TESTS_WEBHOOK_URL }}
+        test-scenario:
+          - "ui"
+          - "helm-chart"
+          - "cli-upgrade"
+          - "helm-upgrade"
+          - "runtime-detection"
+          - "instrumentation-lifecycle"
+          - "instrumentation-rollback"
+          - "instrumentation-rollback-stability-window"
+          - "environment-variables"
+          - "trace-collection"
+          - "log-collection"
+          - "source"
+          - "webhooks"
+          - "env-injection"
+          - "data-streams"
+          - "mount-method"
+          - "argo-rollouts"
+          - "head-sampling-http-nodejs"
+          - "head-sampling-http-python"
+          - "head-sampling-http-java"
+          - "tail-sampling-nodejs"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Run Kubernetes test
+        uses: ./.github/actions/kubernetes-tests
+        with:
+          kubernetes-version: ${{ matrix.kubernetes-version }}
+          test-scenario: ${{ matrix.test-scenario }}
+
+  kubernetes-tests-report:
+    if: always()
+    needs: kubernetes-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v5
+
+      - name: Report Test Outcome
+        uses: ./.github/actions/nightly/report
+        with:
+          status: ${{ needs.kubernetes-tests.result }}
+          suite_name: kubernetes-tests
+          suite_parameters: '{"kubernetes_versions": "1.21.12, 1.37"}'
+          slack_webhook_url: ${{ secrets.CLOUD_PROVIDERS_TESTS_WEBHOOK_URL }}
 
   chaos-tests:
     runs-on: depot-ubuntu-24.04-8

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,9 +36,6 @@ permissions:
   contents: read
 
 jobs:
-  build-images:
-    uses: ./.github/workflows/build-dev-images.yml
-
   build-cli:
     runs-on: depot-ubuntu-24.04
     steps:
@@ -77,8 +74,14 @@ jobs:
           path: cli/odigos
           key: ${{ github.run_id }}-odigos-cli
 
-  build-odigos-images:
+  # Images are built once with the e2e-test tag: the Kubernetes tests load them into kind from
+  # the cache, and the cloud suites pull the same images from ECR under the commit hash tag.
+  build-images:
     runs-on: depot-ubuntu-24.04-8
+    env:
+      COMMIT_HASH: ${{ github.sha }}
+      DOCKER_REGISTRY: docker.io/keyval
+      REGISTRY: public.ecr.aws/y2v0v6s7
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -116,8 +119,25 @@ jobs:
             victoria-metrics-image.tar
           key: ${{ github.run_id }}-odigos-images
 
+      - name: Configure AWS credentials from OIDC
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: arn:aws:iam::061717858829:role/ecr-pull-push-role
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        run: |
+          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+
+      - name: Push Docker Images to ECR
+        run: |
+          for image in collector instrumentor ui scheduler autoscaler odiglet cli; do
+            docker tag "${DOCKER_REGISTRY}/odigos-${image}:e2e-test" "${REGISTRY}/odigos-${image}:${COMMIT_HASH}"
+            docker push "${REGISTRY}/odigos-${image}:${COMMIT_HASH}"
+          done
+
   kubernetes-tests:
-    needs: [build-cli, build-odigos-images]
+    needs: [build-cli, build-images]
     runs-on: depot-ubuntu-24.04-8
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,6 +39,17 @@ jobs:
   build-images:
     uses: ./.github/workflows/build-dev-images.yml
 
+  kubernetes-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes-version: ["1.21.12", "1.37"]
+    uses: ./.github/workflows/e2e.yaml
+    with:
+      kubernetes-version: ${{ matrix.kubernetes-version }}
+    secrets:
+      slack_webhook_url: ${{ secrets.CLOUD_PROVIDERS_TESTS_WEBHOOK_URL }}
+
   chaos-tests:
     runs-on: depot-ubuntu-24.04-8
     needs: build-images
@@ -96,4 +107,3 @@ jobs:
           suite_name: cross-cloud-tests
           suite_parameters: '{"provider": "${{ matrix.provider }}", "test_scenario": "${{ matrix.test_scenario }}"}, "platform": "${{ matrix.platform }}"}'
           slack_webhook_url: ${{ secrets.CLOUD_PROVIDERS_TESTS_WEBHOOK_URL }}
-


### PR DESCRIPTION
Change the PR cycle to only test a single K8S version

#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->
Move kubernetes-test to be a standalone composite action
PR will now only test K8S version 1.32
Allow testing specific versions via the `test-k8s/<version>` PR labels
Nightly will test version `1.21.12` (Minimum supported version) and `1.37` (Latest stable K8S)

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
None
```
