### PR TITLE
Carry custom Go probe installation generations in configuration

### DIFF
--- a/api/config/crd/bases/odigos.io_instrumentationconfigs.yaml
+++ b/api/config/crd/bases/odigos.io_instrumentationconfigs.yaml
@@ -310,6 +310,16 @@ spec:
                                       FunctionName is the name of the golang function to be instrumented, ie package name is "net/http" and the function
                                       name will be "ListenAndServe"; Function name is disallowed if ReceiverName and ReceiverMethodName are provided
                                     type: string
+                                  generation:
+                                    description: |-
+                                      Generation identifies one installation in emitted custom spans. Use a
+                                      fresh nonzero 128-bit ID for a new installation; empty preserves legacy behavior.
+                                    maxLength: 32
+                                    pattern: ^$|^[0-9a-f]{32}$
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: generation must be nonzero
+                                      rule: self != '00000000000000000000000000000000'
                                   packageName:
                                     description: PackageName is the name of the golang
                                       package (ie net/http); Package name is always

--- a/api/config/crd/bases/odigos.io_instrumentationrules.yaml
+++ b/api/config/crd/bases/odigos.io_instrumentationrules.yaml
@@ -126,6 +126,16 @@ spec:
                             FunctionName is the name of the golang function to be instrumented, ie package name is "net/http" and the function
                             name will be "ListenAndServe"; Function name is disallowed if ReceiverName and ReceiverMethodName are provided
                           type: string
+                        generation:
+                          description: |-
+                            Generation identifies one installation in emitted custom spans. Use a
+                            fresh nonzero 128-bit ID for a new installation; empty preserves legacy behavior.
+                          maxLength: 32
+                          pattern: ^$|^[0-9a-f]{32}$
+                          type: string
+                          x-kubernetes-validations:
+                          - message: generation must be nonzero
+                            rule: self != '00000000000000000000000000000000'
                         packageName:
                           description: PackageName is the name of the golang package
                             (ie net/http); Package name is always required

--- a/common/api/instrumentationrules/custom_instrumentation.go
+++ b/common/api/instrumentationrules/custom_instrumentation.go
@@ -1,8 +1,10 @@
 package instrumentationrules
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 )
 
 // +kubebuilder:object:generate=true
@@ -84,10 +86,25 @@ type GolangCustomProbe struct {
 	// for example for "net/http" package, "response" is a receiver struct and "WriteHeader" is a method of that struct
 	// ReceiverMethodName is mandatory if ReceiverName is provided, and disallowed if FunctionName is provided
 	ReceiverMethodName string `json:"receiverMethodName,omitempty" yaml:"receiverMethodName,omitempty"`
+	// Generation identifies one installation in emitted custom spans. Use a
+	// fresh nonzero 128-bit ID for a new installation; empty preserves legacy behavior.
+	// +kubebuilder:validation:Pattern=`^$|^[0-9a-f]{32}$`
+	// +kubebuilder:validation:MaxLength=32
+	// +kubebuilder:validation:XValidation:rule="self != '00000000000000000000000000000000'",message="generation must be nonzero"
+	Generation string `json:"generation,omitempty" yaml:"generation,omitempty"`
 }
 
 // For golang we require package name and either function name or receiver name + method name
 func (gcp *GolangCustomProbe) Verify() error {
+	if gcp.Generation != "" {
+		if len(gcp.Generation) != 32 || gcp.Generation != strings.ToLower(gcp.Generation) {
+			return errors.New("generation must be a nonzero 128-bit lowercase hex ID")
+		}
+		id, err := hex.DecodeString(gcp.Generation)
+		if err != nil || len(id) != 16 || gcp.Generation == strings.Repeat("0", 32) {
+			return errors.New("generation must be a nonzero 128-bit lowercase hex ID")
+		}
+	}
 	switch {
 	case gcp.PackageName == "":
 		return errors.New("package name is required")

--- a/common/api/instrumentationrules/generation_test.go
+++ b/common/api/instrumentationrules/generation_test.go
@@ -1,0 +1,16 @@
+package instrumentationrules
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGolangGenerationValidation(t *testing.T) {
+	for _, value := range []string{"", "0123456789abcdef0123456789abcdef", "0", strings.Repeat("0", 32), strings.Repeat("a", 33), strings.Repeat("g", 32), strings.Repeat("A", 32)} {
+		p := GolangCustomProbe{PackageName: "main", FunctionName: "work", Generation: value}
+		valid := value == "" || value == "0123456789abcdef0123456789abcdef"
+		if err := p.Verify(); (err == nil) != valid {
+			t.Errorf("generation %q: valid=%v, error=%v", value, valid, err)
+		}
+	}
+}

--- a/helm/odigos/templates/crds/odigos.io_instrumentationconfigs.yaml
+++ b/helm/odigos/templates/crds/odigos.io_instrumentationconfigs.yaml
@@ -310,6 +310,16 @@ spec:
                                       FunctionName is the name of the golang function to be instrumented, ie package name is "net/http" and the function
                                       name will be "ListenAndServe"; Function name is disallowed if ReceiverName and ReceiverMethodName are provided
                                     type: string
+                                  generation:
+                                    description: |-
+                                      Generation identifies one installation in emitted custom spans. Use a
+                                      fresh nonzero 128-bit ID for a new installation; empty preserves legacy behavior.
+                                    maxLength: 32
+                                    pattern: ^$|^[0-9a-f]{32}$
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: generation must be nonzero
+                                      rule: self != '00000000000000000000000000000000'
                                   packageName:
                                     description: PackageName is the name of the golang
                                       package (ie net/http); Package name is always

--- a/helm/odigos/templates/crds/odigos.io_instrumentationrules.yaml
+++ b/helm/odigos/templates/crds/odigos.io_instrumentationrules.yaml
@@ -126,6 +126,16 @@ spec:
                             FunctionName is the name of the golang function to be instrumented, ie package name is "net/http" and the function
                             name will be "ListenAndServe"; Function name is disallowed if ReceiverName and ReceiverMethodName are provided
                           type: string
+                        generation:
+                          description: |-
+                            Generation identifies one installation in emitted custom spans. Use a
+                            fresh nonzero 128-bit ID for a new installation; empty preserves legacy behavior.
+                          maxLength: 32
+                          pattern: ^$|^[0-9a-f]{32}$
+                          type: string
+                          x-kubernetes-validations:
+                          - message: generation must be nonzero
+                            rule: self != '00000000000000000000000000000000'
                         packageName:
                           description: PackageName is the name of the golang package
                             (ie net/http); Package name is always required


### PR DESCRIPTION
<!-- interrogation-review-navigation -->
**Review navigation:** [Cross-repository review order and evidence guide](https://github.com/odigos-io/odigos-enterprise/blob/codex/interrogation-profiles/interrogation/docs/review-guide.md). This draft belongs to a native GitHub PR stack; use the stack map and review layers from bottom to top.

Follow-on native expiry and draining milestone: https://github.com/odigos-io/odigos/pull/5800

Native generation integration and real Jaeger proof: [https://github.com/odigos-io/odigos-enterprise/pull/3720](https://github.com/odigos-io/odigos-enterprise/pull/3720).

#### What this PR does / why we need it:

Interrogation needs to distinguish repeated installations of the same function. Add an optional nonzero 128-bit lowercase hex generation to Go custom probe configuration, with shared validation and regenerated API/Helm CRD schemas. Empty values preserve existing configuration behavior.

Built from the enterprise-pinned 96e7fdc0a868 revision. Common validation race tests and the API suite with `-tags embed_manifests` pass. The field propagated through Instrumentor and Odiglet to actual generation-tagged spans in a dedicated kind cluster. Companion Go runtime and enterprise changes are required to emit and validate the attribute; this schema alone does not add probe expiry or acknowledgments.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??

```release-note
Accept optional installation generations in custom Go instrumentation rules and configurations.
```
