### PR TITLE
fix: add sys_ptrace to data-collection when profiling is enabled

### DIFF
--- a/helm/odigos/templates/odiglet/daemonset.yaml
+++ b/helm/odigos/templates/odiglet/daemonset.yaml
@@ -320,6 +320,8 @@ spec:
               {{- /* the eBPF profiler reads /proc/kallsyms addresses and raises RLIMIT_MEMLOCK */}}
               {{- if not (has "SYSLOG" $caps) }}{{- $caps = append $caps "SYSLOG" }}{{- end }}
               {{- if not (has "SYS_RESOURCE" $caps) }}{{- $caps = append $caps "SYS_RESOURCE" }}{{- end }}
+              {{- /* the eBPF profiler uses process_vm_readv to read interpreter state, this requires SYS_PTRACE */}}
+              {{- if not (has "SYS_PTRACE" $caps) }}{{- $caps = append $caps "SYS_PTRACE" }}{{- end }}
               {{- end }}
               {{- toYaml $caps | nindent 14 }}
               drop:

--- a/helm/odigos/values.schema.json
+++ b/helm/odigos/values.schema.json
@@ -1585,7 +1585,7 @@
           "description": "Configuration for the data-collection container.",
           "properties": {
             "capabilities": {
-              "description": "capabilities to add to the data-collection container when running non-privileged - this will be ignored when running as privileged.\nSYS_ADMIN required when running in unprivileged mode if one of the following is true:\n 1. kernel version is older than 5.8 (In \u003e= 5.8 BPF and PERMON were added)\n 2. kernel.perf_event_paranoid sysctl is set to 2 or higher\nSYSLOG and SYS_RESOURCE are added automatically when profiling.enabled is true.",
+              "description": "capabilities to add to the data-collection container when running non-privileged - this will be ignored when running as privileged.\nSYS_ADMIN required when running in unprivileged mode if one of the following is true:\n 1. kernel version is older than 5.8 (In \u003e= 5.8 BPF and PERMON were added)\n 2. kernel.perf_event_paranoid sysctl is set to 2 or higher\nSYSLOG, SYS_RESOURCE and SYS_PTRACE are added automatically when profiling.enabled is true.",
               "items": {
                 "anyOf": [
                   {

--- a/helm/odigos/values.yaml
+++ b/helm/odigos/values.yaml
@@ -976,7 +976,7 @@ odiglet:
     #   SYS_ADMIN required when running in unprivileged mode if one of the following is true:
     #    1. kernel version is older than 5.8 (In >= 5.8 BPF and PERMON were added)
     #    2. kernel.perf_event_paranoid sysctl is set to 2 or higher
-    #   SYSLOG and SYS_RESOURCE are added automatically when profiling.enabled is true.
+    #   SYSLOG, SYS_RESOURCE and SYS_PTRACE are added automatically when profiling.enabled is true.
     # @schema
     capabilities:
       - SYS_ADMIN


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->

#### Additional Kubernetes versions to test:
<!--
The Kubernetes E2E suite runs against 1.32 by default. Apply one or more
`test-k8s/<version>` labels (for example, `test-k8s/1.29`) to add versions.
-->

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

cherry-pick:v1.37

```release-note
fix: add sys_ptrace to data-collection when profiling is enabled
```
