### PR TITLE
Carry expiration deadlines for temporary Go instrumentation

### DIFF
--- a/api/config/crd/bases/odigos.io_instrumentationconfigs.yaml
+++ b/api/config/crd/bases/odigos.io_instrumentationconfigs.yaml
@@ -305,6 +305,12 @@ spec:
                                   golang custom probe contains the details for a custom probe for golang applications,
                                   which includes the package name, function name or receiver name and method name to be instrumented.
                                 properties:
+                                  expiresAt:
+                                    description: ExpiresAt stops new capture for this
+                                      generation. In-flight calls may drain.
+                                    format: date-time
+                                    maxLength: 35
+                                    type: string
                                   functionName:
                                     description: |-
                                       FunctionName is the name of the golang function to be instrumented, ie package name is "net/http" and the function
@@ -339,6 +345,10 @@ spec:
                                 required:
                                 - packageName
                                 type: object
+                                x-kubernetes-validations:
+                                - message: expiry requires generation
+                                  rule: '!has(self.expiresAt) || (has(self.generation)
+                                    && size(self.generation) == 32)'
                               type: array
                             java:
                               items:

--- a/api/config/crd/bases/odigos.io_instrumentationrules.yaml
+++ b/api/config/crd/bases/odigos.io_instrumentationrules.yaml
@@ -121,6 +121,12 @@ spec:
                         golang custom probe contains the details for a custom probe for golang applications,
                         which includes the package name, function name or receiver name and method name to be instrumented.
                       properties:
+                        expiresAt:
+                          description: ExpiresAt stops new capture for this generation.
+                            In-flight calls may drain.
+                          format: date-time
+                          maxLength: 35
+                          type: string
                         functionName:
                           description: |-
                             FunctionName is the name of the golang function to be instrumented, ie package name is "net/http" and the function
@@ -154,6 +160,10 @@ spec:
                       required:
                       - packageName
                       type: object
+                      x-kubernetes-validations:
+                      - message: expiry requires generation
+                        rule: '!has(self.expiresAt) || (has(self.generation) && size(self.generation)
+                          == 32)'
                     type: array
                   java:
                     items:

--- a/common/api/instrumentationrules/custom_instrumentation.go
+++ b/common/api/instrumentationrules/custom_instrumentation.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 )
 
 // +kubebuilder:object:generate=true
@@ -73,6 +74,7 @@ func (jcp *JavaCustomProbe) String() string {
 // which includes the package name, function name or receiver name and method name to be instrumented.
 // +kubebuilder:object:generate=true
 // +kubebuilder:deepcopy-gen=true
+// +kubebuilder:validation:XValidation:rule="!has(self.expiresAt) || (has(self.generation) && size(self.generation) == 32)",message="expiry requires generation"
 type GolangCustomProbe struct {
 	// PackageName is the name of the golang package (ie net/http); Package name is always required
 	PackageName string `json:"packageName" yaml:"packageName"`
@@ -92,10 +94,23 @@ type GolangCustomProbe struct {
 	// +kubebuilder:validation:MaxLength=32
 	// +kubebuilder:validation:XValidation:rule="self != '00000000000000000000000000000000'",message="generation must be nonzero"
 	Generation string `json:"generation,omitempty" yaml:"generation,omitempty"`
+	// ExpiresAt stops new capture for this generation. In-flight calls may drain.
+	// +kubebuilder:validation:Format=date-time
+	// +kubebuilder:validation:MaxLength=35
+	ExpiresAt string `json:"expiresAt,omitempty" yaml:"expiresAt,omitempty"`
 }
 
 // For golang we require package name and either function name or receiver name + method name
 func (gcp *GolangCustomProbe) Verify() error {
+	if gcp.ExpiresAt != "" {
+		if gcp.Generation == "" {
+			return errors.New("custom probe expiry requires an installation generation")
+		}
+		expires, err := time.Parse(time.RFC3339Nano, gcp.ExpiresAt)
+		if len(gcp.ExpiresAt) > 35 || err != nil || expires.IsZero() {
+			return errors.New("custom probe expiry must be a nonzero RFC3339 timestamp")
+		}
+	}
 	if gcp.Generation != "" {
 		if len(gcp.Generation) != 32 || gcp.Generation != strings.ToLower(gcp.Generation) {
 			return errors.New("generation must be a nonzero 128-bit lowercase hex ID")

--- a/common/api/instrumentationrules/generation_test.go
+++ b/common/api/instrumentationrules/generation_test.go
@@ -14,3 +14,21 @@ func TestGolangGenerationValidation(t *testing.T) {
 		}
 	}
 }
+
+func TestGolangExpirationValidation(t *testing.T) {
+	for _, tc := range []struct {
+		generation, expiry string
+		valid              bool
+	}{
+		{"", "", true},
+		{"", "2026-09-10T18:30:00Z", false},
+		{"0123456789abcdef0123456789abcdef", "2026-09-10T18:30:00Z", true},
+		{"0123456789abcdef0123456789abcdef", "yesterday", false},
+		{"0123456789abcdef0123456789abcdef", "0001-01-01T00:00:00Z", false},
+	} {
+		p := GolangCustomProbe{PackageName: "main", FunctionName: "work", Generation: tc.generation, ExpiresAt: tc.expiry}
+		if err := p.Verify(); (err == nil) != tc.valid {
+			t.Errorf("expiry %q: valid=%v, error=%v", tc.expiry, tc.valid, err)
+		}
+	}
+}

--- a/helm/odigos/templates/crds/odigos.io_instrumentationconfigs.yaml
+++ b/helm/odigos/templates/crds/odigos.io_instrumentationconfigs.yaml
@@ -305,6 +305,12 @@ spec:
                                   golang custom probe contains the details for a custom probe for golang applications,
                                   which includes the package name, function name or receiver name and method name to be instrumented.
                                 properties:
+                                  expiresAt:
+                                    description: ExpiresAt stops new capture for this
+                                      generation. In-flight calls may drain.
+                                    format: date-time
+                                    maxLength: 35
+                                    type: string
                                   functionName:
                                     description: |-
                                       FunctionName is the name of the golang function to be instrumented, ie package name is "net/http" and the function
@@ -339,6 +345,10 @@ spec:
                                 required:
                                 - packageName
                                 type: object
+                                x-kubernetes-validations:
+                                - message: expiry requires generation
+                                  rule: '!has(self.expiresAt) || (has(self.generation)
+                                    && size(self.generation) == 32)'
                               type: array
                             java:
                               items:

--- a/helm/odigos/templates/crds/odigos.io_instrumentationrules.yaml
+++ b/helm/odigos/templates/crds/odigos.io_instrumentationrules.yaml
@@ -121,6 +121,12 @@ spec:
                         golang custom probe contains the details for a custom probe for golang applications,
                         which includes the package name, function name or receiver name and method name to be instrumented.
                       properties:
+                        expiresAt:
+                          description: ExpiresAt stops new capture for this generation.
+                            In-flight calls may drain.
+                          format: date-time
+                          maxLength: 35
+                          type: string
                         functionName:
                           description: |-
                             FunctionName is the name of the golang function to be instrumented, ie package name is "net/http" and the function
@@ -154,6 +160,10 @@ spec:
                       required:
                       - packageName
                       type: object
+                      x-kubernetes-validations:
+                      - message: expiry requires generation
+                        rule: '!has(self.expiresAt) || (has(self.generation) && size(self.generation)
+                          == 32)'
                     type: array
                   java:
                     items:


### PR DESCRIPTION
<!-- interrogation-review-navigation -->
**Review navigation:** [Cross-repository review order and evidence guide](https://github.com/odigos-io/odigos-enterprise/blob/codex/interrogation-profiles/interrogation/docs/review-guide.md). This draft belongs to a native GitHub PR stack; use the stack map and review layers from bottom to top.

Enterprise verification and raw Jaeger proof: https://github.com/odigos-io/odigos-enterprise/pull/3722

Add optional `expiresAt` to Go custom probe configuration so a bounded interrogation plan can reach the native runtime unchanged. Common validation requires a nonzero RFC3339 timestamp and installation generation; generated InstrumentationRule/InstrumentationConfig CRDs and Helm schemas preserve the field and reject expiry without a generation. Existing configurations without expiry remain valid.

Validation: common validation race tests, API suite with `-tags embed_manifests`, regenerated CRDs/Helm sync, and admission of the generated cross-field validation in the dedicated kind cluster. The native runtime enforces the 15-minute admission bound at attachment; this schema does not claim to enforce time-dependent runtime policy.

Stacked on #5799. Companion runtime and Enterprise PRs implement enforcement and preserve real controller-crash/Jaeger verification evidence.

Native lifecycle status/reporting follow-up: https://github.com/odigos-io/odigos/pull/5801.

```release-note
Carry expiration deadlines for temporary Go instrumentation.
```
